### PR TITLE
Rename security functions with wpcom_vip_ prefix

### DIFF
--- a/security.php
+++ b/security.php
@@ -8,7 +8,7 @@ Version: 1.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-function login_limiter( $username ) {
+function wpcom_vip_login_limiter( $username ) {
 	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 	$key1 = $ip . '|' . $username; // IP + username
 	$key2 = $ip; // IP only
@@ -19,9 +19,9 @@ function login_limiter( $username ) {
 	wp_cache_incr( $key1, 1, 'login_limit' );
 	wp_cache_incr( $key2, 1, 'login_limit' );
 }
-add_action( 'wp_login_failed', 'login_limiter' );
+add_action( 'wp_login_failed', 'wpcom_vip_login_limiter' );
 
-function login_limiter_on_success( $username, $user ) {
+function wpcom_vip_login_limiter_on_success( $username, $user ) {
 
 	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 	$key1 = $ip . '|' . $username; // IP + username
@@ -30,43 +30,43 @@ function login_limiter_on_success( $username, $user ) {
 	wp_cache_decr( $key1, 1, 'login_limit' );
 	wp_cache_decr( $key2, 1, 'login_limit' );
 }
-add_action( 'wp_login', 'login_limiter_on_success', 10, 2 );
+add_action( 'wp_login', 'wpcom_vip_login_limiter_on_success', 10, 2 );
 
-function login_limiter_authenticate( $user, $username, $password ) {
+function wpcom_vip_login_limiter_authenticate( $user, $username, $password ) {
 	if ( empty( $username ) && empty( $password ) )
 		return $user;
 
-	if ( $error = login_is_limited( $username ) ) {
+	if ( $error = wpcom_vip_login_is_limited( $username ) ) {
 		return $error;
 	}
 
 	return $user;
 }
-add_filter( 'authenticate', 'login_limiter_authenticate', 30, 3 );
+add_filter( 'authenticate', 'wpcom_vip_login_limiter_authenticate', 30, 3 );
 
-function login_limit_dont_show_login_form() {
+function wpcom_vip_login_limit_dont_show_login_form() {
 	if ( 'post' != strtolower( $_SERVER['REQUEST_METHOD'] ) || !isset( $_POST['log'] ) ) {
 		return;
 	}
 
 	$username = sanitize_user( $_POST['log'] );
-	if ( $error = login_is_limited( $username ) ) {
+	if ( $error = wpcom_vip_login_is_limited( $username ) ) {
 		login_header( __( 'Error' ), '', $error );
 		login_footer();
 		exit;
 	}
 }
-add_action( 'login_form_login', 'login_limit_dont_show_login_form' );
+add_action( 'login_form_login', 'wpcom_vip_login_limit_dont_show_login_form' );
 
-function login_limit_xmlrpc_error( $error, $user ) {
+function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
 	if ( is_wp_error( $user ) && 'login_limit_exceeded' == $user->get_error_code() )
 		return new IXR_Error( 503, $user->get_error_message() );
 
 	return $error;
 }
-add_filter( 'xmlrpc_login_error', 'login_limit_xmlrpc_error', 10, 2 );
+add_filter( 'xmlrpc_login_error', 'wpcom_vip_login_limit_xmlrpc_error', 10, 2 );
 
-function login_is_limited( $username ) {
+function wpcom_vip_login_is_limited( $username ) {
 	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 
 	$key1 = $ip . '|' . $username;


### PR DESCRIPTION
Makes them less generic and less likely to conflict with client code.

Fixes #9
