### PR TITLE
Fix strict standards warning in VIPV2_SMTP during admin-ajax requests

### DIFF
--- a/vipv2-mail.php
+++ b/vipv2-mail.php
@@ -10,7 +10,7 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 
 class VIPV2_SMTP {
 	function init() {
-		add_action( 'phpmailer_init', array( 'VIPV2_SMTP', 'phpmailer_init' ) );
+		add_action( 'phpmailer_init', array( $this, 'phpmailer_init' ) );
 	}
 
 	function phpmailer_init( $phpmailer ) {


### PR DESCRIPTION
Seeing an error from this mu-plugin when making admin-ajax.php requests:

```
<b>Strict Standards</b>:  call_user_func_array() expects parameter 1 to be a valid callback, non-static method VIPV2_SMTP::phpmailer_init() should not be called statically in <b>/srv/www/w/htdocs/wp-includes/plugin.php</b> on line <b>571</b><br />
```
