### PR TITLE
Only load VIP Dashboard if `is_admin()`

### DIFF
--- a/vip-dashboard.php
+++ b/vip-dashboard.php
@@ -12,4 +12,6 @@ Text Domain: vip-dashboard
 Domain Path: /languages/
 */
 
-require __DIR__ . '/vip-dashboard/vip-dashboard.php';
+if ( is_admin() ) {
+  require __DIR__ . '/vip-dashboard/vip-dashboard.php';
+}


### PR DESCRIPTION
Note: This has already been deployed on production.
