### PR TITLE
Fix `FILE_SERVICE_ENPOINT` spelling to `FILE_SERVICE_ENDPOINT`

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -12,8 +12,8 @@ Author URI: http://automattic.com/
  * used to catch imports and push the files to the VIP MogileFS service
  */
 
-if ( ! defined( 'FILE_SERVICE_ENPOINT' ) )
-	define( 'FILE_SERVICE_ENPOINT', 'files.vipv2.net' );
+if ( ! defined( 'FILE_SERVICE_ENDPOINT' ) )
+	define( 'FILE_SERVICE_ENDPOINT', 'files.vipv2.net' );
 
 define( 'LOCAL_UPLOADS', '/tmp/uploads' );
 
@@ -421,7 +421,7 @@ class A8C_Files {
 	}
 
 	function get_files_service_hostname() {
-		return 'https://' . FILE_SERVICE_ENPOINT;
+		return 'https://' . FILE_SERVICE_ENDPOINT;
 	}
 
 	/**


### PR DESCRIPTION
No uses elsewhere, we believe.

See #44 
