### PR TITLE
Do not send the cache headers through to Varnish for 404s

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -9,7 +9,7 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 
 // Ensure we do not send the cache headers through to Varnish,
 // so responses obey the cache settings we have configured.
-function check_for_404_and_remove_cache_headers( $headers ) {
+function wpcom_vip_check_for_404_and_remove_cache_headers( $headers ) {
 	if ( is_404() ) {
 		unset( $headers['Expires'] );
 		unset( $headers['Cache-Control'] );
@@ -17,7 +17,7 @@ function check_for_404_and_remove_cache_headers( $headers ) {
 	}
 	return $headers;
 }
-add_filter( 'nocache_headers', 'check_for_404_and_remove_cache_headers' );
+add_filter( 'nocache_headers', 'wpcom_vip_check_for_404_and_remove_cache_headers' );
 
 // Cleaner permalink options
 add_filter( 'got_url_rewrite', '__return_true' );


### PR DESCRIPTION
Do not send the cache headers, when the request results is a 404,
otherwise it prevents Varnish from caching the 404 page according to
the cache settings we have defined in the config.
