### PR TITLE
Require wp-admin/includes/plugin.php for the get_plugins() function

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1,5 +1,9 @@
 <?php
 
+// We need to include this manually, because we need get_plugins() to work early,
+// for proper plugin loading when using wpcom_vip_load_plugin()
+require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
 /**
  * Utility function to trigger a callback on a hook with priority or execute immediately if the hook has already been fired previously.
  *


### PR DESCRIPTION
Needed to find the actual plugin file when loading plugins via
wpcom_vip_load_plugin()

Fixes #49
