### PR TITLE
Enable SAVEQUERIES when the debug bar is enabled

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -24,6 +24,10 @@ add_action( 'after_setup_theme', function() {
 
     require_once( __DIR__ . '/debug-bar/debug-bar.php' );
 
+    if ( ! defined( 'SAVEQUERIES' ) ) {
+        define( 'SAVEQUERIES', true );
+    }
+
     // Setup extra panels
     add_filter( 'debug_bar_panels', function( $panels ) {
         // @todo, see wpcom for details


### PR DESCRIPTION
Luckily, WP doesn't define this constant, so we can define it ourselves
(if it hasn't been defined previously, of course).

This is a little late, and will probably miss some queries, but the
majority are going to be happening here.

At some point, we need to move this out of here into an earlier loading
spot - this is more a stopgap solution
