### PR TITLE
Also set the save_queries property on hyperdb, to actually save the q…

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -24,13 +24,14 @@ add_action( 'after_setup_theme', function() {
 
     if ( ! defined( 'SAVEQUERIES' ) ) {
         define( 'SAVEQUERIES', true );
+
+        // For hyperdb, which doesn't use SAVEQUERIES
+        global $wpdb;
+
+        $wpdb->save_queries = true;
     }
 
     require_once( __DIR__ . '/debug-bar/debug-bar.php' );
-
-    if ( ! defined( 'SAVEQUERIES' ) ) {
-        define( 'SAVEQUERIES', true );
-    }
 
     // Setup extra panels
     add_filter( 'debug_bar_panels', function( $panels ) {


### PR DESCRIPTION
…ueries

HyperDB doesn't use `SAVEQUERIES` like normal, so have to set the
`save_queries` property in addition to setting the constant
