### PR TITLE
Bump newscred grunt-contrib-uglify version

### DIFF
--- a/shared-plugins/newscred/package.json
+++ b/shared-plugins/newscred/package.json
@@ -5,7 +5,7 @@
         "grunt": "0.4.0",
         "handlebars": "1.0.10",
         "grunt-contrib-concat": "0.1.2",
-        "grunt-contrib-uglify": "0.1.1",
+        "grunt-contrib-uglify": "0.9.2",
         "grunt-contrib-compass": "0.1.2",
         "grunt-contrib-watch": "0.2.0",
         "grunt-contrib-cssmin": "0.5.0"


### PR DESCRIPTION
To latest, fixes potential vulnerability in Uglify
