### PR TITLE
Change VIP Mail sender (synced from SVN)

### DIFF
--- a/vip-mail.php
+++ b/vip-mail.php
@@ -17,7 +17,7 @@ class VIP_SMTP {
 		global $all_smtp_servers;
 
 		$phpmailer->isSMTP();
-		$phpmailer->Sender = "donotreply@{$_SERVER['SERVER_NAME']}";
+		$phpmailer->Sender = "donotreply@wordpress.com";
 
 		if ( ! is_array( $all_smtp_servers ) || empty( $all_smtp_servers ) )
 			return;


### PR DESCRIPTION
Change the From to wordpress.com as we are still using the WP.com infrastructure for sending mails.

r64659-deploy
