### PR TITLE
Pass $taxonomy to get_term_by

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -117,6 +117,11 @@ function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
 add_action( 'delete_term', 'wp_flush_term_exists', 10, 4 );
 function wp_flush_term_exists( $term, $tt_id, $taxonomy, $deleted_term ){
 	$term = get_term_by( 'id', $term, $taxonomy );
+
+	if ( ! $term ) {
+		return;
+	}
+	
 	foreach( array( 'id', 'name', 'slug' ) as $field ) {
 		$cache_key = $term->$field . '|' . $taxonomy ;
 		$cache_group = 'term_exists';


### PR DESCRIPTION
When flushing the term_exists cache.

Also adds an early return if the term lookup failed
