### PR TITLE
Sync wp_flush_term_exists() with the wpcom version

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -116,14 +116,8 @@ function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
  */
 add_action( 'delete_term', 'wp_flush_term_exists', 10, 4 );
 function wp_flush_term_exists( $term, $tt_id, $taxonomy, $deleted_term ){
-	$term = get_term_by( 'id', $term, $taxonomy );
-
-	if ( ! $term ) {
-		return;
-	}
-	
-	foreach( array( 'id', 'name', 'slug' ) as $field ) {
-		$cache_key = $term->$field . '|' . $taxonomy ;
+	foreach( array( 'term_id', 'name', 'slug' ) as $field ) {
+		$cache_key = $deleted_term->$field . '|' . $taxonomy ;
 		$cache_group = 'term_exists';
 		wp_cache_delete( $cache_key, $cache_group );
 	}


### PR DESCRIPTION
Keeps us consistent with wpcom, fixes #74 
