### PR TITLE
Update the plugin loading order to prioritize client plugins over shared plugins

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -993,8 +993,8 @@ function wpcom_vip_load_plugin( $plugin = false, $folder_not_used = null, $load_
 		$test_directories[] = WP_CONTENT_DIR . '/mu-plugins/shared-plugins/release-candidates';
 	}
 
-	$test_directories[] = WP_CONTENT_DIR . '/mu-plugins/shared-plugins';
 	$test_directories[] = WP_PLUGIN_DIR;
+	$test_directories[] = WP_CONTENT_DIR . '/mu-plugins/shared-plugins';
 
 	$includepath = null;
 	$plugin_type = null;


### PR DESCRIPTION
Allows clients to more easily run their own version of shared plugins.

If both exist, the client version will be loaded, instead of the shared
plugin.

Fixes #96
