### PR TITLE
Change the URL for VIP Jetpack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = git@github.com:Automattic/vip-support.git
 [submodule "vip-jetpack"]
 	path = vip-jetpack
-	url = git@github.com:Automattic/vipv2-jetpack.git
+	url = git@github.com:Automattic/vip-jetpack.git
 [submodule "advanced-post-cache"]
 	path = advanced-post-cache
 	url = git@github.com:Automattic/advanced-post-cache.git


### PR DESCRIPTION
The repo was renamed from https://github.com/Automattic/vipv2-jetpack
to https://github.com/Automattic/vip-jetpack as part of making our
repositories public where possible.
