### PR TITLE
a8c-files: prefer Photon's image_downsize when the module is active

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -33,7 +33,7 @@ class A8C_Files {
 		add_filter( 'wp_save_image_file',        array( &$this, 'save_image_file' ), 10, 5 );
 		add_filter( 'wp_save_image_editor_file', array( &$this, 'save_image_file' ), 10, 5 );
 
-		add_filter( 'image_downsize', array( &$this, 'image_resize' ), 10, 3 );
+		add_filter( 'image_downsize', array( &$this, 'image_resize' ), 5, 3 ); // Ensure this runs before Jetpack, when Photon is active
 
 		// disable the automatic creation of intermediate image sizes
 		add_filter( 'intermediate_image_sizes',          function( $sizes ) { return array(); } );


### PR DESCRIPTION
When Photon is active, its `image_downsize` callback should be used instead, keeping a8c-files as a fallback.

Right now, since both are at the same priority, a8c-files has priority. This is because its callback isn't added until the `init` action, whereas Photon adds its at `plugins_loaded`.
