### PR TITLE
Add query param to disable CSS and JS concat.

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -23,11 +23,11 @@ add_filter( 'nocache_headers', 'wpcom_vip_check_for_404_and_remove_cache_headers
 add_filter( 'got_url_rewrite', '__return_true' );
 
 // Activate concatenation
-if ( ! isset( $_GET['concat_js'] ) || 'yes' == $_GET['concat_js'] ) {
+if ( ! isset( $_GET['concat_js'] ) || 'yes' === $_GET['concat_js'] ) {
 	require __DIR__ .'/http-concat/jsconcat.php';
 }
 
-if ( ! isset( $_GET['concat_css'] ) || 'yes' == $_GET['concat_css'] ) {
+if ( ! isset( $_GET['concat_css'] ) || 'yes' === $_GET['concat_css'] ) {
 	require __DIR__ .'/http-concat/cssconcat.php';
 }
 


### PR DESCRIPTION
On WordPress.com, we can disable CSS and JS concat with a query parameter that allows us to disable each of them.
