### PR TITLE
Always set Jetpack to staging mode outside the VIP environment.

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -14,9 +14,9 @@
  
 add_filter( 'jetpack_client_verify_ssl_certs', '__return_true' );
 
-add_filter( 'jetpack_is_staging_site', function() {
-	return ! ( defined('WPCOM_IS_VIP_ENV') && WPCOM_IS_VIP_ENV );
-});
+if ( ! @constant( 'WPCOM_IS_VIP_ENV' ) ) {
+	add_filter( 'jetpack_is_staging_site', '__return_true' );
+}
 
 $jetpack_to_load = __DIR__ . '/jetpack/jetpack.php';
 


### PR DESCRIPTION
This is a first pass at a fix for #127 and doesn't cover every case.
Namely, it doesn't cover staging sites hosted on VIP Go. The biggest
risk right now is developers downloading a production backup from
VaultPress which includes the Jetpack connection information, and
restoring that to their local environment. So long as they also use our
mu-plugins, this would avoid breaking the Jetpack connection in that
case.
