### PR TITLE
Fix helper to disable New Relic so that it works when template_redirect is running but not finished.

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1108,7 +1108,7 @@ function is_automattician( $user_id = false ) {
  * Must be called at or before the `template_redirect` action.
  */
 function wpcom_vip_disable_new_relic_js() {
-	if ( did_action( 'template_redirect' ) ) {
+	if ( did_action( 'template_redirect' ) && ! doing_action( 'template_redirect' ) ) {
 		_doing_it_wrong( __FUNCTION__, 'New Relic&#8217;s browser tracking can only be disabled at or before the `template_redirect` action.', '1.0' );
 		return;
 	}


### PR DESCRIPTION
Allows NR to be disabled within callbacks hooked to actions that are triggered within `template_redirect` callbacks.

For example, AMP's `pre_amp_render_post` action is called from a callback hooked to `template_redirect`, so it's happening within the `template_redirect` action, which is acceptable and should be supported.

Really fixes #134, following upon #141.
