### PR TITLE
Mimic how WPCom disables intermediate sizes, for backwards compatibility

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -601,4 +601,3 @@ if ( defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' ) ) {
 	add_filter( 'intermediate_image_sizes', 'wpcom_intermediate_sizes' );
 	add_filter( 'intermediate_image_sizes_advanced', 'wpcom_intermediate_sizes' );
 }
-


### PR DESCRIPTION
In some cases, it's necessary for code to know what intermediate sizes would've been created, if we didn't block them in favor of on-demand resizing. On WordPress.com, a function `wpcom_intermediate_sizes()` is used, which allows code to remove the callback when it needs to identify intermediate sizes.

By using the same function name, existing code, such as the [Thumbnail editor](https://github.com/Automattic/wpcom-thumbnail-editor/blob/1a25448431a4421c966e60f7e15597b83f7f41e4/wpcom-thumbnail-editor.php#L489), continues to function without requiring a code change.
