### PR TITLE
Replicate `X-hacker` header from WordPress.com

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -30,4 +30,11 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require_once( __DIR__ . '/vip-helpers/vip-wp-cli.php' );
 }
 
+// Add Automattic's custom header
+add_action( 'send_headers', function() {
+	if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
+		header( "X-hacker: If you're reading this, you should visit automattic.com/jobs and apply to join the fun, mention this header." );
+	}
+} );
+
 do_action( 'vip_loaded' );


### PR DESCRIPTION
It's been successful on WordPress.com, no reason Go shouldn't promote Automattic as well.
