### PR TITLE
Use HTTP_X_COUNTRY_CODE

### DIFF
--- a/shared-plugins/vip-go-geo-uniques/vip-go-geo-uniques.php
+++ b/shared-plugins/vip-go-geo-uniques/vip-go-geo-uniques.php
@@ -17,8 +17,8 @@ class VIP_Go_Geo_Uniques {
 	}
 
 	static function get_country_code() {
-		if ( ! empty( $_SERVER['GEOIP_COUNTRY_CODE'] ) ) {
-			$loc = $_SERVER['GEOIP_COUNTRY_CODE'];
+		if ( ! empty( $_SERVER['HTTP_X_COUNTRY_CODE'] ) ) {
+			$loc = $_SERVER['HTTP_X_COUNTRY_CODE'];
 
 			if ( self::is_valid_location( $loc ) ) {
 				return $loc;


### PR DESCRIPTION
Every request should have HTTP_X_COUNTRY_CODE because we're setting it on LBs. We should use that anyway in case the GEOIP databases were to get out of sync between LBs and web containers.
