### PR TITLE
Hook into both Core upload methods

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -25,6 +25,7 @@ class A8C_Files {
 		add_filter( 'wp_insert_attachment_data', array( &$this, 'check_to_upload_file' ), 10, 2 );
 
 		add_filter( 'wp_handle_upload_prefilter', array( &$this, 'get_unique_filename' ), 10, 1 );
+		add_filter( 'wp_handle_sideload_prefilter', array( &$this, 'get_unique_filename' ), 10, 1 );
 		add_filter( 'upload_dir', array( &$this, 'get_upload_dir' ), 10, 1 );
 
 		add_filter( 'wp_handle_upload', array( &$this, 'upload_file' ), 10, 2 );


### PR DESCRIPTION
WP provides two ways to upload fiels, through `wp_handle_upload()` and `wp_handle_sideload()`. The unique-filename checks hooked into the former should also be applied to the latter.

Currently, sideloaded media, such as items uploaded via the REST API, don't receive unique filenames.
