### PR TITLE
Fix a PHP warning because a filter callback didn't return anything

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -595,7 +595,7 @@ function a8c_files_init() {
  * Function name parallels wpcom's implementation to accommodate existing code
  */
 function wpcom_intermediate_sizes( $sizes ) {
-	__return_empty_array();
+	return __return_empty_array();
 }
 
 if ( defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' ) ) {


### PR DESCRIPTION
One cannot simply call `__return_empty_array()` inside a function and walk away. One must return what's returned.

Since there was no return value, the effect was the same, but triggered a warning when WP later tried to iterate over a null when it expected an array.

I caused this with 989083f.