### PR TITLE
Update hooks used to check filename uniqueness and filetype validity

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -183,7 +183,7 @@ class A8C_Files {
 	}
 
 	/**
-	 *
+	 * Filter's the return value of `wp_unique_filename()`
 	 */
 	function filter_unique_filename( $filename, $ext, $dir, $unique_filename_callback ) {
 		if ( '.tmp' === $ext || '/tmp/' === $dir ) {
@@ -208,6 +208,9 @@ class A8C_Files {
 		return $filename;
 	}
 
+	/**
+	 * Ensure filename uniqueness prior to WP 4.5's wp_unique_filename filter
+	 */
 	function get_unique_filename( $file ) {
 		$filename = strtolower( $file['name'] );
 		$info = pathinfo( $filename );
@@ -241,7 +244,7 @@ class A8C_Files {
 	}
 
 	/**
-	 *
+	 * Common method to check Mogile backend for filename uniqueness
 	 */
 	private function _check_uniqueness_with_backend( $filename ) {
 		$headers = array(

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -190,6 +190,8 @@ class A8C_Files {
 			return $filename;
 		}
 
+		$ext = strtolower( $ext );
+
 		// This should probably be `sanitize_file_name()` instead, but for legacy reasons, we go through this process
 		$filename = str_replace( $ext, '', $filename );
 		$filename = str_replace( '%', '', sanitize_title_with_dashes( $filename ) ) . $ext;

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -225,48 +225,16 @@ class A8C_Files {
 		$filename = str_replace( $ext, '', $filename );
 		$filename = str_replace( '%', '', sanitize_title_with_dashes( $filename ) ) . $ext;
 
-		$headers = array(
-					'X-Client-Site-ID: ' . constant( 'FILES_CLIENT_SITE_ID' ),
-					'X-Access-Token: ' . constant( 'FILES_ACCESS_TOKEN' ),
-					'X-Action: unique_filename',
-				);
+		$check = $this->_check_uniqueness_with_backend( $filename );
 
-		if ( ! ( ( $uploads = wp_upload_dir() ) && false === $uploads['error'] ) ) {
-			$file['error'] = $uploads['error'];
-			return $file;
-		}
-
-		$url_parts = parse_url( $uploads['url'] . '/' . $filename );
-		$file_path = $url_parts['path'];
-		if ( is_multisite() &&
-			preg_match( '/^\/[_0-9a-zA-Z-]+\/' . str_replace( '/', '\/', $this->get_upload_path() ) . '\/sites\/[0-9]+\//', $file_path ) ) {
-			$file_path = preg_replace( '/^\/[_0-9a-zA-Z-]+/', '', $file_path );
-		}
-
-		$post_url = $this->get_files_service_hostname() . $file_path;
-
-		$ch = curl_init( $post_url );
-
-		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-		curl_setopt( $ch, CURLOPT_HEADER, false );
-		curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
-		curl_setopt( $ch, CURLOPT_TIMEOUT, 10 );
-		curl_setopt( $ch, CURLOPT_VERBOSE, true );
-		curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, 0 );
-		curl_setopt( $ch, CURLOPT_SSL_VERIFYHOST, 0 );
-
-		$content = curl_exec( $ch );
-		$http_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
-		curl_close( $ch );
-
-		if ( 200 == $http_code ) {
-			$obj = json_decode( $content );
+		if ( 200 == $check['http_code'] ) {
+			$obj = json_decode( $check['content'] );
 			if ( isset(  $obj->filename ) && basename( $obj->filename ) != basename( $post_url ) )
 				$file['name'] = $obj->filename;
-		} else if ( 406 == $http_code ) {
+		} else if ( 406 == $check['http_code'] ) {
 			$file['error'] = __( 'The file type you uploaded is not supported.' );
 		} else {
-			$file['error'] = sprintf( __( 'Error getting the file name from the remote servers: Code %d' ), $http_code );
+			$file['error'] = sprintf( __( 'Error getting the file name from the remote servers: Code %d' ), $check['http_code'] );
 		}
 
 		return $file;


### PR DESCRIPTION
WordPress 4.5 introduced a new filter, `wp_unique_filename`, which we can use instead of relying on a variable hook to modify the ultimate filename. Since themes and plugins can change the action that is used in the variable hook, it's possible for our filters to be bypassed. Switching to this new filter ensures that regardless of how files are uploaded to Go sites, they'll receive unique filenames.