### PR TITLE
Add a filter to allow purged urls to be modified by client code

### DIFF
--- a/cache-manager.php
+++ b/cache-manager.php
@@ -229,6 +229,8 @@ class WPCOM_VIP_Cache_Manager {
 
 		foreach ( $feeds as $feed )
 			$this->purge_urls[] = $feed;
+
+		$this->purge_urls = apply_filters( 'wpcom_vip_cache_purge_urls', $this->purge_urls, $post_id );
 	}
 }
 


### PR DESCRIPTION
Clients have custom endpoints, such as feeds, etc, that also need
purged to avoid a 30m TTL.

This makes the list of purged urls filterable by client code, passing
the list and post id as arguments