### PR TITLE
Use WP-Cron Control to, well, control cron execution from an external service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "query-monitor"]
 	path = query-monitor
 	url = git@github.com:johnbillion/query-monitor.git
+[submodule "wp-cron-control"]
+	path = wp-cron-control
+	url = https://github.com/Automattic/WP-Cron-Control.git

--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -8,7 +8,7 @@
  Text Domain: wp-cron-control
  */
 
-class WPCom_VIP_Cron_Control {
+class WPCOM_VIP_Cron_Control {
 	/**
 	 * Register hooks
 	 */
@@ -57,4 +57,4 @@ class WPCom_VIP_Cron_Control {
 	}
 }
 
-new WPCom_VIP_Cron_Control;
+new WPCOM_VIP_Cron_Control;

--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -8,12 +8,9 @@
  Text Domain: wp-cron-control
  */
 
-// TODO:
-// Global WP_CRON_CONTROL_SECRET
-
 class WPCom_VIP_Cron_Control {
 	/**
-	 *
+	 * Register hooks
 	 */
 	public function __construct() {
 		add_filter( 'pre_option_wpcroncontrol_settings', array( $this, 'set_options' ) );

--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -21,7 +21,7 @@ class WPCom_VIP_Cron_Control {
 		add_action( 'admin_init', array( $this, 'block_admin_page' ) );
 
 		// Load plugin
-		require( __DIR__ . '/wp-cron-control/wp-cron-control.php' );
+		require_once( __DIR__ . '/wp-cron-control/wp-cron-control.php' );
 	}
 
 	/**

--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -10,23 +10,54 @@
 
 // TODO:
 // Global WP_CRON_CONTROL_SECRET
-// Remove menu - add_action( 'admin_menu', array( &$this, 'register_settings_page' ) ); WP_Cron_Control::instance
 
-/**
- * Enforce Platform-wide use of WP-Cron Control
- *
- * wpcroncontrol_settings: a:2:{s:6:"enable";s:1:"1";s:32:"enable_scheduled_post_validation";s:1:"1";}
- */
-function wpcom_vip_cron_control_options( $options ) {
-	return array(
-		'enable' =>                           '1',
-		'enable_scheduled_post_validation' => '1',
+class WPCom_VIP_Cron_Control {
+	/**
+	 *
+	 */
+	public function __construct() {
+		add_filter( 'pre_option_wpcroncontrol_settings', array( $this, 'set_options' ) );
+		add_action( 'admin_menu', array( $this, 'remove_menu_page' ), 99 );
+		add_action( 'admin_init', array( $this, 'block_admin_page' ) );
 
-	);
+		// Load plugin
+		require( __DIR__ . '/wp-cron-control/wp-cron-control.php' );
+	}
+
+	/**
+	 * Enforce Platform-wide use of WP-Cron Control
+	 *
+	 * wpcroncontrol_settings: a:2:{s:6:"enable";s:1:"1";s:32:"enable_scheduled_post_validation";s:1:"1";}
+	 */
+	public function set_options( $options ) {
+		return array(
+			'enable' =>                           '1',
+			'enable_scheduled_post_validation' => '1',
+
+		);
+	}
+
+	/**
+	 * Remove the menu page
+	 */
+	public function remove_menu_page() {
+		remove_submenu_page( 'options-general.php', 'wp-cron-control' ); // WP_Cron_Control::instance()->dashed_name
+	}
+
+	/**
+	 * Block access to the plugin's options page; everything is hardcoded
+	 */
+	public function block_admin_page() {
+		global $plugin_page;
+
+		if ( false !== stripos( $plugin_page, 'wp-cron-control' ) ) {
+			wp_die( 'This plugin\'s options are unavailable.<br /><br />Please open a support ticket with any questions.', 'Unauthorized', array(
+				'response' => 401,
+				'back_link' => true,
+			) );
+			// exit;
+		}
+	}
 }
-add_filter( 'pre_option_wpcroncontrol_settings', 'wpcom_vip_cron_control_options' );
 
-/**
- * Load plugin
- */
-require( __DIR__ . '/wp-cron-control/wp-cron-control.php' );
+new WPCom_VIP_Cron_Control;

--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ Plugin Name: WP-Cron Control
+ Plugin URI: https://wordpress.org/plugins/wp-cron-control/
+ Description: Take control of wp-cron execution.
+ Author: Thorsten Ott, Erick Hitter, Automattic
+ Version: 0.7.1
+ Text Domain: wp-cron-control
+ */
+
+// TODO:
+// Global WP_CRON_CONTROL_SECRET
+// Remove menu - add_action( 'admin_menu', array( &$this, 'register_settings_page' ) ); WP_Cron_Control::instance
+
+/**
+ * Enforce Platform-wide use of WP-Cron Control
+ *
+ * wpcroncontrol_settings: a:2:{s:6:"enable";s:1:"1";s:32:"enable_scheduled_post_validation";s:1:"1";}
+ */
+function wpcom_vip_cron_control_options( $options ) {
+	return array(
+		'enable' =>                           '1',
+		'enable_scheduled_post_validation' => '1',
+
+	);
+}
+add_filter( 'pre_get_option_wpcroncontrol_settings', 'wpcom_vip_cron_control_options' );
+
+/**
+ * Load plugin
+ */
+require( __DIR__ . '/wp-cron-control/wp-cron-control.php' );

--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -24,7 +24,7 @@ function wpcom_vip_cron_control_options( $options ) {
 
 	);
 }
-add_filter( 'pre_get_option_wpcroncontrol_settings', 'wpcom_vip_cron_control_options' );
+add_filter( 'pre_option_wpcroncontrol_settings', 'wpcom_vip_cron_control_options' );
 
 /**
  * Load plugin


### PR DESCRIPTION
The WordPress.com jobs system will be used trigger cron tasks, with the aid of the WP-Cron Control plugin. This is, essentially, how cron works on WordPress.com VIP.