### PR TITLE
Sync syndication cache

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -29,6 +29,7 @@ require_once( __DIR__ . '/vip-helpers/vip-media.php' );
 require_once( __DIR__ . '/vip-helpers/vip-elasticsearch.php' );
 require_once( __DIR__ . '/vip-helpers/vip-stats.php' );
 require_once( __DIR__ . '/vip-helpers/vip-deprecated.php' );
+require_once( __DIR__ . '/vip-helpers/vip-syndication-cache.php' );
 
 // Load WP_CLI helpers
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/vip-helpers/vip-syndication-cache.php
+++ b/vip-helpers/vip-syndication-cache.php
@@ -1,0 +1,7 @@
+<?php
+
+add_action( 'syn_after_setup_server', function() {
+	if ( ! class_exists( 'WP_Feed_Cache' ) ) {
+			require_once( ABSPATH . WPINC . '/class-feed.php' );
+	}
+} );


### PR DESCRIPTION
In order to properly setup the cache class for the Syndication plugin as it was implemented by @sboisvert on WordPress.com platform, we have to load the class early during the WP init

This code has already been deployed to the VIP Go platform