### PR TITLE
Updating Jetpack to 4.0.3

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: http://jetpack.me
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 3.9.6
+ * Version: 4.0.3
  * Author URI: http://jetpack.me
  * License: GPL2+
  * Text Domain: jetpack


### PR DESCRIPTION
Updating Jetpack to 4.0.3

We are a version behind the Subversion which powers the mu-plugins in production on the VIP Go platform.