### PR TITLE
Jetpack: remove unused alternate Jetpack build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,6 +31,3 @@
 [submodule "wp-cron-control"]
 	path = wp-cron-control
 	url = https://github.com/Automattic/WP-Cron-Control.git
-[submodule "jetpack-built"]
-	path = jetpack-built
-	url = git@github.com:Automattic/jetpack.git


### PR DESCRIPTION
We're no longer testing an alternate version of Jetpack, so the extra submodule is unnecessary.