### PR TITLE
Introduce REST API endpoint to list domains for current site

### DIFF
--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -119,19 +119,22 @@ class WPCOM_VIP_REST_API_Endpoints {
 	 * Consistency simplifies incorporating data from the VIP Go API with this API
 	 */
 	private function format_response( $data ) {
-		$response = array();
-
 		if ( is_wp_error( $data ) ) {
-			$response['status'] = 'error';
-			$response['data']   = false;
+			$response = array(
+				'status' => 'error',
+				'data'   => false,
+			);
 		} else {
-			$response['status'] = 'success';
-			$response['page']      = 1;
-			$response['pagesize']  = 1000;
-			$response['totalrecs'] = count( $data );
-			$response['result']    = $response['totalrecs'];
+			$response = array(
+				'status'    => 'success',
+				'page'      => 1,
+				'pagesize'  => 1000,
+				'totalrecs' => count( $data ),
+				'result'    => null, // placeholder to maintain array order
+				'data'      => $data,
+			);
 
-			$response['data'] = $data;
+			$response['result'] = $response['totalrecs'];
 		}
 
 		return $response;

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -128,7 +128,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 			$response = array(
 				'status'    => 'success',
 				'page'      => 1,
-				'pagesize'  => 1000,
+				'pagesize'  => 500,
 				'totalrecs' => count( $data ),
 				'result'    => null, // placeholder to maintain array order
 				'data'      => $data,

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -28,7 +28,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 	/**
 	 * Class properties
 	 */
-	private $namespace = 'wpcom-vip/v1';
+	private $namespace = 'vip/v1';
 
 	private $cached_sites_list = 'wpcom-vip-sites-list';
 

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -95,7 +95,9 @@ class WPCOM_VIP_REST_API_Endpoints {
 					switch_to_blog( $_site );
 
 					$sites[] = array(
-						'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
+						'primary_domain' => array(
+							'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
+						),
 					);
 
 					restore_current_blog();
@@ -106,7 +108,9 @@ class WPCOM_VIP_REST_API_Endpoints {
 		} else {
 			// Provided for consistency, even though this provides no insightful response
 			$sites[] = array(
-				'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
+				'primary_domain' => array(
+					'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
+				),
 			);
 		}
 

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -95,9 +95,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 					switch_to_blog( $_site );
 
 					$sites[] = array(
-						'primary_domain' => array(
-							'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
-						),
+						'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
 					);
 
 					restore_current_blog();
@@ -108,40 +106,11 @@ class WPCOM_VIP_REST_API_Endpoints {
 		} else {
 			// Provided for consistency, even though this provides no insightful response
 			$sites[] = array(
-				'primary_domain' => array(
-					'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
-				),
+				'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
 			);
 		}
 
-		return new WP_REST_Response( $this->format_response( $sites ) );
-	}
-
-	/**
-	 * Mimic response format from VIP Go API
-	 *
-	 * Consistency simplifies incorporating data from the VIP Go API with this API
-	 */
-	private function format_response( $data ) {
-		if ( is_wp_error( $data ) ) {
-			$response = array(
-				'status' => 'error',
-				'data'   => false,
-			);
-		} else {
-			$response = array(
-				'status'    => 'success',
-				'page'      => 1,
-				'pagesize'  => 500,
-				'totalrecs' => count( $data ),
-				'result'    => null, // placeholder to maintain array order
-				'data'      => $data,
-			);
-
-			$response['result'] = $response['totalrecs'];
-		}
-
-		return $response;
+		return new WP_REST_Response( $sites );
 	}
 }
 

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ Plugin Name: VIP REST API Endpoints
+ Plugin URI: https://vip.wordpress.com/
+ Description: Add custom REST API endpoints for VIP requests
+ Author: Erick Hitter, Automattic
+ Version: 0.1
+ */
+
+class WPCOM_VIP_REST_API_Endpoints {
+	/**
+	 * SINGLETON
+	 */
+	private static $__instance = null;
+
+	public static function instance() {
+		if ( ! is_a( self::$__instance, __CLASS__ ) ) {
+			self::$__instance = new self;
+		}
+
+		return self::$__instance;
+	}
+
+	/**
+	 * PLUGIN SETUP
+	 */
+
+	/**
+	 * Class properties
+	 */
+	private $namespace = 'wpcom-vip/v1';
+
+	/**
+	 * Register hooks
+	 */
+	private function __construct() {
+		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
+	}
+
+	/**
+	 * Register API routes
+	 */
+	public function rest_api_init() {
+		register_rest_route( $this->namespace, '/sites/', array(
+			'methods' => 'GET',
+			'callback' => array( $this, 'list_sites' ),
+		) );
+	}
+
+	/**
+	 * PLUGIN FUNCTIONALITY
+	 */
+
+	/**
+	 *
+	 */
+	public function list_sites() {
+		$sites = array();
+
+		if ( is_multisite() ) {
+			//
+		} else {
+			$sites[] = array(
+				'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
+			);
+		}
+
+		$response = new WP_REST_Response( $this->format_response( $sites ) );
+		return $response;
+	}
+
+	/**
+	 * Mimic response format from VIP Go API
+	 *
+	 * Consistency simplifies incorporating data from the VIP Go API with this API
+	 */
+	private function format_response( $data ) {
+		$response = array();
+
+		if ( is_wp_error( $data ) ) {
+			$response['status'] = 'error';
+			$response['data']   = array();
+		} else {
+			$response['status'] = 'success';
+			$response['page']      = 1;
+			$response['pagesize']  = 1000;
+			$response['totalrecs'] = count( $data );
+			$response['result']    = $response['totalrecs'];
+
+			$response['data'] = $data;
+		}
+
+		return $response;
+	}
+}
+
+WPCOM_VIP_REST_API_Endpoints::instance();


### PR DESCRIPTION
To ensure we can access a list of subsites on a multisite network, we need a REST API endpoint on the multisite network that will list all sites (main and its subsites) on the network. The VIP Go API is only aware of the main site, and in lieu of synching a list of subsites to the API, we'll rely on the WordPress network to report on itself.

For consistency, the response matches that from the VIP Go API. I've also added a response for single-site installs.

The domain name isn't simply pulled from the `wp_blogs` table, as that would bypass any filtering VIP or clients may apply to the domain name. While `switch_to_blog()` doesn't load the full blog context for each subsite, retrieving the `home_url()` while switched to each child blog will, at least, encounter some of the filtering we may add.

WordPress 4.6 should simplify the retrieval of sites in a multisite network thanks to its introduction of `get_sites()` and the `WP_Site_Query` class: https://core.trac.wordpress.org/ticket/35791. In the meantime, we fall back to a DB query that's cached for 30 minutes. Invalidation isn't warranted at this point, given the low number of multisite networks we host, and the extreme infrequency with which they've added new subsites. Should that change before `get_sites()` is in Core, we may consider hooks for invalidations.

Currently, the endpoint has no authentication, and is discoverable through GET requests to the JSON API's endpoints. As the endpoint only lists a domain name, though, I'm not sure if there's a need for any authentication.

Fixes #225.