### PR TITLE
Remove errant merge artifact

### DIFF
--- a/cache-manager.php
+++ b/cache-manager.php
@@ -276,9 +276,6 @@ class WPCOM_VIP_Cache_Manager {
 			return;
 		}
 		foreach ( $terms as $term ) {
-			if ( ! term_exists( $term->term_id, $taxonomy ) ) {
-				continue;
-			}
 			$this->queue_purge_urls_for_term( $term );
 		}
 	}


### PR DESCRIPTION
Somehow, when merging #229 and #232, this redundant check of a term's existence was reinstated. As noted in #229, the term can't be returned by `get_terms()` if it doesn't exist.