### PR TITLE
Revert "We should be using `break` not `continue`"

### DIFF
--- a/cache-manager.php
+++ b/cache-manager.php
@@ -209,12 +209,12 @@ class WPCOM_VIP_Cache_Manager {
 
 		foreach ( $taxonomies as $taxonomy ) {
 			if ( true !== $taxonomy->public ) {
-				break;
+				continue;
 			}
 			$taxonomy_name = $taxonomy->name;
 			$terms = get_the_terms( $post_id, $taxonomy_name );
 			if ( false === $terms ) {
-				break;
+				continue;
 			}
 			foreach ( $terms as $term ) {
 				$this->queue_purge_urls_for_term( $term );


### PR DESCRIPTION
This reverts commit cf8b9906a503a0a2206331070a99c0ac915d929e.