### PR TITLE
Update/qm and debug bar query saver

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -30,7 +30,7 @@ add_action( 'init', function() {
 		$total = count( $panels );
 
 		for ( $i = 0; $i < $total; $i++) {
-			if ( $panels[ $i ] instanceof Debug_Bar_Queries ) {
+			if ( $panels[ $i ] instanceof Debug_Bar_Queries && function_exists( 'wpcom_vip_save_query_callback' ) ) {
 				$panels[ $i ] = new WPCOM_VIP_Debug_Bar_Queries();
 			} elseif ( $panels[ $i ] instanceof Debug_Bar_Object_Cache ) {
 				$panels[ $i ] = new WPCOM_VIP_Debug_Bar_Memcached();

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -21,17 +21,6 @@ add_action( 'init', function() {
 		return;
 	}
 
-	if ( ! defined( 'SAVEQUERIES' ) ) {
-		define('SAVEQUERIES', true);
-	}
-
-	// For hyperdb, which doesn't use SAVEQUERIES
-	global $wpdb;
-
-	$wpdb->save_queries        = true;
-	$wpdb->save_backtrace      = true;
-	$wpdb->save_query_callback = 'wpcom_vip_save_query_callback';
-
 	require_once( __DIR__ . '/debug-bar/debug-bar.php' );
 
 	// Setup extra panels

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -72,6 +72,7 @@ function wpcom_vip_qm_require() {
 	$wpcom_vip_qm_file = __DIR__ . '/query-monitor/query-monitor.php';
 
 	require_once( $wpcom_vip_qm_file );
+	require_once( __DIR__ . '/vip-helpers/vip-query-monitor.php' );
 
 	// Because we're including Query Monitor as an MU plugin, we need to
 	// manually call the `activate` method on `activation`.
@@ -85,6 +86,14 @@ function wpcom_vip_qm_require() {
 
 	// We know we haven't got the QM DB drop-in in place, so don't show the message
 	add_filter( 'qm/show_extended_query_prompt', '__return_false' );
+
+	if ( function_exists( 'wpcom_vip_save_query_callback' ) ) {
+		add_filter('qm/collectors', function (array $collectors, QueryMonitor $qm) {
+			$collectors['db_queries'] = new WPCOM_VIP_QM_Collector_DB_Queries();
+
+			return $collectors;
+		}, 99, 2);
+	}
 
 }
 add_action( 'plugins_loaded', 'wpcom_vip_qm_require', 1 );

--- a/vip-helpers/vip-query-monitor.php
+++ b/vip-helpers/vip-query-monitor.php
@@ -1,0 +1,92 @@
+<?php
+
+class WPCOM_VIP_QM_Collector_DB_Queries extends QM_Collector_DB_Queries
+{
+	public function process_db_object($id, wpdb $db)
+	{
+		$rows = array();
+		$types = array();
+		$total_time = 0;
+		$has_result = false;
+		$has_trace = false;
+
+		foreach ((array)$db->queries as $query) {
+
+			# @TODO: decide what I want to do with this:
+			if (false !== strpos($query['trace'], 'wp_admin_bar') and !isset($_REQUEST['qm_display_admin_bar'])) {
+				continue;
+			}
+
+			$sql = $query['query'];
+			$ltime = $query['elapsed'];
+			$stack = $query['debug'];
+
+			$result = null;
+
+			$total_time += $ltime;
+
+			$trace = null;
+			$component = null;
+			$callers = explode(',', $stack);
+			$caller = trim(end($callers));
+
+			if (false !== strpos($caller, '(')) {
+				$caller_name = substr($caller, 0, strpos($caller, '(')) . '()';
+			} else {
+				$caller_name = $caller;
+			}
+
+			$sql = $type = trim($sql);
+
+			if (0 === strpos($sql, '/*')) {
+				// Strip out leading comments such as `/*NO_SELECT_FOUND_ROWS*/` before calculating the query type
+				$type = preg_replace('|^/\*[^\*/]+\*/|', '', $sql);
+			}
+
+			$type = preg_split('/\b/', trim($type), 2, PREG_SPLIT_NO_EMPTY);
+			$type = strtoupper($type[0]);
+
+			$this->log_type($type);
+			$this->log_caller($caller_name, $ltime, $type);
+
+			if ($component) {
+				$this->log_component($component, $ltime, $type);
+			}
+
+			if (!isset($types[ $type ]['total'])) {
+				$types[ $type ]['total'] = 1;
+			} else {
+				$types[ $type ]['total']++;
+			}
+
+			if (!isset($types[ $type ]['callers'][ $caller ])) {
+				$types[ $type ]['callers'][ $caller ] = 1;
+			} else {
+				$types[ $type ]['callers'][ $caller ]++;
+			}
+
+			$row = compact('caller', 'caller_name', 'stack', 'sql', 'ltime', 'result', 'type', 'component', 'trace');
+
+			if (is_wp_error($result)) {
+				$this->data['errors'][] = $row;
+			}
+
+			if (self::is_expensive($row)) {
+				$this->data['expensive'][] = $row;
+			}
+
+			$rows[] = $row;
+
+		}
+
+		$total_qs = count($rows);
+
+		$this->data['total_qs'] += $total_qs;
+		$this->data['total_time'] += $total_time;
+
+		# @TODO put errors in here too:
+		# @TODO proper class instead of (object)
+		$this->data['dbs'][ $id ] = (object)compact('rows', 'types', 'has_result', 'has_trace', 'total_time', 'total_qs');
+
+	}
+}

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1130,36 +1130,3 @@ function wpcom_vip_add_URI_to_newrelic(){
 	}
 }
 add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
-
-function wpcom_vip_save_query_callback( $query, $elapsed, $backtrace, &$wpdb ) {
-	if ( ! $wpdb->save_queries ) {
-		return;
-	}
-
-	$host            = $wpdb->current_host;
-	$microtime       = microtime();
-	$callback_result = $wpdb->callback_result;
-	$connection      = $wpdb->last_connection;
-
-	if ( isset( $backtrace ) && is_array( $backtrace ) ) {
-		// Convert debug_backtrace array (large) into trac links (smaller).
-		// Moved from admin-bar-debug.php to reduce peak memory usage.
-		$backtrace = array_reverse( $backtrace );
-		$folder    = 'trunk';
-
-		foreach ( (array) $backtrace as $call ) {
-			$line     = isset( $call['line'] ) ? $call['line'] : '';
-			$function = $call['function'];
-
-			if ( isset( $call['class'] ) ) {
-				$function = $call['class'] . "->$function";
-			}
-
-			$debug[] = $function;
-		}
-
-		$debug = join( ', ', $debug );
-	}
-
-	return compact('elapsed', 'host', 'microtime', 'debug', 'query', 'dbhname', 'dataset', 'callback_result', 'connection');
-}


### PR DESCRIPTION
Moving the custom query collector to a lower level (db-config.php), and only using the custom panels if the collector is present, so that the debug plugins work in dev environments

Adds custom collector for Query Monitor db queries, to support the VIP style saved queries