### PR TITLE
Default to no pingbacks

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -79,3 +79,19 @@ add_action( 'update_option', function( $option ) {
 		}
 	}
 }, 10, 1 );
+
+/**
+ * Hooks pre_ping to stop any pinging from happening,
+ * unless `WPCOM_VIP_DO_PINGS` is set to `true`.
+ *
+ * @param array $post_links The URLs to be pinged
+ */
+function wpcom_vip_pre_ping( $post_links ) {
+	if ( ! defined( 'WPCOM_VIP_DO_PINGS' ) || true !== WPCOM_VIP_DO_PINGS ) {
+		return;
+	}
+	// Clear our the post links array, so we ping nothing
+	$post_links = array();
+}
+add_action( 'pre_ping', 'wpcom_vip_pre_ping' );
+

--- a/misc.php
+++ b/misc.php
@@ -82,7 +82,7 @@ add_action( 'update_option', function( $option ) {
 
 /**
  * Hooks pre_ping to stop any pinging from happening,
- * unless `WPCOM_VIP_DO_PINGS` is set to `true`.
+ * unless `WPCOM_VIP_DO_PINGS` is set to `true` (boolean).
  *
  * @param array $post_links The URLs to be pinged
  */

--- a/misc.php
+++ b/misc.php
@@ -82,12 +82,12 @@ add_action( 'update_option', function( $option ) {
 
 /**
  * Hooks pre_ping to stop any pinging from happening,
- * unless `WPCOM_VIP_DO_PINGS` is set to `true` (boolean).
+ * unless `VIP_DO_PINGS` is set to `true` (boolean).
  *
  * @param array $post_links The URLs to be pinged
  */
 function wpcom_vip_pre_ping( $post_links ) {
-	$do_pings = ( defined( 'VIP_DO_PINGS' ) && true === WPCOM_VIP_DO_PINGS );
+	$do_pings = ( defined( 'VIP_DO_PINGS' ) && true === VIP_DO_PINGS );
 	if ( ! $do_pings ) {
 		return;
 	}

--- a/misc.php
+++ b/misc.php
@@ -89,10 +89,10 @@ add_action( 'update_option', function( $option ) {
 function wpcom_vip_pre_ping( $post_links ) {
 	$do_pings = ( defined( 'VIP_DO_PINGS' ) && true === VIP_DO_PINGS );
 	if ( ! $do_pings ) {
+		// Clear our the post links array, so we ping nothing
+		$post_links = array();
 		return;
 	}
-	// Clear our the post links array, so we ping nothing
-	$post_links = array();
 }
 add_action( 'pre_ping', 'wpcom_vip_pre_ping' );
 

--- a/misc.php
+++ b/misc.php
@@ -87,7 +87,8 @@ add_action( 'update_option', function( $option ) {
  * @param array $post_links The URLs to be pinged
  */
 function wpcom_vip_pre_ping( $post_links ) {
-	if ( ! defined( 'WPCOM_VIP_DO_PINGS' ) || true !== WPCOM_VIP_DO_PINGS ) {
+	$do_pings = ( defined( 'VIP_DO_PINGS' ) && true === WPCOM_VIP_DO_PINGS );
+	if ( ! $do_pings ) {
 		return;
 	}
 	// Clear our the post links array, so we ping nothing


### PR DESCRIPTION
Hooks `pre_ping` to stop any pinging from happening, unless `WPCOM_VIP_DO_PINGS` is set to `true`