### PR TITLE
Use wp_mail_from filter, instead of setting $phpmailer->Sender directly

### DIFF
--- a/vip-mail.php
+++ b/vip-mail.php
@@ -12,13 +12,14 @@ class VIP_SMTP {
 	function init() {
 		add_action( 'phpmailer_init',    array( $this, 'phpmailer_init' ) );
 		add_action( 'bp_phpmailer_init', array( $this, 'phpmailer_init' ) );
+
+		add_filter( 'wp_mail_from', array( $this, 'filter_wp_mail_from' ) );
 	}
 
 	function phpmailer_init( $phpmailer ) {
 		global $all_smtp_servers;
 
 		$phpmailer->isSMTP();
-		$phpmailer->Sender = "donotreply@wordpress.com";
 
 		if ( ! is_array( $all_smtp_servers ) || empty( $all_smtp_servers ) )
 			return;
@@ -27,6 +28,10 @@ class VIP_SMTP {
 			shuffle( $all_smtp_servers );
 
 		$phpmailer->Host = current( $all_smtp_servers );
+	}
+
+	public function filter_wp_mail_from( $from ) {
+		return 'donotreply@wordpress.com';
 	}
 }
 


### PR DESCRIPTION
WP 4.6 adds some improvements to how it handles the 'from' address, so
by using the filter we take advantage of that and use the 'native' way