### PR TITLE
On add|update|delete of autoloaded option, clear alloptions cache

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -95,7 +95,7 @@ add_action( 'update_option', function( $option ) {
 	global $wp_object_cache;
 	if ( ! wp_installing()
 		&& method_exists( $wp_object_cache, 'key' )
-			&& method_exists( $wp_object_cache, 'cache' ) ) { ) {
+			&& method_exists( $wp_object_cache, 'cache' ) ) {
 		$alloptions = wp_load_alloptions(); //alloptions should be cached at this point
 		if ( isset( $alloptions[$option] ) ) { //only if option is among alloptions
 			$key = $wp_object_cache->key( 'alloptions', 'options' );

--- a/misc.php
+++ b/misc.php
@@ -93,7 +93,9 @@ add_action( 'deleted_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
  */
 add_action( 'update_option', function( $option ) {
 	global $wp_object_cache;
-	if ( ! wp_installing() ) {
+	if ( ! wp_installing()
+		&& method_exists( $wp_object_cache, 'key' )
+			&& method_exists( $wp_object_cache, 'cache' ) ) { ) {
 		$alloptions = wp_load_alloptions(); //alloptions should be cached at this point
 		if ( isset( $alloptions[$option] ) ) { //only if option is among alloptions
 			$key = $wp_object_cache->key( 'alloptions', 'options' );

--- a/misc.php
+++ b/misc.php
@@ -75,11 +75,9 @@ add_action( 'deleted_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
 
 function _wpcom_vip_maybe_clear_alloptions_cache( $option ) {
 	if ( ! wp_installing() ) {
-		$alloptions = wp_load_alloptions(); //alloptions should be cached at
-this point
+		$alloptions = wp_load_alloptions(); //alloptions should be cached at this point
 
-		if ( isset( $alloptions[ $option ] ) ) { //only if option is among al
-loptions
+		if ( isset( $alloptions[ $option ] ) ) { //only if option is among alloptions
 			wp_cache_delete( 'alloptions', 'options' );
 		}
 	}

--- a/misc.php
+++ b/misc.php
@@ -69,10 +69,6 @@ add_action( 'pre_amp_render_post', 'wpcom_vip_disable_new_relic_js' );
  *
  * See https://core.trac.wordpress.org/ticket/31245
  */
-add_action( 'added_option',   '_wpcom_vip_maybe_clear_alloptions_cache' );
-add_action( 'updated_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
-add_action( 'deleted_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
-
 function _wpcom_vip_maybe_clear_alloptions_cache( $option ) {
 	if ( ! wp_installing() ) {
 		$alloptions = wp_load_alloptions(); //alloptions should be cached at this point
@@ -81,4 +77,29 @@ function _wpcom_vip_maybe_clear_alloptions_cache( $option ) {
 			wp_cache_delete( 'alloptions', 'options' );
 		}
 	}
+}
+
+// Temporary testing of new approach...leaving un-indented for better diffs
+if ( defined( 'VIP_JETPACK_ALT' ) && true === VIP_JETPACK_ALT ) {
+
+add_action( 'added_option',   '_wpcom_vip_maybe_clear_alloptions_cache' );
+add_action( 'updated_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
+add_action( 'deleted_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
+
+} else {
+
+/**
+ * Fix a race condition in alloptions caching
+ */
+add_action( 'update_option', function( $option ) {
+	global $wp_object_cache;
+	if ( ! wp_installing() ) {
+		$alloptions = wp_load_alloptions(); //alloptions should be cached at this point
+		if ( isset( $alloptions[$option] ) ) { //only if option is among alloptions
+			$key = $wp_object_cache->key( 'alloptions', 'options' );
+			unset( $wp_object_cache->cache[$key] ); //remove in-memory cache for obtaining the value from memcache
+		}
+	}
+}, 10, 1 );
+
 }

--- a/misc.php
+++ b/misc.php
@@ -66,16 +66,21 @@ add_action( 'pre_amp_render_post', 'wpcom_vip_disable_new_relic_js' );
 
 /**
  * Fix a race condition in alloptions caching
+ *
+ * See https://core.trac.wordpress.org/ticket/31245
  */
-add_action( 'update_option', function( $option ) {
-	global $wp_object_cache;
-	if ( ! wp_installing()
-	     && method_exists( $wp_object_cache, 'key' )
-		 && method_exists( $wp_object_cache, 'cache' ) ) {
-		$alloptions = wp_load_alloptions(); //alloptions should be cached at this point
-		if ( isset( $alloptions[$option] ) ) { //only if option is among alloptions
-			$key = $wp_object_cache->key( 'alloptions', 'options' );
-			unset( $wp_object_cache->cache[$key] ); //remove in-memory cache for obtaining the value from memcache
+add_action( 'added_option',   '_wpcom_vip_maybe_clear_alloptions_cache' );
+add_action( 'updated_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
+add_action( 'deleted_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
+
+function _wpcom_vip_maybe_clear_alloptions_cache( $option ) {
+	if ( ! wp_installing() ) {
+		$alloptions = wp_load_alloptions(); //alloptions should be cached at
+this point
+
+		if ( isset( $alloptions[ $option ] ) ) { //only if option is among al
+loptions
+			wp_cache_delete( 'alloptions', 'options' );
 		}
 	}
-}, 10, 1 );
+}


### PR DESCRIPTION
The DB gets updated properly, but the cache gets fubar'd because old
data can overwrite new in concurrent environments

See https://core.trac.wordpress.org/ticket/31245

And specifically https://core.trac.wordpress.org/ticket/31245#comment:19 and https://core.trac.wordpress.org/ticket/31245#comment:26 (fix comes from the latter)