### PR TITLE
Enable new alloptions cache clearing for all sites

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -79,29 +79,6 @@ function _wpcom_vip_maybe_clear_alloptions_cache( $option ) {
 	}
 }
 
-// Temporary testing of new approach...leaving un-indented for better diffs
-if ( defined( 'VIP_JETPACK_ALT' ) && true === VIP_JETPACK_ALT ) {
-
 add_action( 'added_option',   '_wpcom_vip_maybe_clear_alloptions_cache' );
 add_action( 'updated_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
 add_action( 'deleted_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
-
-} else {
-
-/**
- * Fix a race condition in alloptions caching
- */
-add_action( 'update_option', function( $option ) {
-	global $wp_object_cache;
-	if ( ! wp_installing()
-		&& method_exists( $wp_object_cache, 'key' )
-			&& method_exists( $wp_object_cache, 'cache' ) ) {
-		$alloptions = wp_load_alloptions(); //alloptions should be cached at this point
-		if ( isset( $alloptions[$option] ) ) { //only if option is among alloptions
-			$key = $wp_object_cache->key( 'alloptions', 'options' );
-			unset( $wp_object_cache->cache[$key] ); //remove in-memory cache for obtaining the value from memcache
-		}
-	}
-}, 10, 1 );
-
-}


### PR DESCRIPTION
Switches all sites to use the new alloptions cache clearing strategy to
prevent concurrency issues.