### PR TITLE
Rewrite Rules Inspector: prevent resetting permalink structure

### DIFF
--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -44,8 +44,15 @@ function rri_wpcom_flush_rules() {
 	/**
 	 * VIPs and other themes can declare the permastruct, tag and category bases in their themes.
 	 * This is done by filtering the option. To ensure we're getting the proper data, refresh.
+	 *
+	 * However, wpcom_vip_refresh_wp_rewrite() noops the values in the database so we only want to run it
+	 * if the permastructs are defined in the theme (not for clients using the admin screen)
 	 */
-	wpcom_vip_refresh_wp_rewrite();
+	if ( ( defined( 'WPCOM_VIP_CUSTOM_PERMALINKS' ) && WPCOM_VIP_CUSTOM_PERMALINKS )
+		|| ( defined( 'WPCOM_VIP_CUSTOM_CATEGORY_BASE' ) && WPCOM_VIP_CUSTOM_CATEGORY_BASE )
+		|| ( defined( 'WPCOM_VIP_CUSTOM_TAG_BASE' ) && WPCOM_VIP_CUSTOM_TAG_BASE ) ) {
+		wpcom_vip_refresh_wp_rewrite();
+	}
 
 	/**
 	 * We can't use flush_rewrite_rules( false ) in this context because


### PR DESCRIPTION
…to default in case the site is not setting permalink structure via code, but rather via admin screen

Calling the `wpcom_vip_refresh_wp_rewrite` function in case none of the helper functions for setting permalinks via theme's code, eg.: `wpcom_vip_load_permastruct`, is used leads to resetting the permalink structure to the default WordPress one.

All of the helper functions for setting a custom permalink structure set a constant which can be used for the necessary check inside the Rewrite Rules Inspector's custom hook which is calling the `wpcom_vip_refresh_wp_rewrite`.

This commit adds the conditional, taking advantage of mentioned constans, and only runs the `wpcom_vip_refresh_wp_rewrite` if the permalink structure is being set via code.