### PR TITLE
Considerations concurrent with constant consistency

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -16,6 +16,8 @@ function wpcom_vip_maybe_convert_deprecated_constant( $deprecated_constant, $val
 
 wpcom_vip_maybe_convert_deprecated_constant( 'VIP_JETPACK_ALT', 'WPCOM_VIP_JETPACK_ALT' );
 wpcom_vip_maybe_convert_deprecated_constant( 'VIP_JETPACK_ALT_SUFFIX', 'WPCOM_VIP_JETPACK_ALT_SUFFIX' );
+wpcom_vip_maybe_convert_deprecated_constant( 'VIP_DO_PINGS', 'WPCOM_VIP_DO_PINGS' );
+
 
 /**
  * @constant VIP_GO_ENV The name of the current VIP Go environment. Falls back to `false`.

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -13,6 +13,10 @@ function wpcom_vip_maybe_convert_deprecated_constant( $deprecated_constant, $val
 		define( $valid_constant, constant( $deprecated_constant ) );
 	}
 }
+
+wpcom_vip_maybe_convert_deprecated_constant( 'VIP_JETPACK_ALT', 'WPCOM_VIP_JETPACK_ALT' );
+wpcom_vip_maybe_convert_deprecated_constant( 'VIP_JETPACK_ALT_SUFFIX', 'WPCOM_VIP_JETPACK_ALT_SUFFIX' );
+
 /**
  * @constant VIP_GO_ENV The name of the current VIP Go environment. Falls back to `false`.
  */

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -17,6 +17,8 @@ function wpcom_vip_maybe_convert_deprecated_constant( $deprecated_constant, $val
 wpcom_vip_maybe_convert_deprecated_constant( 'VIP_JETPACK_ALT', 'WPCOM_VIP_JETPACK_ALT' );
 wpcom_vip_maybe_convert_deprecated_constant( 'VIP_JETPACK_ALT_SUFFIX', 'WPCOM_VIP_JETPACK_ALT_SUFFIX' );
 wpcom_vip_maybe_convert_deprecated_constant( 'VIP_DO_PINGS', 'WPCOM_VIP_DO_PINGS' );
+wpcom_vip_maybe_convert_deprecated_constant( 'VIP_VERIFY_PATH', 'WPCOM_VIP_VERIFY_PATH' );
+wpcom_vip_maybe_convert_deprecated_constant( 'VIP_VERIFY_STRING', 'WPCOM_VIP_VERIFY_STRING' );
 
 
 /**

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -1,5 +1,18 @@
 <?php
 
+
+/**
+ * Takes the value of a deprecated constant, and sets the currently valid constant to
+ * that value… if that valid constant is not already set.
+ *
+ * @param string $deprecated_constant The deprecated constant name
+ * @param string $valid_constant The valid constant name
+ */
+function wpcom_vip_maybe_convert_deprecated_constant( $deprecated_constant, $valid_constant ) {
+	if ( defined( $deprecated_constant ) && ! defined( $valid_constant ) ) {
+		define( $valid_constant, constant( $deprecated_constant ) );
+	}
+}
 /**
  * @constant VIP_GO_ENV The name of the current VIP Go environment. Falls back to `false`.
  */

--- a/jetpack.php
+++ b/jetpack.php
@@ -20,29 +20,29 @@ if ( ! @constant( 'WPCOM_IS_VIP_ENV' ) ) {
 
 $jetpack_to_load = __DIR__ . '/jetpack/jetpack.php';
 
-// If the VIP_JETPACK_ALT constant is defined, we should attempt to load
+// If the WPCOM_VIP_JETPACK_ALT constant is defined, we should attempt to load
 // an alternative to the standard Jetpack
 // Logic:
 // * If no constant is specified, the Jetpack in `mu-plugins/jetpack/`
 //   is loaded
-// * If VIP_JETPACK_ALT alone is specified, the Jetpack in
+// * If WPCOM_VIP_JETPACK_ALT alone is specified, the Jetpack in
 //   `mu-plugins/jetpack-beta/` is loaded
-// * If VIP_JETPACK_ALT and VIP_JETPACK_ALT_SUFFIX are specified,
-//   the Jetpack in `mu-plugins/jetpack-VIP_JETPACK_ALT_SUFFIX/` is loaded
-if ( defined( 'VIP_JETPACK_ALT' ) && VIP_JETPACK_ALT ) {
+// * If WPCOM_VIP_JETPACK_ALT and WPCOM_VIP_JETPACK_ALT_SUFFIX are specified,
+//   the Jetpack in `mu-plugins/jetpack-WPCOM_VIP_JETPACK_ALT_SUFFIX/` is loaded
+if ( defined( 'WPCOM_VIP_JETPACK_ALT' ) && WPCOM_VIP_JETPACK_ALT ) {
 
 	// Set the default alternative Jetpack
 	$jetpack_to_test = __DIR__ . '/jetpack-beta/jetpack.php';
 
 	// Allow the alternative version of Jetpack to be specified on
 	// a site by site basis
-	if ( defined( 'VIP_JETPACK_ALT_SUFFIX' ) && VIP_JETPACK_ALT_SUFFIX ) {
+	if ( defined( 'WPCOM_VIP_JETPACK_ALT_SUFFIX' ) && WPCOM_VIP_JETPACK_ALT_SUFFIX ) {
 
-		// Use `validate_file` to check that VIP_JETPACK_ALT_SUFFIX has not
+		// Use `validate_file` to check that WPCOM_VIP_JETPACK_ALT_SUFFIX has not
 		// had unexpected strings like `/../`, etc, added to it.
 		// Note that validate_file returns 0 if the string passes validation :\
-		if ( 0 !== validate_file( VIP_JETPACK_ALT_SUFFIX ) ) {
-			$error_msg = sprintf( 'The Jetpack "VIP_JETPACK_ALT_SUFFIX" constant does not have a valid value: "%s"', VIP_JETPACK_ALT_SUFFIX );
+		if ( 0 !== validate_file( WPCOM_VIP_JETPACK_ALT_SUFFIX ) ) {
+			$error_msg = sprintf( 'The Jetpack "WPCOM_VIP_JETPACK_ALT_SUFFIX" constant does not have a valid value: "%s"', WPCOM_VIP_JETPACK_ALT_SUFFIX );
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				error_log( $error_msg );
 
@@ -54,7 +54,7 @@ if ( defined( 'VIP_JETPACK_ALT' ) && VIP_JETPACK_ALT ) {
 			}
 		} else {
 			// Set a specific alternative Jetpack
-			$jetpack_to_test = __DIR__ . '/jetpack' . VIP_JETPACK_ALT_SUFFIX . '/jetpack.php';
+			$jetpack_to_test = __DIR__ . '/jetpack' . WPCOM_VIP_JETPACK_ALT_SUFFIX . '/jetpack.php';
 		}
 	}
 

--- a/misc.php
+++ b/misc.php
@@ -90,7 +90,7 @@ add_action( 'deleted_option', '_wpcom_vip_maybe_clear_alloptions_cache' );
  * @param array $post_links The URLs to be pinged (passed by ref)
  */
 function wpcom_vip_pre_ping( $post_links ) {
-	$do_pings = ( defined( 'VIP_DO_PINGS' ) && true === VIP_DO_PINGS );
+	$do_pings = ( defined( 'WPCOM_VIP_DO_PINGS' ) && true === WPCOM_VIP_DO_PINGS );
 	if ( ! $do_pings ) {
 		// Clear our the post links array, so we ping nothing
 		$post_links = array();

--- a/misc.php
+++ b/misc.php
@@ -36,10 +36,10 @@ if ( defined( 'VIP_GO_ENV' ) && false !== VIP_GO_ENV ) {
 }
 
 /**
- * This function uses the VIP_VERIFY_STRING and VIP_VERIFY_PATH
+ * This function uses the WPCOM_VIP_VERIFY_STRING and WPCOM_VIP_VERIFY_PATH
  * constants to respond with a verification string at a particular
- * path. So if you have a VIP_VERIFY_STRING of `Hello` and a
- * VIP_VERIFY_PATH of `whatever.html`, then the URL
+ * path. So if you have a WPCOM_VIP_VERIFY_STRING of `Hello` and a
+ * WPCOM_VIP_VERIFY_PATH of `whatever.html`, then the URL
  * yourdomain.com/whatever.html will return `Hello`.
  *
  * We suggest adding these constants in your `vip-config.php`
@@ -47,13 +47,13 @@ if ( defined( 'VIP_GO_ENV' ) && false !== VIP_GO_ENV ) {
  * @return void
  */
 function action_wpcom_vip_verify_string() {
-	if ( ! defined( 'VIP_VERIFY_PATH' ) || ! defined( 'VIP_VERIFY_STRING' ) ) {
+	if ( ! defined( 'WPCOM_VIP_VERIFY_PATH' ) || ! defined( 'WPCOM_VIP_VERIFY_STRING' ) ) {
 		return;
 	}
-	$verification_path = '/' . VIP_VERIFY_PATH;
+	$verification_path = '/' . WPCOM_VIP_VERIFY_PATH;
 	if ( $verification_path === $_SERVER['REQUEST_URI'] ) {
 		status_header( 200 );
-		echo VIP_VERIFY_STRING;
+		echo WPCOM_VIP_VERIFY_STRING;
 		exit;
 	}
 }


### PR DESCRIPTION
Constants to consider:
- [ ] `WPCOM_IS_VIP_ENV`
- [x] `VIP_JETPACK_ALT`
- [x] `VIP_JETPACK_ALT_SUFFIX`
- [ ] `VIP_GO_ENV`
- [ ] `WPCOM_API_KEY`
- [x] `VIP_DO_PINGS`
- [x] `VIP_VERIFY_PATH`
- [x] `VIP_VERIFY_STRING`
- [ ] `WPCOM_SANDBOXED`
