### PR TITLE
Disable future-post cron validation until limit is added to query.

### DIFF
--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -29,7 +29,7 @@ class WPCOM_VIP_Cron_Control {
 	public function set_options( $options ) {
 		return array(
 			'enable' =>                           '1',
-			'enable_scheduled_post_validation' => '1',
+			'enable_scheduled_post_validation' => '0',
 
 		);
 	}


### PR DESCRIPTION
Future-post validation performs query for `future` posts without any limit, which causes performance issues on sites with many scheduled posts.

See https://github.com/Automattic/WP-Cron-Control/issues/3.