### PR TITLE
Add Jetpack Force 2FA

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "jetpack-beta"]
 	path = jetpack-beta
 	url = git@github.com:Automattic/jetpack.git
+[submodule "jetpack-force-2fa"]
+	path = jetpack-force-2fa
+	url = git@github.com:Automattic/jetpack-force-2fa.git

--- a/jetpack-force-2fa.php
+++ b/jetpack-force-2fa.php
@@ -1,0 +1,1 @@
+jetpack-force-2fa/jetpack-force-2fa.php

--- a/misc.php
+++ b/misc.php
@@ -19,6 +19,9 @@ function wpcom_vip_check_for_404_and_remove_cache_headers( $headers ) {
 }
 add_filter( 'nocache_headers', 'wpcom_vip_check_for_404_and_remove_cache_headers' );
 
+// Disable admin notice for jetpack_force_2fa
+add_filter( 'jetpack_force_2fa_dependency_notice', '__return_false' );
+
 // Cleaner permalink options
 add_filter( 'got_url_rewrite', '__return_true' );
 


### PR DESCRIPTION
In https://github.com/Automattic/jetpack-force-2fa/pull/11, we only load
the plugin if the necessary module is active. This means we can load it
as an mu-plugin without worrying about breaking things.

This also disables the standard admin notice since it's mostly
unnecessary on VIP Go. In the future we will enable Jetpack SSO in code.
If for some reason it's not enabled, it will be an explicit choice by
the site owner.