### PR TITLE
CLI command to convert `utf8` tables to `utf8mb4`

### DIFF
--- a/wp-cli.php
+++ b/wp-cli.php
@@ -5,3 +5,4 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 }
 
 require __DIR__ . '/wp-cli/vip-fixers.php';
+require __DIR__ . '/wp-cli/vip-utf8-to-utf8mb4.php';

--- a/wp-cli/vip-utf8-to-utf8mb4.php
+++ b/wp-cli/vip-utf8-to-utf8mb4.php
@@ -1,14 +1,51 @@
 <?php
 
 class VIP_Go_Convert_utf8_utf8mb4 extends WPCOM_VIP_CLI_Command {
+	/**
+	 * Command arguments
+	 */
+	private $dry_run = true;
 
 	/**
 	 * Convert site using `utf8` to use `utf8mb4`
 	 *
 	 * @subcommand convert
 	 */
-	public function maybe_convert( $args, $assoc_args ) {
-		WP_CLI::line( 'Hi' );
+	public function convert( $args, $assoc_args ) {
+		global $wpdb;
+
+		WP_CLI::line( 'CONVERSION TO `utf8mb4` REQUESTED' );
+
+		// Parse arguments
+		if ( is_array( $assoc_args ) && ! empty( $assoc_args ) ) {
+			if ( isset( $assoc_args['dry-run'] ) && is_bool( $assoc_args['dry-run'] ) ) {
+				$this->dry_run = $assoc_args['dry-run'];
+			}
+		}
+
+		WP_CLI::line( '' );
+		WP_CLI::line( 'ARGUMENTS' );
+		WP_CLI::line( '* dry run: ' . ( $this->dry_run ? 'yes' : 'no' ) );
+		WP_CLI::line( '' );
+
+		// Validate starting charset to avoid catastrophe
+		WP_CLI::line( 'PREFLIGHT CHECKS' );
+		if ( 'utf8' === $wpdb->charset ) {
+			WP_CLI::line( '* Expected charset (`utf8`) found.' );
+		} elseif ( 'utf8mb4' === $wpdb->charset ) {
+			WP_CLI::error( 'Site is already using `utf8mb4`. Aborting!' );
+			return;
+		} else {
+			WP_CLI::error( "Unacceptable starting encoding: `{$wpdb->charset}`. Aborting!" );
+			return;
+		}
+
+		// Describe scope
+		if ( is_multisite() ) {
+			WP_CLI::line( '* Multisite detected, so this process will convert all network and global tables, along with the blog tables for all sites.' );
+		} else {
+			WP_CLI::line( '* Single site detected, so global and blog-specific tables will be converted. Any multisite tables will be skipped.' );
+		}
 	}
 }
 

--- a/wp-cli/vip-utf8-to-utf8mb4.php
+++ b/wp-cli/vip-utf8-to-utf8mb4.php
@@ -66,6 +66,8 @@ class VIP_Go_Convert_utf8_utf8mb4 extends WPCOM_VIP_CLI_Command {
 		WP_CLI::line( 'Proceeding...' );
 		WP_CLI::line( '' );
 
+		unset( $tables_count, $tables_string );
+
 		// Do the work we came here for
 		foreach ( $this->tables as $table ) {
 			WP_CLI::line( "Converting {$table}..." );
@@ -87,6 +89,7 @@ class VIP_Go_Convert_utf8_utf8mb4 extends WPCOM_VIP_CLI_Command {
 			WP_CLI::line( '' );
 		}
 
+		// Wrap up
 		WP_CLI::line( '' );
 		WP_CLI::line( '' );
 		WP_CLI::line( 'DONE!' );
@@ -121,7 +124,7 @@ class VIP_Go_Convert_utf8_utf8mb4 extends WPCOM_VIP_CLI_Command {
 	/**
 	 * If a table only contains utf8 or utf8mb4 columns, convert it to utf8mb4.
 	 *
-	 * Copied from wp-admin/includes/upgrade.php
+	 * Copied from wp-admin/includes/upgrade.php, with modifications for CLI usage
 	 */
 	private function maybe_convert_table_to_utf8mb4( $table ) {
 		global $wpdb;

--- a/wp-cli/vip-utf8-to-utf8mb4.php
+++ b/wp-cli/vip-utf8-to-utf8mb4.php
@@ -1,0 +1,15 @@
+<?php
+
+class VIP_Go_Convert_utf8_utf8mb4 extends WPCOM_VIP_CLI_Command {
+
+	/**
+	 * Convert site using `utf8` to use `utf8mb4`
+	 *
+	 * @subcommand convert
+	 */
+	public function maybe_convert( $args, $assoc_args ) {
+		WP_CLI::line( 'Hi' );
+	}
+}
+
+WP_CLI::add_command( 'vip-go-utf8mb4', 'VIP_Go_Convert_utf8_utf8mb4' );

--- a/wp-cli/vip-utf8-to-utf8mb4.php
+++ b/wp-cli/vip-utf8-to-utf8mb4.php
@@ -179,8 +179,7 @@ class VIP_Go_Convert_utf8_utf8mb4 extends WPCOM_VIP_CLI_Command {
 		if ( $this->dry_run ) {
 			return false;
 		} else {
-			return true;
-			//return $wpdb->query( "ALTER TABLE $table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" );
+			return $wpdb->query( "ALTER TABLE $table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" );
 		}
 	}
 }

--- a/wp-cli/vip-utf8-to-utf8mb4.php
+++ b/wp-cli/vip-utf8-to-utf8mb4.php
@@ -61,7 +61,10 @@ class VIP_Go_Convert_utf8_utf8mb4 extends WPCOM_VIP_CLI_Command {
 		WP_CLI::line( '' );
 
 		// Provide an opportunity to abort
-		WP_CLI::confirm( "Proceed and potentially convert {$tables_count} tables from `utf8` to `utf8mb4`?" );
+		WP_CLI::confirm( "Proceed with " . ( $this->dry_run ? 'DRY' : 'LIVE' ) . " RUN and " . ( $this->dry_run ? 'test converting' : 'potentially convert' ) . " {$tables_count} tables from `utf8` to `utf8mb4`?" );
+		if ( ! $this->dry_run ) {
+			WP_CLI::confirm( 'ARE YOU REALLY SURE?' );
+		}
 		WP_CLI::line( '' );
 		WP_CLI::line( 'Proceeding...' );
 		WP_CLI::line( '' );
@@ -179,7 +182,9 @@ class VIP_Go_Convert_utf8_utf8mb4 extends WPCOM_VIP_CLI_Command {
 		if ( $this->dry_run ) {
 			return false;
 		} else {
-			return $wpdb->query( "ALTER TABLE $table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" );
+			$convert = $wpdb->query( "ALTER TABLE $table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" );
+
+			return is_int( $convert ) ? true : $convert;
 		}
 	}
 }


### PR DESCRIPTION
Modeled on Core's `upgrade_430()` and `upgrade_network()` functions, and leveraging a clone of its `maybe_convert_table_to_utf8mb4()` function, this CLI command will convert an installation's eligible `utf8` tables to `utf8mb4`.