### PR TITLE
Update WP-Cron Control with improved future-post validation

### DIFF
--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -29,7 +29,7 @@ class WPCOM_VIP_Cron_Control {
 	public function set_options( $options ) {
 		return array(
 			'enable' =>                           '1',
-			'enable_scheduled_post_validation' => '0',
+			'enable_scheduled_post_validation' => '1',
 
 		);
 	}


### PR DESCRIPTION
Now that limit is in place and index is used, also restores future-post validation.

See https://github.com/Automattic/WP-Cron-Control/issues/3