### PR TITLE
New Device Notifications on Go incorrectly exclude super admins

### DIFF
--- a/shared-plugins/new-device-notification/new-device-notification.php
+++ b/shared-plugins/new-device-notification/new-device-notification.php
@@ -48,11 +48,11 @@ class New_Device_Notification {
 		get_currentuserinfo();
 
 		// By default, users to skip:
-		// * Super admins (Automattic employees visiting your site)
 		// * Users who don't have /wp-admin/ access
-		$is_privileged_user = ! is_super_admin() && current_user_can( 'edit_posts' );
-		if ( false === apply_filters( 'ndn_run_for_current_user', $is_privileged_user ) )
+		$is_privileged_user = current_user_can( 'edit_posts' );
+		if ( false === apply_filters( 'ndn_run_for_current_user', $is_privileged_user ) ) {
 			return;
+		}
 
 		// Set up the per-blog salt
 		$salt = get_option( 'newdevicenotification_salt' );


### PR DESCRIPTION
By default [NewDeviceNotifications](https://github.com/Automattic/vip-go-mu-plugins/blob/master/shared-plugins/new-device-notification/new-device-notification.php#L53
) excludes super admins from NDN notifications.

`$is_privileged_user = ! is_super_admin() && current_user_can( 'edit_posts' );`

This was presumably copied wholesale from WPCOM where it excluded A8C employees, and on VIP Go it will exclude NDN for all admin users which isn't the original intent, and undoes much of the benefit of NDN.