### PR TITLE
Support multisite in wp imports

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -105,8 +105,14 @@ class A8C_Files {
 		if ( ! $file || file_exists( $file ) )
 			return;
 
+		$service_url = $this->get_files_service_hostname() . '/' . $this->get_upload_path();
+
+		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
+			$service_url .= '/sites/' . get_current_blog_id();
+		}
+
 		$file_url = str_ireplace( constant( 'LOCAL_UPLOADS' ),
-						$this->get_files_service_hostname() . '/' . $this->get_upload_path(),
+						$service_url,
 						$file );
 
 		$opts = array(


### PR DESCRIPTION
Needs the `/sites/ . get_current_blog_id()` code from
`save_image_file()` to properly generate urls when downloading the
import file

props @emrikol - he did all the work, I just copied his 'screen shot' :)