### PR TITLE
Cache Purging: More sensible purge limits

### DIFF
--- a/cache-manager.php
+++ b/cache-manager.php
@@ -329,10 +329,10 @@ class WPCOM_VIP_Cache_Manager {
 		 * @param int The maximum page to purge from each term archive
 		 * }
 		 */
-		$max_pages = apply_filters( 'wpcom_vip_cache_purge_urls_max_pages', 5 );
+		$max_pages = apply_filters( 'wpcom_vip_cache_purge_urls_max_pages', 2 );
 
 		// Set some limits on max and min values for pages
-		$max_pages = max( 1, min( 20, $max_pages ) );
+		$max_pages = max( 1, min( 5, $max_pages ) );
 
 		$taxonomy_name = $term->taxonomy;
 		$maybe_purge_url = get_term_link( $term, $taxonomy_name );


### PR DESCRIPTION
Trying to purge too many URLs at once slows down post saving and will eventually cause post save actions to fail. We can be a bit more conservative with the number of pages that we purge. Luckily, this method of manually sending purge requests to each cache node is temporary and the new method should be much more robust.