### PR TITLE
Conditionally load debug-bar.php plugin

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -21,7 +21,9 @@ add_action( 'init', function() {
 		return;
 	}
 
-	require_once( __DIR__ . '/debug-bar/debug-bar.php' );
+	if ( ! class_exists( 'Debug_Bar' ) ) {
+		require_once( __DIR__ . '/debug-bar/debug-bar.php' );
+	}
 
 	// Setup extra panels
 	add_filter( 'debug_bar_panels', function( $panels ) {


### PR DESCRIPTION
Since client sites may include Debug Bar in their repository and load it as a plugin, we should not attempt to load it again if it's already present.

This commit fixes fatal errors for Automatticians in case Debug Bar plugin is present and being loaded from client repository by checking if `class_exists( 'Debug Bar' )` before requiring the plugin.

It also still loads the WordPress.com VIP custom panels.