### PR TITLE
Do not output curl data

### DIFF
--- a/cache-manager.php
+++ b/cache-manager.php
@@ -86,6 +86,7 @@ class WPCOM_VIP_Cache_Manager {
 						'Content-Length: ' . strlen( $json )
 					) );
 				curl_setopt( $curl, CURLOPT_TIMEOUT, 5 );
+				curl_setopt( $curl, CURLOPT_RETURNTRANSFER, true );
 				curl_multi_add_handle( $curl_multi, $curl );
 			} else {
 				// Purge HTTP


### PR DESCRIPTION
Fix the issue where {“status”:”ok”} was appended to all requests that performed cache invalidations.