### PR TITLE
Add Jetpack IDC branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "wp-cron-control"]
 	path = wp-cron-control
 	url = https://github.com/Automattic/WP-Cron-Control.git
+[submodule "jetpack-idc"]
+	path = jetpack-idc
+	url = git@github.com:Automattic/jetpack.git


### PR DESCRIPTION
This will allow self-selected sites to test the various fixes for Jetpack Identity Crises which are being worked on. 

This PR for VIP Go MU plugins provides in this fix for testing: https://github.com/Automattic/jetpack/pull/5278