### PR TITLE
Add is_proxied_automattician()

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -4,6 +4,10 @@ if ( file_exists( __DIR__ . '/.secrets/vip-secrets.php' ) ) {
 	require __DIR__ . '/.secrets/vip-secrets.php';
 }
 
+if ( ! defined( 'A8C_PROXIED_REQUEST' ) ) {
+	define( 'A8C_PROXIED_REQUEST', false );
+}
+
 /**
  * @constant VIP_GO_ENV The name of the current VIP Go environment. Falls back to `false`.
  */

--- a/shared-plugins/new-device-notification/new-device-notification.php
+++ b/shared-plugins/new-device-notification/new-device-notification.php
@@ -52,7 +52,7 @@ class New_Device_Notification {
 		// By default, users to skip:
 		// * Super admins (Automattic employees visiting your site)
 		// * Users who don't have /wp-admin/ access
-		$is_privileged_user = ! is_automattician() && current_user_can( 'edit_posts' );
+		$is_privileged_user = ! is_proxied_automattician() && current_user_can( 'edit_posts' );
 		if ( false === apply_filters( 'ndn_run_for_current_user', $is_privileged_user ) )
 			return;
 

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1079,6 +1079,8 @@ function _wpcom_vip_include_plugin( $file ) {
  * It's possible to fake that data (it's just meta and user_email), so don't use this
  * for protecting sensitive info or performing sensitive tasks
  *
+ * NOTE: This does not guarantee the current user is proxied. Use is_proxied_automattician() for that
+ *
  * @param int The WP User id
  * @return bool Bool indicating if user is an Automattician
  */
@@ -1098,13 +1100,15 @@ function is_automattician( $user_id = false ) {
 		return false;
 	}
 
-	// $vip_support = WPCOM_VIP_Support_User::init();
-
 	if ( WPCOM_VIP_Support_User::is_verified_automattician( $user->ID ) ) {
 		return true;
 	}
 
 	return false;
+}
+
+function is_proxied_automattician() {
+	return A8C_PROXIED_REQUEST && is_automattician();
 }
 
 /**


### PR DESCRIPTION
Now that we can make a proxy check, we should add a function which
checks if the current user is proxied. Instead of adding this directly
to is_automattician() like I originally thought, we're introducing a new
function because is_automattician() can also check other users.

Fixes #314