### PR TITLE
Updating wpcom_vip_wp_oembed_helper()

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -906,12 +906,12 @@ function wpcom_vip_bulk_user_management_whitelist( $users ) {
  * @return string
  */
 function wpcom_vip_wp_oembed_get( $url, $args = array() ) {
-	$cache_key = md5( $url . '|' . serialize( $args ) );
+	$cache_key = md5( $url . '||' . serialize( $args ) );
 
-	if ( false === $html = wp_cache_get( $cache_key, 'wpcom_vip_wp_oembed_get' ) ) {
+	if ( false === $html = wp_cache_get( $cache_key, 'wpcom_vip_wp_oembed' ) ) {
 		$html = wp_oembed_get( $url, $args );
 
-		wp_cache_set( $cache_key, $html, 'wpcom_vip_wp_oembed_get' );
+		wp_cache_set( $cache_key, $html, 'wpcom_vip_wp_oembed', 6 * HOUR_IN_SECONDS );
 	}
 
 	return $html;


### PR DESCRIPTION
`wpcom_vip_wp_oembed_helper()` was recently updated on WordPress.com to allow the cache to expire, otherwise old and/or unwanted data might stay in it forever