### PR TITLE
Filter WP API urls to always use HTTPS

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -117,3 +117,20 @@ if ( defined( 'VIP_CUSTOM_PINGS' ) && true === VIP_CUSTOM_PINGS ) {
 		generic_ping();
 	});
 }
+
+/**
+ * On Go, all API usage must be over HTTPS for security
+ *
+ * Filter `rest_url` to always return the https:// version
+ *
+ * If this must be disabled for local development, the filter
+ * can be removed, but be aware that HTTPS is enforced at the web server
+ * level in production, meaning non-HTTPS API calls will result in a 406 error.
+ */
+add_filter( 'rest_url', '_vip_filter_rest_url_for_ssl' );
+
+function _vip_filter_rest_url_for_ssl( $url ) {
+	$url = set_url_scheme( $url, 'https' );
+
+	return $url;
+}


### PR DESCRIPTION
Always use HTTPS on WP API urls, regardless of other site settings.

This applies to the production as well as local development
environments, to keep theme as close as possible.

If this must be disabled for local development, the filter can be
removed, but HTTPS is enforced at the web server level in production.