### PR TITLE
Purge entire site cache check

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -43,7 +43,7 @@ class WPCOM_VIP_Cache_Manager {
 	}
 
 	public function init() {
-		if ( is_super_admin() && isset( $_GET['cm_purge_all'] ) && check_admin_referer( 'manual_purge' ) ) {
+		if ( isset( $_GET['cm_purge_all'] ) && current_user_can( 'wpcom_vip_cache_manager_purge_entire_site' ) && check_admin_referer( 'manual_purge' ) ) {
 			$this->purge_site_cache();
 			add_action( 'admin_notices' , array( $this, 'manual_purge_message' ) );
 		}
@@ -69,7 +69,7 @@ class WPCOM_VIP_Cache_Manager {
 
 		$nobutton_html =  esc_html__( 'You do not have permission to purge the cache for the whole site. Please contact your administrator.' );
 
-		if ( is_super_admin() ) {
+		if ( current_user_can( 'wpcom_vip_cache_manager_purge_entire_site' ) ) {
 			echo "<p>$button_html</p>\n";
 		} else {
 			echo "<p>$nobutton_html</p>\n";

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -15,6 +15,12 @@ class WPCOM_VIP_Cache_Manager {
 	private $purge_urls = array();
 	private $site_cache_purged = false;
 
+	/**
+	 * A version used to determine any necessary
+	 * update routines to be run.
+	 */
+	const VERSION = 1;
+
 	static public function instance() {
 		static $instance = false;
 		if ( ! $instance ) {
@@ -41,6 +47,8 @@ class WPCOM_VIP_Cache_Manager {
 			$this->purge_site_cache();
 			add_action( 'admin_notices' , array( $this, 'manual_purge_message' ) );
 		}
+
+		add_action( 'admin_init', array( $this, 'update' ) );
 
 		add_action( 'clean_post_cache', array( $this, 'queue_post_purge' ) );
 		add_action( 'clean_term_cache', array( $this, 'queue_terms_purges' ), 10, 2 );
@@ -539,6 +547,38 @@ class WPCOM_VIP_Cache_Manager {
 		$this->purge_urls[] = $url;
 		return true;
 	}
+
+	/**
+	 * Checks the version option value against the version
+	 * property value, and runs update routines as appropriate.
+	 *
+	 */
+	public function update() {
+		$option_name = 'vipcachemanager_version';
+		$version = absint( get_option( $option_name, 0 ) );
+
+		if ( $version >= self::VERSION ) {
+			return;
+		}
+
+		if ( $version < 1 ) {
+			// Sites in a subdirectory multisite install can affect each
+			// other, so let's constrain site cache purging in those to
+			// just Super Admins
+			$subdirectory_multisite = ( is_multisite() && ! is_subdomain_install() );
+			if ( true !== $subdirectory_multisite ) {
+				$role = get_role( 'administrator' );
+				$role->add_cap( 'wpcom_vip_cache_manager_purge_entire_site' );
+			}
+		}
+
+		// N.B. Remember to increment self::VERSION above when you add a new IF
+
+		update_option( $option_name, self::VERSION );
+		error_log( "VIP Cache Manager: Done upgrade, now at version " . self::VERSION );
+
+	}
+
 }
 
 WPCOM_VIP_Cache_Manager::instance();


### PR DESCRIPTION
**Branches off https://github.com/Automattic/vip-go-mu-plugins/pull/247 Please merge that PR first.**

From @ethitter and @joshbetz's [comments here](https://github.com/Automattic/vip-go-mu-plugins/pull/247#discussion_r84173878):

> _ethitter 5 days ago_
> For single-site WordPress, is_super_admin() uses the delete_users capability (let's set aside that this function even existing in single-site is just silly). manage_options strikes me as a more-appropriate single-site capability to check. Thoughts?
> 
> _joshbetz 5 days ago Automattic member_
> For single sites, I think manage_options makes sense. It's probably also OK for sub-domain multisites. It may make sense to require super_admin on sub-directory multisites, at least on the main site, as that will clear cache for the entire network.

Instead I've added an additional capability, which I've succinctly named `wpcom_vip_cache_manager_purge_entire_site`. 

This diff may help reviewing changes, prior to https://github.com/Automattic/vip-go-mu-plugins/pull/247 being merged: https://github.com/Automattic/vip-go-mu-plugins/compare/246-cache-purging-api...246-address-is_super_admin-check

Feedback welcome 😄 
