### PR TITLE
Only purge edge cache for public posts

### DIFF
--- a/cache-manager.php
+++ b/cache-manager.php
@@ -236,11 +236,18 @@ class WPCOM_VIP_Cache_Manager {
 			return;
 		}
 
+		$post_type = get_post_type( $post_id );
+
+		// Only send PURGE requests for public post types
+		if ( ! is_post_type_viewable( $post_type ) ) {
+			return;
+		}
+
 		$this->purge_urls[] = get_permalink( $post_id );
 		$this->purge_urls[] = trailingslashit( home_url() );
 
 		// Don't just purge the attachment page, but also include the file itself
-		if ( 'attachment' === get_post_type( $post_id ) ) {
+		if ( 'attachment' === $post_type ) {
 			$this->purge_urls[] = wp_get_attachment_url( $post_id );
 		}
 


### PR DESCRIPTION
This could potentially save many unnecessary cache purges for things
like async sitemap generation.

Fixes #336