### PR TITLE
Only PURGE the_permalink on clean_post_cache

### DIFF
--- a/cache-manager.php
+++ b/cache-manager.php
@@ -287,7 +287,7 @@ class WPCOM_VIP_Cache_Manager {
 		}
 
 		if ( 'publish' !== get_post_status( $post_id ) ) {
-			return
+			return;
 		}
 
 		$fields = apply_filters( 'wpcom_vip_cache_purge_on_updated_fields', array( 'post_title', 'post_excerpt' ), $post );

--- a/cache-manager.php
+++ b/cache-manager.php
@@ -269,7 +269,7 @@ class WPCOM_VIP_Cache_Manager {
 			return;
 		}
 		
-		$this->clear_feed_urls( $post );
+		$this->clear_related_urls( $post );
 	}
 
 	function post_updated( $post_id, $post, $old_post ) {
@@ -295,13 +295,13 @@ class WPCOM_VIP_Cache_Manager {
 		// PURGE all feeds if one of the whitelisted fields is updated
 		foreach( $fields as $field ) {
 			if ( $post->{$field} != $old_post->{$field} ) {
-				$this->clear_feed_urls( $post );
+				$this->clear_related_urls( $post );
 				return;
 			}
 		}
 	}
 
-	function clear_feed_urls( $post ) {
+	function clear_related_urls( $post ) {
 		$this->purge_urls[] = trailingslashit( home_url() );
 
 		// Don't just purge the attachment page, but also include the file itself


### PR DESCRIPTION
For normal post updates (publish->publish), we don't need to clear all related URLs because the post still exists. Only clear all the related URLs when the status transitions (i.e. draft->publish or publish->draft).
