### PR TITLE
Fix a filter name

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -345,7 +345,7 @@ class WPCOM_VIP_Cache_Manager {
 		 * }
 		 * @param type  $post_id The ID of the post which is the primary reason for the purge
 		 */
-		$post_purge_urls = apply_filters( 'wpcom_vip_cache_purge_post_urls', $post_purge_urls, $post_id );
+		$post_purge_urls = apply_filters( 'wpcom_vip_cache_purge_urls', $post_purge_urls, $post_id );
 
 		$this->purge_urls = array_merge( $this->purge_urls, $post_purge_urls );
 


### PR DESCRIPTION
In https://github.com/Automattic/vip-go-mu-plugins/pull/247 the `wpcom_vip_cache_purge_urls`
filter name was erroneously changed. This changes it back.