### PR TITLE
Allow a Jetpack in the plugins directory

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -18,7 +18,7 @@ if ( ! @constant( 'WPCOM_IS_VIP_ENV' ) ) {
 	add_filter( 'jetpack_is_staging_site', '__return_true' );
 }
 
-$jetpack_to_load = __DIR__ . '/jetpack/jetpack.php';
+$jetpack_to_load = WPMU_PLUGIN_DIR . '/jetpack/jetpack.php';
 
 // If the VIP_JETPACK_ALT constant is defined, we should attempt to load
 // an alternative to the standard Jetpack

--- a/jetpack.php
+++ b/jetpack.php
@@ -20,6 +20,16 @@ if ( ! @constant( 'WPCOM_IS_VIP_ENV' ) ) {
 
 $jetpack_to_load = WPMU_PLUGIN_DIR . '/jetpack/jetpack.php';
 
+if ( defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && WPCOM_VIP_JETPACK_LOCAL ) {
+	// Set a specific alternative Jetpack
+	$jetpack_to_test = WP_PLUGIN_DIR . '/jetpack/jetpack.php';
+
+	// Test that our proposed Jetpack exists, otherwise do not use it
+	if ( file_exists( $jetpack_to_test ) ) {
+		$jetpack_to_load = $jetpack_to_test;
+	}
+}
+
 require_once( $jetpack_to_load );
 
 require_once( __DIR__ . '/vip-jetpack/vip-jetpack.php' );

--- a/jetpack.php
+++ b/jetpack.php
@@ -20,50 +20,6 @@ if ( ! @constant( 'WPCOM_IS_VIP_ENV' ) ) {
 
 $jetpack_to_load = WPMU_PLUGIN_DIR . '/jetpack/jetpack.php';
 
-// If the VIP_JETPACK_ALT constant is defined, we should attempt to load
-// an alternative to the standard Jetpack
-// Logic:
-// * If no constant is specified, the Jetpack in `mu-plugins/jetpack/`
-//   is loaded
-// * If VIP_JETPACK_ALT alone is specified, the Jetpack in
-//   `mu-plugins/jetpack-beta/` is loaded
-// * If VIP_JETPACK_ALT and VIP_JETPACK_ALT_SUFFIX are specified,
-//   the Jetpack in `mu-plugins/jetpack-VIP_JETPACK_ALT_SUFFIX/` is loaded
-if ( defined( 'VIP_JETPACK_ALT' ) && VIP_JETPACK_ALT ) {
-
-	// Set the default alternative Jetpack
-	$jetpack_to_test = __DIR__ . '/jetpack-beta/jetpack.php';
-
-	// Allow the alternative version of Jetpack to be specified on
-	// a site by site basis
-	if ( defined( 'VIP_JETPACK_ALT_SUFFIX' ) && VIP_JETPACK_ALT_SUFFIX ) {
-
-		// Use `validate_file` to check that VIP_JETPACK_ALT_SUFFIX has not
-		// had unexpected strings like `/../`, etc, added to it.
-		// Note that validate_file returns 0 if the string passes validation :\
-		if ( 0 !== validate_file( VIP_JETPACK_ALT_SUFFIX ) ) {
-			$error_msg = sprintf( 'The Jetpack "VIP_JETPACK_ALT_SUFFIX" constant does not have a valid value: "%s"', VIP_JETPACK_ALT_SUFFIX );
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				error_log( $error_msg );
-
-			}
-			// Only die if we're not running in VIP Go, e.g. if we
-			// are running in local dev, etc.
-			if ( ! defined( 'WPCOM_IS_VIP_ENV' ) || ! WPCOM_IS_VIP_ENV ) {
-				wp_die( $error_msg );
-			}
-		} else {
-			// Set a specific alternative Jetpack
-			$jetpack_to_test = __DIR__ . '/jetpack' . VIP_JETPACK_ALT_SUFFIX . '/jetpack.php';
-		}
-	}
-
-	// Test that our proposed Jetpack exists, otherwise do not use it
-	if ( file_exists( $jetpack_to_test ) ) {
-		$jetpack_to_load = $jetpack_to_test;
-	}
-
-}
 require_once( $jetpack_to_load );
 
 require_once( __DIR__ . '/vip-jetpack/vip-jetpack.php' );


### PR DESCRIPTION
If there's a Jetpack in the `plugins` directory, then allow it to override the one in MU plugins. Require a `VIP_JETPACK_LOCAL` constant to trigger this behaviour.