### PR TITLE
Improve perfomance of _WP_Editors::wp_link_query

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -168,6 +168,7 @@ if ( defined( 'WPCOM_VIP_QUERY_LOG' ) && WPCOM_VIP_QUERY_LOG ) {
  * Improve perfomance of the `_WP_Editors::wp_link_query` method
  *
  * The WordPress core is currently not setting `no_found_rows` inside the `_WP_Editors::wp_link_query`
+ * See https://core.trac.wordpress.org/ticket/38784
  * 
  * Since the `_WP_Editors::wp_link_query` method is not using the `found_posts` nor `max_num_pages`
  * properties of `WP_Query` class, the `SQL_CALC_FOUND_ROWS` in produced SQL query is extra and

--- a/misc.php
+++ b/misc.php
@@ -168,23 +168,16 @@ if ( defined( 'WPCOM_VIP_QUERY_LOG' ) && WPCOM_VIP_QUERY_LOG ) {
  * Improve perfomance of the `_WP_Editors::wp_link_query` method
  *
  * The WordPress core is currently not setting `no_found_rows` inside the `_WP_Editors::wp_link_query`
- * and is setting `suppress_filters` to `true`.
  * 
  * Since the `_WP_Editors::wp_link_query` method is not using the `found_posts` nor `max_num_pages`
  * properties of `WP_Query` class, the `SQL_CALC_FOUND_ROWS` in produced SQL query is extra and
  * useless.
  *
- * Setting `suppress_filters` to `false`, on the other hand, is blocking the Advanced Posts Cache
- * plugin and thus all those queries are not being cached, despite being the same across multiple
- * post edit screens for all logged in users
  */
 function wpcom_vip_wp_link_query_args( $query ) {
 	//Since the WP_Query is not checking the $found_posts nor $max_num_pages properties
 	//we don't need to know the total number of matching posts in the database
 	$query['no_found_rows'] = true;
-
-	//The query is suppressing filters by default, but it blocks the caching plugins, eg Advanced Posts Cache
-	$query['suppress_filters'] = false;
 
 	return $query;
 }


### PR DESCRIPTION
The WordPress core is currently [not setting `no_found_rows`](https://github.com/WordPress/WordPress/blob/493f76a3d2ef8c030ab5dcd4333f9a401208f534/wp-includes/class-wp-editor.php#L1351,L1358) inside the `_WP_Editors::wp_link_query` and [is setting `suppress_filters` to `true`](https://github.com/WordPress/WordPress/blob/493f76a3d2ef8c030ab5dcd4333f9a401208f534/wp-includes/class-wp-editor.php#L1353).

Since the `_WP_Editors::wp_link_query` method [is not using the `found_posts` nor `max_num_pages` properties](https://github.com/WordPress/WordPress/blob/493f76a3d2ef8c030ab5dcd4333f9a401208f534/wp-includes/class-wp-editor.php#L1383,L1385) of `WP_Query` class, the `SQL_CALC_FOUND_ROWS` in produced SQL query is extra and useless.

Setting `suppress_filters` to `false`, on the other hand, is blocking the Advanced Posts Cache plugin and thus all those queries are not being cached, despite being the same across multiple post edit screens for all logged in users