### PR TITLE
Adding filter for disabling term cache updates

### DIFF
--- a/vip-helpers/vip-clean-term-cache.php
+++ b/vip-helpers/vip-clean-term-cache.php
@@ -64,8 +64,10 @@ class VIP_Suspend_Cache_Invalidation {
 
 		wp_suspend_cache_invalidation( true );
 
-		//schedule WP Cron event for purging the cache
-    	wp_schedule_single_event( time(), 'wpcom_vip_clean_tax_relations_cache', array( $tt_id, $taxonomy ) );
+		if ( false === apply_filters( 'wpcom_vip_disable_term_cache_invalidation', false, $tt_id, $taxonomy ) ) {
+			//schedule WP Cron event for purging the cache
+			wp_schedule_single_event( time(), 'wpcom_vip_clean_tax_relations_cache', array( $tt_id, $taxonomy ) );
+		}
 
 	}
 


### PR DESCRIPTION
Following code can be used from within a theme for disabling term cache updates

```
add_filter( 'wpcom_vip_disable_term_cache_invalidation', '__return_true' );
```