### PR TITLE
vip-cache-manager: adding cache purging logic for changed permalinks

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -519,7 +519,7 @@ class WPCOM_VIP_Cache_Manager {
 		 * }
 		 * @param type  $term_id The ID of the term which is the primary reason for the purge
 		 */
-		$term_purge_urls = apply_filters( "wpcom_vip_cache_purge_{$taxonomy_name}_term_urls", $term_purge_urls, $term_id );
+		$term_purge_urls = apply_filters( "wpcom_vip_cache_purge_{$taxonomy_name}_term_urls", $term_purge_urls, $$term->term_id );
 
 		return $term_purge_urls;
 	}

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -519,7 +519,7 @@ class WPCOM_VIP_Cache_Manager {
 		 * }
 		 * @param type  $term_id The ID of the term which is the primary reason for the purge
 		 */
-		$term_purge_urls = apply_filters( "wpcom_vip_cache_purge_{$taxonomy_name}_term_urls", $term_purge_urls, $$term->term_id );
+		$term_purge_urls = apply_filters( "wpcom_vip_cache_purge_{$taxonomy_name}_term_urls", $term_purge_urls, $term->term_id );
 
 		return $term_purge_urls;
 	}


### PR DESCRIPTION
In case a permalink is changed during the post update, the old permalink is never purged as `get_permalink` call inside the `queue_post_purge` is being called with `$post_id` and thus returns the current/new URL.

This commit is adding a new `WPCOM_VIP_Cache_Manager::queue_old_permalink_purge` method hooked to `post_udapted` action and obtains the old permalink by calling `get_permalink` while passing it the `$post_before` WP_Post object.

The cache purge is scheduled only in case the permalink got changed and if the post's status before the update was 'publish'.