### PR TITLE
Require the required class files separately, if necessary

### DIFF
--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -7,10 +7,14 @@
 set -ex
 
 cd $TRAVIS_BUILD_DIR
-if [ -w .gitmodules ]; then
-    sed -i -e "s|git@\([^:]*\):|https://\1/|" .gitmodules
-fi;
-git submodule update --init --recursive
+
+# Convert the URLs in the superproject .gitmodules file, 
+# then init those submodules
+sed -i -e "s|git@\([^:]*\):|https://\1/|" .gitmodules
+git submodule update --init
+# Now recurse over all the contained submodules, 
+# sub-submodules, etc, to do the same
+date; git submodule foreach --recursive 'if [ -w .gitmodules ]; then sed -i -e "s|git@\([^:]*\):|https://\1/|" "$toplevel/$path/.gitmodules"; fi; git submodule update --init "$toplevel/$path";'; date;
 
 # Install unit tests
 # ==================

--- a/vip-helpers/vip-syndication-cache.php
+++ b/vip-helpers/vip-syndication-cache.php
@@ -2,6 +2,17 @@
 
 add_action( 'syn_after_setup_server', function() {
 	if ( ! class_exists( 'WP_Feed_Cache' ) ) {
+		if ( file_exists( ABSPATH . WPINC . '/class-wp-feed-cache.php' ) ) {
+			if ( ! class_exists( 'SimplePie', false ) ) {
+				require_once( ABSPATH . WPINC . '/class-simplepie.php' );
+			}
+
+			require_once( ABSPATH . WPINC . '/class-wp-feed-cache.php' );
+			require_once( ABSPATH . WPINC . '/class-wp-feed-cache-transient.php' );
+			require_once( ABSPATH . WPINC . '/class-wp-simplepie-file.php' );
+			require_once( ABSPATH . WPINC . '/class-wp-simplepie-sanitize-kses.php' );
+		} else if ( file_exists( ABSPATH . WPINC . '/class-feed.php' ) ) {
 			require_once( ABSPATH . WPINC . '/class-feed.php' );
+		}
 	}
 } );

--- a/vip-helpers/vip-syndication-cache.php
+++ b/vip-helpers/vip-syndication-cache.php
@@ -12,6 +12,9 @@ add_action( 'syn_after_setup_server', function() {
 			require_once( ABSPATH . WPINC . '/class-wp-simplepie-file.php' );
 			require_once( ABSPATH . WPINC . '/class-wp-simplepie-sanitize-kses.php' );
 		} else if ( file_exists( ABSPATH . WPINC . '/class-feed.php' ) ) {
+			// This branch of the conditional can be removed when we're
+			// no longer supporting 4.6.1 (the files moved to the above
+			// filenames in 4.7)
 			require_once( ABSPATH . WPINC . '/class-feed.php' );
 		}
 	}


### PR DESCRIPTION
Cribs from the core approach here:
https://github.com/WordPress/WordPress/blob/493f76a3d2ef8c030ab5dcd4333f9a401208f534/wp-includes/feed.php#L672-L679

Addresses #365