### PR TITLE
Load Debug Bar Cron if it isn't already present

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "cron-control"]
 	path = cron-control
 	url = git@github.com:Automattic/Cron-Control.git
+[submodule "debug-bar-cron"]
+	path = debug-bar-cron
+	url = https://github.com/tollmanz/debug-bar-cron.git

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -23,6 +23,11 @@ add_action( 'init', function() {
 
 	require_once( __DIR__ . '/debug-bar/debug-bar.php' );
 
+	// Load additional plugins
+	if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) ) {
+		require_once( __DIR__ . '/debug-bar-cron/debug-bar-cron.php' );
+	}
+
 	// Setup extra panels
 	add_filter( 'debug_bar_panels', function( $panels ) {
 		require_once( __DIR__ . '/vip-helpers/vip-debug-bar-panels.php' );


### PR DESCRIPTION
Since we're already including the Debug Bar plugin, Debug Bar Cron would be a helpful addition, particularly to monitor the new cron plugin (#329).

Fixes #371