### PR TITLE
a8c-files.php: fix media upload after switch_to_blog

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -546,8 +546,8 @@ class A8C_Files {
 	}
 
 	public function upload_url_path( $upload_url_path, $option ) {
-		// No modifications needed outside multisite or in case the option is not empty
-		if ( false === is_multisite() || false === empty( $upload_url_path ) ) {
+		// No modifications needed outside multisite
+		if ( false === is_multisite() ) {
 			return $upload_url_path;
 		}
 		// Change the upload url path to site's URL + wp-content/uploads without trailing slash

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -60,7 +60,7 @@ class A8C_Files {
 		add_filter( 'pre_option_uploads_use_yearmonth_folders', function( $arg ) { return '1'; } );
 
 		// ensure the correct upload URL is used even after switch_to_blog is called
-		add_filter( 'option_upload_url_path', array( &$this, 'upload_url_path' ), 10, 2 );
+		add_filter( 'option_upload_url_path', array( $this, 'upload_url_path' ), 10, 2 );
 	}
 
 	function check_to_upload_file( $data, $postarr ) {

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -60,7 +60,7 @@ class A8C_Files {
 		add_filter( 'pre_option_uploads_use_yearmonth_folders', function( $arg ) { return '1'; } );
 
 		// ensure the correct upload URL is used even after switch_to_blog is called
-		add_filter( 'pre_option_upload_url_path', array( &$this, 'upload_url_path' ), 10, 1 );
+		add_filter( 'option_upload_url_path', array( &$this, 'upload_url_path' ), 10, 2 );
 	}
 
 	function check_to_upload_file( $data, $postarr ) {
@@ -545,9 +545,9 @@ class A8C_Files {
 		return 'https://' . FILE_SERVICE_ENDPOINT;
 	}
 
-	public function upload_url_path( $upload_url_path ) {
-		// No modifications needed outside multisite.
-		if ( false === is_multisite() ) {
+	public function upload_url_path( $upload_url_path, $option ) {
+		// No modifications needed outside multisite or in case the option is not empty
+		if ( false === is_multisite() || false === empty( $upload_url_path ) ) {
 			return $upload_url_path;
 		}
 		// Change the upload url path to site's URL + wp-content/uploads without trailing slash

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -552,7 +552,7 @@ class A8C_Files {
 		}
 		// Change the upload url path to site's URL + wp-content/uploads without trailing slash
 		// Related core code: https://core.trac.wordpress.org/browser/tags/4.6.1/src/wp-includes/functions.php#L1929
-		$upload_url_path = trailingslashit( get_site_url() ) . 'wp-content/uploads';
+		$upload_url_path = untrailingslashit( get_site_url( null, 'wp-content/uploads' ) );
 		
 		return $upload_url_path;
 	}

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -58,6 +58,9 @@ class A8C_Files {
 
 		// ensure we always upload with year month folder layouts
 		add_filter( 'pre_option_uploads_use_yearmonth_folders', function( $arg ) { return '1'; } );
+
+		// ensure the correct upload URL is used even after switch_to_blog is called
+		add_filter( 'pre_option_upload_url_path', array( &$this, 'upload_url_path' ), 10, 1 );
 	}
 
 	function check_to_upload_file( $data, $postarr ) {
@@ -540,6 +543,18 @@ class A8C_Files {
 
 	function get_files_service_hostname() {
 		return 'https://' . FILE_SERVICE_ENDPOINT;
+	}
+
+	public function upload_url_path( $upload_url_path ) {
+		// No modifications needed outside multisite.
+		if ( false === is_multisite() ) {
+			return $upload_url_path;
+		}
+		// Change the upload url path to site's URL + wp-content/uploads without trailing slash
+		// Related core code: https://core.trac.wordpress.org/browser/tags/4.6.1/src/wp-includes/functions.php#L1929
+		$upload_url_path = trailingslashit( get_site_url() ) . 'wp-content/uploads';
+		
+		return $upload_url_path;
 	}
 
 	/**


### PR DESCRIPTION
In case code swiches from a site with a directory style URL (eg. /my-awesome-site) to a main site using `switch_to_blog`, the upload URL path does not get properly set, since the `upload_url_path` option inside the _wp_upload_dir() function call is empty. The `WP_CONTENT_DIR` constant gets used, but it is already set to previous site's url path.

This commit is filtering the `upload_url_path` option and always, when `is_multisite` is true, sets it to `site_url() . '/wp-content/uploads'` which resolves the issues.