### PR TITLE
No Core Update Nags

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -1,0 +1,15 @@
+<?php
+
+function wpcom_vip_disable_core_update_nag() {
+	remove_action( 'admin_notices', 'update_nag', 3 );
+	remove_action( 'network_admin_notices', 'update_nag', 3 );
+}
+add_action( 'admin_init', 'wpcom_vip_disable_core_update_nag' );
+
+function wpcom_vip_disable_core_update_cap( $caps, $cap ) {
+	if ( 'update_core' === $cap ) {
+		$caps = [ 'do_not_allow' ];
+	}
+	return $caps;
+}
+add_filter( 'map_meta_cap', 'wpcom_vip_disable_core_update_cap', 100, 2 );

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -1,0 +1,16 @@
+<?php
+
+class VIP_Go_Core_Updates_Test extends WP_UnitTestCase {
+	public function test__super_admin_should_not_have_update_core_cap() {
+		$super_admin = $this->factory->user->create_and_get( array( 'role' => 'contributor' ) );
+		grant_super_admin( $super_admin->ID );
+
+		$this->assertFalse( user_can( $super_admin, 'update_core' ), 'Superadmin user should not have `update_core` cap' ); 
+	}
+
+	public function test__administrator_should_not_have_update_core_cap() {
+		$admin = $this->factory->user->create_and_get( array( 'role' => 'contributor' ) );
+
+		$this->assertFalse( user_can( $admin, 'update_core' ), 'Admin user should not have `update_core` cap' ); 
+	}
+}


### PR DESCRIPTION
We don't want to show core update nags since VIP currently maintains the update. Two related changes here:

- Removes `update_core` cap from all users (including super admins).
- Disables the displays of the core update nags (since those are still shown to users that cannot update core).