### PR TITLE
Revert "Move the health check early"

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -1,15 +1,5 @@
 <?php
 
-// Execute the healthcheck as quickly as possible
-// See `mu-plugins/vip-cache-manager/` for other caching functionality
-if ( '/cache-healthcheck?' === $_SERVER['REQUEST_URI'] ) {
-	if ( function_exists( 'newrelic_end_transaction' ) ) {
-		# See: https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-end-txn
-		newrelic_end_transaction( true );
-	}
-	die( 'ok' );
-}
-
 if ( file_exists( __DIR__ . '/.secrets/vip-secrets.php' ) ) {
 	require __DIR__ . '/.secrets/vip-secrets.php';
 }

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -24,7 +24,15 @@ class WPCOM_VIP_Cache_Manager {
 	}
 
 	public function __construct() {
-		// N.B. The caching health check is run at the top of `000-vip-init.php`
+		// Execute the healthcheck as quickly as possible
+		if ( '/cache-healthcheck?' === $_SERVER['REQUEST_URI'] ) {
+			if ( function_exists( 'newrelic_end_transaction' ) ) {
+				# See: https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-end-txn
+				newrelic_end_transaction( true );
+			}
+			die( 'ok' );
+		}
+
 		add_action( 'init', array( $this, 'init' ) );
 	}
 


### PR DESCRIPTION
Reverts Automattic/vip-go-mu-plugins#359

@darthhexx says:

> the check is happening before any DB or Memcached queries so the container could be broken and yet still be kept in the Varnish cache "Healthy" list.

We need to run the check at a point where we're confident that db and memcache connections are active and working.