### PR TITLE
a8c-files: image_resize should return false if image does not exists

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -645,6 +645,10 @@ class A8C_Files {
 		$resized = false;
 		$img_url = wp_get_attachment_url( $id );
 
+		if ( false === $img_url ) {
+			return false;
+		}
+
 		/**
 		 * Filter the original image Photon-compatible parameters before changes are
 		 *

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -585,6 +585,13 @@ class A8C_Files {
 	function image_resize( $ignore, $id, $size ) {
 		global $_wp_additional_image_sizes, $post;
 
+		// Don't bother resizing non-image (and non-existent) attachment.
+		// We fallthrough to core's image_downsize but that bails as well.
+		$is_img = wp_attachment_is_image( $id );
+		if ( ! $is_img ) {
+			return false;
+		}
+
 		$content_width = isset( $GLOBALS['content_width'] ) ? $GLOBALS['content_width'] : null;
 		$crop = false;
 		$args = array();
@@ -644,10 +651,6 @@ class A8C_Files {
 
 		$resized = false;
 		$img_url = wp_get_attachment_url( $id );
-
-		if ( false === $img_url ) {
-			return false;
-		}
 
 		/**
 		 * Filter the original image Photon-compatible parameters before changes are


### PR DESCRIPTION
In case the `wp_get_attachment_url` returns `false`, we should return false from the `image_resize` in order to not interfere with core's `image_downsize` functionality.

See related code:
* https://developer.wordpress.org/reference/functions/wp_get_attachment_url/
* https://developer.wordpress.org/reference/functions/image_downsize/
* https://developer.wordpress.org/reference/functions/wp_get_attachment_image_url/