### PR TITLE
Performance: Add plugin that stores lastpostmodified async

### DIFF
--- a/performance.php
+++ b/performance.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once( __DIR__ . '/performance/lastpostmodified.php' );

--- a/performance/lastpostmodified.php
+++ b/performance/lastpostmodified.php
@@ -77,5 +77,7 @@ class Last_Post_Modified {
 	}
 }
 
-// TODO: make this opt-in to start
-add_action( 'init', [ 'Automattic\VIP\Performance\Last_Post_Modified', 'init' ] );
+// Temporarily behind a constant so we can test it out on some sites first
+if ( defined( 'WPCOM_VIP_OVERRIDE_LASTPOSTMODIFIED' ) && true === WPCOM_VIP_OVERRIDE_LASTPOSTMODIFIED ) {
+	add_action( 'init', [ 'Automattic\VIP\Performance\Last_Post_Modified', 'init' ] );
+}

--- a/performance/lastpostmodified.php
+++ b/performance/lastpostmodified.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Automattic\VIP\Performance;
+
+class Last_Post_Modified {
+	const OPTION_PREFIX = 'wpcom_vip_lastpostmodified';
+	const DEFAULT_TIMEZONE = 'gmt';
+
+	public static function init() {
+		add_filter( 'pre_get_lastpostmodified', [ __CLASS__, 'override_get_lastpostmodified' ], 10, 3 );
+		add_action( 'transition_post_status', [ __CLASS__, 'handle_post_transition' ], 10, 3 );
+		add_action( 'wpcom_vip_bump_lastpostmodified', [ __CLASS__, 'bump_lastpostmodified' ] );
+	}
+
+	public static function handle_post_transition( $new_status, $old_status, $post ) {
+		if ( ! in_array( 'publish', array( $old_status, $new_status ) ) ) {
+			return;
+		}
+
+		$public_post_types = get_post_types( array( 'public' => true ) );
+		if ( ! in_array( $post->post_type, $public_post_types ) ) {
+			return;
+		}
+
+		do_action( 'wpcom_vip_bump_lastpostmodified', $post );
+	}
+
+	public static function override_get_lastpostmodified( $lastpostmodified, $timezone, $post_type ) {
+		$stored_lastpostmodified = self::get_lastpostmodified( $timezone, $post_type );
+		if ( false === $stored_lastpostmodified ) {
+			return $lastpostmodified;
+		}
+
+		return $stored_lastpostmodified;
+	}
+
+	public static function bump_lastpostmodified( $post ) {
+		self::update_lastpostmodified( $post->post_modified_gmt, 'gmt', $post->post_type );
+		self::update_lastpostmodified( $post->post_modified_gmt, 'server', $post->post_type );
+		self::update_lastpostmodified( $post->post_modified, 'blog', $post->post_type );
+	}
+
+	public static function get_lastpostmodified( $timezone, $post_type ) {
+		$option_name = self::get_option_name( $timezone, $post_type );
+		return get_option( $option_name );
+	}
+
+	public static function update_lastpostmodified( $time, $timezone, $post_type ) {
+		$option_name = self::get_option_name( $timezone, $post_type );
+		return update_option( $option_name, $time );
+	}
+
+	private static function get_option_name( $timezone, $post_type ) {
+		$timezone = strtolower( $timezone );
+		return sprintf( '%s_%s_%s', self::OPTION_PREFIX, $timezone, $post_type );
+	}
+}
+
+// TODO: make this opt-in to start
+add_action( 'init', [ 'Automattic\VIP\Performance\Last_Post_Modified', 'init' ] );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,8 +9,8 @@ require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	require __DIR__ . '/../000-vip-init.php';
+	require __DIR__ . '/../performance.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
-

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,8 @@ require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	require __DIR__ . '/../000-vip-init.php';
+
+	define( 'WPCOM_VIP_OVERRIDE_LASTPOSTMODIFIED', true );
 	require __DIR__ . '/../performance.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/test-performance-lastpostmodified.php
+++ b/tests/test-performance-lastpostmodified.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Automattic\VIP\Performance;
+
+class lastpostmodified_Test extends \WP_UnitTestCase {
+	protected $post;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->post = $this->factory->post->create_and_get( [ 'post_status' => 'draft' ] );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function test__transition_post_status__save_on_publish() {
+		\wp_transition_post_status( 'publish', 'publish', $this->post );
+
+		$this->assertEquals( 1, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+	}
+
+	public function test__transition_post_status__save_on_update() {
+		\wp_transition_post_status( 'publish', 'publish', $this->post );
+
+		$this->assertEquals( 1, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+	}
+
+	public function test__transition_post_status__ignore_non_publish_status() {
+		\wp_transition_post_status( 'draft', 'future', $this->post );
+
+		$this->assertEquals( 0, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+	}
+
+	public function test__transition_post_status__ignore_non_public_post_type() {
+		$this->post->post_type = 'book';
+
+		\wp_transition_post_status( 'publish', 'publish', $this->post );
+
+		$this->assertEquals( 0, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+	}
+
+	public function test__bump_lastpostmodified() {
+		$this->post->post_type = 'book';
+		$this->post->post_modified = '2003-05-27 00:00:00';
+		$this->post->post_modified_gmt = '2003-05-27 05:00:00';
+
+		Last_Post_Modified::bump_lastpostmodified( $this->post );
+
+		$blog_actual = Last_Post_Modified::get_lastpostmodified( 'blog', 'book' );
+		$this->assertEquals( '2003-05-27 00:00:00', $blog_actual );
+		$gmt_actual = Last_Post_Modified::get_lastpostmodified( 'gmt', 'book' );
+		$this->assertEquals( '2003-05-27 05:00:00', $gmt_actual );
+		$server_actual = Last_Post_Modified::get_lastpostmodified( 'server', 'book' );
+		$this->assertEquals( '2003-05-27 05:00:00', $server_actual );
+
+	}
+
+	public function test__override_lastpostmodified__is_set() {
+		Last_Post_Modified::update_lastpostmodified( '2003-05-27', 'gmt', 'post' );
+
+		$actual = get_lastpostmodified( 'gmt', 'post' );
+
+		$this->assertEquals( '2003-05-27', $actual );
+	}
+
+	public function test__override_lastpostmodified__is_not_set() {
+		$actual = get_lastpostmodified( 'gmt', 'post' );
+
+		$this->assertEquals( $this->post_modified_gmt, $actual );
+	}
+}

--- a/tests/test-performance-lastpostmodified.php
+++ b/tests/test-performance-lastpostmodified.php
@@ -41,6 +41,14 @@ class lastpostmodified_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 0, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
 	}
 
+	public function test__transition_post_status__ignore_when_locked() {
+		// The first update sets the lock so the action should only fire once when updating twice
+		\wp_transition_post_status( 'publish', 'publish', $this->post );
+		\wp_transition_post_status( 'publish', 'publish', $this->post );
+
+		$this->assertEquals( 1, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+	}
+
 	public function test__bump_lastpostmodified() {
 		$this->post->post_type = 'book';
 		$this->post->post_modified = '2003-05-27 00:00:00';


### PR DESCRIPTION
Instead of calculating on-the-fly, which can be slow on large sites (or problematic when publishing large volumes of content), store the modified date of the last post save on publish/update and use that value instead.