### PR TITLE
get_lastpostmodified defaults post_type to any

### DIFF
--- a/performance/lastpostmodified.php
+++ b/performance/lastpostmodified.php
@@ -42,6 +42,12 @@ class Last_Post_Modified {
 	}
 
 	public static function bump_lastpostmodified( $post ) {
+		// Update default of `any`
+		self::update_lastpostmodified( $post->post_modified_gmt, 'gmt' );
+		self::update_lastpostmodified( $post->post_modified_gmt, 'server' );
+		self::update_lastpostmodified( $post->post_modified, 'blog' );
+
+		// Update value for post_type
 		self::update_lastpostmodified( $post->post_modified_gmt, 'gmt', $post->post_type );
 		self::update_lastpostmodified( $post->post_modified_gmt, 'server', $post->post_type );
 		self::update_lastpostmodified( $post->post_modified, 'blog', $post->post_type );
@@ -52,7 +58,7 @@ class Last_Post_Modified {
 		return get_option( $option_name );
 	}
 
-	public static function update_lastpostmodified( $time, $timezone, $post_type ) {
+	public static function update_lastpostmodified( $time, $timezone, $post_type = 'any' ) {
 		$option_name = self::get_option_name( $timezone, $post_type );
 		return update_option( $option_name, $time );
 	}

--- a/tests/test-performance-lastpostmodified.php
+++ b/tests/test-performance-lastpostmodified.php
@@ -49,7 +49,21 @@ class lastpostmodified_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 1, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
 	}
 
-	public function test__bump_lastpostmodified() {
+	public function test__bump_lastpostmodified__any() {
+		$this->post->post_modified = '1989-12-13 01:00:00';
+		$this->post->post_modified_gmt = '1989-12-13 06:00:00';
+
+		Last_Post_Modified::bump_lastpostmodified( $this->post );
+
+		$blog_actual = Last_Post_Modified::get_lastpostmodified( 'blog', 'any' );
+		$this->assertEquals( '1989-12-13 01:00:00', $blog_actual );
+		$gmt_actual = Last_Post_Modified::get_lastpostmodified( 'gmt', 'any' );
+		$this->assertEquals( '1989-12-13 06:00:00', $gmt_actual );
+		$server_actual = Last_Post_Modified::get_lastpostmodified( 'server', 'any' );
+		$this->assertEquals( '1989-12-13 06:00:00', $server_actual );
+	}
+
+	public function test__bump_lastpostmodified__cpt() {
 		$this->post->post_type = 'book';
 		$this->post->post_modified = '2003-05-27 00:00:00';
 		$this->post->post_modified_gmt = '2003-05-27 05:00:00';
@@ -62,10 +76,17 @@ class lastpostmodified_Test extends \WP_UnitTestCase {
 		$this->assertEquals( '2003-05-27 05:00:00', $gmt_actual );
 		$server_actual = Last_Post_Modified::get_lastpostmodified( 'server', 'book' );
 		$this->assertEquals( '2003-05-27 05:00:00', $server_actual );
-
 	}
 
-	public function test__override_lastpostmodified__is_set() {
+	public function test__override_lastpostmodified__is_set_any() {
+		Last_Post_Modified::update_lastpostmodified( '1989-12-13', 'gmt' );
+
+		$actual = get_lastpostmodified( 'gmt' );
+
+		$this->assertEquals( '1989-12-13', $actual );
+	}
+
+	public function test__override_lastpostmodified__is_set_post() {
 		Last_Post_Modified::update_lastpostmodified( '2003-05-27', 'gmt', 'post' );
 
 		$actual = get_lastpostmodified( 'gmt', 'post' );
@@ -73,7 +94,7 @@ class lastpostmodified_Test extends \WP_UnitTestCase {
 		$this->assertEquals( '2003-05-27', $actual );
 	}
 
-	public function test__override_lastpostmodified__is_not_set() {
+	public function test__override_lastpostmodified__is_not_set_post() {
 		$actual = get_lastpostmodified( 'gmt', 'post' );
 
 		$this->assertEquals( $this->post_modified_gmt, $actual );


### PR DESCRIPTION
We should store and properly return that value when requested.