### PR TITLE
MediaPass: replace PHP4-style constructor

### DIFF
--- a/shared-plugins/mediapass/mediapass_api.php
+++ b/shared-plugins/mediapass/mediapass_api.php
@@ -55,7 +55,7 @@ class MediaPass {
 	
 	public $membership_duration_increments;
 	
-	public function MediaPass( $access_token, $asset_id, $env = 'default' ) {
+	public function __construct( $access_token, $asset_id, $env = 'default' ) {
 		$this->access_token = $access_token;
 		$this->asset_id     = $asset_id;
 		


### PR DESCRIPTION
With `__construct` for PHP7+ compat

See #402