### PR TITLE
Disqus: replace PHP4-style constructors

### DIFF
--- a/shared-plugins/disqus/lib/api/disqus/disqus.php
+++ b/shared-plugins/disqus/lib/api/disqus/disqus.php
@@ -72,7 +72,7 @@ class DisqusAPI {
 	 * @param $api_url
 	 *   (optional) The prefix URL to use when calling the Disqus API.
 	 */
-	function DisqusAPI($user_api_key, $forum_api_key, $api_url='http://www.disqus.com/api/') {
+	function __construct($user_api_key, $forum_api_key, $api_url='http://www.disqus.com/api/') {
 		$this->user_api_key = $user_api_key;
 		$this->forum_api_key = $forum_api_key;
 		$this->api_url = $api_url;

--- a/shared-plugins/disqus/lib/api/disqus/json.php
+++ b/shared-plugins/disqus/lib/api/disqus/json.php
@@ -71,7 +71,7 @@ class JSON
      */
     var $error;
     
-    function Json() {
+    function __construct() {
         $this->error = false;
     }
     

--- a/shared-plugins/disqus/lib/wpapi.php
+++ b/shared-plugins/disqus/lib/wpapi.php
@@ -33,7 +33,7 @@ class DisqusWordPressAPI {
 	var $short_name;
 	var $forum_api_key;
 
-	function DisqusWordPressAPI($short_name=null, $forum_api_key=null, $user_api_key=null) {
+	function __construct($short_name=null, $forum_api_key=null, $user_api_key=null) {
 		$this->short_name = $short_name;
 		$this->forum_api_key = $forum_api_key;
 		$this->user_api_key = $user_api_key;


### PR DESCRIPTION
With `__construct` for PHP7+ compat

See #402