### PR TITLE
Update wordpress-importer to v0.6.3

### DIFF
--- a/wordpress-importer/languages/wordpress-importer.pot
+++ b/wordpress-importer/languages/wordpress-importer.pot
@@ -1,18 +1,19 @@
-# Copyright (C) 2011 WordPress Importer
+# Copyright (C) 2016 WordPress Importer
 # This file is distributed under the same license as the WordPress Importer package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WordPress Importer 0.5\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/tag/wordpress-importer\n"
-"POT-Creation-Date: 2011-07-16 15:45:12+00:00\n"
+"Project-Id-Version: WordPress Importer 0.6.3\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wordpress-"
+"importer\n"
+"POT-Creation-Date: 2016-08-19 13:28:24+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2010-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
-#: parsers.php:42 parsers.php:63
+#: parsers.php:42 parsers.php:72 parsers.php:80
 msgid "There was an error when reading this WXR file"
 msgstr ""
 
@@ -22,49 +23,56 @@ msgid ""
 "parser..."
 msgstr ""
 
-#: parsers.php:67 parsers.php:72 parsers.php:262 parsers.php:451
+#: parsers.php:84 parsers.php:89 parsers.php:306 parsers.php:495
 msgid ""
 "This does not appear to be a WXR file, missing/invalid WXR version number"
 msgstr ""
 
-#: wordpress-importer.php:134 wordpress-importer.php:143
-#: wordpress-importer.php:194 wordpress-importer.php:202
+#: wordpress-importer.php:132 wordpress-importer.php:141
+#: wordpress-importer.php:192 wordpress-importer.php:196
+#: wordpress-importer.php:205
 msgid "Sorry, there has been an error."
 msgstr ""
 
-#: wordpress-importer.php:135
+#: wordpress-importer.php:133
 msgid "The file does not exist, please try again."
 msgstr ""
 
-#: wordpress-importer.php:178
+#: wordpress-importer.php:176
 msgid "All done."
 msgstr ""
 
-#: wordpress-importer.php:178
+#: wordpress-importer.php:176
 msgid "Have fun!"
 msgstr ""
 
-#: wordpress-importer.php:179
+#: wordpress-importer.php:177
 msgid "Remember to update the passwords and roles of imported users."
 msgstr ""
 
-#: wordpress-importer.php:210
+#: wordpress-importer.php:197
+msgid ""
+"The export file could not be found at <code>%s</code>. It is likely that "
+"this was caused by a permissions problem."
+msgstr ""
+
+#: wordpress-importer.php:213
 msgid ""
 "This WXR file (version %s) may not be supported by this version of the "
 "importer. Please consider updating."
 msgstr ""
 
-#: wordpress-importer.php:235
+#: wordpress-importer.php:238
 msgid ""
 "Failed to import author %s. Their posts will be attributed to the current "
 "user."
 msgstr ""
 
-#: wordpress-importer.php:261
+#: wordpress-importer.php:264
 msgid "Assign Authors"
 msgstr ""
 
-#: wordpress-importer.php:262
+#: wordpress-importer.php:265
 msgid ""
 "To make it easier for you to edit and save the imported content, you may "
 "want to reassign the author of the imported item to an existing user of this "
@@ -72,137 +80,137 @@ msgid ""
 "code>s entries."
 msgstr ""
 
-#: wordpress-importer.php:264
+#: wordpress-importer.php:267
 msgid ""
 "If a new user is created by WordPress, a new password will be randomly "
 "generated and the new user&#8217;s role will be set as %s. Manually changing "
 "the new user&#8217;s details will be necessary."
 msgstr ""
 
-#: wordpress-importer.php:274
+#: wordpress-importer.php:277
 msgid "Import Attachments"
 msgstr ""
 
-#: wordpress-importer.php:277
+#: wordpress-importer.php:280
 msgid "Download and import file attachments"
 msgstr ""
 
-#: wordpress-importer.php:281
+#: wordpress-importer.php:284
 msgid "Submit"
 msgstr ""
 
-#: wordpress-importer.php:294
+#: wordpress-importer.php:297
 msgid "Import author:"
 msgstr ""
 
-#: wordpress-importer.php:305
+#: wordpress-importer.php:308
 msgid "or create new user with login name:"
 msgstr ""
 
-#: wordpress-importer.php:308
+#: wordpress-importer.php:311
 msgid "as a new user:"
 msgstr ""
 
-#: wordpress-importer.php:316
+#: wordpress-importer.php:319
 msgid "assign posts to an existing user:"
 msgstr ""
 
-#: wordpress-importer.php:318
+#: wordpress-importer.php:321
 msgid "or assign posts to an existing user:"
 msgstr ""
 
-#: wordpress-importer.php:319
+#: wordpress-importer.php:322
 msgid "- Select -"
 msgstr ""
 
-#: wordpress-importer.php:369
+#: wordpress-importer.php:372
 msgid ""
 "Failed to create new user for %s. Their posts will be attributed to the "
 "current user."
 msgstr ""
 
-#: wordpress-importer.php:418
+#: wordpress-importer.php:424
 msgid "Failed to import category %s"
 msgstr ""
 
-#: wordpress-importer.php:456
+#: wordpress-importer.php:467
 msgid "Failed to import post tag %s"
 msgstr ""
 
-#: wordpress-importer.php:500 wordpress-importer.php:626
+#: wordpress-importer.php:516 wordpress-importer.php:738
 msgid "Failed to import %s %s"
 msgstr ""
 
-#: wordpress-importer.php:522
+#: wordpress-importer.php:605
 msgid "Failed to import &#8220;%s&#8221;: Invalid post type %s"
 msgstr ""
 
-#: wordpress-importer.php:543
+#: wordpress-importer.php:642
 msgid "%s &#8220;%s&#8221; already exists."
 msgstr ""
 
-#: wordpress-importer.php:598
+#: wordpress-importer.php:704
 msgid "Failed to import %s &#8220;%s&#8221;"
 msgstr ""
 
-#: wordpress-importer.php:744
+#: wordpress-importer.php:869
 msgid "Menu item skipped due to missing menu slug"
 msgstr ""
 
-#: wordpress-importer.php:751
+#: wordpress-importer.php:876
 msgid "Menu item skipped due to invalid menu slug: %s"
 msgstr ""
 
-#: wordpress-importer.php:814
+#: wordpress-importer.php:939
 msgid "Fetching attachments is not enabled"
 msgstr ""
 
-#: wordpress-importer.php:827
+#: wordpress-importer.php:952
 msgid "Invalid file type"
 msgstr ""
 
-#: wordpress-importer.php:871
+#: wordpress-importer.php:996
 msgid "Remote server did not respond"
 msgstr ""
 
-#: wordpress-importer.php:877
+#: wordpress-importer.php:1002
 msgid "Remote server returned error response %1$d %2$s"
 msgstr ""
 
-#: wordpress-importer.php:884
+#: wordpress-importer.php:1009
 msgid "Remote file is incorrect size"
 msgstr ""
 
-#: wordpress-importer.php:889
+#: wordpress-importer.php:1014
 msgid "Zero size file downloaded"
 msgstr ""
 
-#: wordpress-importer.php:895
+#: wordpress-importer.php:1020
 msgid "Remote file is too large, limit is %s"
 msgstr ""
 
-#: wordpress-importer.php:994
+#: wordpress-importer.php:1119
 msgid "Import WordPress"
 msgstr ""
 
-#: wordpress-importer.php:1001
+#: wordpress-importer.php:1126
 msgid ""
 "A new version of this importer is available. Please update to version %s to "
 "ensure compatibility with newer export files."
 msgstr ""
 
-#: wordpress-importer.php:1016
+#: wordpress-importer.php:1141
 msgid ""
 "Howdy! Upload your WordPress eXtended RSS (WXR) file and we&#8217;ll import "
 "the posts, pages, comments, custom fields, categories, and tags into this "
 "site."
 msgstr ""
 
-#: wordpress-importer.php:1017
+#: wordpress-importer.php:1142
 msgid "Choose a WXR (.xml) file to upload, then click Upload file and import."
 msgstr ""
 
-#: wordpress-importer.php:1091
+#: wordpress-importer.php:1216
 msgid ""
 "Import <strong>posts, pages, comments, custom fields, categories, and tags</"
 "strong> from a WordPress export file."

--- a/wordpress-importer/parsers.php
+++ b/wordpress-importer/parsers.php
@@ -114,28 +114,46 @@ class WXR_Parser_SimpleXML {
 		// grab cats, tags and terms
 		foreach ( $xml->xpath('/rss/channel/wp:category') as $term_arr ) {
 			$t = $term_arr->children( $namespaces['wp'] );
-			$categories[] = array(
+			$category = array(
 				'term_id' => (int) $t->term_id,
 				'category_nicename' => (string) $t->category_nicename,
 				'category_parent' => (string) $t->category_parent,
 				'cat_name' => (string) $t->cat_name,
 				'category_description' => (string) $t->category_description
 			);
+
+			foreach ( $t->termmeta as $meta ) {
+				$category['termmeta'][] = array(
+					'key' => (string) $meta->meta_key,
+					'value' => (string) $meta->meta_value
+				);
+			}
+
+			$categories[] = $category;
 		}
 
 		foreach ( $xml->xpath('/rss/channel/wp:tag') as $term_arr ) {
 			$t = $term_arr->children( $namespaces['wp'] );
-			$tags[] = array(
+			$tag = array(
 				'term_id' => (int) $t->term_id,
 				'tag_slug' => (string) $t->tag_slug,
 				'tag_name' => (string) $t->tag_name,
 				'tag_description' => (string) $t->tag_description
 			);
+
+			foreach ( $t->termmeta as $meta ) {
+				$tag['termmeta'][] = array(
+					'key' => (string) $meta->meta_key,
+					'value' => (string) $meta->meta_value
+				);
+			}
+
+			$tags[] = $tag;
 		}
 
 		foreach ( $xml->xpath('/rss/channel/wp:term') as $term_arr ) {
 			$t = $term_arr->children( $namespaces['wp'] );
-			$terms[] = array(
+			$term = array(
 				'term_id' => (int) $t->term_id,
 				'term_taxonomy' => (string) $t->term_taxonomy,
 				'slug' => (string) $t->term_slug,
@@ -143,6 +161,15 @@ class WXR_Parser_SimpleXML {
 				'term_name' => (string) $t->term_name,
 				'term_description' => (string) $t->term_description
 			);
+
+			foreach ( $t->termmeta as $meta ) {
+				$term['termmeta'][] = array(
+					'key' => (string) $meta->meta_key,
+					'value' => (string) $meta->meta_value
+				);
+			}
+
+			$terms[] = $term;
 		}
 
 		// grab posts
@@ -204,7 +231,7 @@ class WXR_Parser_SimpleXML {
 						);
 					}
 				}
-			
+
 				$post['comments'][] = array(
 					'comment_id' => (int) $comment->comment_id,
 					'comment_author' => (string) $comment->comment_author,
@@ -324,7 +351,11 @@ class WXR_Parser_XML {
 		if ( ! trim( $cdata ) )
 			return;
 
-		$this->cdata .= trim( $cdata );
+		if ( false !== $this->in_tag || false !== $this->in_sub_tag ) {
+			$this->cdata .= $cdata;
+		} else {
+			$this->cdata .= trim( $cdata );
+		}
 	}
 
 	function tag_close( $parser, $tag ) {
@@ -400,10 +431,6 @@ class WXR_Parser_Regex {
 	var $tags = array();
 	var $terms = array();
 	var $base_url = '';
-
-	function WXR_Parser_Regex() {
-		$this->__construct();
-	}
 
 	function __construct() {
 		$this->has_gzip = is_callable( 'gzopen' );

--- a/wordpress-importer/readme.txt
+++ b/wordpress-importer/readme.txt
@@ -1,10 +1,9 @@
 === WordPress Importer ===
 Contributors: wordpressdotorg
-Donate link: 
 Tags: importer, wordpress
 Requires at least: 3.0
-Tested up to: 4.1
-Stable tag: 0.6.1
+Tested up to: 4.6
+Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +37,15 @@ If you would prefer to do things manually then follow these instructions:
 1. Go to the Tools -> Import screen, click on WordPress
 
 == Changelog ==
+
+= 0.6.3 =
+* Add support for import term metadata.
+* Fix bug that caused slashes to be stripped from imported content.
+* Fix bug that caused characters to be stripped inside of CDATA in some cases.
+* Fix PHP notices.
+
+= 0.6.2 =
+* Add wp_import_existing_post filter. See: https://core.trac.wordpress.org/ticket/33721
 
 = 0.6 =
 * Support for WXR 1.2 and multiple CDATA sections

--- a/wordpress-importer/wordpress-importer.php
+++ b/wordpress-importer/wordpress-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/wordpress-importer/
 Description: Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.6.1
+Version: 0.6.3
 Text Domain: wordpress-importer
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
@@ -62,8 +62,6 @@ class WP_Import extends WP_Importer {
 	var $fetch_attachments = false;
 	var $url_remap = array();
 	var $featured_images = array();
-
-	function WP_Import() { /* nothing */ }
 
 	/**
 	 * Registered callback function for the WordPress Importer
@@ -416,6 +414,7 @@ class WP_Import extends WP_Importer {
 				'cat_name' => $cat['cat_name'],
 				'category_description' => $category_description
 			);
+			$catarr = wp_slash( $catarr );
 
 			$id = wp_insert_category( $catarr );
 			if ( ! is_wp_error( $id ) ) {
@@ -428,6 +427,8 @@ class WP_Import extends WP_Importer {
 				echo '<br />';
 				continue;
 			}
+
+			$this->process_termmeta( $cat, $id['term_id'] );
 		}
 
 		unset( $this->categories );
@@ -454,6 +455,7 @@ class WP_Import extends WP_Importer {
 				continue;
 			}
 
+			$tag = wp_slash( $tag );
 			$tag_desc = isset( $tag['tag_description'] ) ? $tag['tag_description'] : '';
 			$tagarr = array( 'slug' => $tag['tag_slug'], 'description' => $tag_desc );
 
@@ -468,6 +470,8 @@ class WP_Import extends WP_Importer {
 				echo '<br />';
 				continue;
 			}
+
+			$this->process_termmeta( $tag, $id['term_id'] );
 		}
 
 		unset( $this->tags );
@@ -500,6 +504,7 @@ class WP_Import extends WP_Importer {
 				$parent = term_exists( $term['term_parent'], $term['term_taxonomy'] );
 				if ( is_array( $parent ) ) $parent = $parent['term_id'];
 			}
+			$term = wp_slash( $term );
 			$description = isset( $term['term_description'] ) ? $term['term_description'] : '';
 			$termarr = array( 'slug' => $term['slug'], 'description' => $description, 'parent' => intval($parent) );
 
@@ -514,9 +519,72 @@ class WP_Import extends WP_Importer {
 				echo '<br />';
 				continue;
 			}
+
+			$this->process_termmeta( $term, $id['term_id'] );
 		}
 
 		unset( $this->terms );
+	}
+
+	/**
+	 * Add metadata to imported term.
+	 *
+	 * @since 0.6.2
+	 *
+	 * @param array $term    Term data from WXR import.
+	 * @param int   $term_id ID of the newly created term.
+	 */
+	protected function process_termmeta( $term, $term_id ) {
+		if ( ! isset( $term['termmeta'] ) ) {
+			$term['termmeta'] = array();
+		}
+
+		/**
+		 * Filters the metadata attached to an imported term.
+		 *
+		 * @since 0.6.2
+		 *
+		 * @param array $termmeta Array of term meta.
+		 * @param int   $term_id  ID of the newly created term.
+		 * @param array $term     Term data from the WXR import.
+		 */
+		$term['termmeta'] = apply_filters( 'wp_import_term_meta', $term['termmeta'], $term_id, $term );
+
+		if ( empty( $term['termmeta'] ) ) {
+			return;
+		}
+
+		foreach ( $term['termmeta'] as $meta ) {
+			/**
+			 * Filters the meta key for an imported piece of term meta.
+			 *
+			 * @since 0.6.2
+			 *
+			 * @param string $meta_key Meta key.
+			 * @param int    $term_id  ID of the newly created term.
+			 * @param array  $term     Term data from the WXR import.
+			 */
+			$key = apply_filters( 'import_term_meta_key', $meta['key'], $term_id, $term );
+			if ( ! $key ) {
+				continue;
+			}
+
+			// Export gets meta straight from the DB so could have a serialized string
+			$value = maybe_unserialize( $meta['value'] );
+
+			add_term_meta( $term_id, $key, $value );
+
+			/**
+			 * Fires after term meta is imported.
+			 *
+			 * @since 0.6.2
+			 *
+			 * @param int    $term_id ID of the newly created term.
+			 * @param string $key     Meta key.
+			 * @param mixed  $value   Meta value.
+			 */
+			do_action( 'import_term_meta', $term_id, $key, $value );
+		}
 	}
 
 	/**
@@ -555,10 +623,26 @@ class WP_Import extends WP_Importer {
 			$post_type_object = get_post_type_object( $post['post_type'] );
 
 			$post_exists = post_exists( $post['post_title'], '', $post['post_date'] );
+
+			/**
+			* Filter ID of the existing post corresponding to post currently importing.
+			*
+			* Return 0 to force the post to be imported. Filter the ID to be something else
+			* to override which existing post is mapped to the imported post.
+			*
+			* @see post_exists()
+			* @since 0.6.2
+			*
+			* @param int   $post_exists  Post ID, or 0 if post did not exist.
+			* @param array $post         The post array to be inserted.
+			*/
+			$post_exists = apply_filters( 'wp_import_existing_post', $post_exists, $post );
+
 			if ( $post_exists && get_post_type( $post_exists ) == $post['post_type'] ) {
 				printf( __('%s &#8220;%s&#8221; already exists.', 'wordpress-importer'), $post_type_object->labels->singular_name, esc_html($post['post_title']) );
 				echo '<br />';
 				$comment_post_ID = $post_id = $post_exists;
+				$this->processed_posts[ intval( $post['post_id'] ) ] = intval( $post_exists );
 			} else {
 				$post_parent = (int) $post['post_parent'];
 				if ( $post_parent ) {
@@ -591,6 +675,8 @@ class WP_Import extends WP_Importer {
 
 				$original_post_ID = $post['post_id'];
 				$postdata = apply_filters( 'wp_import_post_data_processed', $postdata, $post );
+
+				$postdata = wp_slash( $postdata );
 
 				if ( 'attachment' == $postdata['post_type'] ) {
 					$remote_url = ! empty($post['attachment_url']) ? $post['attachment_url'] : $post['guid'];
@@ -1107,7 +1193,7 @@ class WP_Import extends WP_Importer {
 	 * Added to http_request_timeout filter to force timeout at 60 seconds during import
 	 * @return int 60
 	 */
-	function bump_request_timeout() {
+	function bump_request_timeout( $val ) {
 		return 60;
 	}
 


### PR DESCRIPTION
[Changelog](https://wordpress.org/plugins/wordpress-importer/changelog/) for 0.6.2 + 0.6.3:

- Add support for import term metadata.
- Fix bug that caused slashes to be stripped from imported content.
- Fix bug that caused characters to be stripped inside of CDATA in some cases.
- Fix PHP notices.
- Add wp_import_existing_post filter. See: https://core.trac.wordpress.org/ticket/33721