### PR TITLE
Swap bool uses of VIP_GO_ENV to WPCOM_IS_VIP_ENV

### DIFF
--- a/001-cron.php
+++ b/001-cron.php
@@ -58,7 +58,7 @@ class WPCOM_VIP_Cron_Control {
 
 // Allow testing of new approach to cron execution
 $whitelisted_sites = array();
-if ( VIP_GO_ENV && in_array( FILES_CLIENT_SITE_ID, $whitelisted_sites ) ) {
+if ( true === WPCOM_IS_VIP_ENV && in_array( FILES_CLIENT_SITE_ID, $whitelisted_sites ) ) {
 	add_filter( 'wpcom_vip_go_enable_new_cron_control', '__return_true' );
 }
 

--- a/misc.php
+++ b/misc.php
@@ -28,9 +28,8 @@ add_filter( 'got_url_rewrite', '__return_true' );
 // Disable custom fields meta box dropdown (very slow)
 add_filter( 'postmeta_form_keys', '__return_false' );
 
-// Checking for VIP_GO_ENV allows this code to work outside VIP Go environments,
-// albeit without concatenation of JS and CSS.
-if ( defined( 'VIP_GO_ENV' ) && false !== VIP_GO_ENV ) {
+// We don't want concat running outside VIP Go environments.
+if ( true === WPCOM_IS_VIP_ENV ) {
 	// Activate concatenation
 	if ( ! isset( $_GET['concat_js'] ) || 'yes' === $_GET['concat_js'] ) {
 		require __DIR__ .'/http-concat/jsconcat.php';


### PR DESCRIPTION
VIP_GO_ENV isn't really meant to be used as a boolean value; More as a
way to differentiate Go-environments.

WPCOM_IS_VIP_ENV is a better choice here.

Fixes #354