### PR TITLE
Allow Core's cron behaviour to be restored

### DIFF
--- a/001-cron.php
+++ b/001-cron.php
@@ -56,6 +56,16 @@ class WPCOM_VIP_Cron_Control {
 	}
 }
 
+// Non-public multisites can't be reached by our cron runners, so should use Core's native approach
+if ( is_multisite() ) {
+	$details = get_blog_details( get_current_blog_id(), false );
+
+	// get_blog_details() uses numeric strings for backcompat
+	if ( '1' !== $details->public || in_array( '1', array( $details->archived, $details->spam, $details->deleted ), true ) ) {
+		add_filter( 'wpcom_vip_go_use_core_cron', '__return_true' );
+	}
+}
+
 // Allow all cron overrides to be disabled, such as during local development
 if ( apply_filters( 'wpcom_vip_go_use_core_cron', false ) ) {
 	return;

--- a/001-cron.php
+++ b/001-cron.php
@@ -14,7 +14,8 @@
  * @return bool
  */
 function wpcom_vip_use_core_cron() {
-	if ( ! is_multisite() ) {
+	// Bail early for anything that isn't a multisite subsite
+	if ( ! is_multisite() || is_main_site() ) {
 		return false;
 	}
 

--- a/001-cron.php
+++ b/001-cron.php
@@ -56,6 +56,11 @@ class WPCOM_VIP_Cron_Control {
 	}
 }
 
+// Allow all cron overrides to be disabled, such as during local development
+if ( apply_filters( 'wpcom_vip_go_use_core_cron', false ) ) {
+	return;
+}
+
 // Allow testing of new approach to cron execution
 $whitelisted_sites = array();
 if ( VIP_GO_ENV && in_array( FILES_CLIENT_SITE_ID, $whitelisted_sites ) ) {

--- a/001-cron.php
+++ b/001-cron.php
@@ -8,6 +8,33 @@
  Text Domain: wp-cron-control
  */
 
+/**
+ * Non-public multisite subsites can't be reached by our cron runners, so should use Core's native approach
+ *
+ * @return bool
+ */
+function wpcom_vip_use_core_cron() {
+	if ( ! is_multisite() ) {
+		return false;
+	}
+
+	$details = get_blog_details( get_current_blog_id(), false );
+
+	// get_blog_details() uses numeric strings for backcompat
+	if ( '1' !== $details->public || in_array( '1', array( $details->archived, $details->spam, $details->deleted ), true ) ) {
+		return true;
+	}
+
+	return false;
+}
+
+if ( wpcom_vip_use_core_cron() ) {
+	return;
+}
+
+/**
+ * Platform-wide settings for WP-Cron Control
+ */
 class WPCOM_VIP_Cron_Control {
 	/**
 	 * Register hooks
@@ -54,21 +81,6 @@ class WPCOM_VIP_Cron_Control {
 			) );
 		}
 	}
-}
-
-// Non-public multisites can't be reached by our cron runners, so should use Core's native approach
-if ( is_multisite() ) {
-	$details = get_blog_details( get_current_blog_id(), false );
-
-	// get_blog_details() uses numeric strings for backcompat
-	if ( '1' !== $details->public || in_array( '1', array( $details->archived, $details->spam, $details->deleted ), true ) ) {
-		add_filter( 'wpcom_vip_go_use_core_cron', '__return_true' );
-	}
-}
-
-// Allow all cron overrides to be disabled, such as during local development
-if ( apply_filters( 'wpcom_vip_go_use_core_cron', false ) ) {
-	return;
 }
 
 // Allow testing of new approach to cron execution


### PR DESCRIPTION
Depending on site's needs, we offer two approaches to improving Core's cron reliability. In some cases, such as local development environments or private multisite subsites, we aren't able to execute either alternative approach, so Core's offering should be used.