### PR TITLE
Update Travis to check latest stable PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ git:
 php:
   - 5.6
   - 7
+  - 7.1
 
 env:
   matrix:


### PR DESCRIPTION
Now that PHP 7.1 is the latest stable release, we should prepare for it.