### PR TITLE
Whitelisted Proxy IP Forwarding

### DIFF
--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Automattic\VIP\Proxy;
+
+/**
+ * This allows more securely forwarding the origin IP address when there are multiple proxies in play.
+ *
+ * Example setup:
+ * User => Remote Proxy (e.g. Cloudflare) => Local Proxy (Varnish) => Application (PHP/WP)
+ *
+ * Without this, the Application will see the Remote Proxy's IP address as the REMOTE_ADDR.
+ * With this, if Remote Proxy's IP address matches a known whitelist, the Application will see the User's real IP address as REMOTE_ADDR.
+ *
+ * Only two levels of proxies are supported.
+ *
+ * @param (string) $ip_trail Comma-separated list of IPs (something like `user_ip, proxy_ip`)
+ * @param (string|array) $proxy_ip_whitelist Whitelisted IP addresses for the remote proxy. Supports IPv4 and IPv6, including CIDR format.
+ *
+ * @return (bool) true, if REMOTE_ADDR updated; false, if not.
+ */
+function fix_remote_address_from_ip_trail( $ip_trail, $proxy_ip_whitelist ) {
+	// If X-Forwarded-For is not set, we're not dealing with a remote proxy or something in the proxy configs is doing it wrong.
+	if ( ! isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+		return false;
+	}
+
+	// Verify that the IP trail has multiple IPs but only two levels (remote + local).
+	$ip_addresses = explode( ',', $ip_trail );
+	$ip_addresses = array_map( 'trim', $ip_addresses );
+	if ( 2 !== count( $ip_addresses ) ) {
+		return false;
+	}
+
+	list( $user_ip, $remote_proxy_ip ) = $ip_addresses;
+
+	// This should probably never happen, but validate just in case.
+	if ( $remote_proxy_ip !== $_SERVER['HTTP_X_FORWARDED_FOR'] ) {
+		return false;
+	}
+
+	require_once( __DIR__ . '/ip-utils.php' );
+
+	// Verify that our remote proxy matches out whitelist
+	$is_whitelisted_proxy_ip = IpUtils::checkIp( $remote_proxy_ip, $proxy_ip_whitelist );
+	if ( ! $is_whitelisted_proxy_ip ) {
+		return false;
+	}
+
+	// Everything looks good so we can set our SERVER var
+	$_SERVER['REMOTE_ADDR'] = $user_ip;
+
+	return true;
+}

--- a/lib/proxy/ip-utils.php
+++ b/lib/proxy/ip-utils.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file was borrowed and modified from this Symfony package:
+ * https://github.com/symfony/http-foundation
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please https://github.com/symfony/http-foundation/blob/master/LICENSE
+ */
+
+namespace Automattic\VIP\Proxy;
+
+/**
+ * Http utility functions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class IpUtils
+{
+    /**
+     * This class should not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Checks if an IPv4 or IPv6 address is contained in the list of given IPs or subnets.
+     *
+     * @param string       $requestIp IP to check
+     * @param string|array $ips       List of IPs or subnets (can be a string if only a single one)
+     *
+     * @return bool Whether the IP is valid
+     */
+    public static function checkIp($requestIp, $ips)
+    {
+        if (!is_array($ips)) {
+            $ips = array($ips);
+        }
+
+        $method = substr_count($requestIp, ':') > 1 ? 'checkIp6' : 'checkIp4';
+
+        foreach ($ips as $ip) {
+            if (self::$method($requestIp, $ip)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Compares two IPv4 addresses.
+     * In case a subnet is given, it checks if it contains the request IP.
+     *
+     * @param string $requestIp IPv4 address to check
+     * @param string $ip        IPv4 address or subnet in CIDR notation
+     *
+     * @return bool Whether the request IP matches the IP, or whether the request IP is within the CIDR subnet
+     */
+    public static function checkIp4($requestIp, $ip)
+    {
+        if (!filter_var($requestIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            return false;
+        }
+
+        if (false !== strpos($ip, '/')) {
+            list($address, $netmask) = explode('/', $ip, 2);
+
+            if ($netmask === '0') {
+                return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
+            }
+
+            if ($netmask < 0 || $netmask > 32) {
+                return false;
+            }
+        } else {
+            $address = $ip;
+            $netmask = 32;
+        }
+
+        return 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);
+    }
+
+    /**
+     * Compares two IPv6 addresses.
+     * In case a subnet is given, it checks if it contains the request IP.
+     *
+     * @author David Soria Parra <dsp at php dot net>
+     *
+     * @see https://github.com/dsp/v6tools
+     *
+     * @param string $requestIp IPv6 address to check
+     * @param string $ip        IPv6 address or subnet in CIDR notation
+     *
+     * @return bool Whether the IP is valid
+     *
+     * @throws \RuntimeException When IPV6 support is not enabled
+     */
+    public static function checkIp6($requestIp, $ip)
+    {
+        if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1'))) {
+            throw new \RuntimeException('Unable to check Ipv6. Check that PHP was not compiled with option "disable-ipv6".');
+        }
+
+        if (false !== strpos($ip, '/')) {
+            list($address, $netmask) = explode('/', $ip, 2);
+
+            if ($netmask < 1 || $netmask > 128) {
+                return false;
+            }
+        } else {
+            $address = $ip;
+            $netmask = 128;
+        }
+
+        $bytesAddr = unpack('n*', @inet_pton($address));
+        $bytesTest = unpack('n*', @inet_pton($requestIp));
+
+        if (!$bytesAddr || !$bytesTest) {
+            return false;
+        }
+
+        for ($i = 1, $ceil = ceil($netmask / 16); $i <= $ceil; ++$i) {
+            $left = $netmask - 16 * ($i - 1);
+            $left = ($left <= 16) ? $left : 16;
+            $mask = ~(0xffff >> $left) & 0xffff;
+            if (($bytesAddr[$i] & $mask) != ($bytesTest[$i] & $mask)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,7 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	require __DIR__ . '/../000-vip-init.php';
 	require __DIR__ . '/../performance.php';
+	require __DIR__ . '/../lib/proxy/ip-forward.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/test-lib-proxy-ip-forward.php
+++ b/tests/test-lib-proxy-ip-forward.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Automattic\VIP\Proxy;
+
+class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
+	const DEFAULT_REMOTE_ADDR = '1.0.1.0';
+
+	public function setUp() {
+		$this->original_remote_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
+		$this->original_x_forwarded_for = isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : null;
+
+		$_SERVER['REMOTE_ADDR'] = self::DEFAULT_REMOTE_ADDR;
+	}
+
+	public function tearDown() {
+		if ( $this->original_remote_addr ) {
+			$_SERVER['REMOTE_ADDR'] = $this->original_remote_addr;
+		}
+
+		if ( $this->original_x_forwarded_for ) {
+			$_SERVER['HTTP_X_FORWARDED_FOR'] = $this->original_x_forwarded_for;
+		}
+	}
+
+	public function test__fix_remote_address__no_forwarded_for() {
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		$ip_trail = '1.2.3.4, 5.6.7.8';
+		$whitelist = [ '5.6.7.8' ];
+
+		$result = fix_remote_address_from_ip_trail( $ip_trail, $whitelist );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
+	}
+
+	public function test__fix_remote_address__ip_trail_has_lt_2_ips() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
+		$ip_trail = '1.2.3.4';
+		$whitelist = [ '5.6.7.8' ];
+
+		$result = fix_remote_address_from_ip_trail( $ip_trail, $whitelist );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
+	}
+
+	public function test__fix_remote_address__ip_trail_has_gt_2_ips() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
+		$ip_trail = '1.2.3.4, 9.0.21.0, 5.6.7.8';
+		$whitelist = [ '5.6.7.8' ];
+
+		$result = fix_remote_address_from_ip_trail( $ip_trail, $whitelist );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
+	}
+
+	public function test__fix_remote_address__proxy_doesnt_match_forwarded_for() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.5.5.5';
+		$ip_trail = '1.2.3.4, 5.6.7.8';
+		$whitelist = [ '0.0.0.0' ];
+
+		$result = fix_remote_address_from_ip_trail( $ip_trail, $whitelist );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
+	}
+
+	public function test__fix_remote_address__ip_not_in_whitelist() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
+		$ip_trail = '1.2.3.4, 5.6.7.8';
+		$whitelist = [ '0.0.0.0' ];
+
+		$result = fix_remote_address_from_ip_trail( $ip_trail, $whitelist );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
+	}
+
+	public function test__fix_remote_address__ip_in_whitelist() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
+		$ip_trail = '1.2.3.4, 5.6.7.8';
+		$whitelist = [ '5.6.7.8' ];
+
+		$result = fix_remote_address_from_ip_trail( $ip_trail, $whitelist );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( '1.2.3.4', $_SERVER['REMOTE_ADDR'] );
+	}
+}


### PR DESCRIPTION
This allows more securely forwarding the origin IP address. It requires a trusted whitelist of proxy IP addresses (both IPv4 -- exact and CIDR -- and IPv6 are supported).

Assumes that the local proxy passes through a server var with comma-separated IPs in the form of `user_ip, remote_proxy_ip`.

In `vip-config/vip-config`:

```
$proxy_lib = ABSPATH . '/wp-content/mu-plugins/lib/proxy/ip-forward.php';
if ( file_exists( $proxy_lib ) && ! empty( $_SERVER['HTTP_X_SECRET_TRAIL_KEY'] ) ) {
    require_once( ABSPATH . '/wp-content/mu-plugins/lib/proxy/ip-forward.php' );

    $ip_whitelist = [ '1.2.3.4', '5.6.7/8' ];
    Automattic\VIP\Proxy\fix_remote_address_from_ip_trail( $_SERVER['HTTP_X_SECRET_TRAIL_KEY'], $ip_whitelist );
    unset( $ip_whitelist );
}
```