### PR TITLE
Allow unauth-ed access to /vip/ sites endpoint

### DIFF
--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -47,11 +47,26 @@ class WPCOM_VIP_REST_API_Endpoints {
 			'methods' => 'GET',
 			'callback' => array( $this, 'list_sites' ),
 		) );
+
+		add_filter( 'rest_authentication_errors', array( $this, 'disable_auth' ), 999 ); // hook in late to bypass any others that override our auth requirements
 	}
 
 	/**
 	 * PLUGIN FUNCTIONALITY
 	 */
+
+	/**
+	 * Some `/vip/` endpoints need to be accessible unauthenticated (for now).
+	 *
+	 * This will be replaced with a proper auth scheme in the near future.
+	 */
+	public function disable_auth( $result ) {
+		if ( 0 === strpos( $_SERVER['REQUEST_URI'], '/wp-json/vip/v1/sites' ) ) {
+			return true;
+		}
+
+		return $result;
+	}
 
 	/**
 	 * Build list of sites on a multisite network


### PR DESCRIPTION
The endpoint does not have any secret data and is used for several internal tools. This will be replaced with a more thorough auth system in the near future.