### PR TITLE
Disable term counting for bulk edit

### DIFF
--- a/performance.php
+++ b/performance.php
@@ -1,3 +1,4 @@
 <?php
 
 require_once( __DIR__ . '/performance/lastpostmodified.php' );
+require_once( __DIR__ . '/performance/bulk-edit.php' );

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Automattic\VIP\Performance;
+
+// Bulk edits of lots of posts can trigger slow term count queries for each post updated
+add_action( 'load-edit.php', function() {
+	if ( isset( $_REQUEST['bulk_edit'] ) ) {
+		wp_defer_term_counting( true );
+		add_action( 'shutdown', function() {
+			wp_defer_term_counting( false );
+		} );
+	}
+} );


### PR DESCRIPTION
Each post updated triggers a term count update which can be very slow, especially when updating lots of posts.