### PR TITLE
Split fix_remote_addr_from_ip_trail

### DIFF
--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -21,8 +21,8 @@ function fix_remote_address( $user_ip, $remote_proxy_ip, $proxy_ip_whitelist ) {
 	// Validate that user_ip is a valid IP address
 	if ( ! filter_var( $user_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 )
 		&& ! filter_var( $user_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
-            return false;
-        }
+			return false;
+	}
 
 	require_once( __DIR__ . '/ip-utils.php' );
 

--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -2,7 +2,46 @@
 
 namespace Automattic\VIP\Proxy;
 
+
 /**
+ * Set REMOTE_ADDR to the end-user's IP address.
+ *
+ * This allows more securely forwarding the origin IP address when your site is fronted by a proxy like Cloudflare or Akamai.
+ *
+ * Without this, the Application will see the Remote Proxy's IP address as the REMOTE_ADDR.
+ * With this, if Remote Proxy's IP address matches a known whitelist, the Application will see the User's real IP address as REMOTE_ADDR.
+ *
+ * @param (string) $user_ip IP Address of the end-user passed through by the proxy.
+ * @param (string) $remote_proxy_ip IP Address of the remote proxy.
+ * @param (string|array) $proxy_ip_whitelist Whitelisted IP addresses for the remote proxy. Supports IPv4 and IPv6, including CIDR format.
+ *
+ * @return (bool) true, if REMOTE_ADDR updated; false, if not.
+ */
+function fix_remote_address( $user_ip, $remote_proxy_ip, $proxy_ip_whitelist ) {
+	// Validate that user_ip is a valid IP address
+	if ( ! filter_var( $user_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 )
+		&& ! filter_var( $user_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+            return false;
+        }
+
+	require_once( __DIR__ . '/ip-utils.php' );
+
+	// Verify that the remote proxy matches our whitelist
+	$is_whitelisted_proxy_ip = IpUtils::checkIp( $remote_proxy_ip, $proxy_ip_whitelist );
+
+	if ( ! $is_whitelisted_proxy_ip ) {
+		return false;
+	}
+
+	// Everything looks good so we can set our SERVER var
+	$_SERVER['REMOTE_ADDR'] = $user_ip;
+
+	return true;
+}
+
+/**
+ * Set REMOTE_ADDR to the end-user's IP address from a trail of IP Addresses.
+ *
  * This allows more securely forwarding the origin IP address when there are multiple proxies in play.
  *
  * Example setup:
@@ -38,23 +77,5 @@ function fix_remote_address_from_ip_trail( $ip_trail, $proxy_ip_whitelist ) {
 		return false;
 	}
 
-	// Validate that user_ip is a valid IP address
-	if ( ! filter_var( $user_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 )
-		&& ! filter_var( $user_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
-            return false;
-        }
-
-	require_once( __DIR__ . '/ip-utils.php' );
-
-	// Verify that the remote proxy matches our whitelist
-	$is_whitelisted_proxy_ip = IpUtils::checkIp( $remote_proxy_ip, $proxy_ip_whitelist );
-
-	if ( ! $is_whitelisted_proxy_ip ) {
-		return false;
-	}
-
-	// Everything looks good so we can set our SERVER var
-	$_SERVER['REMOTE_ADDR'] = $user_ip;
-
-	return true;
+	return fix_remote_address( $user_ip, $remote_proxy_ip, $proxy_ip_whitelist );
 }

--- a/tests/test-lib-proxy-ip-forward.php
+++ b/tests/test-lib-proxy-ip-forward.php
@@ -24,7 +24,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
-	public function test__fix_remote_address__no_forwarded_for() {
+	public function test__fix_remote_address_from_ip_trail__no_forwarded_for() {
 		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
 		$ip_trail = '1.2.3.4, 5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];
@@ -35,7 +35,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
 	}
 
-	public function test__fix_remote_address__ip_trail_has_lt_2_ips() {
+	public function test__fix_remote_address_from_ip_trail__ip_trail_has_lt_2_ips() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$ip_trail = '1.2.3.4';
 		$whitelist = [ '5.6.7.8' ];
@@ -46,7 +46,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
 	}
 
-	public function test__fix_remote_address__ip_trail_has_gt_2_ips() {
+	public function test__fix_remote_address_from_ip_trail__ip_trail_has_gt_2_ips() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$ip_trail = '1.2.3.4, 9.0.21.0, 5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];
@@ -57,7 +57,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
 	}
 
-	public function test__fix_remote_address__proxy_doesnt_match_forwarded_for() {
+	public function test__fix_remote_address_from_ip_trail__proxy_doesnt_match_forwarded_for() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.5.5.5';
 		$ip_trail = '1.2.3.4, 5.6.7.8';
 		$whitelist = [ '0.0.0.0' ];
@@ -68,7 +68,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
 	}
 
-	public function test__fix_remote_address__invalid_remote_ip() {
+	public function test__fix_remote_address_from_ip_trail__invalid_remote_ip() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$ip_trail = '1.2.3.4, 123456789';
 		$whitelist = [ '5.6.7.8' ];
@@ -79,7 +79,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
 	}
 
-	public function test__fix_remote_address__invalid_user_ip() {
+	public function test__fix_remote_address_from_ip_trail__invalid_user_ip() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$ip_trail = 'bad_ip, 5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];
@@ -90,7 +90,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
 	}
 
-	public function test__fix_remote_address__ip_not_in_whitelist() {
+	public function test__fix_remote_address_from_ip_trail__ip_not_in_whitelist() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$ip_trail = '1.2.3.4, 5.6.7.8';
 		$whitelist = [ '0.0.0.0' ];
@@ -101,7 +101,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
 	}
 
-	public function test__fix_remote_address__ip_in_whitelist_ipv4() {
+	public function test__fix_remote_address_from_ip_trail__ip_in_whitelist_ipv4() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$ip_trail = '1.2.3.4, 5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];
@@ -112,7 +112,7 @@ class IP_Foward_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( '1.2.3.4', $_SERVER['REMOTE_ADDR'] );
 	}
 
-	public function test__fix_remote_address__ip_in_whitelist_ipv6() {
+	public function test__fix_remote_address_from_ip_trail__ip_in_whitelist_ipv6() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$ip_trail = '2001:db8::1234:ace:6006:1e, 5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];


### PR DESCRIPTION
Split into a more focused function that takes user ip + remote proxy ip which can be used on its own if needed.

- [x] Split up function.
- [x] Split up tests so new function has coverage.