### PR TITLE
Use new irc system

### DIFF
--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -57,8 +57,13 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 		return;
 	}
 
+	$irc_alert_level = 2; // ALERT
+
 	if ( $blocked ) {
 		$msg = "This site is now BLOCKED from loading until option sizes are under control.";
+
+		// If site is blocked, then the IRC alert is CRITICAL
+		$irc_alert_level = 3;
 	} else {
 		$msg = "Site will be blocked from loading if option sizes get too much bigger.";
 	}
@@ -101,9 +106,9 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 		$to_irc = $subject . ' #vipoptions';
 
 		// Send to IRC, if we have a host configured
-			wpcom_vip_irc( '#nagios-vip', $to_irc, 'a8c-alloptions' );
-			wpcom_vip_irc( '#wordpress.com-errors', $to_irc , 'a8c-alloptions' );
 		if ( defined( 'ALERT_SERVICE_ADDRESS' ) && ALERT_SERVICE_ADDRESS ) {
+			wpcom_vip_irc( '#nagios-vip', $to_irc, $irc_alert_level, 'a8c-alloptions' );
+			wpcom_vip_irc( '#wordpress.com-errors', $to_irc , $irc_alert_level, 'a8c-alloptions' );
 		}
 
 		$email_recipient = defined( 'VIP_ALLOPTIONS_NOTIFY_EMAIL' ) ? VIP_ALLOPTIONS_NOTIFY_EMAIL : false;

--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -98,7 +98,7 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 			size_format( $size )
 		);
 
-		$to_irc = wpcom_vip_irc_color( 'CRITICAL', 'red', 'black' ) . $subject . ' #vipoptions';
+		$to_irc = $subject . ' #vipoptions';
 
 		// Send to IRC, if we have a host configured
 		if ( defined( 'VIP_IRC_HOSTNAME' ) && VIP_IRC_HOSTNAME ) {

--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -101,9 +101,9 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 		$to_irc = $subject . ' #vipoptions';
 
 		// Send to IRC, if we have a host configured
-		if ( defined( 'VIP_IRC_HOSTNAME' ) && VIP_IRC_HOSTNAME ) {
 			wpcom_vip_irc( '#nagios-vip', $to_irc, 'a8c-alloptions' );
 			wpcom_vip_irc( '#wordpress.com-errors', $to_irc , 'a8c-alloptions' );
+		if ( defined( 'ALERT_SERVICE_ADDRESS' ) && ALERT_SERVICE_ADDRESS ) {
 		}
 
 		$email_recipient = defined( 'VIP_ALLOPTIONS_NOTIFY_EMAIL' ) ? VIP_ALLOPTIONS_NOTIFY_EMAIL : false;

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1223,7 +1223,7 @@ function wpcom_vip_irc( $channel_or_user, $message, $level = 0, $kind = '', $int
 		return false;
 	}
 
-	$url = ALERT_SERVICE_ADDRESS . ':' . ALERT_SERVICE_PORT;
+	$url = 'http://' . ALERT_SERVICE_ADDRESS . ':' . ALERT_SERVICE_PORT . '/v1.0/alert';
 
 	$body = array(
 		'channel' => $channel_or_user,

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1238,42 +1238,6 @@ function wpcom_vip_irc( $channel_or_user, $message, $botname = null, $type = '',
 
 	return true;
 }
-
-/**
- * Colour a message to be sent to IRC.
- *
- * Example Usage
- *
- * wpcom_vip_irc_color('WARNING', 'red', 'black');
- *
- * @param string $message Message to be coloured
- * @param string $foreground Foreground colour to be used - see code for list of colours
- * @param string $background Background colour to be used (default is black)
- */
-function wpcom_vip_irc_color( $message, $foreground, $background = 'black' ) {
-	static $colour_map = array (
-		'white' => '00',
-		'black' => '01',
-		'blue'  => '02',
-		'green' => '03',
-		'red'   => '04',
-		'brown' => '05',
-		'purple' => '06',
-		'orange' => '07',
-		'yellow' => '08',
-		'lime'   => '09',
-		'teal'   => '10',
-		'aqua'   => '11',
-		'lightblue' => '12',
-		'pink' => '13',
-		'grey' => '14',
-		'silver' => '15',
-	);
-
-	static $ctrl_c = "\x03";
-
-	if ( isset( $colour_map[ $foreground ] ) && $colour_map[ $background ] ) {
-		return $ctrl_c . $colour_map[ $foreground ] . ',' . $colour_map[ $background ] . $message . $ctrl_c;
 	}
 
 	return $message;

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1180,14 +1180,14 @@ function wpcom_vip_irc( $channel_or_user, $message, $botname = null, $type = '',
 		}
 	}
 
-	if ( ! defined( 'VIP_IRC_HOSTNAME' ) || ! VIP_IRC_HOSTNAME ) {
-		error_log( 'Missing IRC host configuration in VIP_IRC_HOSTNAME constant' );
+	if ( ! defined( 'ALERT_SERVICE_ADDRESS' ) || ! ALERT_SERVICE_ADDRESS ) {
+		error_log( 'Missing IRC host configuration in ALERT_SERVICE_ADDRESS constant' );
 
 		return false;
 	}
 
-	if ( ! defined( 'VIP_IRC_PORT' ) || ! VIP_IRC_PORT ) {
-		error_log( 'Missing IRC port configuration in VIP_IRC_PORT constant' );
+	if ( ! defined( 'ALERT_SERVICE_PORT' ) || ! ALERT_SERVICE_PORT ) {
+		error_log( 'Missing IRC port configuration in ALERT_SERVICE_PORT constant' );
 
 		return false;
 	}


### PR DESCRIPTION
Update IRC function to use new IRC delivery service.

Updates constants, adds an argument for ‘level’ (instead of using the
`wpcom_vip_irc_color()` function) and replaces the socket connection
with an WP HTTP API POST to the new IRC service.

Depends on VIPd changes.

Depends on updating IRC constants with new ones in config.

Fixes #464