### PR TITLE
Don't autoload lastpostmodified options

### DIFF
--- a/performance/lastpostmodified.php
+++ b/performance/lastpostmodified.php
@@ -63,7 +63,7 @@ class Last_Post_Modified {
 
 	public static function update_lastpostmodified( $time, $timezone, $post_type = 'any' ) {
 		$option_name = self::get_option_name( $timezone, $post_type );
-		return update_option( $option_name, $time );
+		return update_option( $option_name, $time, false );
 	}
 
 	private static function is_locked( $post_type ) {


### PR DESCRIPTION
We only need them for feeds and don't need them loaded for every request.