### PR TITLE
Impose limits on bulk-editing

### DIFF
--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -22,6 +22,7 @@ class Bulk_Edit {
 			} );
 		}
 	}
+
 	/**
 	 * Suppress bulk actions when too many posts would be affected
 	 *

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -65,9 +65,31 @@ function bulk_edit_admin_notice() {
 		return;
 	}
 
+	// HTML class doubles as key used to track dismissed notices
+	$id = 'notice-vip-bulk-edit-limited';
+
+	$dismissed_pointers = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
+	if ( in_array( $id, $dismissed_pointers, true ) ) {
+		return;
+	}
+
 	?>
-	<div class="notice notice-error is-dismissible">
+	<div id="<?php echo esc_attr( $id ); ?>" class="notice notice-error is-dismissible">
 		<p><?php _e( 'Bulk actions are disabled due to the number of items displayed in the table below.', 'wpcom-vip' ); ?></p>
+
+		<script>jQuery(document).ready( function($) { $( '#<?php echo esc_js( $id ); ?>' ).on( 'remove', function() {
+			$.ajax( {
+				url: ajaxurl,
+				type: 'POST',
+				xhrFields: {
+					withCredentials: true
+				},
+				data: {
+					action: 'dismiss-wp-pointer',
+					pointer: '<?php echo esc_js( $id ); ?>'
+				}
+			} );
+		} ) } );</script>
 	</div>
 	<?php
 }

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -2,58 +2,49 @@
 
 namespace Automattic\VIP\Performance;
 
-class Bulk_Edit {
-	/**
-	 * Generic callback to register class's hooks
-	 */
-	public static function register_hooks() {
-		add_action( 'load-edit.php', array( __CLASS__, 'defer_term_counting' ) );
-
-		add_action( 'wp_loaded', array( __CLASS__, 'limit_bulk_edit_for_registered_post_types' ) );
-	}
-
-	/**
-	 * Bulk edits of lots of posts can trigger slow term count queries for each post updated
-	 */
-	public static function defer_term_counting() {
-		if ( isset( $_REQUEST['bulk_edit'] ) ) {
-			wp_defer_term_counting( true );
-			add_action( 'shutdown', function() {
-				wp_defer_term_counting( false );
-			} );
-		}
-	}
-
-	/**
-	 * Impose our bulk-edit limitations on all registered post types that provide an admin UI
-	 */
-	public static function limit_bulk_edit_for_registered_post_types() {
-		$types = get_post_types( array(
-			'show_ui' => true,
-		) );
-
-		foreach ( $types as $type ) {
-			add_action( 'bulk_actions-edit-' . $type, array( __CLASS__, 'limit_bulk_edit' ) );
-		}
-	}
-
-	/**
-	 * Suppress bulk actions when too many posts would be affected
-	 *
-	 * Often causes database issues when too many posts are modified,
-	 * but since Core expects this to work with 20 posts, we limit to the same.
-	 */
-	public static function limit_bulk_edit( $bulk_actions ) {
-		$per_page = get_query_var( 'posts_per_page' );
-
-		// Core defaults to 20 posts per page
-		// If requesting more, or all entries, hide bulk actions
-		if ( $per_page > 20 || -1 === $per_page ) {
-			$bulk_actions = array();
-		}
-
-		return $bulk_actions;
+/**
+ * Bulk edits of lots of posts can trigger slow term count queries for each post updated
+ */
+function defer_term_counting() {
+	if ( isset( $_REQUEST['bulk_edit'] ) ) {
+		wp_defer_term_counting( true );
+		add_action( 'shutdown', function() {
+			wp_defer_term_counting( false );
+		} );
 	}
 }
 
-Bulk_Edit::register_hooks();
+add_action( 'load-edit.php', __NAMESPACE__ . '\defer_term_counting' );
+
+/**
+ * Impose our bulk-edit limitations on all registered post types that provide an admin UI
+ */
+function limit_bulk_edit_for_registered_post_types() {
+	$types = get_post_types( array(
+		'show_ui' => true,
+	) );
+
+	foreach ( $types as $type ) {
+		add_action( 'bulk_actions-edit-' . $type, __NAMESPACE__ . '\limit_bulk_edit' );
+	}
+}
+
+add_action( 'wp_loaded', __NAMESPACE__ . '\limit_bulk_edit_for_registered_post_types' );
+
+/**
+ * Suppress bulk actions when too many posts would be affected
+ *
+ * Often causes database issues when too many posts are modified,
+ * but since Core expects this to work with 20 posts, we limit to the same.
+ */
+function limit_bulk_edit( $bulk_actions ) {
+	$per_page = get_query_var( 'posts_per_page' );
+
+	// Core defaults to 20 posts per page
+	// If requesting more, or all entries, hide bulk actions
+	if ( $per_page > 20 || -1 === $per_page ) {
+		$bulk_actions = array();
+	}
+
+	return $bulk_actions;
+}

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -30,11 +30,9 @@ class Bulk_Edit {
 	 * but since Core expects this to work with 20 posts, we limit to the same.
 	 */
 	public static function limit_bulk_edit( $bulk_actions ) {
-		$posts_per_page = get_query_var( 'posts_per_page' );
-
 		// Core defaults to 20 posts per page
 		// If requesting more, hide bulk actions
-		if ( $posts_per_page > 20 ) {
+		if ( get_query_var( 'posts_per_page' ) > 20 ) {
 			$bulk_actions = array();
 		}
 

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -8,7 +8,8 @@ class Bulk_Edit {
 	 */
 	public static function register_hooks() {
 		add_action( 'load-edit.php', array( __CLASS__, 'defer_term_counting' ) );
-		add_action( 'bulk_actions-edit-post', array( __CLASS__, 'limit_bulk_edit' ) );
+
+		add_action( 'wp_loaded', array( __CLASS__, 'limit_bulk_edit_for_registered_post_types' ) );
 	}
 
 	/**
@@ -24,15 +25,30 @@ class Bulk_Edit {
 	}
 
 	/**
+	 * Impose our bulk-edit limitations on all registered post types that provide an admin UI
+	 */
+	public static function limit_bulk_edit_for_registered_post_types() {
+		$types = get_post_types( array(
+			'show_ui' => true,
+		) );
+
+		foreach ( $types as $type ) {
+			add_action( 'bulk_actions-edit-' . $type, array( __CLASS__, 'limit_bulk_edit' ) );
+		}
+	}
+
+	/**
 	 * Suppress bulk actions when too many posts would be affected
 	 *
 	 * Often causes database issues when too many posts are modified,
 	 * but since Core expects this to work with 20 posts, we limit to the same.
 	 */
 	public static function limit_bulk_edit( $bulk_actions ) {
+		$per_page = get_query_var( 'posts_per_page' );
+
 		// Core defaults to 20 posts per page
-		// If requesting more, hide bulk actions
-		if ( get_query_var( 'posts_per_page' ) > 20 ) {
+		// If requesting more, or all entries, hide bulk actions
+		if ( $per_page > 20 || -1 === $per_page ) {
 			$bulk_actions = array();
 		}
 

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -2,6 +2,9 @@
 
 namespace Automattic\VIP\Performance;
 
+// Core defaults to 20, so let's assume that's safe
+const BULK_EDIT_LIMIT = 20;
+
 /**
  * Bulk edits of lots of posts can trigger slow term count queries for each post updated
  */
@@ -24,7 +27,7 @@ function bulk_editing_is_limited() {
 
 	// Core defaults to 20 posts per page
 	// If requesting more--or all--entries, hide bulk actions
-	return $per_page > 20 || -1 === $per_page;
+	return $per_page > BULK_EDIT_LIMIT || -1 === $per_page;
 }
 
 /**
@@ -75,7 +78,7 @@ function bulk_edit_admin_notice() {
 
 	?>
 	<div id="<?php echo esc_attr( $id ); ?>" class="notice notice-error is-dismissible">
-		<p><?php _e( 'Bulk actions are disabled due to the number of items displayed in the table below.', 'wpcom-vip' ); ?></p>
+		<p><?php printf( __( 'Bulk actions are disabled because more than %s items were requested. Please adjust your setting under <em>Screen Options</em>.', 'wpcom-vip' ), number_format_i18n( BULK_EDIT_LIMIT ) ); ?></p>
 
 		<script>jQuery(document).ready( function($) { $( '#<?php echo esc_js( $id ); ?>' ).on( 'remove', function() {
 			$.ajax( {

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -11,3 +11,32 @@ add_action( 'load-edit.php', function() {
 		} );
 	}
 } );
+
+class Bulk_Edit {
+	/**
+	 * Generic callback to register class's hooks
+	 */
+	public static function register_hooks() {
+		add_action( 'bulk_actions-edit-post', array( __CLASS__, 'limit_bulk_edit' ) );
+	}
+
+	/**
+	 * Suppress bulk actions when too many posts would be affected
+	 *
+	 * Often causes database issues when too many posts are modified,
+	 * but since Core expects this to work with 20 posts, we limit to the same.
+	 */
+	public static function limit_bulk_edit( $bulk_actions ) {
+		$posts_per_page = get_query_var( 'posts_per_page' );
+
+		// Core defaults to 20 posts per page
+		// If requesting more, hide bulk actions
+		if ( $posts_per_page > 20 ) {
+			$bulk_actions = array();
+		}
+
+		return $bulk_actions;
+	}
+}
+
+Bulk_Edit::register_hooks();

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -2,24 +2,26 @@
 
 namespace Automattic\VIP\Performance;
 
-// Bulk edits of lots of posts can trigger slow term count queries for each post updated
-add_action( 'load-edit.php', function() {
-	if ( isset( $_REQUEST['bulk_edit'] ) ) {
-		wp_defer_term_counting( true );
-		add_action( 'shutdown', function() {
-			wp_defer_term_counting( false );
-		} );
-	}
-} );
-
 class Bulk_Edit {
 	/**
 	 * Generic callback to register class's hooks
 	 */
 	public static function register_hooks() {
+		add_action( 'load-edit.php', array( __CLASS__, 'defer_term_counting' ) );
 		add_action( 'bulk_actions-edit-post', array( __CLASS__, 'limit_bulk_edit' ) );
 	}
 
+	/**
+	 * Bulk edits of lots of posts can trigger slow term count queries for each post updated
+	 */
+	public static function defer_term_counting() {
+		if ( isset( $_REQUEST['bulk_edit'] ) ) {
+			wp_defer_term_counting( true );
+			add_action( 'shutdown', function() {
+				wp_defer_term_counting( false );
+			} );
+		}
+	}
 	/**
 	 * Suppress bulk actions when too many posts would be affected
 	 *


### PR DESCRIPTION
Bulk editing can have a considerable, negative impact on database servers, so by limiting the number of posts that can be processed at one time, the feature can be used without endangering stability.

WordPress is a little funny with this, and for hierarchical post types, uses a per-page value of `-1` to ensure all children can be nested under their parents. In that case, we block all bulk actions as there's no reliable way of knowing how many entries might be affected.