### PR TITLE
Prevent Jetpack version ping-pong on sandboxes

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -26,6 +26,13 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 	return $modules;
 }, 999 );
 
+// Prevent Jetpack version ping-pong when a sandbox has an old version of stacks
+if ( true === WPCOM_SANDBOXED ) {
+	add_action( 'updating_jetpack_version', function() {
+		wp_die( '😱😱😱 Oh no! Looks like your sandbox is trying to change the version of Jetpack. This is probably not a good idea. As a precaution, we\'re killing this request to prevent this from happening (this === 💥💥💥). Please run `vip stacks update` on your sandbox before doing anything else.', 400 );
+	}, 0 ); // No need to wait till priority 10 since we're going to die anyway
+}
+
 /**
  * Load Jetpack Force 2fa
  */


### PR DESCRIPTION
When a sandbox has an old version of stacks, this can lead to some serious issues because Jetpack tries to auto-correct the version on each load. The mismatch between the sandbox environment and live environment leads to a constant fight to override the option.

This just kills a request when an attempt to do a Jetpack version update is triggered from a sandbox.