### PR TITLE
Fix PHP notice from Akismet overrides

### DIFF
--- a/akismet.php
+++ b/akismet.php
@@ -15,7 +15,10 @@ require_once( __DIR__ . '/akismet/akismet.php' );
 
 // By default, Akismet tries to delete batches of 10,000 at a time.
 // That's way too high. Let's set a more reasonable limit.
-define( 'AKISMET_DELETE_LIMIT', 500 );
+function wpcom_vip_akismet_delete_limit( $limit ) {
+	return 500;
+}
+add_filter( 'akismet_delete_comment_limit', 'wpcom_vip_akismet_delete_limit' );
 
 // Identify outgoing requests as coming from VIP Go
 function wpcom_vip_akismet_ua( $ua ) {


### PR DESCRIPTION
Use filter instead of constant, since Akismet doesn't check if constant is already defined before defining its default.

`PHP Notice:  Constant AKISMET_DELETE_LIMIT already defined in /.../wp-content/mu-plugins/akismet.php on line 18`

See 46faf19 and #472