### PR TITLE
Don't track publish events during imports

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -11,7 +11,7 @@ if ( true === WPCOM_IS_VIP_ENV ) {
  * Count publish events regardless of post type
  */
 function track_publish_post( $new_status, $old_status ) {
-	if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+	if ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) {
 		return;
 	}
 

--- a/stats.php
+++ b/stats.php
@@ -3,7 +3,7 @@
 namespace Automattic\VIP\Stats;
 
 // Limit tracking to production
-if ( true === WPCOM_IS_VIP_ENV && ( ! defined( 'WP_IMPORTING' ) || ! WP_IMPORTING ) ) {
+if ( true === WPCOM_IS_VIP_ENV ) {
 	add_action( 'transition_post_status', __NAMESPACE__ . '\track_publish_post', 9999, 2 );
 }
 
@@ -11,6 +11,10 @@ if ( true === WPCOM_IS_VIP_ENV && ( ! defined( 'WP_IMPORTING' ) || ! WP_IMPORTIN
  * Count publish events regardless of post type
  */
 function track_publish_post( $new_status, $old_status ) {
+	if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+		return;
+	}
+
 	if ( 'publish' !== $new_status || 'publish' === $old_status ) {
 		return;
 	}

--- a/stats.php
+++ b/stats.php
@@ -3,7 +3,7 @@
 namespace Automattic\VIP\Stats;
 
 // Limit tracking to production
-if ( true === WPCOM_IS_VIP_ENV ) {
+if ( true === WPCOM_IS_VIP_ENV && ( ! defined( 'WP_IMPORTING' ) || ! WP_IMPORTING ) ) {
 	add_action( 'transition_post_status', __NAMESPACE__ . '\track_publish_post', 9999, 2 );
 }
 


### PR DESCRIPTION
The stat shouldn't be bumped when `WP_IMPORTING` is defined and `true`.