### PR TITLE
Kill AMP attachment lookups

### DIFF
--- a/performance.php
+++ b/performance.php
@@ -4,3 +4,4 @@ require_once( __DIR__ . '/performance/lastpostmodified.php' );
 require_once( __DIR__ . '/performance/bulk-edit.php' );
 require_once( __DIR__ . '/performance/vip-tweaks.php' );
 require_once( __DIR__ . '/performance/do-pings.php' );
+require_once( __DIR__ . '/performance/plugins.php' );

--- a/performance/plugins.php
+++ b/performance/plugins.php
@@ -1,0 +1,11 @@
+<?php
+
+// Plugin-specific tweaks go in here
+
+namespace Automattic\VIP\Performance;
+
+// AMP: disable reverse attachment lookups since they usually don't work (querystrings) and are slow
+// This is fixed in AMP > v0.4
+add_action( 'amp_extract_image_dimensions_callbacks_registered', function() {
+	remove_filter( 'amp_extract_image_dimensions', array( 'AMP_Image_Dimension_Extractor', 'extract_from_attachment_metadata' ) );
+} );


### PR DESCRIPTION
These are pretty slow on large sites and don't work well on Go anyway, since most images have querystrings attached. This feature has already been removed in the AMP plugin upstream and this is a workaround until that is rolled out everywhere.