### PR TITLE
Run phpcs on Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ phpcs:
 	test -d /tmp/phpcs || git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs
 	test -d /tmp/wpcs || git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /tmp/wpcs
 	/tmp/phpcs/scripts/phpcs --config-set installed_paths /tmp/wpcs
-	/tmp/phpcs/scripts/phpcs -p . --standard=WordPress --extensions=php --error-severity=6 --warning-severity=8 --ignore=shared-plugins/*,advanced-post-cache/*,cron-control/*,debug-bar-cron/*,cron-control/*,jetpack/*,vaultpress/*,debug-bar/*,akismet/*,http-concat/*,query-monitor/*,rewrite-rules-inspector/*,vip-dashboard/*,vip-support/*,wp-cron-control/*,wordpress-importer/*
+	/tmp/phpcs/scripts/phpcs -p . --standard=WordPress --extensions=php --runtime-set ignore_warnings_on_exit true --ignore=shared-plugins/*,advanced-post-cache/*,cron-control/*,debug-bar-cron/*,cron-control/*,jetpack/*,vaultpress/*,debug-bar/*,akismet/*,http-concat/*,query-monitor/*,rewrite-rules-inspector/*,vip-dashboard/*,vip-support/*,wp-cron-control/*,wordpress-importer/*
 
 phpcbf:
 	test -d /tmp/phpcs || git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,13 @@ phpcs:
 	test -d /tmp/phpcs || git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs
 	test -d /tmp/wpcs || git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /tmp/wpcs
 	/tmp/phpcs/scripts/phpcs --config-set installed_paths /tmp/wpcs
-	/tmp/phpcs/scripts/phpcs -p . --standard=WordPress --extensions=php --runtime-set ignore_warnings_on_exit true --ignore=shared-plugins/*,advanced-post-cache/*,cron-control/*,debug-bar-cron/*,cron-control/*,jetpack/*,vaultpress/*,debug-bar/*,akismet/*,http-concat/*,query-monitor/*,rewrite-rules-inspector/*,vip-dashboard/*,vip-support/*,wp-cron-control/*,wordpress-importer/*
+	/tmp/phpcs/scripts/phpcs -p .
 
 phpcbf:
 	test -d /tmp/phpcs || git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs
 	test -d /tmp/wpcs || git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /tmp/wpcs
 	/tmp/phpcs/scripts/phpcs --config-set installed_paths /tmp/wpcs
-	/tmp/phpcs/scripts/phpcbf -p . --standard=WordPress --extensions=php --ignore=shared-plugins/*,advanced-post-cache/*,cron-control/*,debug-bar-cron/*,cron-control/*,jetpack/*,vaultpress/*,debug-bar/*,akismet/*,http-concat/*,query-monitor/*,rewrite-rules-inspector/*,vip-dashboard/*,vip-support/*,wp-cron-control/*,wordpress-importer/*
+	/tmp/phpcs/scripts/phpcbf -p .
+
+clean:
+	rm -rf /tmp/phpcs /tmp/wpcs

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: lint phpunit phpdoc
+.PHONY: lint phpunit phpdoc phpcs phpcbf
 
-test: lint phpunit
+test: lint phpunit phpcs
 
 lint:
 	find . -name \*.php -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -d display_errors=stderr -l > /dev/null
@@ -10,3 +10,15 @@ phpunit:
 
 phpdoc:
 	phpdoc run --no-interaction
+
+phpcs:
+	test -d /tmp/phpcs || git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs
+	test -d /tmp/wpcs || git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /tmp/wpcs
+	/tmp/phpcs/scripts/phpcs --config-set installed_paths /tmp/wpcs
+	/tmp/phpcs/scripts/phpcs -p . --standard=WordPress --extensions=php --error-severity=6 --warning-severity=8 --ignore=shared-plugins/*,advanced-post-cache/*,cron-control/*,debug-bar-cron/*,cron-control/*,jetpack/*,vaultpress/*,debug-bar/*,akismet/*,http-concat/*,query-monitor/*,rewrite-rules-inspector/*,vip-dashboard/*,vip-support/*,wp-cron-control/*,wordpress-importer/*
+
+phpcbf:
+	test -d /tmp/phpcs || git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs
+	test -d /tmp/wpcs || git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /tmp/wpcs
+	/tmp/phpcs/scripts/phpcs --config-set installed_paths /tmp/wpcs
+	/tmp/phpcs/scripts/phpcbf -p . --standard=WordPress --extensions=php --ignore=shared-plugins/*,advanced-post-cache/*,cron-control/*,debug-bar-cron/*,cron-control/*,jetpack/*,vaultpress/*,debug-bar/*,akismet/*,http-concat/*,query-monitor/*,rewrite-rules-inspector/*,vip-dashboard/*,vip-support/*,wp-cron-control/*,wordpress-importer/*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ PHP Linting and PHP Unit tests are run by Travis, see the `script` section of [`
 
 For notes on running tests locally, see [README-PUBLIC.md](README-PUBLIC.md).
 
+## PHPCS
+
+As part of the continuous integration process, we run the WordPress-VIP PHP Codesniffer suite. PHPCS includes a tool, phpcbf, to automatically fix some types of errors. We recommend running this with `make phpcbf` or installing a plugin for your text editor which will run it automatically on save.
+
 ## Deployment
 
 When the tests have been successfully run, the [`deploy.sh` script](https://github.com/Automattic/vip-go-mu-plugins/blob/master/ci/deploy.sh) deploys a build of this repository and it's submodules to the public repository at [Automattic/vip-mu-plugins-public](https://github.com/Automattic/vip-mu-plugins-public/).

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="VIP-Go-mu-plugins">
+	<description>VIP Go mu-plugins</description>
+
+	<config name="ignore_warnings_on_exit">true</config>
+
+	<exclude-pattern>.git/*</exclude-pattern>
+	<exclude-pattern>advanced-post-cache/*</exclude-pattern>
+	<exclude-pattern>akismet/*</exclude-pattern>
+	<exclude-pattern>cron-control/*</exclude-pattern>
+	<exclude-pattern>debug-bar-cron/*</exclude-pattern>
+	<exclude-pattern>debug-bar/*</exclude-pattern>
+	<exclude-pattern>http-concat/*</exclude-pattern>
+	<exclude-pattern>jetpack/*</exclude-pattern>
+	<exclude-pattern>query-monitor/*</exclude-pattern>
+	<exclude-pattern>rewrite-rules-inspector/*</exclude-pattern>
+	<exclude-pattern>shared-plugins/*</exclude-pattern>
+	<exclude-pattern>vaultpress/*</exclude-pattern>
+	<exclude-pattern>vip-dashboard/*</exclude-pattern>
+	<exclude-pattern>vip-support/*</exclude-pattern>
+	<exclude-pattern>wordpress-importer/*</exclude-pattern>
+	<exclude-pattern>wp-cron-control/*</exclude-pattern>
+
+	<rule ref="WordPress-VIP"/>
+</ruleset>


### PR DESCRIPTION
Initial effort to start enforcing PHPCS. The thresholds (`--error-severity`, `--warning-severity`) are currently set such that all existing code passes. I think we'd eventually want to dial these down until we're flagging all errors, at least.

The phpcbf target will do some automated fixing and you can also configure your editor to run phpcbf automatically, though probably after we get the existing errors fixed.