### PR TITLE
Force disable dev mode for Photon

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -68,6 +68,10 @@ class A8C_Files {
 			return home_url();
 		} );
 
+		// If Jetpack dev mode is enabled, jetpack_photon_url is short-circuited.
+		// This results in all images being full size (which is not ideal)
+		add_filter( 'jetpack_photon_development_mode', '__return_false', 9999 );
+
 		// The sizes metadata is not used and mostly useless on Go so let's empty it out.
 		// This may need some revisiting for `srcset` handling.
 		add_filter( 'wp_get_attachment_metadata', function( $data, $post_id ) {


### PR DESCRIPTION
When using Jetpack Photon with Jetpack dev mode enabled, we end up with full size images everywhere enabled because jetpack_photon_url is short-circuited.

By force disabling dev mode for Photon, we can work around this.