### PR TITLE
Fallback to Go image_downsize for is_admin

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -47,17 +47,9 @@ class A8C_Files {
 		// This will be phased out and become the default eventually.
 		$use_jetpack_photon = $this->use_jetpack_photon();
 		if ( $use_jetpack_photon ) {
-			// The files service has Photon capabilities, but is served from the same domain.
-			// Force Jetpack to use it instead of the default Photon domains (`i*.wp.com`).
-			add_filter( 'jetpack_photon_domain', function() {
-				return home_url();
-			} );
-
-			// If Photon isn't active, we need to init the necessary filters.
-			// This takes care of rewriting intermediate images for us.
-			Jetpack_Photon::instance();
+			$this->init_jetpack_photon_filters();
 		} else {
-			add_filter( 'image_downsize', array( &$this, 'image_resize' ), 5, 3 ); // Ensure this runs before Jetpack, when Photon is active
+			$this->init_vip_photon_filters();
 		}
 
 		// Automatic creation of intermediate image sizes is disabled via `wpcom_intermediate_sizes()`
@@ -69,7 +61,23 @@ class A8C_Files {
 		add_filter( 'option_upload_url_path', array( $this, 'upload_url_path' ), 10, 2 );
 	}
 
-	function use_jetpack_photon() {
+	private function init_jetpack_photon_filters() {
+		// The files service has Photon capabilities, but is served from the same domain.
+		// Force Jetpack to use it instead of the default Photon domains (`i*.wp.com`).
+		add_filter( 'jetpack_photon_domain', function() {
+			return home_url();
+		} );
+
+		// If Photon isn't active, we need to init the necessary filters.
+		// This takes care of rewriting intermediate images for us.
+		Jetpack_Photon::instance();
+	}
+
+	private function init_vip_photon_filters() {
+		add_filter( 'image_downsize', array( &$this, 'image_resize' ), 5, 3 ); // Ensure this runs before Jetpack, when Photon is active
+	}
+
+	private function use_jetpack_photon() {
 		if (  defined( 'WPCOM_VIP_USE_JETPACK_PHOTON' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON ) {
 			return true;
 		}

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -68,10 +68,11 @@ class A8C_Files {
 			return home_url();
 		} );
 
-		// The sizes metadata is not used and mostly useless on Go so let's strip it out.
+		// The sizes metadata is not used and mostly useless on Go so let's empty it out.
+		// This may need some revisiting for `srcset` handling.
 		add_filter( 'wp_get_attachment_metadata', function( $data, $post_id ) {
 			if ( isset( $data['sizes'] ) ) {
-				unset( $data['sizes'] );
+				$data['sizes'] = array();
 			}
 			return $data;
 		}, 10, 2 );

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -68,6 +68,14 @@ class A8C_Files {
 			return home_url();
 		} );
 
+		// The sizes metadata is not used and mostly useless on Go so let's strip it out.
+		add_filter( 'wp_get_attachment_metadata', function( $data, $post_id ) {
+			if ( isset( $data['sizes'] ) ) {
+				unset( $data['sizes'] );
+			}
+			return $data;
+		}, 10, 2 );
+
 		// If Photon isn't active, we need to init the necessary filters.
 		// This takes care of rewriting intermediate images for us.
 		Jetpack_Photon::instance();

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -79,6 +79,12 @@ class A8C_Files {
 		// If Photon isn't active, we need to init the necessary filters.
 		// This takes care of rewriting intermediate images for us.
 		Jetpack_Photon::instance();
+
+		// Jetpack_Photon's downsize filter doesn't run when is_admin(), so we need to fallback to the Go filters.
+		// This is temporary until Jetpack allows more easily running these filters for is_admin().
+		if ( is_admin() ) {
+			$this->init_vip_photon_filters();
+		}
 	}
 
 	private function init_vip_photon_filters() {


### PR DESCRIPTION
Continued from #515

Jetpack Photon's filters aren't currently supported for the Dashboard so all images end up full size since we don't allow intermediate sizes (and there is nothing else dynamically resizing them).

Until Jetpack allows using Photon in the admin (https://github.com/Automattic/jetpack/pull/6702), we can just fallback to Go's image downsize behaviour.