### PR TITLE
Add wp-cli command to remove `sizes` metadata

### DIFF
--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -115,8 +115,8 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 				if ( isset( $metadata['sizes'] ) ) {
 					WP_CLI::line( '--> removing `sizes` metadata' );
 
-					unset( $metadata['sizes'] );
-					//wp_update_attachment_metadata( $attachment_id, $metadata );
+					$metadata['sizes'] = array();
+					wp_update_attachment_metadata( $attachment_id, $metadata );
 				}
 			}
 


### PR DESCRIPTION
The data is not very useful on Go sites since all intermediate images are dynamically generated.

Related #515 and #523 (although this conflicts/breaks with the `wp_get_attachment_metadata` filter in the latter).