### PR TITLE
Add function to remove core's meta_key INDEX

### DIFF
--- a/schema.php
+++ b/schema.php
@@ -27,3 +27,9 @@ function get_postmeta_key_value_index() {
 	// 100 for meta_value is arbitrary-ish.
 	return '`vip_meta_key_value` (`meta_key`(191), `meta_value`(100))';
 }
+
+function remove_core_meta_key_index() {
+	// TODO: need to find someway to fire this after dbDelta
+	global $wpdb;
+	return $wpdb->query( "ALTER ONLINE TABLE $this->postmeta DROP INDEX `meta_key`" );
+}


### PR DESCRIPTION
dbDelta does not drop indexes so we need to do it manually.

TODO: 
- [ ] Find a way to automagically call this after `dbDelta`

Related #445