### PR TITLE
Customize install defaults

### DIFF
--- a/wp-install-defaults.php
+++ b/wp-install-defaults.php
@@ -4,17 +4,60 @@
  * Description: Set default values during install
  */
 
+if ( ! function_exists( 'wp_install_defaults' ) ) :
 /**
  * Generic handler for any install defaults
  */
 function wp_install_defaults( $user_id ) {
 	do_action( 'wpcom_vip_install_defaults', $user_id );
 }
+endif;
 
 /**
- * Replicate the minimums needed from Core, such as the default category
+ * Replicate the minimum install defaults needed from Core
+ * Duplicated from Core's `wp_install_defaults()` as needed
+ *
+ * Excludes the default post, comment, and page
  */
-function wp_install_defaults_from_core( $user_id ) {
+function wpcom_vip_install_defaults_from_core( $user_id ) {
+	global $wpdb, $wp_rewrite, $table_prefix;
+
 	// Default category
+	$cat_name = __('Uncategorized');
+	/* translators: Default category slug */
+	$cat_slug = sanitize_title(_x('Uncategorized', 'Default category slug'));
+
+	if ( global_terms_enabled() ) {
+		$cat_id = $wpdb->get_var( $wpdb->prepare( "SELECT cat_ID FROM {$wpdb->sitecategories} WHERE category_nicename = %s", $cat_slug ) );
+		if ( $cat_id == null ) {
+			$wpdb->insert( $wpdb->sitecategories, array('cat_ID' => 0, 'cat_name' => $cat_name, 'category_nicename' => $cat_slug, 'last_updated' => current_time('mysql', true)) );
+			$cat_id = $wpdb->insert_id;
+		}
+		update_option('default_category', $cat_id);
+	} else {
+		$cat_id = 1;
+	}
+
+	$wpdb->insert( $wpdb->terms, array('term_id' => $cat_id, 'name' => $cat_name, 'slug' => $cat_slug, 'term_group' => 0) );
+	$wpdb->insert( $wpdb->term_taxonomy, array('term_id' => $cat_id, 'taxonomy' => 'category', 'description' => '', 'parent' => 0, 'count' => 0));
+	$cat_tt_id = $wpdb->insert_id;
+
+	// Multisite love
+	if ( is_multisite() ) {
+		// Flush rules to pick up the new page.
+		$wp_rewrite->init();
+		$wp_rewrite->flush_rules();
+
+		$user = new WP_User($user_id);
+		$wpdb->update( $wpdb->options, array('option_value' => $user->user_email), array('option_name' => 'admin_email') );
+
+		// Remove all perms except for the login user.
+		$wpdb->query( $wpdb->prepare("DELETE FROM $wpdb->usermeta WHERE user_id != %d AND meta_key = %s", $user_id, $table_prefix.'user_level') );
+		$wpdb->query( $wpdb->prepare("DELETE FROM $wpdb->usermeta WHERE user_id != %d AND meta_key = %s", $user_id, $table_prefix.'capabilities') );
+
+		// Delete any caps that snuck into the previously active blog. (Hardcoded to blog 1 for now.) TODO: Get previous_blog_id.
+		if ( !is_super_admin( $user_id ) && $user_id != 1 )
+			$wpdb->delete( $wpdb->usermeta, array( 'user_id' => $user_id , 'meta_key' => $wpdb->base_prefix.'1_capabilities' ) );
+	}
 }
-add_action( 'wpcom_vip_install_defaults', 'wp_install_defaults_from_core' );
+add_action( 'wpcom_vip_install_defaults', 'wpcom_vip_install_defaults_from_core' );

--- a/wp-install-defaults.php
+++ b/wp-install-defaults.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Plugin Name: Install Defaults
+ * Description: Set default values during install
+ */
+
+/**
+ * Generic handler for any install defaults
+ */
+function wp_install_defaults( $user_id ) {
+	do_action( 'wpcom_vip_install_defaults', $user_id );
+}
+
+/**
+ * Replicate the minimums needed from Core, such as the default category
+ */
+function wp_install_defaults_from_core( $user_id ) {
+	// Default category
+}
+add_action( 'wpcom_vip_install_defaults', 'wp_install_defaults_from_core' );


### PR DESCRIPTION
* Stop creating the default post, comment, and page
* Allow other code to initialize itself during install

The `function_exists` check is a necessary quirk of Core. Without it, our `wp_install_defaults()` runs during install, but then causes a "cannot redeclare" fatal error once WP is installed.

Also worth noting that the contents of `wpcom_vip_install_defaults_from_core()`, with the exception of the `// Multisite love` line, are verbatim from Core's `wp_install_defaults()`. Hence the curiosities like `global_terms_enabled()`.