### PR TITLE
Strip dimensions from intermediate images in the_content

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -81,6 +81,8 @@ class A8C_Files {
 			return $data;
 		}, 10, 2 );
 
+		
+
 		// If Photon isn't active, we need to init the necessary filters.
 		// This takes care of rewriting intermediate images for us.
 		Jetpack_Photon::instance();
@@ -717,6 +719,27 @@ class A8C_Files {
 		return array( $img_url, $w, $h, $resized );
 	}
 
+}
+
+class A8C_Files_Utils {
+	public static function strip_dimensions_from_url_path( $url ) {
+		$path = parse_url( $image_url, PHP_URL_PATH );
+
+		if ( ! $path ) {
+			return $image_url;
+		}
+
+		// Look for images ending with something like `-100x100.jpg`.
+		// We include the period in the dimensions match to avoid double string replacing when the file looks something like `image-100x100-100x100.png` (we only catch the latter dimensions).
+		$matched = preg_match( '#(-\d+x\d+\.)(jpg|jpeg|png|gif)$#i', $image_url, $parts );
+		if ( $matched ) {
+			// Strip off the dimensions and return the image
+			$updated_url = str_replace( $parts[1], '.', $image_url );
+			return $updated_url;
+		}
+
+		return $image_url;
+	}	
 }
 
 function a8c_files_init() {

--- a/tests/a8c-files-utils.php
+++ b/tests/a8c-files-utils.php
@@ -1,0 +1,61 @@
+<?php
+
+class VIP_Go_A8C_Files_Utils_Test extends WP_UnitTestCase {
+	public function get_data_for_strip_dimensions_from_url_path() {
+		return [
+			'invalid-url' => [
+				'invalid-url',
+				'invalid-url',
+			],
+
+			'no-dimensions' => [
+				'https://example.com/wp-content/uploads/image.jpg',
+				'https://example.com/wp-content/uploads/image.jpg',
+			],
+
+			'dimensions-jpg' => [
+				'https://example.com/wp-content/uploads/image-800x400.jpg',
+				'https://example.com/wp-content/uploads/image.jpg',
+			],
+
+			'dimensions-png' => [
+				'https://example.com/wp-content/uploads/image-800x400.png',
+				'https://example.com/wp-content/uploads/image.png',
+			],
+
+			'dimensions-gif' => [
+				'https://example.com/wp-content/uploads/image-800x400.gif',
+				'https://example.com/wp-content/uploads/image.gif',
+			],
+
+			'dimensions-jpeg' => [
+				'https://example.com/wp-content/uploads/image-800x400.jpeg',
+				'https://example.com/wp-content/uploads/image.jpeg',
+			],
+
+			'dimensions-jpg-case-insensitive' => [
+				'https://example.com/wp-content/uploads/Image-800x400.jPg',
+				'https://example.com/wp-content/uploads/Image.jPg',
+			],
+
+			'double-dimensions' => [
+				'https://example.com/wp-content/uploads/image-800x400-350x120.jpg',
+				'https://example.com/wp-content/uploads/image-800x400.jpg',
+			],
+
+			'double-same-dimensions' => [
+				'https://example.com/wp-content/uploads/image-400x400-400x400.jpg',
+				'https://example.com/wp-content/uploads/image-400x400.jpg',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_data_for_strip_dimensions_from_url_path
+	 */
+	public function test__strip_dimensions_from_url_path( $source, $expected ) {
+		$actual = A8C_Files_Utils::strip_dimensions_from_url_path( $source );
+
+		$this->assertEquals( $actual, $expected );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,7 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	require __DIR__ . '/../000-vip-init.php';
 	require __DIR__ . '/../001-core.php';
+	require __DIR__ . '/../a8c-files.php';
 	require __DIR__ . '/../performance.php';
 
 	require __DIR__ . '/../schema.php';

--- a/tests/test-a8c-files-utils.php
+++ b/tests/test-a8c-files-utils.php
@@ -47,6 +47,11 @@ class VIP_Go_A8C_Files_Utils_Test extends WP_UnitTestCase {
 				'https://example.com/wp-content/uploads/image-400x400-400x400.jpg',
 				'https://example.com/wp-content/uploads/image-400x400.jpg',
 			],
+
+			'dimensions-with-querystring' => [
+				'https://example.com/wp-content/uploads/image-400x450.png?resize=338%2C600&strip=all',
+				'https://example.com/wp-content/uploads/image.png?resize=338%2C600&strip=all',
+			],
 		];
 	}
 


### PR DESCRIPTION
Jetpack's [dimension stripping](https://github.com/Automattic/jetpack/blob/master/class.photon.php#L867-L874) doesn't quite work for us since it requires `file_exists` lookups. For now, filter `the_content` to strip out the dimensions from image file names.