### PR TITLE
Prevent core from doing filename lookups

### DIFF
--- a/performance.php
+++ b/performance.php
@@ -4,4 +4,5 @@ require_once( __DIR__ . '/performance/lastpostmodified.php' );
 require_once( __DIR__ . '/performance/bulk-edit.php' );
 require_once( __DIR__ . '/performance/vip-tweaks.php' );
 require_once( __DIR__ . '/performance/do-pings.php' );
+require_once( __DIR__ . '/performance/media.php' );
 require_once( __DIR__ . '/performance/plugins.php' );

--- a/performance/media.php
+++ b/performance/media.php
@@ -1,0 +1,7 @@
+<?php
+
+// Prevent core from doing filename lookups for media search.
+// https://core.trac.wordpress.org/ticket/39358
+add_action( 'pre_get_posts', function() {
+	remove_filter( 'post_clauses', '_filter_query_attachment_filenames' );
+} );


### PR DESCRIPTION
For media search. This results in meta queries that are super slow on large sites and can take upwards of 30+ seconds for search.

see https://core.trac.wordpress.org/ticket/39358

Fixes #545 