### PR TITLE
Print whole command to add user to shadow blog

### DIFF
--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -80,7 +80,11 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 			if ( false !== strpos( $message, self::API_ERROR_EXISTING_SUBSCRIPTION ) ) {
 				$message = 'There is an existing Jetpack Start subcription for this site. Please disconnect using the `cancel` subcommand and try again.';
 			} elseif ( false !== strpos( $message, self::API_ERROR_USER_PERMISSIONS ) ) {
-				$message = sprintf( 'This site already has an existing Jetpack shadow site but the `%s` is not an administrator on it.' . PHP_EOL . 'From within `wp shell` on your WPCom sandbox: `add_user_to_blog( %d, get_user_by( "login", "wpcomvip" )->ID, "administrator" ); `', WPCOM_VIP_MACHINE_USER_LOGIN, Jetpack_Options::get_option( 'id' ) );
+                                $jetpack_shadow_site_id = Jetpack_Options::get_option( 'id' );
+                                if ( false === $jetpack_shadow_site_id ) {
+                                        $jetpack_shadow_site_id = '%JETPACK_SHADOW_SITE_ID%';
+                                }
+                                $message = sprintf( 'This site already has an existing Jetpack shadow site but the `%s` is not an administrator on it.' . PHP_EOL . 'From within `wp shell` on your WPCom sandbox: `add_user_to_blog( %d, get_user_by( "login", "wpcomvip" )->ID, "administrator" ); `', WPCOM_VIP_MACHINE_USER_LOGIN, $jetpack_shadow_site_id );
 			}
 			WP_CLI::error( 'Failed to fetch keys from Jetpack Start: ' . $message );
 		}

--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -80,7 +80,7 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 			if ( false !== strpos( $message, self::API_ERROR_EXISTING_SUBSCRIPTION ) ) {
 				$message = 'There is an existing Jetpack Start subcription for this site. Please disconnect using the `cancel` subcommand and try again.';
 			} elseif ( false !== strpos( $message, self::API_ERROR_USER_PERMISSIONS ) ) {
-				$message = sprintf( 'This site already has an existing Jetpack shadow site but the `%s` WP.com user is either not a member of the site or not an administrator. Please use `add_user_to_blog` on your WP.com sandbox to add the account before continuing.', WPCOM_VIP_MACHINE_USER_LOGIN );
+				$message = sprintf( 'This site already has an existing Jetpack shadow site but the `%s` is not an administrator on it.' . PHP_EOL . 'From within `wp shell` on your WPCom sandbox: `add_user_to_blog( %d, get_user_by( "login", "wpcomvip" )->ID, "administrator" ); `', WPCOM_VIP_MACHINE_USER_LOGIN, Jetpack_Options::get_option( 'id' ) );
 			}
 			WP_CLI::error( 'Failed to fetch keys from Jetpack Start: ' . $message );
 		}


### PR DESCRIPTION
Output looks like this:

``` bash
# wp --allow-root jetpack-start connect --force --url=https://example.go-vip.co/nl/;
-- Verifying VIP machine user exists (or creating one, if not)
-- Fetching keys from Jetpack Start API
Error: Failed to fetch keys from Jetpack Start: This site already has an existing Jetpack shadow site but the `wpcomvip` is not an administrator on it.
From within `wp shell` on your WPCom sandbox: `add_user_to_blog( 12345, get_user_by( "login", "wpcomvip" )->ID, "administrator" ); `
```