### PR TITLE
Allow remote images to be served from Photon

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -63,10 +63,16 @@ class A8C_Files {
 
 	private function init_jetpack_photon_filters() {
 		// The files service has Photon capabilities, but is served from the same domain.
-		// Force Jetpack to use it instead of the default Photon domains (`i*.wp.com`).
-		add_filter( 'jetpack_photon_domain', function() {
-			return home_url();
-		} );
+		// Force Jetpack to use the files service instead of the default Photon domains (`i*.wp.com`) for internal files.
+		// Externally hosted files continue to use the remot Photon service.
+		add_filter( 'jetpack_photon_domain', function( $photon_url, $image_url ) {
+			$home_url = home_url();
+			if ( wp_startswith( $image_url, $home_url ) ) {
+				return $home_url;
+			}
+
+			return $photon_url;
+		}, 10, 2 );
 
 		// If Jetpack dev mode is enabled, jetpack_photon_url is short-circuited.
 		// This results in all images being full size (which is not ideal)

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -737,9 +737,9 @@ class A8C_Files_Utils {
 				return $home_url;
 			}
 
-			$image_host = parse_url( $image_url, PHP_URL_HOST );
-			if ( wp_endswith( $image_host, '.go-vip.co' ) ) {
-				return $image_host;
+			$image_url_parsed = parse_url( $image_url );
+			if ( wp_endswith( $image_url_parsed['host'], '.go-vip.co' ) ) {
+				return $image_url_parsed['scheme'] . '://' . $image_url_parsed['host'];
 			}
 
 			return $photon_url;

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -65,14 +65,7 @@ class A8C_Files {
 		// The files service has Photon capabilities, but is served from the same domain.
 		// Force Jetpack to use the files service instead of the default Photon domains (`i*.wp.com`) for internal files.
 		// Externally hosted files continue to use the remot Photon service.
-		add_filter( 'jetpack_photon_domain', function( $photon_url, $image_url ) {
-			$home_url = home_url();
-			if ( wp_startswith( $image_url, $home_url ) ) {
-				return $home_url;
-			}
-
-			return $photon_url;
-		}, 10, 2 );
+		add_filter( 'jetpack_photon_domain', [ 'A8C_Files_Utils', 'filter_photon_domain' ], 10, 2 );
 
 		// If Jetpack dev mode is enabled, jetpack_photon_url is short-circuited.
 		// This results in all images being full size (which is not ideal)
@@ -738,6 +731,20 @@ class A8C_Files {
 }
 
 class A8C_Files_Utils {
+	public static function filter_photon_domain( $photon_url, $image_url ) {
+			$home_url = home_url();
+			if ( wp_startswith( $image_url, $home_url ) ) {
+				return $home_url;
+			}
+
+			$image_host = parse_url( $image_url, PHP_URL_HOST );
+			if ( wp_endswith( $image_host, '.go-vip.co' ) ) {
+				return $image_host;
+			}
+
+			return $photon_url;
+	}
+
 	public static function strip_dimensions_from_url_path( $url ) {
 		$path = parse_url( $url, PHP_URL_PATH );
 

--- a/tests/test-a8c-files-utils.php
+++ b/tests/test-a8c-files-utils.php
@@ -1,6 +1,38 @@
 <?php
 
 class VIP_Go_A8C_Files_Utils_Test extends WP_UnitTestCase {
+	public function get_data_for_filter_photon_domain() {
+		return [
+			'image_on_home_url' => [
+				'http://example.com/image.jpg',
+				'http://example.com',
+			],
+
+			'image_on_go-vip_url' => [
+				'http://example.go-vip.co/image.jpg',
+				'http://example.go-vip.co',
+			],
+
+			'image_on_external_url' => [
+				'http://external-url.com/image.jpg',
+				'http://i0.wp.com',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_data_for_filter_photon_domain
+	 */
+	public function test__filter_photon_domain( $image_url, $expected_photon_url ) {
+		add_filter( 'home_url', function() {
+			return 'http://example.com';
+		} );
+
+		$actual_photon_url = A8C_Files_Utils::filter_photon_domain( 'http://i0.wp.com', $image_url );
+
+		$this->assertEquals( $expected_photon_url, $actual_photon_url );
+	}
+
 	public function get_data_for_strip_dimensions_from_url_path() {
 		return [
 			'invalid-url' => [
@@ -61,6 +93,6 @@ class VIP_Go_A8C_Files_Utils_Test extends WP_UnitTestCase {
 	public function test__strip_dimensions_from_url_path( $source, $expected ) {
 		$actual = A8C_Files_Utils::strip_dimensions_from_url_path( $source );
 
-		$this->assertEquals( $actual, $expected );
+		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
Otherwise passing those URLs through `jetpack_photon_url` ends up attempting to serve the image through the Go Files service, which does not work.

Without the patch (and with `WPCOM_VIP_USE_JETPACK_PHOTON` enabled), passing a remote image through a site ends up with the domain: `https://example.go-vip.co/example.com/wp-content/file.jpg`. With the patch, we get a correct Photon URL: `https://i0.wp.com/example.com/wp-content/file.jpg`