### PR TITLE
Run the `wpcom_vip_set_old_slug_redirect_cache` early 

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -660,7 +660,8 @@ function wpcom_vip_wp_old_slug_redirect() {
 		$redirect = wp_cache_get( 'old_slug' . $wp_query->query_vars['name'] );
 
 		if ( false === $redirect ) {
-			add_filter( 'old_slug_redirect_url', 'wpcom_vip_set_old_slug_redirect_cache', 9999, 1 );
+			// Run the caching callback as the very firts one in order to capture the value returned by WordPress from database. This allows devs from using `old_slug_redirect_url` filter w/o polluting the cache
+			add_filter( 'old_slug_redirect_url', 'wpcom_vip_set_old_slug_redirect_cache', -9999, 1 );
 			// If an old slug is not found the function returns early and does not apply the old_slug_redirect_url filter. so we will set the cache for not found and if it is found it will be overwritten later in wpcom_vip_set_old_slug_redirect_cache()
 			wp_cache_set( 'old_slug' . $wp_query->query_vars['name'], 'not_found', 'default', 12 * HOUR_IN_SECONDS + mt_rand( 0, 12 * HOUR_IN_SECONDS ) );
 		} elseif ( 'not_found' === $redirect ) {
@@ -668,6 +669,8 @@ function wpcom_vip_wp_old_slug_redirect() {
 			remove_action( 'template_redirect', 'wp_old_slug_redirect' );
 			return;
 		} else {
+			/** This filter is documented in wp-includes/query.php. */
+			$redirect = apply_filters( 'old_slug_redirect_url', $redirect );
 			wp_redirect( $redirect, 301 ); // this is kept to not safe_redirect to match the functionality of wp_old_slug_redirect
 			exit;
 		}

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -660,7 +660,7 @@ function wpcom_vip_wp_old_slug_redirect() {
 		$redirect = wp_cache_get( 'old_slug' . $wp_query->query_vars['name'] );
 
 		if ( false === $redirect ) {
-			add_filter( 'old_slug_redirect_url', 'wpcom_vip_set_old_slug_redirect_cache' );
+			add_filter( 'old_slug_redirect_url', 'wpcom_vip_set_old_slug_redirect_cache', 9999, 1 );
 			// If an old slug is not found the function returns early and does not apply the old_slug_redirect_url filter. so we will set the cache for not found and if it is found it will be overwritten later in wpcom_vip_set_old_slug_redirect_cache()
 			wp_cache_set( 'old_slug' . $wp_query->query_vars['name'], 'not_found', 'default', 12 * HOUR_IN_SECONDS + mt_rand( 0, 12 * HOUR_IN_SECONDS ) );
 		} elseif ( 'not_found' === $redirect ) {


### PR DESCRIPTION
By running our callback as the very first one, we would capture the value returend from the database. That means custom callbacks to `old_slug_redirect_url` run on any later callback won't pollute the cache.

By adding the `apply_filters( 'old_slug_redirect_url', $redirect )` call to before the custom `wp_redirect` one the plugin now actually makes any custom callbacks working on cached old slug redirects.