### PR TITLE
Fix typo in filter name

### DIFF
--- a/performance/media.php
+++ b/performance/media.php
@@ -3,5 +3,5 @@
 // Prevent core from doing filename lookups for media search.
 // https://core.trac.wordpress.org/ticket/39358
 add_action( 'pre_get_posts', function() {
-	remove_filter( 'post_clauses', '_filter_query_attachment_filenames' );
+	remove_filter( 'posts_clauses', '_filter_query_attachment_filenames' );
 } );


### PR DESCRIPTION
Causing the filter to not be removed correctly.