### PR TITLE
Don't skip empty events, as it causes them to be rescheduled infinitely

### DIFF
--- a/001-cron.php
+++ b/001-cron.php
@@ -34,7 +34,7 @@ function wpcom_vip_use_core_cron() {
  *
  * Functionality will be fixed or removed, but this stops the runaway event creation in the meantime
  */
-add_action( 'a8c_cron_control_run_event_with_no_callbacks', '__return_true' );
+add_filter( 'a8c_cron_control_run_event_with_no_callbacks', '__return_true' );
 
 /**
  * Should Cron Control load

--- a/001-cron.php
+++ b/001-cron.php
@@ -30,6 +30,13 @@ function wpcom_vip_use_core_cron() {
 }
 
 /**
+ * Don't skip empty events, as it causes them to be rescheduled infinitely
+ *
+ * Functionality will be fixed or removed, but this stops the runaway event creation in the meantime
+ */
+add_action( 'a8c_cron_control_run_event_with_no_callbacks', '__return_true' );
+
+/**
  * Should Cron Control load
  */
 if ( ! wpcom_vip_use_core_cron() ) {


### PR DESCRIPTION
For "efficiency" reasons, Cron Control skips events whose actions have no callbacks. Unfortunately, this causes some jobs to be rescheduled infinitely. This functionality will be fixed or removed upstream, but this stops the runaway event creation in the meantime.