### PR TITLE
Include our helpers for any network or site plugins loaded outside of our custom methods

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1097,8 +1097,6 @@ add_action( 'muplugins_loaded', 'wpcom_vip_load_helpers_for_network_active_plugi
 /**
  * Load `vipgo-helper.php` if it exists for a plugin loaded outside of our custom UI and helpers
  *
- * Loaded at priority 6 because all plugins are typically loaded before 'plugins_loaded', and the UI-enabled plugins use priority 5
- *
  * Technically tries to include the main plugin file again, but we don't care, because it uses `include_once()` and is called after Core loads the plugin
  */
 function wpcom_vip_load_helpers_for_sites_core_plugins() {
@@ -1106,7 +1104,7 @@ function wpcom_vip_load_helpers_for_sites_core_plugins() {
 		_wpcom_vip_include_plugin( $plugin );
 	}
 }
-add_action( 'plugins_loaded', 'wpcom_vip_load_helpers_for_sites_core_plugins', 6 );
+add_action( 'plugins_loaded', 'wpcom_vip_load_helpers_for_sites_core_plugins', 6 ); // Loaded at priority 6 because all plugins are typically loaded before 'plugins_loaded', and the UI-enabled plugins use priority 5
 
 /**
  * Include a plugin and its helper, handling variable scope in the process

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1077,6 +1077,43 @@ function wpcom_vip_plugin_is_loaded( $plugin ) {
 	return in_array( $plugin, wpcom_vip_get_loaded_plugins() );
 }
 
+/**
+ * Load `vipgo-helper.php` if it exists for a network-activated plugin
+ *
+ * Technically tries to include the main plugin file again, but we don't care, because it uses `include_once()` and is called after Core loads the plugin
+ */
+function wpcom_vip_load_helpers_for_network_active_plugins() {
+	// wp_get_active_network_plugins() won't exist otherwise
+	if ( ! is_multisite() ) {
+		return;
+	}
+
+	foreach ( wp_get_active_network_plugins() as $plugin ) {
+		_wpcom_vip_include_plugin( $plugin );
+	}
+}
+add_action( 'muplugins_loaded', 'wpcom_vip_load_helpers_for_network_active_plugins' );
+
+/**
+ * Load `vipgo-helper.php` if it exists for a plugin loaded outside of our custom UI and helpers
+ *
+ * Loaded at priority 6 because all plugins are typically loaded before 'plugins_loaded', and the UI-enabled plugins use priority 5
+ *
+ * Technically tries to include the main plugin file again, but we don't care, because it uses `include_once()` and is called after Core loads the plugin
+ */
+function wpcom_vip_load_helpers_for_sites_core_plugins() {
+	foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
+		_wpcom_vip_include_plugin( $plugin );
+	}
+}
+add_action( 'plugins_loaded', 'wpcom_vip_load_helpers_for_sites_core_plugins', 6 );
+
+/**
+ * Include a plugin and its helper, handling variable scope in the process
+ *
+ * @param string $file Plugin file to load
+ * @return true
+ */
 function _wpcom_vip_include_plugin( $file ) {
 	// Since we're going to be include()'ing inside of a function,
 	// we need to do some hackery to get the variable scope we want.


### PR DESCRIPTION
Network-activated plugins, and community plugins activated via the wp-admin UI, won't have their `vipgo-helper.php` loaded. In many cases, performance- and architecture-related changes are omitted as a result.

For a plugin like msm-sitemap, this causes performance issues when generating sitemaps.

This is a continuation of https://github.com/Automattic/vip-dashboard/pull/71, properly situated and incorporating feedback from @mjangda.

Fixes #580 