### PR TITLE
Force a lower timeout for VaultPress

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -11,4 +11,10 @@
  * Domain Path: /languages/
  */
 
+// VaultPress uses a default timeout of 60s, which can be bad in the rare cases where its API is slow to respond.
+// Drop it down to something a bit more reasonable.
+if ( ! defined( 'VAULTPRESS_TIMEOUT' ) ) {
+	define( 'VAULTPRESS_TIMEOUT', 10 );
+}
+
 require_once( __DIR__ . '/vaultpress/vaultpress.php' );


### PR DESCRIPTION
To prevent issues in the rare cases when the VaultPress API is slow to respond. 10s is a bit arbitrary but better than the default 60s.