### PR TITLE
Fix image_downsize filer for no image.

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -645,6 +645,11 @@ class A8C_Files {
 		$resized = false;
 		$img_url = wp_get_attachment_url( $id );
 
+		// If there is no image, don't try to modify a non-existent URL.
+		if ( ! $img_url ) {
+			return false;
+		}
+
 		/**
 		 * Filter the original image Photon-compatible parameters before changes are
 		 *
@@ -762,7 +767,7 @@ class A8C_Files_Utils {
 		}
 
 		return $url;
-	}	
+	}
 }
 
 function a8c_files_init() {


### PR DESCRIPTION
When the `image_downsize` filter is called but there is no valid image for the given `$id`, the hooked function in the files service continues to try and manipulate the image URL despite there being no image.

The result of this is that functions like `wp_get_attachment_image_url()` that should return false in this situation return a URL based on the request URI instead.

This change checks if a valid image URL is available and returns false at the earliest opportunity if there is no image URL to process.