### PR TITLE
Caching some expensive queries for media

### DIFF
--- a/performance/media.php
+++ b/performance/media.php
@@ -1,7 +1,95 @@
 <?php
 
+namespace Automattic\VIP\Performance;
+
 // Prevent core from doing filename lookups for media search.
 // https://core.trac.wordpress.org/ticket/39358
 add_action( 'pre_get_posts', function() {
 	remove_filter( 'posts_clauses', '_filter_query_attachment_filenames' );
 } );
+
+/**
+ * Stores query for audio items in a transient so it doesn't have to run on every page load
+ *
+ * @param null $show_audio_playlist
+ * @return mixed|null|string
+ */
+function cache_has_audio_query( $show_audio_playlist ) {
+
+	if ( false === ( $show_audio_playlist = get_transient( 'media_library_show_audio_playlist' ) ) ) {
+
+		global $wpdb;
+
+		$show_audio_playlist = $wpdb->get_var( " 
+			SELECT ID 
+			FROM $wpdb->posts 
+			WHERE post_type = 'attachment' 
+			AND post_mime_type LIKE 'audio%' 
+			LIMIT 1 
+		" );
+
+		set_transient( 'media_library_show_audio_playlist', $show_audio_playlist, HOUR_IN_SECONDS + rand( 0, 10 * MINUTE_IN_SECONDS ) );
+
+	}
+
+	return $show_audio_playlist;
+
+}
+add_filter( 'media_library_show_audio_playlist', __NAMESPACE__ . '\cache_has_audio_query' );
+
+/**
+ * Stores query for video items in a transient so it doesn't have to run on every page load
+ *
+ * @param null $show_video_playlist
+ * @return mixed|null|string
+ */
+function cache_has_video_query( $show_video_playlist ) {
+
+	if ( false === ( $show_video_playlist = get_transient( 'media_library_show_video_playlist' ) ) ) {
+
+		global $wpdb;
+
+		$show_video_playlist = $wpdb->get_var( " 
+			SELECT ID 
+			FROM $wpdb->posts 
+			WHERE post_type = 'attachment' 
+			AND post_mime_type LIKE 'video%' 
+			LIMIT 1 
+		" );
+
+		set_transient( 'media_library_show_video_playlist', $show_video_playlist, HOUR_IN_SECONDS + rand( 0, 10 * MINUTE_IN_SECONDS ) );
+
+	}
+
+	return $show_video_playlist;
+
+}
+add_filter( 'media_library_show_video_playlist', __NAMESPACE__ . '\cache_has_video_query' );
+
+/**
+ * Stores query for months that have media items so it doesn't have to run on every page load
+ *
+ * @param null $months
+ * @return array|mixed|null|object
+ */
+function cache_media_months_query( $months ) {
+
+	if ( false === ( $months = get_transient( 'media_library_months' ) ) ) {
+
+		global $wpdb;
+
+		$months = $wpdb->get_results( $wpdb->prepare( " 
+			SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month 
+			FROM $wpdb->posts 
+			WHERE post_type = %s 
+			ORDER BY post_date DESC 
+		", 'attachment' ) );
+
+		set_transient( 'media_library_months', $months, HOUR_IN_SECONDS + rand( 0, 10 * MINUTE_IN_SECONDS ) );
+
+	}
+
+	return $months;
+
+}
+add_filter( 'media_library_months_with_files', __NAMESPACE__ . '\cache_media_months_query' );


### PR DESCRIPTION
Hi VIP folks, was going to add a plugin to our own repo to do this, but figured other sites on go might also want to take advantage of these new filters from 4.7.4? I assume we aren't the only sites that are seeing these queries be super slow. Let me know if that's not the case, and it would be better to just put this in our own codebase though.

This PR takes advantage of 3 new filters added from these commits -> https://core.trac.wordpress.org/changeset/40382 & https://core.trac.wordpress.org/changeset/40421

Essentially this just stores the results of 3 notoriously slow queries in a transient for ~1 hour. I'm also randomizing the expiration so we don't end up with a waterfall of expensive queries if they all expire at the same time. I didn't add any transient busting on media upload actions since that could be happening quite often on high traffic sites, but could potentially add that so the data returned from the query would always be accurate. Personally, I think that's a little overkill, but I'm open to discussion/suggestions. Thanks!