### PR TITLE
Update to reduce slow media queries

### DIFF
--- a/performance/vip-tweaks.php
+++ b/performance/vip-tweaks.php
@@ -76,12 +76,12 @@ if ( is_admin() ) {
 		$months = get_transient( 'wpcom_media_months_array' );
 
 		if ( false === $months ) {
-        	$months = $wpdb->get_results( $wpdb->prepare( "
-            	SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
-            	FROM $wpdb->posts
-            	WHERE post_type = %s
-            	ORDER BY post_date DESC
-        	", 'attachment' ) );
+        		$months = $wpdb->get_results( $wpdb->prepare( "
+            		     SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+            			FROM $wpdb->posts
+            			WHERE post_type = %s
+            			ORDER BY post_date DESC
+        			", 'attachment' ) );
 			set_transient( 'wpcom_media_months_array', $months );
 		}
 

--- a/performance/vip-tweaks.php
+++ b/performance/vip-tweaks.php
@@ -33,19 +33,7 @@ function wpcom_vip_disable_performance_tweaks() {
 	remove_action( 'after_setup_theme', 'wpcom_vip_enable_performance_tweaks' );
 }
 
-/**
- * Filter to clear out the transients for the core hack mentioned here: https://keepingtheirblogsgoing.wordpress.com/2016/04/27/speeding-up-wp-admin/ and implemented in wp-includes/media.php
- * Deletion of the media_month array is taken care of in wpcom_vip_bust_media_months_cache
- */
-add_filter( 'add_attachment', 'wpcom_vip_media_clear_caches' );
-function wpcom_vip_media_clear_caches( $id ) {
-	$upload_post = get_post( $id );
-	if ( strpos( $upload_post->post_mime_type, "video" ) === 0 ) {//check if it starts with video
-		delete_transient( 'wpcom_media_has_video' );
-	} else if ( strpos( $upload_post->post_mime_type, "audio" ) === 0 ) {//check if it starts with audio
-		delete_transient( 'wpcom_media_has_audio' );
-	}
-}
+
 add_action( 'add_attachment', 'wpcom_vip_bust_media_months_cache' );
 function wpcom_vip_bust_media_months_cache( $post_id ) {
 	if( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
@@ -77,7 +65,7 @@ function wpcom_vip_bust_media_months_cache( $post_id ) {
 
 }
 
-if ( wpcom_is_vip() && is_admin() ) {
+if ( is_admin() ) {
 	add_filter( 'media_library_show_video_playlist', '__return_true' );
 	add_filter( 'media_library_show_audio_playlist', '__return_true' );
 

--- a/performance/vip-tweaks.php
+++ b/performance/vip-tweaks.php
@@ -32,3 +32,23 @@ add_action( 'after_setup_theme', 'wpcom_vip_enable_performance_tweaks' );
 function wpcom_vip_disable_performance_tweaks() {
 	remove_action( 'after_setup_theme', 'wpcom_vip_enable_performance_tweaks' );
 }
+
+add_filter( 'media_library_show_video_playlist', '__return_true' );
+add_filter( 'media_library_show_audio_playlist', '__return_true' );
+
+add_filter( 'media_library_months_with_files', 'wpcom_vip_media_library_months_with_files' );
+function wpcom_vip_media_library_months_with_files() {
+    $months = get_transient( 'wpcom_media_months_array' );
+
+    if ( false === $months ) {
+        $months = $wpdb->get_results( $wpdb->prepare( "
+            SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+            FROM $wpdb->posts
+            WHERE post_type = %s
+            ORDER BY post_date DESC
+        ", 'attachment' ) );
+        set_transient( 'wpcom_media_months_array', $months );
+    }
+
+    return $months;
+}


### PR DESCRIPTION
Ticket about slow queries on Laughing Squid: https://wordpressvip.zendesk.com/agent/tickets/65236

The slowness is the result of a select-distinct query when looking for media. Select-distinct is already expensive so it should be cached. But if it doesn't get any results, it still has to do a bunch of complicated processing, returns nothing, and nothing isn't cached, so the query stays slow. 

This filter caches the nothing, as it were. It is active on Wordpress.com and tests okay on LaughingSquid.com, a VIP site. 

Here's context for the bug:  https://keepingtheirblogsgoing.wordpress.com/2016/04/27/speeding-up-wp-admin/
Here's the same code that was pushed on wp.com on 19 April: https://wpcom.trac.automattic.com/changeset/154832