### PR TITLE
Don't cache sandboxed requests by default

### DIFF
--- a/vip-helpers/sandbox.php
+++ b/vip-helpers/sandbox.php
@@ -4,9 +4,11 @@ if ( ! WPCOM_SANDBOXED ) {
 	return;
 }
 
+// Don't cache sandboxed requests by default
+add_action( 'send_headers', 'nocache_headers' );
+
 add_action( 'wp_footer', 'wpcom_do_sandbox_bar', 100 );
 add_action( 'admin_footer', 'wpcom_do_sandbox_bar', 100 );
-
 function wpcom_do_sandbox_bar() {
 	if( is_user_logged_in() && ! is_admin_bar_showing() )
 		return;


### PR DESCRIPTION
We show a sandboxed icon on sandboxed requests. This can be confusing coming from WordPress.com, where sandboxed requests skip batcache by default. We should also skip the page cache by default. If you want to test the page cache while sandboxed, you can easily unhook this.

Fixes #598