### PR TITLE
Add object-cache drop-in

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "shared-plugins/two-factor"]
 	path = shared-plugins/two-factor
 	url = https://github.com/georgestephanis/two-factor.git
+[submodule "drop-ins/object-cache"]
+	path = drop-ins/object-cache
+	url = git@github.com:Automattic/wp-memcached.git


### PR DESCRIPTION
This change lets us provide our memcache drop-in code for easier local testing. The code currently lives in (private) VIP Go internals. Note that on it's own, this doesn't do anything as it needs to be loaded manually.

Once deployed, we can update the VIP Go internals to use this instead:

TODO post-merge and deploy:

- [ ] Update docs on how to use this drop-in locally.
- [ ] Update Go internal object-cache.php file to load this one.

 We can later look at including HyperDB as well.