### PR TITLE
Use the WPMU_PLUGIN_DIR constant to allow mu-plugins to be moved outs…

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -994,7 +994,7 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 		$test_directories[] = WP_PLUGIN_DIR . '/' . $folder;
 	} else {
 		$test_directories[] = WP_PLUGIN_DIR;
-		$test_directories[] = WP_CONTENT_DIR . '/mu-plugins/shared-plugins';
+		$test_directories[] = WPMU_PLUGIN_DIR . '/shared-plugins';
 	}
 
 	$includepath = null;


### PR DESCRIPTION
…ide of the default location in wp-content.

Apologies if this PR is not in line with your internal workflow, just wanted to point this out:

The current implementation assumes that mu-plugins will always be in the default location of wp-content/mu-plugins . However on local dev environments for VIP Go projects we sometimes use the WPMU_PLUGIN_DIR constant in wp-config.php to keep mu-plugins out of the project repo. 

I know you use .gitignore to prevent mu-plugins from being committed to the repo anyway, but since WPMU_PLUGIN_DIR is a standard practice in WP Core I feel it still needs to be supported: https://codex.wordpress.org/Must_Use_Plugins

Thanks for your consideration.