### PR TITLE
Add support for additional mu-plugins

### DIFF
--- a/z-client-mu-plugins.php
+++ b/z-client-mu-plugins.php
@@ -1,0 +1,50 @@
+<?php
+
+// Note: This file is prefixed with `z-` for load order
+
+define( 'WPCOM_VIP_CLIENT_MU_PLUGIN_DIR', WP_CONTENT_DIR . '/client-mu-plugins' );
+
+function wpcom_vip_load_client_mu_plugins() {
+	static $loaded = false;
+
+	// Prevent running this multiple times
+	if ( $loaded ) {
+		return;
+	}
+
+	$loaded = true;
+
+	// Code below is adapted from wp_get_mu_plugins()
+	$client_mu_plugins = [];
+
+	if ( ! is_dir( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR ) ) {
+		return;
+	}
+
+	$dh = opendir( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR );
+	if ( ! $dh ) {
+		return;
+	}
+
+	do {
+		$plugin = readdir( $dh );
+		if ( false === $plugin ) {
+			break;
+		}
+
+		if ( substr( $plugin, -4 ) === '.php' ) {
+			$client_mu_plugins[] = WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . '/' . $plugin;
+		}
+	} while ( false !== $plugin );
+
+	closedir( $dh );
+
+	// Make sure plugins load in a consistent, predictable order
+	sort( $client_mu_plugins );
+
+	foreach ( $client_mu_plugins as $plugin ) {
+		include_once( $plugin );
+	}
+}
+
+wpcom_vip_load_client_mu_plugins();


### PR DESCRIPTION
This change allows sites to add a `client-mu-plugins` folder (open to name change) in their VIP Go repo, which we load similar to mu-plugins. The client mu-plugins are loaded after the VIP Go mu-plugins are loaded ("enforced" by the filename prefix).

As part of this change, we will probably need a few others:

- [x] Update `vip-go-skeleton` to include the folder.
- [ ] Update `vip-go-api` to make the new folder required on site init.
- [x] Update `vipd` to map the folder inside `wp-content` within web containers.
- [ ] Update docs (https://vip.wordpress.com/documentation/vip-go/local-vip-go-development-environment/)

We will also probably need to re-create web containers for any sites that want to use this.

See #166 