### PR TITLE
Adding vip-cache.php

### DIFF
--- a/wp-cli/vip-cache.php
+++ b/wp-cli/vip-cache.php
@@ -1,0 +1,15 @@
+<?php
+
+class VIP_Cache_CLI extends WPCOM_VIP_CLI_Command {
+	/**
+	 * Purges the site's varnish cache.
+	 */
+	function purge( $args, $assoc_args ) {
+		// This sets up the URL/regex to be banned.  There's no need to manually
+		// execute a purge since it is handled automatically on the `shutdown` hook.
+		WPCOM_VIP_Cache_Manager::instance()->purge_site_cache();
+		WP_CLI::success( 'Varnish cache purged!' );
+	}
+}
+
+WP_CLI::add_command( 'vip cache', 'VIP_Cache_CLI' );


### PR DESCRIPTION
This file will hopefully contain helper scripts for cache related commands.

Right now, I've started it with a command to purge a site's Varnish cache.  This is useful for automating site cloning, so a support user doesn't have to log in to every newly cloned site and manually purge the cache.  It's pretty barebones (it's got one job) but I'm open to suggestions of other additions if needed.