### PR TITLE
Add modified search-replace command

### DIFF
--- a/wp-cli/search-replace.php
+++ b/wp-cli/search-replace.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Adapted from https://github.com/wp-cli/search-replace-command
+ */
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	return;
+}
+
+require_once( __DIR__ . '/search-replace/command.php' );
+require_once( __DIR__ . '/search-replace/search-replacer.php' );
+
+WP_CLI::add_command( 'search-replace', 'Search_Replace_Command' );

--- a/wp-cli/search-replace.php
+++ b/wp-cli/search-replace.php
@@ -11,4 +11,4 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 require_once( __DIR__ . '/search-replace/command.php' );
 require_once( __DIR__ . '/search-replace/search-replacer.php' );
 
-WP_CLI::add_command( 'search-replace', 'Search_Replace_Command' );
+WP_CLI::add_command( 'vip search-replace', 'VIP_Search_Replace_Command' );

--- a/wp-cli/search-replace/command.php
+++ b/wp-cli/search-replace/command.php
@@ -1,6 +1,6 @@
 <?php
 
-class VIP_Search_Replace_Command extends WP_CLI_Command {
+class VIP_Search_Replace_Command extends WPCOM_VIP_CLI_Command {
 
 	private $dry_run;
 	private $export_handle = false;
@@ -129,6 +129,8 @@ class VIP_Search_Replace_Command extends WP_CLI_Command {
 		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
 		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
 
+		$this->start_bulk_operation();
+
 		if ( $old === $new && ! $this->regex ) {
 			WP_CLI::warning( "Replacement value '{$old}' is identical to search value '{$new}'. Skipping operation." );
 			exit;
@@ -225,6 +227,7 @@ class VIP_Search_Replace_Command extends WP_CLI_Command {
 					WP_CLI::log( '---==---' );
 					WP_CLI::log( '' );
 				}
+				$this->stop_the_insanity();
 			}
 		}
 
@@ -264,6 +267,7 @@ class VIP_Search_Replace_Command extends WP_CLI_Command {
 			$success_message .= $runtime_message;
 			WP_CLI::success( sprintf( $success_message, $total ) );
 		}
+		$this->end_bulk_operation();
 	}
 
 	private function php_export_table( $table, $old, $new ) {

--- a/wp-cli/search-replace/command.php
+++ b/wp-cli/search-replace/command.php
@@ -401,6 +401,8 @@ class VIP_Search_Replace_Command extends WPCOM_VIP_CLI_Command {
 			WP_CLI::log( 'Processing %s rows', count( $rows ) );
 		}
 
+		$i = 0;
+
 		foreach ( $rows as $keys ) {
 			$where_sql = '';
 			foreach( (array) $keys as $k => $v ) {
@@ -433,6 +435,10 @@ class VIP_Search_Replace_Command extends WPCOM_VIP_CLI_Command {
 				}
 
 				$count += $wpdb->update( $table, array( $col => $value ), $where );
+			}
+			if ( ++$i === 100 ) {
+				$this->stop_the_insanity();
+				$i = 0;
 			}
 		}
 

--- a/wp-cli/search-replace/command.php
+++ b/wp-cli/search-replace/command.php
@@ -1,6 +1,6 @@
 <?php
 
-class Search_Replace_Command extends WP_CLI_Command {
+class VIP_Search_Replace_Command extends WP_CLI_Command {
 
 	private $dry_run;
 	private $export_handle = false;

--- a/wp-cli/search-replace/command.php
+++ b/wp-cli/search-replace/command.php
@@ -338,7 +338,7 @@ class VIP_Search_Replace_Command extends WPCOM_VIP_CLI_Command {
 		$col_start_time = microtime( true );
 		$total_count = 0;
 		$current_index = 0;
-		$per_query = 10000;
+		$per_query = 50000;
 
 		while ( $current_index <= $max_id ) {
 			$count = 0;

--- a/wp-cli/search-replace/command.php
+++ b/wp-cli/search-replace/command.php
@@ -130,6 +130,7 @@ class VIP_Search_Replace_Command extends WPCOM_VIP_CLI_Command {
 		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
 
 		$this->start_bulk_operation();
+		$this->start_time = microtime( true );
 
 		if ( $old === $new && ! $this->regex ) {
 			WP_CLI::warning( "Replacement value '{$old}' is identical to search value '{$new}'. Skipping operation." );

--- a/wp-cli/search-replace/command.php
+++ b/wp-cli/search-replace/command.php
@@ -1,0 +1,466 @@
+<?php
+
+class Search_Replace_Command extends WP_CLI_Command {
+
+	private $dry_run;
+	private $export_handle = false;
+	private $export_insert_size;
+	private $recurse_objects;
+	private $regex;
+	private $regex_flags;
+	private $skip_columns;
+	private $include_columns;
+
+	/**
+	 * Search/replace strings in the database.
+	 *
+	 * Searches through all rows in a selection of tables and replaces
+	 * appearances of the first string with the second string.
+	 *
+	 * By default, the command uses tables registered to the $wpdb object. On
+	 * multisite, this will just be the tables for the current site unless
+	 * --network is specified.
+	 *
+	 * Search/replace intelligently handles PHP serialized data, and does not
+	 * change primary key values.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <old>
+	 * : A string to search for within the database.
+	 *
+	 * <new>
+	 * : Replace instances of the first string with this new string.
+	 *
+	 * [<table>...]
+	 * : List of database tables to restrict the replacement to. Wildcards are
+	 * supported, e.g. `'wp_*options'` or `'wp_post*'`.
+	 *
+	 * [--dry-run]
+	 * : Run the entire search/replace operation and show report, but don't save
+	 * changes to the database.
+	 *
+	 * [--network]
+	 * : Search/replace through all the tables registered to $wpdb in a
+	 * multisite install.
+	 *
+	 * [--all-tables-with-prefix]
+	 * : Enable replacement on any tables that match the table prefix even if
+	 * not registered on $wpdb.
+	 *
+	 * [--all-tables]
+	 * : Enable replacement on ALL tables in the database, regardless of the
+	 * prefix, and even if not registered on $wpdb. Overrides --network
+	 * and --all-tables-with-prefix.
+	 *
+	 * [--export[=<file>]]
+	 * : Write transformed data as SQL file instead of saving replacements to
+	 * the database. If <file> is not supplied, will output to STDOUT.
+	 *
+	 * [--export_insert_size=<rows>]
+	 * : Define number of rows in single INSERT statement when doing SQL export.
+	 * You might want to change this depending on your database configuration
+	 * (e.g. if you need to do fewer queries). Default: 50
+	 *
+	 * [--skip-columns=<columns>]
+	 * : Do not perform the replacement on specific columns. Use commas to
+	 * specify multiple columns.
+	 *
+	 * [--include-columns=<columns>]
+	 * : Perform the replacement on specific columns. Use commas to
+	 * specify multiple columns.
+	 *
+	 * [--precise]
+	 * : Force the use of PHP (instead of SQL) which is more thorough,
+	 * but slower.
+	 *
+	 * [--recurse-objects]
+	 * : Enable recursing into objects to replace strings. Defaults to true;
+	 * pass --no-recurse-objects to disable.
+	 *
+	 * [--verbose]
+	 * : Prints rows to the console as they're updated.
+	 *
+	 * [--regex]
+	 * : Runs the search using a regular expression (without delimiters).
+	 * Warning: search-replace will take about 15-20x longer when using --regex.
+	 *
+	 * [--regex-flags=<regex-flags>]
+	 * : Pass PCRE modifiers to regex search-replace (e.g. 'i' for case-insensitivity).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Search and replace but skip one column
+	 *     $ wp search-replace 'http://example.dev' 'http://example.com' --skip-columns=guid
+	 *
+	 *     # Run search/replace operation but dont save in database
+	 *     $ wp search-replace 'foo' 'bar' wp_posts wp_postmeta wp_terms --dry-run
+	 *
+	 *     # Run case-insensitive regex search/replace operation (slow)
+	 *     $ wp search-replace '\[foo id="([0-9]+)"' '[bar id="\1"' --regex --regex-flags='i'
+	 *
+	 *     # Turn your production multisite database into a local dev database
+	 *     $ wp search-replace --url=example.com example.com example.dev 'wp_*options' wp_blogs
+	 *
+	 *     # Search/replace to a SQL file without transforming the database
+	 *     $ wp search-replace foo bar --export=database.sql
+	 *
+	 *     # Bash script: Search/replace production to development url (multisite compatible)
+	 *     #!/bin/bash
+	 *     if $(wp --url=http://example.com core is-installed --network); then
+	 *         wp search-replace --url=http://example.com 'http://example.com' 'http://example.dev' --recurse-objects --network --skip-columns=guid
+	 *     else
+	 *         wp search-replace 'http://example.com' 'http://example.dev' --recurse-objects --skip-columns=guid
+	 *     fi
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		global $wpdb;
+		$old             = array_shift( $args );
+		$new             = array_shift( $args );
+		$total           = 0;
+		$report          = array();
+		$this->dry_run         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' );
+		$php_only        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'precise' );
+		$this->recurse_objects = \WP_CLI\Utils\get_flag_value( $assoc_args, 'recurse-objects', true );
+		$this->verbose         =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'verbose' );
+		$this->regex           =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex' );
+		$this->regex_flags     =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags' );
+
+		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
+		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
+
+		if ( $old === $new && ! $this->regex ) {
+			WP_CLI::warning( "Replacement value '{$old}' is identical to search value '{$new}'. Skipping operation." );
+			exit;
+		}
+
+		if ( null !== ( $export = \WP_CLI\Utils\get_flag_value( $assoc_args, 'export' ) ) ) {
+			if ( $this->dry_run ) {
+				WP_CLI::error( 'You cannot supply --dry-run and --export at the same time.' );
+			}
+			if ( true === $export ) {
+				$this->export_handle = STDOUT;
+				$this->verbose = false;
+			} else {
+				$this->export_handle = fopen( $assoc_args['export'], 'w' );
+				if ( false === $this->export_handle ) {
+					WP_CLI::error( sprintf( 'Unable to open "%s" for writing.', $assoc_args['export'] ) );
+				}
+			}
+			$export_insert_size = WP_CLI\Utils\get_flag_value( $assoc_args, 'export_insert_size', 50 );
+			if ( (int) $export_insert_size == $export_insert_size && $export_insert_size > 0 ) {
+				$this->export_insert_size = $export_insert_size;
+			}
+			$php_only = true;
+		}
+
+		if ( $this->regex_flags ) {
+			$php_only = true;
+		}
+
+		// never mess with hashed passwords
+		$this->skip_columns[] = 'user_pass';
+
+		// Get table names based on leftover $args or supplied $assoc_args
+		$tables = \WP_CLI\Utils\wp_get_table_names( $args, $assoc_args );
+		foreach ( $tables as $table ) {
+
+			if ( $this->export_handle ) {
+				fwrite( $this->export_handle, "\nDROP TABLE IF EXISTS `$table`;\n" );
+				$row = $wpdb->get_row( "SHOW CREATE TABLE `$table`", ARRAY_N );
+				fwrite( $this->export_handle, $row[1] . ";\n" );
+				list( $table_report, $total_rows ) = $this->php_export_table( $table, $old, $new );
+				$report = array_merge( $report, $table_report );
+				$total += $total_rows;
+				// Don't perform replacements on the actual database
+				continue;
+			}
+
+			list( $primary_keys, $columns, $all_columns ) = self::get_columns( $table );
+
+			// since we'll be updating one row at a time,
+			// we need a primary key to identify the row
+			if ( empty( $primary_keys ) ) {
+				$report[] = array( $table, '', 'skipped' );
+				continue;
+			}
+
+			foreach ( $columns as $col ) {
+				if ( ! empty( $this->include_columns ) && ! in_array( $col, $this->include_columns ) ) {
+					continue;
+				}
+
+				if ( in_array( $col, $this->skip_columns ) ) {
+					continue;
+				}
+
+				if ( $this->verbose ) {
+					$this->start_time = microtime( true );
+					WP_CLI::log( sprintf( 'Checking: %s.%s', $table, $col ) );
+				}
+
+				if ( ! $php_only && ! $this->regex ) {
+					$wpdb->last_error = '';
+					$serialRow = $wpdb->get_row( "SELECT * FROM `$table` WHERE `$col` REGEXP '^[aiO]:[1-9]' LIMIT 1" );
+					// When the regex triggers an error, we should fall back to PHP
+					if ( false !== strpos( $wpdb->last_error, 'ERROR 1139' ) ) {
+						$serialRow = true;
+					}
+				}
+
+				if ( $php_only || $this->regex || NULL !== $serialRow ) {
+					$type = 'PHP';
+					$count = $this->php_handle_col( $col, $primary_keys, $table, $old, $new );
+				} else {
+					$type = 'SQL';
+					$count = $this->sql_handle_col( $col, $table, $old, $new );
+				}
+
+				$report[] = array( $table, $col, $count, $type );
+
+				$total += $count;
+			}
+		}
+
+		if ( $this->export_handle && STDOUT !== $this->export_handle ) {
+			fclose( $this->export_handle );
+		}
+
+		// Only informational output after this point
+		if ( WP_CLI::get_config( 'quiet' ) || STDOUT === $this->export_handle ) {
+			return;
+		}
+
+		$table = new \cli\Table();
+		$table->setHeaders( array( 'Table', 'Column', 'Replacements', 'Type' ) );
+		$table->setRows( $report );
+		$table->display();
+
+		if ( ! $this->dry_run ) {
+			if ( ! empty( $assoc_args['export'] ) ) {
+				$success_message = "Made {$total} replacements and exported to {$assoc_args['export']}.";
+			} else {
+				$success_message = "Made $total replacements.";
+				if ( $total && 'Default' !== WP_CLI\Utils\wp_get_cache_type() ) {
+					$success_message .= ' Please remember to flush your persistent object cache with `wp cache flush`.';
+				}
+			}
+			WP_CLI::success( $success_message );
+		}
+		else {
+			$success_message = ( 1 === $total ) ? '%d replacement to be made.' : '%d replacements to be made.';
+			WP_CLI::success( sprintf( $success_message, $total ) );
+		}
+	}
+
+	private function php_export_table( $table, $old, $new ) {
+		list( $primary_keys, $columns, $all_columns ) = self::get_columns( $table );
+		$chunk_size = getenv( 'BEHAT_RUN' ) ? 10 : 1000;
+		$args = array(
+			'table'      => $table,
+			'fields'     => $all_columns,
+			'chunk_size' => $chunk_size
+		);
+
+		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $this->recurse_objects, $this->regex, $this->regex_flags );
+		$col_counts = array_fill_keys( $all_columns, 0 );
+		if ( $this->verbose ) {
+			$this->start_time = microtime( true );
+			WP_CLI::log( sprintf( 'Checking: %s', $table ) );
+		}
+
+		$rows = array();
+		foreach ( new \WP_CLI\Iterators\Table( $args ) as $i => $row ) {
+			$row_fields = array();
+			foreach( $all_columns as $col ) {
+				$value = $row->$col;
+				if ( $value && ! in_array( $col, $primary_keys ) && ! in_array( $col, $this->skip_columns ) ) {
+					$new_value = $replacer->run( $value );
+					if ( $new_value !== $value ) {
+						$col_counts[ $col ]++;
+						$value = $new_value;
+					}
+				}
+				$row_fields[ $col ] = $value;
+			}
+			$rows[] = $row_fields;
+		}
+		$this->write_sql_row_fields( $table, $rows );
+
+		$table_report = array();
+		$total_rows = $total_cols = 0;
+		foreach ( $col_counts as $col => $col_count ) {
+			$table_report[] = array( $table, $col, $col_count, 'PHP' );
+			if ( $col_count ) {
+				$total_cols++;
+				$total_rows += $col_count;
+			}
+		}
+
+		if ( $this->verbose ) {
+			$time = round( microtime( true ) - $this->start_time, 3 );
+			WP_CLI::log( sprintf( '%d columns and %d total rows affected using PHP (in %ss).', $total_cols, $total_rows, $time ) );
+		}
+
+		return array( $table_report, $total_rows );
+	}
+
+	private function sql_handle_col( $col, $primary_keys, $table, $old, $new ) {
+		global $wpdb;
+
+		if ( $this->dry_run ) {
+			$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(`$col`) FROM `$table` WHERE `$col` LIKE %s;", '%' . self::esc_like( $old ) . '%' ) );
+		} else {
+			$count = $wpdb->query( $wpdb->prepare( "UPDATE `$table` SET `$col` = REPLACE(`$col`, %s, %s);", $old, $new ) );
+		}
+
+		if ( $this->verbose ) {
+			$time = round( microtime( true ) - $this->start_time, 3 );
+			WP_CLI::log( sprintf( '%d rows affected using SQL (in %ss).', $count, $time ) );
+		}
+		return $count;
+	}
+
+	private function php_handle_col( $col, $primary_keys, $table, $old, $new ) {
+		global $wpdb;
+
+		$count = 0;
+		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $this->recurse_objects, $this->regex, $this->regex_flags );
+
+		$where = $this->regex ? '' : " WHERE `$col`" . $wpdb->prepare( ' LIKE %s', '%' . self::esc_like( $old ) . '%' );
+		$primary_keys_sql = esc_sql( implode( ',', $primary_keys ) );
+		$col_sql = esc_sql( $col );
+		$rows = $wpdb->get_results( "SELECT {$primary_keys_sql} FROM `{$table}` {$where}" );
+		foreach ( $rows as $keys ) {
+			$where_sql = '';
+			foreach( (array) $keys as $k => $v ) {
+				if ( strlen( $where_sql ) ) {
+					$where_sql .= ' AND ';
+				}
+				$where_sql .= "{$k}='{$v}'";
+			}
+			$col_value = $wpdb->get_var( "SELECT {$col_sql} FROM `{$table}` WHERE {$where_sql}" );
+			if ( '' === $col_value )
+				continue;
+
+			$value = $replacer->run( $col_value );
+
+			if ( $value === $col_value ) {
+				continue;
+			}
+
+			if ( $this->dry_run ) {
+				if ( $value != $col_value )
+					$count++;
+			} else {
+				$where = array();
+				foreach( (array) $keys as $k => $v ) {
+					$where[ $k ] = $v;
+				}
+
+				$count += $wpdb->update( $table, array( $col => $value ), $where );
+			}
+		}
+
+		if ( $this->verbose ) {
+			$time = round( microtime( true ) - $this->start_time, 3 );
+			WP_CLI::log( sprintf( '%d rows affected using PHP (in %ss).', $count, $time ) );
+		}
+
+		return $count;
+	}
+
+	private function write_sql_row_fields( $table, $rows ) {
+		global $wpdb;
+
+		if(empty($rows)) {
+			return;
+		}
+
+		$insert = "INSERT INTO `$table` (";
+		$insert .= join( ', ', array_map(
+			function ( $field ) {
+				return "`$field`";
+			},
+			array_keys( $rows[0] )
+		) );
+		$insert .= ') VALUES ';
+		$insert .= "\n";
+
+		$sql = $insert;
+		$values = array();
+
+		$index = 1;
+		$count = count( $rows );
+		$export_insert_size = $this->export_insert_size;
+
+		foreach($rows as $row_fields) {
+			$sql .= '(' . join( ', ', array_fill( 0, count( $row_fields ), '%s' ) ) . ')';
+			$values = array_merge( $values, array_values( $row_fields ) );
+
+			// Add new insert statement if needed. Before this we close the previous with semicolon and write statement to sql-file.
+			// "Statement break" is needed:
+			//		1. When the loop is running every nth time (where n is insert statement size, $export_index_size). Remainder is zero also on first round, so it have to be excluded.
+			//			$index % $export_insert_size == 0 && $index > 0
+			//		2. Or when the loop is running last time
+			//			$index == $count
+			if( ( $index % $export_insert_size == 0 && $index > 0 ) || $index == $count ) {
+				$sql .= ";\n";
+
+				$sql = $wpdb->prepare( $sql, array_values( $values ) );
+				fwrite( $this->export_handle, $sql );
+
+				// If there is still rows to loop, reset $sql and $values variables.
+				if( $count > $index ) {
+					$sql = $insert;
+					$values = array();
+				}
+			} else { // Otherwise just add comma and new line
+				$sql .= ",\n";
+			}
+
+			$index++;
+		}
+	}
+
+	private static function get_columns( $table ) {
+		global $wpdb;
+
+		$primary_keys = $text_columns = $all_columns = array();
+		foreach ( $wpdb->get_results( "DESCRIBE `$table`" ) as $col ) {
+			if ( 'PRI' === $col->Key ) {
+				$primary_keys[] = $col->Field;
+			}
+			if ( self::is_text_col( $col->Type ) ) {
+				$text_columns[] = $col->Field;
+			}
+			$all_columns[] = $col->Field;
+		}
+		return array( $primary_keys, $text_columns, $all_columns );
+	}
+
+	private static function is_text_col( $type ) {
+		foreach ( array( 'text', 'varchar' ) as $token ) {
+			if ( false !== strpos( $type, $token ) )
+				return true;
+		}
+
+		return false;
+	}
+
+	private static function esc_like( $old ) {
+		global $wpdb;
+
+		// Remove notices in 4.0 and support backwards compatibility
+		if( method_exists( $wpdb, 'esc_like' ) ) {
+			// 4.0
+			$old = $wpdb->esc_like( $old );
+		} else {
+			// 3.9 or less
+			$old = like_escape( esc_sql( $old ) );
+		}
+
+		return $old;
+	}
+
+}

--- a/wp-cli/search-replace/search-replacer.php
+++ b/wp-cli/search-replace/search-replacer.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace WP_CLI;
+
+class SearchReplacer {
+
+	private $from, $to;
+	private $recurse_objects;
+	private $max_recursion;
+
+	/**
+	 * @param string  $from            String we're looking to replace.
+	 * @param string  $to              What we want it to be replaced with.
+	 * @param bool    $recurse_objects Should objects be recursively replaced?
+	 */
+	function __construct( $from, $to, $recurse_objects = false, $regex = false, $regex_flags = '' ) {
+		$this->from = $from;
+		$this->to = $to;
+		$this->recurse_objects = $recurse_objects;
+		$this->regex = $regex;
+		$this->regex_flags = $regex_flags;
+
+		// Get the XDebug nesting level. Will be zero (no limit) if no value is set
+		$this->max_recursion = intval( ini_get( 'xdebug.max_nesting_level' ) );
+	}
+
+	/**
+	 * Take a serialised array and unserialise it replacing elements as needed and
+	 * unserialising any subordinate arrays and performing the replace on those too.
+	 * Ignores any serialized objects unless $recurse_objects is set to true.
+	 *
+	 * @param array|string $data            The data to operate on.
+	 * @param bool         $serialised      Does the value of $data need to be unserialized?
+	 *
+	 * @return array       The original array with all elements replaced as needed.
+	 */
+	function run( $data, $serialised = false ) {
+		return $this->_run( $data, $serialised );
+	}
+
+	/**
+	 * @param int          $recursion_level Current recursion depth within the original data.
+	 * @param array        $visited_data    Data that has been seen in previous recursion iterations.
+	 */
+	private function _run( $data, $serialised, $recursion_level = 0, $visited_data = array() ) {
+
+		// some unseriliased data cannot be re-serialised eg. SimpleXMLElements
+		try {
+
+			if ( $this->recurse_objects ) {
+
+				// If we've reached the maximum recursion level, short circuit
+				if ( $this->max_recursion != 0 && $recursion_level >= $this->max_recursion ) {
+					return $data;
+				}
+
+				if ( is_array( $data ) || is_object( $data ) ) {
+					// If we've seen this exact object or array before, short circuit
+					if ( in_array( $data, $visited_data, true ) ) {
+						return $data; // Avoid infinite loops when there's a cycle
+					}
+					// Add this data to the list of
+					$visited_data[] = $data;
+				}
+			}
+
+			if ( is_string( $data ) && ( $unserialized = @unserialize( $data ) ) !== false ) {
+				$data = $this->_run( $unserialized, true, $recursion_level + 1 );
+			}
+
+			elseif ( is_array( $data ) ) {
+				$keys = array_keys( $data );
+				foreach ( $keys as $key ) {
+					$data[ $key ]= $this->_run( $data[$key], false, $recursion_level + 1, $visited_data );
+				}
+			}
+
+			elseif ( $this->recurse_objects && is_object( $data ) ) {
+				foreach ( $data as $key => $value ) {
+					$data->$key = $this->_run( $value, false, $recursion_level + 1, $visited_data );
+				}
+			}
+
+			else if ( is_string( $data ) ) {
+				if ( $this->regex ) {
+					$data = preg_replace( "/$this->from/$this->regex_flags", $this->to, $data );
+				} else {
+					$data = str_replace( $this->from, $this->to, $data );
+				}
+			}
+
+			if ( $serialised )
+				return serialize( $data );
+
+		} catch( Exception $error ) {
+
+		}
+
+		return $data;
+	}
+}
+

--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -5,6 +5,152 @@ use \WP_CLI\Utils;
 class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 
 	/**
+	 * Deletes senstive options
+	 *
+	 * @subcommand scrub-site
+	 */
+	public function clear_sensitive_options( $args, $assoc_args ) {
+		WP_CLI::log( 'Clearing sensitive options (like Jetpack connection).' );
+
+		// TODO: if called from preprod site with production values, does it disconnect the preprod site?
+//		WP_CLI::log( '- Disconnecting Jetpack' );
+//		Jetpack::disconnect();
+
+		WP_CLI::log( '- Deleting Options' );
+		$options = [
+			'jetpack_options',
+			'jetpack_private_options',
+			'vaultpress',
+			'wordpress_api_key',
+		];
+
+		foreach ( $options as $option_name ) {
+			WP_CLI::log( '-- ' . $option_name );
+			delete_option( $option_name );
+		}
+	}
+
+	/**
+	 * Update URLs across a whitelist of table columns
+	 *
+	 * ## OPTIONS
+	 *
+	 * --from=<from_url>
+	 * : The URL to search for.
+	 *
+	 * --to=<to_url>
+	 * : The URL to replace with.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp vip migration search-replace-url 'http://example.com' 'http://example.go-vip.co'
+	 *
+	 * @subcommand search-replace-url
+	 */
+	public function search_replace_url( $args, $assoc_args ) {
+		$from_url = $assoc_args['from'] ?? false;
+		$to_url = $assoc_args['to'] ?? false;
+
+		$from_url_parsed = parse_url( $from_url );
+		if ( empty( $from_url ) || ! $from_url_parsed ) {
+			WP_CLI::error( sprintf( 'Please provide a valid `--from` URL (current: %s)', $from_url ) );
+			return;
+		}
+
+		$to_url_parsed = parse_url( $to_url );
+		if ( empty( $to_url ) || ! $to_url_parsed ) {
+			WP_CLI::error( sprintf( 'Please provide a valid `--to` URL (current: %s)', $to_url ) );
+			return;
+		}
+
+		// TODO: should we have a flag to exclude home/siteurl option?
+
+		$tables_and_columns = [
+			'wp_commentmeta' => [
+				'meta_key',
+				'meta_value',
+			],
+
+			'wp_comments' => [
+				'comment_author',
+				'comment_author_url',
+				'comment_content',
+				'comment_agent',
+			],
+
+			'wp_links' => [
+				'link_url',
+				'link_name',
+				'link_image',
+				'link_description',
+				'link_notes',
+				'link_rss',
+			],
+
+			'wp_options' => [
+				'option_name',
+				'option_value',
+			],
+
+			'wp_postmeta' => [
+				'meta_key',
+				'meta_value',
+			],
+
+			'wp_posts' => [
+				'post_content',
+				'post_title',
+				'post_excerpt',
+				'post_name',
+				'post_content_filtered',
+				'guid',
+			],
+
+			'wp_term_taxonomy' => [
+				'taxonomy',
+				'description',
+			],
+
+			'wp_termmeta' => [
+				'meta_key',
+				'meta_value',
+			],
+
+			'wp_terms' => [
+				'name',
+			],
+
+			'wp_usermeta' => [
+				'meta_key',
+				'meta_value',
+			],
+
+			'wp_users' => [
+				'user_url',
+				'display_name',
+			],
+		];
+
+		$runcommand_args = [
+			'exit_error' => false,
+		];
+
+		foreach ( $tables_and_columns as $table => $columns ) {
+			$command = sprintf(
+				'vip search-replace %1$s %2$s %3$s --include-columns=%4$s --verbose',
+				escapeshellarg( $from_url ),
+				escapeshellarg( $to_url ),
+				escapeshellarg( $table ),
+				escapeshellarg( implode( ',', $columns ) )
+			);
+
+			WP_CLI::log( 'Running command: ' . $command );
+			WP_CLI::runcommand( $command, $runcommand_args );
+			WP_CLI::log( '---' );
+		}
+	}
+
+	/**
 	 * Run dbDelta() for the current site.
 	 *
 	 * [--network]


### PR DESCRIPTION
"Forking" the wp-cli `search-replace` command with a few modifications for better handling larger databases.

For each column in each table, we loop through in batches of 5000 based on primary using a `WHERE {key} BETWEEN {start} AND {end}` clause. This is better than a single `UPDATE` query, which on really large tables can sometimes take hours and days.

Sample output:

```
Checking: wp_posts.post_content
Max ID for column: 120625
- (DRY RUN) Processing row IDs 0 to 5000
-- 0 rows affected using SQL (in 0.001s).
- (DRY RUN) Processing row IDs 5001 to 10001
-- 82 rows affected using SQL (in 0.001s).
- (DRY RUN) Processing row IDs 10002 to 15002
-- 45 rows affected using SQL (in 0s).
- (DRY RUN) Processing row IDs 15003 to 20003
...
```

Once this has been tested as working well, we need to send our recommendations/updates upstream to: https://github.com/wp-cli/search-replace-command

See #609 