### PR TITLE
Add more strict conditional for checking incorrect results

### DIFF
--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -126,7 +126,7 @@ class WPCOM_elasticsearch {
 		if ( ! $query->is_main_query() || ! $query->is_search() )
 			return $posts;
 
-		if ( ! is_array( $this->search_result ) )
+		if ( is_wp_error( $this->search_result ) || ! is_array( $this->search_result ) || empty( $this->search_result['results'] ) || empty( $this->search_result['results']['hits'] ) )
 			return $posts;
 
 		// This class handles the heavy lifting of transparently switching blogs and inflating posts


### PR DESCRIPTION
In case the `es_api_search_index` function returns any errors, those are assigned to `WPCOM_elasticsearch::search_result` property - it may either be a WP_Error, false or an array containing an `error` key.

The code is already properly checking for those in https://github.com/Automattic/vip-go-mu-plugins/blob/930f369d80be9d75eeb83b4c22a24e774880fb41/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php#L289 but the conditional in https://github.com/Automattic/vip-go-mu-plugins/blob/930f369d80be9d75eeb83b4c22a24e774880fb41/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php#L129 is doing looser check on the same data, and thus may produce a PHP Warning.

Example value of `$this->search_result` which produced a Warning is as follows:

```
array (
  'error' => 'Bad Request',
  'message' => 'Elasticsearch can never page beyond 10k results.',
)
```

This commit is using the same conditional as on line 289 on line 129 in order to address the PHP Warnings.