### PR TITLE
Add instagram_cache_oembed_api_response_body

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -721,3 +721,11 @@ function wpcom_vip_maybe_skip_old_slug_redirect(){
 function wpcom_vip_enable_maybe_skip_old_slug_redirect() {
 	add_action( 'template_redirect', 'wpcom_vip_maybe_skip_old_slug_redirect', 7 ); //Run this before wpcom_vip_wp_old_slug_redirect so we can also remove our caching helper
 }
+
+/**
+* Enables object caching for the response sent by Instagram when querying for Instagram image HTML.
+*
+* This cannot be included inside Jetpack because it ships with caching disabled by default.
+* By enabling caching it's possible to save time in uncached		 page renders.
+**/
+add_filter( 'instagram_cache_oembed_api_response_body', '__return_true' );

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -726,6 +726,6 @@ function wpcom_vip_enable_maybe_skip_old_slug_redirect() {
 * Enables object caching for the response sent by Instagram when querying for Instagram image HTML.
 *
 * This cannot be included inside Jetpack because it ships with caching disabled by default.
-* By enabling caching it's possible to save time in uncached		 page renders.
+* By enabling caching it's possible to save time in uncached page renders.
 **/
 add_filter( 'instagram_cache_oembed_api_response_body', '__return_true' );


### PR DESCRIPTION
Adding the `instagram_cache_oembed_api_response_body` filter that's currently present on WordPress.com that will cache Instagram oEmbed responses.