### PR TITLE
Jetpack Start for multisites: connections

### DIFF
--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -80,18 +80,17 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 			$starting_blog_id = get_current_blog_id();
 
 			// Track whether there were any failures, to adjust messaging
-			$success = true;
+			$failure_occurred = false;
 
 			foreach ( $sites as $site ) {
 				switch_to_blog( $site );
 
 				WP_CLI::line( sprintf( 'Starting %s (site %d)', home_url( '/' ), $site ) );
 
-				$_success = $this->connect_site( $assoc_args );
+				$connected = $this->connect_site( $assoc_args );
 
-				// Just one failure to flip the message from success
-				if ( true === $success && $success !== $_success ) {
-					$success = $_success;
+				if ( false === $connected ) {
+					$failure_occurred = true;
 				}
 
 				WP_CLI::line( sprintf( 'Done with %s, on to the next site!', home_url( '/' ) ) );
@@ -100,13 +99,13 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 
 			switch_to_blog( $starting_blog_id );
 		} else {
-			$success = $this->connect_site( $assoc_args );
+			$failure_occurred = ! $this->connect_site( $assoc_args );
 		}
 
-		if ( $success ) {
-			WP_CLI::success( 'All done! Welcome to Jetpack! ✈️️✈️️✈️️' );
-		} else {
+		if ( $failure_occurred ) {
 			WP_CLI::warning( 'Attempt completed. Please resolve the issues noted above and try again.' );
+		} else {
+			WP_CLI::success( 'All done! Welcome to Jetpack! ✈️️✈️️✈️️' );
 		}
 	}
 

--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -84,7 +84,7 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 
 				WP_CLI::line( sprintf( 'Starting %s (site %d)', home_url( '/' ), $site ) );
 
-				$this->connect_site();
+				$this->connect_site( $assoc_args );
 
 				WP_CLI::line( sprintf( 'Done with %s, on to the next site!', home_url( '/' ) ) );
 				WP_CLI::line( '' );
@@ -92,13 +92,13 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 
 			switch_to_blog( $starting_blog_id );
 		} else {
-			$this->connect_site();
+			$this->connect_site( $assoc_args );
 		}
 
 		WP_CLI::success( 'All done! Welcome to Jetpack! ✈️️✈️️✈️️' );
 	}
 
-	private function connect_site() {
+	private function connect_site( $assoc_args ) {
 		$force_connection = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 		if ( ! $force_connection && Jetpack::is_active() ) {
 			WP_CLI::error( 'Jetpack is already active; bailing. Run this command with `--force` to bypass this check or disconnect Jetpack before continuing.' );

--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -222,6 +222,8 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 	}
 
 	private function install_keys( $data ) {
+		$site_url = get_site_url();
+
 		$runcommand_args = [
 			'exit_error' => false,
 		];
@@ -230,8 +232,9 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 		WP_CLI::line( '---' );
 		WP_CLI::line( sprintf( 'Got Akismet key: %s', $akismet_key ) );
 		$akismet_result = WP_CLI::runcommand( sprintf(
-			'jetpack-keys akismet --akismet_key=%s',
-			escapeshellarg( $akismet_key )
+			'jetpack-keys akismet --akismet_key=%s --url=%s',
+			escapeshellarg( $akismet_key ),
+			escapeshellarg( $site_url )
 		), $runcommand_args );
 		WP_CLI::line( '' );
 
@@ -239,8 +242,9 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 		WP_CLI::line( '---' );
 		WP_CLI::line( sprintf( 'Got VaultPress key: %s', $vaultpress_key ) );
 		$vaultpress_result = WP_CLI::runcommand( sprintf(
-			'jetpack-keys vaultpress --vaultpress_key=%s',
-			escapeshellarg( $vaultpress_key )
+			'jetpack-keys vaultpress --vaultpress_key=%s --url=%s',
+			escapeshellarg( $vaultpress_key ),
+			escapeshellarg( $site_url )
 		), $runcommand_args );
 		WP_CLI::line( '' );
 
@@ -250,11 +254,12 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 		WP_CLI::line( '---' );
 		WP_CLI::line( sprintf( 'Got Jetpack ID: %s', $jetpack_id ) );
 		$jetpack_result = WP_CLI::runcommand( sprintf(
-			'jetpack-keys jetpack --jetpack_id=%s --jetpack_secret=%s --jetpack_access_token=%s --user=%s',
+			'jetpack-keys jetpack --jetpack_id=%s --jetpack_secret=%s --jetpack_access_token=%s --user=%s --url=%s',
 			escapeshellarg( $jetpack_id ),
 			escapeshellarg( $jetpack_secret ),
 			escapeshellarg( $jetpack_access_token ),
-			escapeshellarg( WPCOM_VIP_MACHINE_USER_LOGIN )
+			escapeshellarg( WPCOM_VIP_MACHINE_USER_LOGIN ),
+			escapeshellarg( $site_url )
 		), $runcommand_args );
 		WP_CLI::line( '' );
 	}

--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -101,13 +101,15 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 	private function connect_site( $assoc_args ) {
 		$force_connection = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 		if ( ! $force_connection && Jetpack::is_active() ) {
-			WP_CLI::error( 'Jetpack is already active; bailing. Run this command with `--force` to bypass this check or disconnect Jetpack before continuing.' );
+			WP_CLI::warning( 'Jetpack is already active; skipping. Run this command with `--force` to bypass this check or disconnect Jetpack before continuing.' );
+			return;
 		}
 
 		WP_CLI::line( '-- Verifying VIP machine user exists (or creating one, if not)' );
 		$user = $this->maybe_create_user();
 		if ( is_wp_error( $user ) ) {
-			WP_CLI::error( $user->get_error_message() );
+			WP_CLI::warning( $user->get_error_message() );
+			return;
 		}
 
 		WP_CLI::line( '-- Fetching keys from Jetpack Start API' );
@@ -120,7 +122,8 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 			} elseif ( false !== strpos( $message, self::API_ERROR_USER_PERMISSIONS ) ) {
 				$message = sprintf( 'This site already has an existing Jetpack shadow site but the `%s` WP.com user is either not a member of the site or not an administrator. Please use `add_user_to_blog` on your WP.com sandbox to add the account before continuing.', WPCOM_VIP_MACHINE_USER_LOGIN );
 			}
-			WP_CLI::error( 'Failed to fetch keys from Jetpack Start: ' . $message );
+			WP_CLI::warning( 'Failed to fetch keys from Jetpack Start: ' . $message );
+			return;
 		}
 
 		WP_CLI::line( '-- Adding keys to site' );

--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -83,6 +83,8 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 			// Network activation request
 			if ( is_int( $site ) ) {
 				switch_to_blog( $site );
+
+				WP_CLI::line( sprintf( 'Starting %s (site %d)', home_url( '/' ), $site ) );
 			}
 
 			$force_connection = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
@@ -116,6 +118,8 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 
 			// Only restore if we could've switched
 			if ( is_int( $site ) ) {
+				WP_CLI::line( sprintf( 'Done with %s, on to the next site!', home_url( '/' ) ) );
+
 				restore_current_blog();
 			}
 		}

--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -66,12 +66,17 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 			WP_CLI::warning( 'JETPACK_DEV_DEBUG mode is enabled. Please remove the constant after connection.' );
 		}
 
+		$sites = [ false ];
+
 		$network = WP_CLI\Utils\get_flag_value( $assoc_args, 'network', false );
 		if ( $network && is_multisite() ) {
-			// TODO: get sites list and populate $sites
-			$sites = [ false ];
-		} else {
-			$sites = [ false ];
+			$sites = get_sites( [
+				'public'   => null,
+				'archived' => 0,
+				'spam'     => 0,
+				'deleted'  => 0,
+				'fields'   => 'ids',
+			] );
 		}
 
 		foreach ( $sites as $site ) {

--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -119,6 +119,7 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 			// Only restore if we could've switched
 			if ( is_int( $site ) ) {
 				WP_CLI::line( sprintf( 'Done with %s, on to the next site!', home_url( '/' ) ) );
+				WP_CLI::line( '' );
 
 				restore_current_blog();
 			}


### PR DESCRIPTION
We should be able to start a multisite without manually looping through subsites. To avoid doing so unexpectedly, the `--network` flag is introduced to the `wp jetpack-start api connect` command.

See #594 