### PR TITLE
Disconnect Jetpack connection before cancelling

### DIFF
--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -70,8 +70,14 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 		}
 
 		$force_connection = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
-		if ( ! $force_connection && Jetpack::is_active() ) {
-			WP_CLI::error( 'Jetpack is already active; bailing. Run this command with `--force` to bypass this check or disconnect Jetpack before continuing.' );
+		if ( Jetpack::is_active() ) {
+			if ( ! $force_connection ) {
+				WP_CLI::error( 'Jetpack is already active; bailing. Run this command with `--force` to bypass this check or disconnect Jetpack before continuing.' );
+				return;
+			}
+
+			// Since we want to force the connection, let's disconnect Jetpack and cancel first
+			$this->cancel( [], [] );
 		}
 
 		WP_CLI::line( '-- Verifying VIP machine user exists (or creating one, if not)' );

--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -25,9 +25,17 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 			$site_id = Jetpack_Options::get_option( 'id' );
 			if ( empty( $site_id ) ) {
 				WP_CLI::error( 'Could not get WP.com blog_id from the local Jetpack install. Please specify the `--jetpack_site_id` of the Jetpack Shadow site to cancel the subscription. You can get this from the Jetpack Debugger or using WP.com Network Admin.' );
+				return;
 			}
+
+			WP_CLI::line( 'Disconnecting Jetpack...' );
+			WP_CLI::runcommand( sprintf(
+				'jetpack disconnect blog --url=%s',
+				escapeshellarg( get_site_url() )
+			) );
 		}
 
+		WP_CLI::line( 'Cancelling Subscription...' );
 		$data = $this->api_cancel_subscription( $site_id );
 		if ( is_wp_error( $data ) ) {
 			WP_CLI::error( $data->get_error_message() );


### PR DESCRIPTION
To avoid unexpected behaviour due to mismatched Jetpack connection locally and remote.

- [x] Disconnect Jetpack
- [ ] Disconnect VaultPress
- [ ] Disconnect Akismet

Fixes #613 