### PR TITLE
Don't block JP version updates when running a different version locally

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -27,7 +27,7 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 }, 999 );
 
 // Prevent Jetpack version ping-pong when a sandbox has an old version of stacks
-if ( true === WPCOM_SANDBOXED ) {
+if ( true === WPCOM_SANDBOXED && ( ! defined( 'WPCOM_VIP_JETPACK_LOCAL' ) || ! WPCOM_VIP_JETPACK_LOCAL ) ) {
 	add_action( 'updating_jetpack_version', function() {
 		wp_die( '😱😱😱 Oh no! Looks like your sandbox is trying to change the version of Jetpack. This is probably not a good idea. As a precaution, we\'re killing this request to prevent this from happening (this === 💥💥💥). Please run `vip stacks update` on your sandbox before doing anything else.', 400 );
 	}, 0 ); // No need to wait till priority 10 since we're going to die anyway


### PR DESCRIPTION
When running a different version of Jetpack, care of the `WPCOM_VIP_JETPACK_LOCAL` constant, version changes are expected.