### PR TITLE
Add support for serving admin queries from ES

### DIFF
--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -177,7 +177,7 @@ class WPCOM_elasticsearch {
 		 * Allow the admin query to be assessed for suitability for being served
 		 * by ES, For example, published posts only.
 		 *
-		 * @var [type]
+		 * @var bool $es Whether (true) or note (false) to run the query through ES.
 		 */
 		if ( is_admin() && false === apply_filters( 'wpcom_elasticsearch_perform_admin_query', false, $query ) ) {
 			return $sql;

--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -198,7 +198,7 @@ class WPCOM_elasticsearch {
 
 		$should_replace = false;
 
-		// By defauly, we only care about main search queries
+		// By default, we only care about main search queries
 		if ( $query->is_main_query() && $query->is_search() ) {
 			$should_replace = true;
 		}
@@ -209,7 +209,7 @@ class WPCOM_elasticsearch {
 		 * Allow the admin query to be assessed for suitability for being served
 		 * by ES, For example, published posts only.
 		 *
-		 * @var bool $es Whether (true) or note (false) to run the query through ES.
+		 * @var bool $es Whether (true) or not (false) to run the query through ES.
 		 */
 		$should_replace = apply_filters( 'wpcom_elasticsearch_should_replace_query', $should_replace, $query );
 

--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -171,6 +171,18 @@ class WPCOM_elasticsearch {
 		if ( ! $query->is_main_query() || ! $query->is_search() )
 			return $sql;
 
+		/**
+		 * Whether to run this admin query through ES.
+		 *
+		 * Allow the admin query to be assessed for suitability for being served
+		 * by ES, For example, published posts only.
+		 *
+		 * @var [type]
+		 */
+		if ( is_admin() && false === apply_filters( 'wpcom_elasticsearch_perform_admin_query', false, $query ) ) {
+			return $sql;
+		}
+
 		$page = ( $query->get( 'paged' ) ) ? absint( $query->get( 'paged' ) ) : 1;
 
 		// Start building the WP-style search query args

--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -75,17 +75,25 @@ class WPCOM_elasticsearch {
 			return;
 		}
 
-		/**
-		 * Whether to allow ES to power admin searches.
-		 *
-		 * Will allow the plugin to act on admin as well as frontend searches if set to true,
-		 * subject to conditions specific to the query being performed.
-		 *
-		 * @var bool Whether (true) or not (false) to allow ES searches in the admin.
-		 */
-		if ( ! is_admin() || apply_filters( 'wpcom_elasticsearch_enable_in_admin', false ) ) {
+		if ( $this->is_enabled() ) {
 			$this->init_hooks();
 		}
+	}
+
+	protected function is_enabled() {
+		if ( is_admin() ) {
+			/**
+			 * Whether to allow ES to power admin searches.
+			 *
+			 * Will allow the plugin to act on admin as well as frontend searches if set to true,
+			 * subject to conditions specific to the query being performed.
+			 *
+			 * @var bool Whether (true) or not (false) to allow ES searches in the admin.
+			 */
+			return apply_filters( 'wpcom_elasticsearch_enable_in_admin', false );
+		}
+
+		return true;
 	}
 
 	public function init_hooks() {

--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -75,7 +75,15 @@ class WPCOM_elasticsearch {
 			return;
 		}
 
-		if ( ! is_admin() ) {
+		/**
+		 * Whether to allow ES to power admin searches.
+		 *
+		 * Will allow the plugin to act on admin as well as frontend searches if set to true,
+		 * subject to conditions specific to the query being performed.
+		 *
+		 * @var bool Whether (true) or not (false) to allow ES searches in the admin.
+		 */
+		if ( ! is_admin() || apply_filters( 'wpcom_elasticsearch_enable_in_admin', false ) ) {
 			$this->init_hooks();
 		}
 	}


### PR DESCRIPTION
Adds two new filters which give plugins/themes the power to have some admin queries served by Elasticsearch.

`wpcom_elasticsearch_enable_in_admin`, when set to true will cause the plugin to run in the admin instead of only the frontend.

When in the admin, `wpcom_elasticsearch_perform_admin_query` provides a mechanism to inspect the query and check if it's suitable for being served by ES (defaults to `false`).

This example would enable admin searches that are searching only published, public posts:

```
add_filter( 'wpcom_elasticsearch_enable_in_admin', '__return_true' );
add_filter( 'wpcom_elasticsearch_perform_admin_query', 'example_wpcom_elasticsearch_perform_admin_query' );
function example_wpcom_elasticsearch_perform_admin_query( $es, $query ) {

	// Explicitly stop attachment queries from using ES.
	if ( in_array( 'attachment', (array) $query->get('post_type') ) ) {
		return false;
	}

	// Only search published posts in ES.
	if ( 'publish' !== $query->get('post_status') ) {
		return false;
	}

	$public_post_types = get_post_types( [
		'public'   => true,
	] );

	// If any of the post types aren't public, don't use ES.
	if ( $query->get('post_type') !== array_intersect( (array) $query->get('post_type'), $public_post_types ) ) {
		return false;
	}

	// We have a query that is only looking for public post types with a
	// published status, so allow it to go through ES.
	return true;

}
```