### PR TITLE
Allow authenticated requests to ES

### DIFF
--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -62,18 +62,36 @@ function es_api_search_index( $args ) {
 
     $args['blog_id'] = absint( $args['blog_id'] );
 
-    $service_url = 'https://public-api.wordpress.com/rest/v1/sites/' . $args['blog_id'] . '/search';
+    $endpoint = sprintf( '/sites/%s/search', $args['blog_id'] );
+    $service_url = 'https://public-api.wordpress.com/rest/v1' . $endpoint;
+
+    $do_authenticated_request = false;
+    if ( class_exists( 'Jetpack_Client' )
+            && isset( $args['authenticated_request'] )
+	    && true === $args['authenticated_request'] ) {
+        $do_authenticated_request = true;
+    }
 
     unset( $args['blog_id'] );
+    unset( $args['authenticated_request'] );
 
-    $start_time = microtime( true );
-
-    $request = wp_remote_post( $service_url, array(
+    $request_args = array(
         'headers' => array(
             'Content-Type' => 'application/json',
         ),
-        'body' => json_encode( $args ),
-    ) );
+    );
+    $request_body = json_encode( $args );
+
+    $start_time = microtime( true );
+
+    if ( $do_authenticated_request ) {
+        $request = Jetpack_Client::wpcom_json_api_request_as_blog( $endpoint, Jetpack_Client::WPCOM_JSON_API_VERSION, $request_args, $request_body );
+    } else {
+	$request_args = array_merge( $request_args, array(
+            'body' => $request_body,
+	) );
+	$request = wp_remote_post( $service_url, $request_args );
+    }
 
     $end_time = microtime( true );
 

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -85,14 +85,15 @@ function es_api_search_index( $args ) {
     $start_time = microtime( true );
 
     if ( $do_authenticated_request ) {
-        $request = Jetpack_Client::wpcom_json_api_request_as_blog( $endpoint, Jetpack_Client::WPCOM_JSON_API_VERSION, $request_args, $request_body );
       $request_args['method'] = 'POST';
 
+      $request = Jetpack_Client::wpcom_json_api_request_as_blog( $endpoint, Jetpack_Client::WPCOM_JSON_API_VERSION, $request_args, $request_body );
     } else {
-	$request_args = array_merge( $request_args, array(
-            'body' => $request_body,
-	) );
-	$request = wp_remote_post( $service_url, $request_args );
+      $request_args = array_merge( $request_args, array(
+        'body' => $request_body,
+	    ) );
+
+      $request = wp_remote_post( $service_url, $request_args );
     }
 
     $end_time = microtime( true );

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -86,6 +86,8 @@ function es_api_search_index( $args ) {
 
     if ( $do_authenticated_request ) {
         $request = Jetpack_Client::wpcom_json_api_request_as_blog( $endpoint, Jetpack_Client::WPCOM_JSON_API_VERSION, $request_args, $request_body );
+      $request_args['method'] = 'POST';
+
     } else {
 	$request_args = array_merge( $request_args, array(
             'body' => $request_body,


### PR DESCRIPTION
Allow setting an arg for `es_api_search_index` (`authenticated_request => true`), which would make an authenticated request to the search API using Jetpack internal auth.

Note that calling methods (e.g. `vip-go-elasticsearch`) need to filter through the returned results list to strip out any content that the user should not have access to.