### PR TITLE
Don't disable Core updates outside of our environments

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -4,7 +4,6 @@ function wpcom_vip_disable_core_update_nag() {
 	remove_action( 'admin_notices', 'update_nag', 3 );
 	remove_action( 'network_admin_notices', 'update_nag', 3 );
 }
-add_action( 'admin_init', 'wpcom_vip_disable_core_update_nag' );
 
 function wpcom_vip_disable_core_update_cap( $caps, $cap ) {
 	if ( 'update_core' === $cap ) {
@@ -12,4 +11,9 @@ function wpcom_vip_disable_core_update_cap( $caps, $cap ) {
 	}
 	return $caps;
 }
-add_filter( 'map_meta_cap', 'wpcom_vip_disable_core_update_cap', 100, 2 );
+
+// Limit to our (non-local) environments
+if ( false !== VIP_GO_ENV ) {
+	add_filter( 'map_meta_cap', 'wpcom_vip_disable_core_update_cap', 100, 2 );
+	add_action( 'admin_init', 'wpcom_vip_disable_core_update_nag' );
+}


### PR DESCRIPTION
We should only block upgrades in our environments, where we know they can't succeed. For local environments, for example, we shouldn't interfere. See poqVs-hAR-P2.