### PR TITLE
Allow local core upgrades

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -1,10 +1,18 @@
 <?php
 
+if ( false !== WPCOM_IS_VIP_ENV ) {
+	add_action( 'muplugins_loaded', 'wpcom_vip_init_core_restrictions' );
+}
+
+function wpcom_vip_init_core_restrictions() {
+	add_action( 'admin_init', 'wpcom_vip_disable_core_update_nag' );
+	add_filter( 'map_meta_cap', 'wpcom_vip_disable_core_update_cap', 100, 2 );
+}
+
 function wpcom_vip_disable_core_update_nag() {
 	remove_action( 'admin_notices', 'update_nag', 3 );
 	remove_action( 'network_admin_notices', 'update_nag', 3 );
 }
-add_action( 'admin_init', 'wpcom_vip_disable_core_update_nag' );
 
 function wpcom_vip_disable_core_update_cap( $caps, $cap ) {
 	if ( 'update_core' === $cap ) {
@@ -12,4 +20,3 @@ function wpcom_vip_disable_core_update_cap( $caps, $cap ) {
 	}
 	return $caps;
 }
-add_filter( 'map_meta_cap', 'wpcom_vip_disable_core_update_cap', 100, 2 );

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -1,6 +1,10 @@
 <?php
 
-class VIP_Go_Core_Updates_Test extends WP_UnitTestCase {
+class VIP_Go__Core__Disable_Update_Caps_Test extends WP_UnitTestCase {
+	public function setUp() {
+		wpcom_vip_init_core_restrictions();
+	}
+
 	public function test__super_admin_should_not_have_update_core_cap() {
 		$super_admin = $this->factory->user->create_and_get( array( 'role' => 'administrator' ) );
 		grant_super_admin( $super_admin->ID );


### PR DESCRIPTION
Upgrade cap restrictions should only apply to production environments where we can't actually trigger upgrades due to the read-only file system.