### PR TITLE
Graceful continue for dbdelta for network flag

### DIFF
--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -23,7 +23,8 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 
 		$network = Utils\get_flag_value( $assoc_args, 'network' );
 		if ( $network && ! is_multisite() ) {
-			WP_CLI::error( 'This is not a multisite install.' );
+			WP_CLI::warning( 'This is not a multisite install. Proceeding as single site.' );
+			$network = false;
 		}
 
 		$dry_run = Utils\get_flag_value( $assoc_args, 'dry-run' );


### PR DESCRIPTION
If we pass the network flag on a single site, show a warning but continue.