### PR TITLE
Introduce new plugins endpoint for querying all types of plugins

### DIFF
--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -148,11 +148,8 @@ class WPCOM_VIP_REST_API_Endpoints {
 	 * Get all the plugins
 	 */
 	public function get_all_plugins() {
+		global $vip_loaded_plugins;
 		$all_plugins = array();
-		$standard_plugins = array();
-		$shared_plugins = array();
-		$mu_plugins = array();
-		$client_mu_plugins = array();
 
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -162,16 +159,42 @@ class WPCOM_VIP_REST_API_Endpoints {
 		$standard_plugins = get_plugins();
 		$tmp_plugins = array();
 		foreach ( $standard_plugins as $key => $plugin ) {
+			$vip_plugin_slug = 'plugins/' . dirname( $key );
 			if ( is_plugin_active( $key ) ) {
 				$tmp_plugins[ $key ] = array(
 					'name' => $plugin['Name'],
 					'version' => $plugin['Version'],
 					'description' => $plugin['Description'],
 					'type' => 'standard',
+					'active' => true,
+				);
+			} elseif ( ! in_array( $vip_plugin_slug, $vip_loaded_plugins, true ) ) {
+				$tmp_plugins[ $key ] = array(
+					'name' => $plugin['Name'],
+					'version' => $plugin['Version'],
+					'description' => $plugin['Description'],
+					'type' => 'standard',
+					'active' => false,
 				);
 			}
 		}
 		$all_plugins['standard'] = $tmp_plugins;
+
+		// array of all code activated standard plugins
+		$tmp_plugins = array();
+		foreach ( $standard_plugins as $key => $plugin ) {
+			$vip_plugin_slug = 'plugins/' . dirname( $key );
+			if ( in_array( $vip_plugin_slug, $vip_loaded_plugins, true ) ) {
+				$tmp_plugins[ $key ] = array(
+					'name' => $plugin['Name'],
+					'version' => $plugin['Version'],
+					'description' => $plugin['Description'],
+					'type' => 'standard-code',
+					'active' => true,
+				);
+			}
+		}
+		$all_plugins['standard-code'] = $tmp_plugins;
 
 		// array of all mu plugins
 		$mu_plugins = get_mu_plugins();

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -133,9 +133,21 @@ class WPCOM_VIP_REST_API_Endpoints {
 	}
 
 	/**
-	 * Build list of active plugins on site ()
+	 * Endpoint to return active plugins on site
 	 */
 	public function list_plugins() {
+		$plugins = $this->get_all_plugins();
+		if ( is_wp_error( $plugins ) ) {
+			return $plugins->get_error_message();
+		}
+
+		return new WP_REST_Response( $plugins );
+	}
+
+	/**
+	 * Get all the plugins
+	 */
+	public function get_all_plugins() {
 		$all_plugins = array();
 		$standard_plugins = array();
 		$shared_plugins = array();
@@ -217,7 +229,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 			$all_plugins['vip-shared-ui'] = $tmp_ui_plugins;
 		}
 
-		return new WP_REST_Response( $all_plugins );
+		return $all_plugins;
 	}
 }
 

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -187,7 +187,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 		$all_plugins['mu-plugin'] = $tmp_plugins;
 
 		// array of all client mu plugins
-		$client_mu_plugins = wpcom_vip_get_client_mu_plugins();
+		$client_mu_plugins = wpcom_vip_get_client_mu_plugins_data();
 		$tmp_plugins = array();
 		foreach ( $client_mu_plugins as $key => $plugin ) {
 			$tmp_plugins[ $key ] = array(

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -137,9 +137,6 @@ class WPCOM_VIP_REST_API_Endpoints {
 	 */
 	public function list_plugins() {
 		$plugins = $this->get_all_plugins();
-		if ( is_wp_error( $plugins ) ) {
-			return $plugins->get_error_message();
-		}
 
 		return new WP_REST_Response( $plugins );
 	}
@@ -147,7 +144,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 	/**
 	 * Get all the plugins
 	 */
-	public function get_all_plugins() {
+	protected function get_all_plugins() {
 		global $vip_loaded_plugins;
 		$all_plugins = array();
 

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -205,6 +205,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 				'version' => $plugin['Version'],
 				'description' => $plugin['Description'],
 				'type' => 'mu-plugin',
+				'active' => true,
 			);
 		}
 		$all_plugins['mu-plugin'] = $tmp_plugins;
@@ -218,6 +219,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 				'version' => $plugin['Version'],
 				'description' => $plugin['Description'],
 				'type' => 'client-mu-plugin',
+				'active' => true,
 			);
 		}
 		$all_plugins['client-mu-plugin'] = $tmp_plugins;
@@ -237,6 +239,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 							'version' => $plugin['Version'],
 							'description' => $plugin['Description'],
 							'type' => 'vip-shared-code',
+							'active' => true,
 						);
 					} else {
 						$tmp_ui_plugins[ $key ] = array(
@@ -244,6 +247,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 							'version' => $plugin['Version'],
 							'description' => $plugin['Description'],
 							'type' => 'vip-shared-ui',
+							'active' => true,
 						);
 					}
 				}

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -175,7 +175,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 		$all_plugins['mu-plugin'] = $tmp_plugins;
 
 		// array of all client mu plugins
-		$client_mu_plugins = get_client_mu_plugins();
+		$client_mu_plugins = wpcom_vip_get_client_mu_plugins();
 		$tmp_plugins = array();
 		foreach ( $client_mu_plugins as $key => $plugin ) {
 			$tmp_plugins[ $key ] = array(

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -217,7 +217,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 			$all_plugins['vip-shared-ui'] = $tmp_ui_plugins;
 		}
 
-		return new WP_REST_Response( array( 'site' => get_home_url(), 'plugins' => $all_plugins ) );
+		return new WP_REST_Response( $all_plugins );
 	}
 }
 

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -195,8 +195,8 @@ class WPCOM_VIP_REST_API_Endpoints {
 			$shared_plugins = $vip_plugins->get_shared_plugins();
 
 			foreach ( $vip_plugins->get_shared_plugins() as $key => $plugin ) {
-				if ( $t = $vip_plugins->is_plugin_active( basename( dirname( $key ) ) ) ) {
-					if ( 'manual' === $t ) {
+				if ( $active_plugin_type = $vip_plugins->is_plugin_active( basename( dirname( $key ) ) ) ) {
+					if ( 'manual' === $active_plugin_type ) {
 						$tmp_code_plugins[ $key ] = array(
 							'name' => $plugin['Name'],
 							'version' => $plugin['Version'],

--- a/z-client-mu-plugins.php
+++ b/z-client-mu-plugins.php
@@ -49,12 +49,12 @@ function wpcom_vip_load_client_mu_plugins() {
 
 function wpcom_vip_get_client_mu_plugins() {
 	$wp_plugins = array();
-	// Files in wp-content/mu-plugins directory
 	$plugin_files = array();
 
 	if ( ! is_dir( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR ) ) {
 		return $wp_plugins;
 	}
+
 	if ( $plugins_dir = @opendir( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR ) ) {
 		while ( ( $file = readdir( $plugins_dir ) ) !== false ) {
 			if ( substr( $file, -4 ) === '.php' ) {
@@ -69,6 +69,16 @@ function wpcom_vip_get_client_mu_plugins() {
 
 	if ( empty( $plugin_files ) ) {
 		return $wp_plugins;
+	}
+
+	return $plugin_files;
+}
+
+function wpcom_vip_get_client_mu_plugins_data() {
+	$plugin_files = wpcom_vip_get_client_mu_plugins();
+
+	if ( empty( $plugin_files ) ) {
+		return $plugin_files;
 	}
 
 	foreach ( $plugin_files as $plugin_file ) {
@@ -93,5 +103,3 @@ function wpcom_vip_get_client_mu_plugins() {
 
 	return $wp_plugins;
 }
-
-wpcom_vip_load_client_mu_plugins();

--- a/z-client-mu-plugins.php
+++ b/z-client-mu-plugins.php
@@ -47,4 +47,51 @@ function wpcom_vip_load_client_mu_plugins() {
 	}
 }
 
+function get_client_mu_plugins() {
+	$wp_plugins = array();
+	// Files in wp-content/mu-plugins directory
+	$plugin_files = array();
+
+	if ( ! is_dir( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR ) ) {
+		return $wp_plugins;
+	}
+	if ( $plugins_dir = @opendir( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR ) ) {
+		while ( ( $file = readdir( $plugins_dir ) ) !== false ) {
+			if ( substr( $file, -4 ) === '.php' ) {
+				$plugin_files[] = $file;
+			}
+		}
+	} else {
+		return $wp_plugins;
+	}
+
+	@closedir( $plugins_dir );
+
+	if ( empty( $plugin_files ) ) {
+		return $wp_plugins;
+	}
+
+	foreach ( $plugin_files as $plugin_file ) {
+		if ( ! is_readable( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . "/$plugin_file" ) ) {
+			continue;
+		}
+
+		$plugin_data = get_plugin_data( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . "/$plugin_file", false, false ); //Do not apply markup/translate as it'll be cached.
+
+		if ( empty( $plugin_data['Name'] ) ) {
+			$plugin_data['Name'] = $plugin_file;
+		}
+
+		$wp_plugins[ $plugin_file ] = $plugin_data;
+	}
+
+	if ( isset( $wp_plugins['index.php'] ) && filesize( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . '/index.php' ) <= 30 ) { // silence is golden
+		unset( $wp_plugins['index.php'] );
+	}
+
+	uasort( $wp_plugins, '_sort_uname_callback' );
+
+	return $wp_plugins;
+}
+
 wpcom_vip_load_client_mu_plugins();

--- a/z-client-mu-plugins.php
+++ b/z-client-mu-plugins.php
@@ -47,6 +47,10 @@ function wpcom_vip_load_client_mu_plugins() {
 	}
 }
 
+// Load the plugins
+// TODO: move out of function scope to avoid issues with globals not being properly set
+wpcom_vip_load_client_mu_plugins();
+
 function wpcom_vip_get_client_mu_plugins() {
 	$wp_plugins = array();
 	$plugin_files = array();

--- a/z-client-mu-plugins.php
+++ b/z-client-mu-plugins.php
@@ -47,7 +47,7 @@ function wpcom_vip_load_client_mu_plugins() {
 	}
 }
 
-function get_client_mu_plugins() {
+function wpcom_vip_get_client_mu_plugins() {
 	$wp_plugins = array();
 	// Files in wp-content/mu-plugins directory
 	$plugin_files = array();


### PR DESCRIPTION
This creates a new private endpoint for determining all active plugins on a site grouped by type:

![screenshot-23-06-2017-18 45 10](https://user-images.githubusercontent.com/411945/27494087-3c888d6e-5844-11e7-9d8c-e0349dbe6406.png)

Also added a helper function to grab client mu plugin information