### PR TITLE
add stripslashes_deep. move stripslashes_deep outside loops

### DIFF
--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -527,6 +527,9 @@ class WPCOM_elasticsearch {
 
 		$facet_data = array();
 
+		// Remove any backslash from the GET parameters
+		$_GET = stripslashes_deep( $_GET );
+
 		foreach ( $facets as $label => $facet ) {
 			if ( empty( $this->facets[ $label ] ) )
 				continue;
@@ -638,9 +641,6 @@ class WPCOM_elasticsearch {
 					default:
 						//continue 2; // switch() is considered a looping structure
 				}
-
-				// Remove any backslash from the GET parameters
-				$_GET = array_map( "stripslashes", $_GET );
 
 				// Need to urlencode param values since add_query_arg doesn't
 				$url_params = urlencode_deep( array_merge( $_GET, $query_vars ) );


### PR DESCRIPTION
- Fix ERROR: 
-- stripslashes() expects parameter 1 to be string, array given. 
-- vip-go-elasticsearch.php (643)
- Solution:
-- add stripslashes_deep.
-- move stripslashes_deep outside loops