### PR TITLE
Introduce a TTL Manager class

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,7 @@ function _manually_load_plugin() {
 	require_once( __DIR__ . '/../lib/proxy/ip-forward.php' );
 	require_once( __DIR__ . '/../lib/proxy/ip-utils.php' );
 
+	require_once( __DIR__ . '/../vip-cache-manager.php' );
 	require_once( __DIR__ . '/../vip-rest-api.php' );
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/test-cache-ttl-manager-rest.php
+++ b/tests/test-cache-ttl-manager-rest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Automattic\VIP\Cache;
+
+class TTL_Manager__REST_API__Test extends \WP_Test_REST_TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new \WP_REST_Server;
+		do_action( 'rest_api_init' );
+
+		register_rest_route( 'tests/v1', '/endpoint', [
+			'methods' => [ 'GET', 'HEAD', 'POST', 'PUT', 'DELETE' ],
+			'callback' => '__return_null',
+		] );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+	}
+
+	protected function dispatch_request( $method ) {
+		$request = new \WP_REST_Request( $method, '/tests/v1/endpoint' );
+		$response = $this->server->dispatch( $request );
+		$dispatched_response = apply_filters( 'rest_post_dispatch', rest_ensure_response( $response ), $this->server, $request );
+
+		return $dispatched_response;
+	}
+
+	public function get_rest_read_methods() {
+		return [
+			[ 'GET' ],
+			[ 'HEAD' ],
+		];
+	}
+
+	public function get_rest_write_methods() {
+		return [
+			[ 'POST' ],
+			[ 'PUT' ],
+			[ 'DELETE' ],
+		];
+	}
+
+	/**
+	 * @dataProvider get_rest_read_methods
+	 */
+	public function test__set_ttl_for_unauthenticated_read_requests( $method ) {
+		$response = $this->dispatch_request( $method );
+
+		$response_headers = $response->get_headers();
+
+		$this->assertArraySubset( [ 'Cache-Control' => 'max-age=60' ], $response_headers );
+	}
+
+	/**
+	 * @dataProvider get_rest_write_methods
+	 */
+	public function test__set_ttl_for_unauthenticated_write_requests( $method ) {
+		$response = $this->dispatch_request( $method );
+
+		$response_headers = $response->get_headers();
+
+		$this->assertArrayNotHasKey( 'Cache-Control', $response_headers );
+	}
+
+	/**
+	 * @dataProvider get_rest_read_methods
+	 */
+	public function test__skip_ttl_for_authenticated_read_requests( $method ) {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$response = $this->dispatch_request( $method );
+
+		$response_headers = $response->get_headers();
+
+		$this->assertArrayNotHasKey( 'Cache-Control', $response_headers );
+	}
+
+	/**
+	 * @dataProvider get_rest_write_methods
+	 */
+	public function test__skip_ttl_for_authenticated_write_requests( $method ) {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$response = $this->dispatch_request( $method );
+
+		$response_headers = $response->get_headers();
+
+		$this->assertArrayNotHasKey( 'Cache-Control', $response_headers );
+	}
+
+	public function test__skip_ttl_for_error_responses() {
+		$request = new \WP_REST_Request( 'GET', '/tests/v1/this-does-not-exist' );
+		$response = $this->server->dispatch( $request );
+		$dispatched_response = apply_filters( 'rest_post_dispatch', rest_ensure_response( $response ), $this->server, $request );
+
+		$response_headers = $dispatched_response->get_headers();
+
+		$this->assertArrayNotHasKey( 'Cache-Control', $response_headers );
+	}
+
+	public function test__skip_ttl_if_already_set() {
+		$request = new \WP_REST_Request( 'GET', '/tests/v1/endpoint' );
+		$response = $this->server->dispatch( $request );
+		$response->header( 'Cache-Control', 'max-age=666' );
+		$dispatched_response = apply_filters( 'rest_post_dispatch', rest_ensure_response( $response ), $this->server, $request );
+
+		$response_headers = $dispatched_response->get_headers();
+
+		$this->assertArraySubset( [ 'Cache-Control' => 'max-age=666' ], $response_headers );
+	}
+}

--- a/vip-cache-manager.php
+++ b/vip-cache-manager.php
@@ -9,3 +9,4 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 */
 
 require_once( __DIR__ . '/vip-cache-manager/vip-cache-manager.php' );
+require_once( __DIR__ . '/vip-cache-manager/ttl-manager.php' );

--- a/vip-cache-manager/ttl-manager.php
+++ b/vip-cache-manager/ttl-manager.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+Plugin name: TTL Manager
+Description: Sets sane and reasonable cache TTLs for site responses.
+Author: Automattic
+Author URI: http://automattic.com/
+Version: 1.0
+License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+*/
+
+namespace Automattic\VIP\Cache;
+
+class TTL_Manager {
+	const DEFAULT_API_TTL = \MINUTE_IN_SECONDS;
+
+	public static function init() {
+		add_filter( 'rest_post_dispatch', [ __CLASS__, 'enforce_rest_api_read_ttl' ], 10, 3 );
+	}
+
+	public static function enforce_rest_api_read_ttl( $response, $rest_server, $request ) {
+		if ( $response->is_error() ) {
+			return $response;
+		}
+
+		$method = $request->get_method();
+		if ( 'GET' !== $method && 'HEAD' !== $method ) {
+			return $response;
+		}
+
+		$response_headers = $response->get_headers();
+		if ( isset( $response_headers[ 'Cache-Control' ] ) ) {
+			return $response;
+		}
+
+		if ( is_user_logged_in() ) {
+			return $response;
+		}
+
+		$ttl = apply_filters( 'wpcom_vip_rest_response_ttl', self::DEFAULT_API_TTL, $response, $rest_server, $request );
+		self::set_rest_response_ttl( $response, $ttl );
+
+		return $response;
+	}
+
+	protected static function set_rest_response_ttl( \WP_REST_Response $response, $ttl ) {
+		$response->header( 'Cache-Control', sprintf( 'max-age=%d', $ttl ) );
+	}
+}
+
+TTL_Manager::init();


### PR DESCRIPTION
Which sets a default TTL of 60s for all unauthenticated, read requests to REST API endpoints instead of the default 30 mins.

```
curl 'http://vagrant.local/?rest_route=/wp/v2/posts' -v -s > /dev/null
...
< Cache-Control: max-age=60
...
```

* [ ] Amend client facing docs here to document filter: https://vip.wordpress.com/documentation/vip-go/controlling-vip-go-page-cache/
* [ ] Amend client facing docs here to document filter: https://vip.wordpress.com/documentation/vip-go/vip-go-and-the-wordpress-rest-api/#caching

Fixes #658 