### PR TITLE
Simplify `fix_remote_address()`

### DIFF
--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -14,7 +14,7 @@ namespace Automattic\VIP\Proxy;
  *
  * @return (bool) true, if REMOTE_ADDR updated; false, if not.
  */
-function fix_remote_address( $user_ip, $remote_proxy_ip, $proxy_ip_whitelist ) {
+function fix_remote_address( $user_ip, $proxy_ip_whitelist ) {
 	if ( ! is_valid_ip( $user_ip ) ) {
 		return false;
 	}
@@ -22,7 +22,7 @@ function fix_remote_address( $user_ip, $remote_proxy_ip, $proxy_ip_whitelist ) {
 	require_once( __DIR__ . '/ip-utils.php' );
 
 	// Verify that the remote proxy matches our whitelist
-	$is_whitelisted_proxy_ip = IpUtils::checkIp( $remote_proxy_ip, $proxy_ip_whitelist );
+	$is_whitelisted_proxy_ip = IpUtils::checkIp( $_SERVER['HTTP_X_FORWARDED_FOR'], $proxy_ip_whitelist );
 
 	if ( ! $is_whitelisted_proxy_ip ) {
 		return false;
@@ -54,9 +54,9 @@ function fix_remote_address_from_ip_trail( $ip_trail, $proxy_ip_whitelist ) {
 		return false;
 	}
 
-	list( $user_ip, $remote_proxy_ip ) = $ip_addresses;
+	list( $user_ip ) = $ip_addresses;
 
-	return fix_remote_address( $user_ip, $remote_proxy_ip, $proxy_ip_whitelist );
+	return fix_remote_address( $user_ip, $proxy_ip_whitelist );
 }
 
 /**
@@ -177,7 +177,7 @@ function is_valid_proxy_verification_key( $submitted_verification_key ) {
 
 /**
  * Get a list of validated IP addresses from a comma-separated string expected to
- * be passed as the X-IP-Trail HTTP request header.
+ * be passed as the X-IP-Trail HTTP request header
  *
  * Takes IP v4 or v6.
  *

--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -43,13 +43,12 @@ function fix_remote_address( $user_ip, $proxy_ip_whitelist ) {
  *
  * @see https://vip.wordpress.com/documentation/vip-go/reverse-proxies-and-vip-go/
  *
- * @param (string) $ip_trail Comma-separated list of IPs (something like `user_ip, proxy_ip`)
  * @param (string|array) $proxy_ip_whitelist Whitelisted IP addresses for the remote proxy. Supports IPv4 and IPv6, including CIDR format.
  *
  * @return (bool) true, if REMOTE_ADDR updated; false, if not.
  */
-function fix_remote_address_from_ip_trail( $ip_trail, $proxy_ip_whitelist ) {
-	$ip_addresses = get_ip_addresses_from_ip_trail( $ip_trail );
+function fix_remote_address_from_ip_trail( $proxy_ip_whitelist ) {
+	$ip_addresses = get_ip_addresses_from_ip_trail( $_SERVER['HTTP_X_IP_TRAIL'] );
 	if ( false === $ip_addresses ) {
 		return false;
 	}

--- a/tests/test-lib-proxy-ip-forward.php
+++ b/tests/test-lib-proxy-ip-forward.php
@@ -151,10 +151,10 @@ class IP_Forward_Tests extends IP_Forward_Test_Base {
 	// fix_remote_address
 	public function test__fix_remote_address__invalid_user_ip() {
 		$user_ip = 'bad_ip';
-		$proxy_ip = '5.6.7.8';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];
 
-		$result = fix_remote_address( $user_ip, $proxy_ip, $whitelist );
+		$result = fix_remote_address( $user_ip, $whitelist );
 
 		$this->assertFalse( $result );
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
@@ -162,10 +162,10 @@ class IP_Forward_Tests extends IP_Forward_Test_Base {
 
 	public function test__fix_remote_address__ip_not_in_whitelist() {
 		$user_ip = '1.2.3.4';
-		$proxy_ip = '5.6.7.8';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$whitelist = [ '0.0.0.0' ];
 
-		$result = fix_remote_address( $user_ip, $proxy_ip, $whitelist );
+		$result = fix_remote_address( $user_ip, $whitelist );
 
 		$this->assertFalse( $result );
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
@@ -173,10 +173,10 @@ class IP_Forward_Tests extends IP_Forward_Test_Base {
 
 	public function test__fix_remote_address__ip_in_whitelist_ipv4() {
 		$user_ip = '1.2.3.4';
-		$proxy_ip = '5.6.7.8';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];
 
-		$result = fix_remote_address( $user_ip, $proxy_ip, $whitelist );
+		$result = fix_remote_address( $user_ip, $whitelist );
 
 		$this->assertTrue( $result );
 		$this->assertEquals( '1.2.3.4', $_SERVER['REMOTE_ADDR'] );
@@ -184,10 +184,10 @@ class IP_Forward_Tests extends IP_Forward_Test_Base {
 
 	public function test__fix_remote_address__ip_in_whitelist_ipv6() {
 		$user_ip = '2001:db8::1234:ace:6006:1e';
-		$proxy_ip = '5.6.7.8';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];
 
-		$result = fix_remote_address( $user_ip, $proxy_ip, $whitelist );
+		$result = fix_remote_address( $user_ip, $whitelist );
 
 		$this->assertTrue( $result );
 		$this->assertEquals( '2001:db8::1234:ace:6006:1e', $_SERVER['REMOTE_ADDR'] );

--- a/tests/test-lib-proxy-ip-forward.php
+++ b/tests/test-lib-proxy-ip-forward.php
@@ -195,10 +195,10 @@ class IP_Forward_Tests extends IP_Forward_Test_Base {
 
 	public function test__fix_remote_address_from_ip_trail__ip_not_in_whitelist() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
-		$ip_trail = '1.2.3.4, 5.6.7.8';
+		$_SERVER['HTTP_X_IP_TRAIL'] = '1.2.3.4, 5.6.7.8';
 		$whitelist = [ '0.0.0.0' ];
 
-		$result = fix_remote_address_from_ip_trail( $ip_trail, $whitelist );
+		$result = fix_remote_address_from_ip_trail( $whitelist );
 
 		$this->assertFalse( $result );
 		$this->assertEquals( self::DEFAULT_REMOTE_ADDR, $_SERVER['REMOTE_ADDR'] );
@@ -206,10 +206,10 @@ class IP_Forward_Tests extends IP_Forward_Test_Base {
 
 	public function test__fix_remote_address_from_ip_trail__ip_in_whitelist() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
-		$ip_trail = '1.2.3.4, 5.6.7.8';
+		$_SERVER['HTTP_X_IP_TRAIL'] = '1.2.3.4, 5.6.7.8';
 		$whitelist = [ '5.6.7.8' ];
 
-		$result = fix_remote_address_from_ip_trail( $ip_trail, $whitelist );
+		$result = fix_remote_address_from_ip_trail( $whitelist );
 
 		$this->assertTrue( $result );
 		$this->assertEquals( '1.2.3.4', $_SERVER['REMOTE_ADDR'] );


### PR DESCRIPTION
The `$remote_proxy_ip` will always be `$_SERVER['HTTP_X_FORWARDED_FOR']`, so we
should simplify the developer experience and not bother asking for it.

Thoughts, @mjangda? At the time of writing, nobody seems to be using this function.