### PR TITLE
Add one-time script for forcing go-vip to SSL

### DIFF
--- a/wp-cli/vip-fixers.php
+++ b/wp-cli/vip-fixers.php
@@ -28,7 +28,8 @@ class VIP_Go_OneTimeFixers_Command extends WPCOM_VIP_CLI_Command {
 				restore_current_blog();
 			}
 
-			$this->flush_cache();
+			// Flush the cache one more time just to be safe
+			wp_cache_flush();
 		} else {
 			$old_home_url = home_url();
 
@@ -67,7 +68,7 @@ class VIP_Go_OneTimeFixers_Command extends WPCOM_VIP_CLI_Command {
 		$updated_siteurl = $this->enforce_govip_ssl_for_option_url( 'siteurl' );
 
 		if ( $updated_home || $updated_siteurl ) {
-			$this->flush_cache( get_site_url() );
+			wp_cache_flush();
 		}
 
 		return [ $updated_home, $updated_siteurl ];
@@ -94,17 +95,6 @@ class VIP_Go_OneTimeFixers_Command extends WPCOM_VIP_CLI_Command {
 	private function get_raw_option_value( $option ) {
 		global $wpdb;
 		return $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s", $option ) );
-	}
-
-	private function flush_cache( $url = false ) {
-		$cmd = 'cache flush';
-		if ( $url ) {
-			$cmd .= ' --url=' . $url;
-		}
-
-		return WP_CLI::runcommand( $cmd, [
-			'return' => true,
-		] );
 	}
 }
 

--- a/wp-cli/vip-fixers.php
+++ b/wp-cli/vip-fixers.php
@@ -1,49 +1,7 @@
 <?php
 
 class VIP_Go_OneTimeFixers_Command extends WPCOM_VIP_CLI_Command {
-
-	private function wpcom_vip_download_image( $image_url, $post_id = 0, $description = '' ) {
-		if ( $post_id < 0 ) {
-			return new WP_Error( 'invalid-post-id', 'Please specify a valid post ID.' );
-		}
-
-		if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
-			return new WP_Error( 'not-a-url', 'Please specify a valid URL.' );
-		}
-
-		$image_url_path = parse_url( $image_url, PHP_URL_PATH );
-		$image_path_info = pathinfo( $image_url_path );
-
-		if ( ! in_array( strtolower( $image_path_info['extension'] ), array( 'avi', 'mp3', 'jpg', 'jpe', 'jpeg', 'gif', 'png' ) ) ) {
-			return new WP_Error( 'not-an-image', 'Specified URL does not have a valid media extension.' );
-		}
-
-		// Download file to temp location; short timeout, because we don't have all day.
-		$downloaded_url = download_url( $image_url, 30 );
-
-		// We couldn't download and store to a temporary location, so bail.
-		if ( is_wp_error( $downloaded_url ) ) {
-			return $downloaded_url;
-		}
-
-		$file_array['name'] = $image_path_info['basename'];
-		$file_array['tmp_name'] = $downloaded_url;
-
-		if ( empty( $description ) ) {
-			$description = $image_path_info['filename'];
-		}
-
-		// Now, let's sideload it.
-		$attachment_id = media_handle_sideload( $file_array, $post_id, $description );
-
-		// If error storing permanently, unlink and return the error
-		if ( is_wp_error( $attachment_id ) ) {
-			@unlink( $file_array['tmp_name'] ); // unlink can throw errors if the file isn't there
-			return $attachment_id;
-		}
-
-		return $attachment_id;
-	}
+	// Nothing to see here...
 }
 
 WP_CLI::add_command( 'vip fixers', 'VIP_Go_OneTimeFixers_Command' );

--- a/wp-cli/vip-fixers.php
+++ b/wp-cli/vip-fixers.php
@@ -1,7 +1,111 @@
 <?php
 
 class VIP_Go_OneTimeFixers_Command extends WPCOM_VIP_CLI_Command {
-	// Nothing to see here...
+	public function enforce_govip_ssl( $args, $assoc_args ) {
+		$results = [];
+
+		if ( is_multisite() ) {
+			$site_ids = get_sites( [
+				'number' => 99999,
+				'fields' => 'ids',
+			] );
+
+			foreach ( $site_ids as $site_id ) {
+				switch_to_blog( $site_id );
+
+				$old_home_url = home_url();
+
+				$updated = $this->enforce_govip_ssl_for_current_site();
+
+				$results[ $old_home_url ] = [
+					// Get from database to avoid set_url_scheme and filters
+					'home' => $this->get_raw_option_value( 'home' ),
+					'siteurl' => $this->get_raw_option_value( 'siteurl' ),
+					'updated' => $updated,
+				];
+
+				refresh_blog_details();
+				restore_current_blog();
+			}
+
+			$this->flush_cache();
+		} else {
+			$old_home_url = home_url();
+
+			$updated = $this->enforce_govip_ssl_for_current_site();
+
+			$results[ $old_home_url ] = [
+				// Get from database to avoid set_url_scheme and filters
+				'home' => $this->get_raw_option_value( 'home' ),
+				'siteurl' => $this->get_raw_option_value( 'siteurl' ),
+				'updated' => $updated,
+			];
+		}
+
+		foreach ( $results as $old_home_url => $result ) {
+			$home = $result['home'];
+			$siteurl = $result['siteurl'];
+			list( $updated_home, $updated_siteurl ) = $result['updated'];
+
+			$message = sprintf(
+				'Finished for %s; home updated? %s (%s) | siteurl updated? %s (%s)',
+				$old_home_url,
+				var_export( $updated_home, true ),
+				$home,
+				var_export( $updated_siteurl, true ),
+				$siteurl
+			);
+
+			WP_CLI::log( '#vip-go-https-cleanup: ' . $message );
+
+			wpcom_vip_irc( '#vip-go-https-cleanup', $message );
+		}
+	}
+
+	private function enforce_govip_ssl_for_current_site() {
+		$updated_home = $this->enforce_govip_ssl_for_option_url( 'home' );
+		$updated_siteurl = $this->enforce_govip_ssl_for_option_url( 'siteurl' );
+
+		if ( $updated_home || $updated_siteurl ) {
+			$this->flush_cache( get_site_url() );
+		}
+
+		return [ $updated_home, $updated_siteurl ];
+	}
+
+	private function enforce_govip_ssl_for_option_url( $option ) {
+		// Get from database to avoid set_url_scheme and filters
+		$url = $this->get_raw_option_value( $option );
+
+		$parsed_url = parse_url( $url );
+
+		if ( ! wp_endswith( $parsed_url['host'], '.go-vip.co' ) ) {
+			return false;
+		}
+
+		if ( 'http' !== $parsed_url['scheme'] ) {
+			return false;
+		}
+
+		$new_url = preg_replace( '/^http:/i', 'https:', $url );
+		return update_option( $option, $new_url );
+	}
+
+	private function get_raw_option_value( $option ) {
+		global $wpdb;
+		return $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s", $option ) );
+	}
+
+	private function flush_cache( $url = false ) {
+		$cmd = 'cache flush';
+		if ( $url ) {
+			$cmd .= ' --url=' . $url;
+		}
+
+		return WP_CLI::runcommand( $cmd, [
+			'return' => true,
+		] );
+	}
 }
 
 WP_CLI::add_command( 'vip fixers', 'VIP_Go_OneTimeFixers_Command' );


### PR DESCRIPTION
Any sites using a go-vip.co domain should have their domain set to https since we enforce that at the server level.
