### PR TITLE
Enforce FS_METHOD as direct.

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -38,6 +38,10 @@ defined( 'WPCOM_VIP_MACHINE_USER_NAME' )  or define( 'WPCOM_VIP_MACHINE_USER_NAM
 defined( 'WPCOM_VIP_MACHINE_USER_EMAIL' ) or define( 'WPCOM_VIP_MACHINE_USER_EMAIL', 'donotreply@wordpress.com' );
 defined( 'WPCOM_VIP_MACHINE_USER_ROLE' )  or define( 'WPCOM_VIP_MACHINE_USER_ROLE', 'administrator' );
 
+// Interaction with the filesystem will always be direct.
+// Avoids issues with `get_filesystem_method` which attempts to write to `WP_CONTENT_DIR` and fails.
+define( 'FS_METHOD', 'direct' );
+
 $hostname = gethostname();
 define( 'WPCOM_SANDBOXED', false !== strpos( $hostname, '_web_dev_' ) );
 


### PR DESCRIPTION
Filesystem interaction on Go will always use the `direct` method. This also helps simplify instantiation of the global filesystem object (via `WP_Filesystem`), which by default tries to write to `WP_CONTENT_DIR` and fails (since only /tmp is writeable).

The workaround without setting this constant would look something like:

```
WP_Filesystem( false, get_temp_dir(), true );
```