### PR TITLE
Force is_ssl() in wp-cli based on siteurl

### DIFF
--- a/phpunit-multisite.xml
+++ b/phpunit-multisite.xml
@@ -1,0 +1,18 @@
+<!-- For local testing -->
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,8 @@ function _manually_load_plugin() {
 	require_once( __DIR__ . '/../lib/proxy/ip-utils.php' );
 
 	require_once( __DIR__ . '/../vip-rest-api.php' );
+
+	require_once( __DIR__ . '/../wp-cli.php' );
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/test-wp-cli-ssl.php
+++ b/tests/test-wp-cli-ssl.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Automattic\VIP\Tests;
+
+use function Automattic\VIP\WP_CLI\maybe_toggle_is_ssl;
+use function Automattic\VIP\WP_CLI\init_is_ssl_toggle_for_multisite;
+
+class VIP_WP_CLI__SSL__Test extends \WP_UnitTestCase {
+	public function setUp() {
+		parent::setUp();
+
+		$this->initial_https_value = $_SERVER['HTTPS'] ?? null;
+	}
+
+	public function tearDown() {
+		$_SERVER['HTTPS'] = $this->initial_https_value;
+
+		parent::tearDown();
+	}
+	public function get_test_data() {
+		return [
+			// 1) siteurl
+			// 2) starting SERVER['HTTPS'] value
+			// 3) expected SERVER['HTTPS'] value
+
+			'https_site_url__not_is_ssl' => [
+				'https://example.com',
+				null,
+				'on',
+			],
+
+			'https_site_url__is_ssl' => [
+				'https://example.com',
+				'on',
+				'on',
+			],
+
+			'http_site_url__not_is_ssl' => [
+				'http://example.com',
+				null,
+				null,
+			],
+
+			'http_site_url__is_ssl' => [
+				'http://example.com',
+				'on',
+				null,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data
+	 */
+	public function test__maybe_toggle_is_ssl( $siteurl, $initial_https_value, $expected_https_value ) {
+		add_filter( 'pre_option_siteurl', function() use ( $siteurl ) {
+			return $siteurl;
+		} );
+
+		if ( ! is_null( $initial_https_value ) ) {
+			$_SERVER['HTTPS'] = $initial_https_value;
+		} else {
+			unset( $_SERVER['HTTPS'] );
+		}
+
+		maybe_toggle_is_ssl();
+		$actual_https_value = $_SERVER['HTTPS'] ?? null;
+
+		$this->assertEquals( $expected_https_value, $actual_https_value );
+	}
+
+	public function test__is_ssl_toggle_for_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not relevant on single-site' );
+			return;
+		}
+
+		$blog_1_id = $this->factory->blog->create_object( [
+			'domain' => 'not-ssl.com',
+			'path' => '/',
+			'title' => 'Not SSL',
+			'site_id' => 1,
+		] );
+
+		$blog_2_id = $this->factory->blog->create_object( [
+			'domain' => 'is-ssl.com',
+			'path' => '/',
+			'title' => 'Is SSL',
+			'site_id' => 1,
+		] );
+		update_blog_option( $blog_2_id, 'siteurl', 'https://is-ssl.com' );
+
+		init_is_ssl_toggle_for_multisite();
+
+		// Change from ! is_ssl() to SSL site => is_ssL() === true
+		switch_to_blog( $blog_2_id );
+		$this->assertEquals( 'on', $_SERVER['HTTPS'] );
+
+		// Change to same site
+		switch_to_blog( $blog_2_id );
+		$this->assertEquals( 'on', $_SERVER['HTTPS'] );
+
+		// Change from is_ssl() to non-SSL site => is_ssl() === false
+		switch_to_blog( $blog_1_id );
+		$this->assertFalse( isset( $_SERVER['HTTPS'] ) );
+
+	}
+}

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -1,9 +1,15 @@
 <?php
 
+/**
+ * Plugin Name: WP-CLI for VIP Go
+ * Description: Scripts for VIP Go
+ * Author: Automattic
+ */
+
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
 
-foreach( glob( __DIR__ . '/wp-cli/*.php' ) as $command ) {
+foreach ( glob( __DIR__ . '/wp-cli/*.php' ) as $command ) {
 	require( $command );
 }

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -6,7 +6,48 @@
  * Author: Automattic
  */
 
+namespace Automattic\VIP\WP_CLI;
+
+function init_is_ssl_toggle() {
+	maybe_toggle_is_ssl();
+
+	if ( is_multisite() ) {
+		init_is_ssl_toggle_for_multisite();
+	}
+}
+
+// Any time a blog is switched, we should toggle is_ssl() based on their preferred scheme.
+function init_is_ssl_toggle_for_multisite() {
+	add_action( 'switch_blog', function( $new_blog_id, $prev_blog_id ) {
+		// Not a strict equality check to match core
+		if ( $new_blog_id == $prev_blog_id ) {
+			return;
+		}
+
+		maybe_toggle_is_ssl();
+	}, 0, 2 ); // run early since this could impact other filters
+}
+
+/**
+ * Fixes is_ssl() for wp-cli requests.
+ *
+ * `get_site_url()` will force the scheme to `http` when `$_SEVER['HTTPS']` is not set.
+ * This can be problematic if the site is always using SSL (i.e. home/siteurl have `https` URLs).
+ * This function toggles the setting so we get correct URLs generated in the wp-cli context.
+ */
+function maybe_toggle_is_ssl() {
+	$is_ssl_siteurl = wp_startswith( get_option( 'siteurl' ), 'https:' );
+
+	if ( $is_ssl_siteurl && ! is_ssl() ) {
+		$_SERVER['HTTPS'] = 'on';
+	} elseif ( ! $is_ssl_siteurl && is_ssl() ) {
+		unset( $_SERVER['HTTPS'] );
+	}
+}
+
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	init_is_ssl_toggle();
+
 	foreach ( glob( __DIR__ . '/wp-cli/*.php' ) as $command ) {
 		require( $command );
 	}

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -6,10 +6,8 @@
  * Author: Automattic
  */
 
-if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
-	return;
-}
-
-foreach ( glob( __DIR__ . '/wp-cli/*.php' ) as $command ) {
-	require( $command );
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	foreach ( glob( __DIR__ . '/wp-cli/*.php' ) as $command ) {
+		require( $command );
+	}
 }


### PR DESCRIPTION
We need to make sure the correct URLs are returned by the site_url() function, which relies on is_ssl() which defaults to `false` in our currently environment. Without this, you end up with incorrect URLs returned which can be problematic when using them to generate data (e.g. Jetpack connections).


