### PR TITLE
Correctly identify Cron & Remove from Apdex

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1230,6 +1230,17 @@ function wpcom_vip_add_URI_to_newrelic(){
 add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
 
 /**
+ * Name cron correctly in New Relic and do not count it as part of the Apdex score
+ */
+function wpcom_vip_cron_for_newrelic(){
+	if ( defined( 'DOING_CRON' ) && DOING_CRON && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
+		newrelic_name_transaction( 'cron-control' );
+		newrelic_ignore_apdex();
+	}
+}
+add_action( 'plugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 );
+
+/**
  * Send a message to IRC
  *
  * $level can be an int of one of the following

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1241,6 +1241,18 @@ function wpcom_vip_cron_for_newrelic(){
 add_action( 'plugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 );
 
 /**
+ * Name wp-cli correctly in New Relic and do not count it as part of the Apdex score
+ */
+function wpcom_vip_wpcli_for_newrelic(){
+	if ( defined( 'WP_CLI' ) && WP_CLI && ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
+		newrelic_name_transaction( 'wp-cron' );
+		newrelic_ignore_apdex();
+	}
+}
+add_action( 'plugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 );
+
+
+/**
  * Send a message to IRC
  *
  * $level can be an int of one of the following

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1245,7 +1245,7 @@ add_action( 'plugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 );
  */
 function wpcom_vip_wpcli_for_newrelic(){
 	if ( defined( 'WP_CLI' ) && WP_CLI && ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
-		newrelic_name_transaction( 'wp-c;i' );
+		newrelic_name_transaction( 'wp-cli' );
 		newrelic_ignore_apdex();
 	}
 }

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1245,11 +1245,11 @@ add_action( 'plugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 );
  */
 function wpcom_vip_wpcli_for_newrelic(){
 	if ( defined( 'WP_CLI' ) && WP_CLI && ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
-		newrelic_name_transaction( 'wp-cron' );
+		newrelic_name_transaction( 'wp-c;i' );
 		newrelic_ignore_apdex();
 	}
 }
-add_action( 'plugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 );
+add_action( 'plugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 );
 
 
 /**

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1234,7 +1234,7 @@ add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
  */
 function wpcom_vip_cron_for_newrelic(){
 	if ( defined( 'DOING_CRON' ) && DOING_CRON && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
-		newrelic_name_transaction( 'cron-control' );
+		newrelic_name_transaction( 'wp-cron' );
 		newrelic_ignore_apdex();
 	}
 }


### PR DESCRIPTION
Currently Cron's go under "index.php" which muddies the waters in terms of what is and what isn't slow. It also makes some sites with low traffic seem slow because cron is a bigger proportion of the requests.
I'm adding this as plugins_loaded 11 instead of earlier to account for https://github.com/Automattic/Cron-Control/blob/master/includes/class-events.php#L27 which may load on plugins_loaded.