### PR TITLE
Bump Akismet to 3.3.4

### DIFF
--- a/akismet.php
+++ b/akismet.php
@@ -4,7 +4,7 @@
 Plugin Name: Akismet Anti-Spam
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 3.3.3
+Version: 3.3.4
 Author: Automattic
 Author URI: https://automattic.com/wordpress-plugins/
 License: GPLv2 or later

--- a/akismet/akismet.php
+++ b/akismet/akismet.php
@@ -6,7 +6,7 @@
 Plugin Name: Akismet Anti-Spam
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 3.3.3
+Version: 3.3.4
 Author: Automattic
 Author URI: https://automattic.com/wordpress-plugins/
 License: GPLv2 or later
@@ -37,7 +37,7 @@ if ( !function_exists( 'add_action' ) ) {
 	exit;
 }
 
-define( 'AKISMET_VERSION', '3.3.3' );
+define( 'AKISMET_VERSION', '3.3.4' );
 define( 'AKISMET__MINIMUM_WP_VERSION', '3.7' );
 define( 'AKISMET__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'AKISMET_DELETE_LIMIT', 100000 );

--- a/akismet/class.akismet-admin.php
+++ b/akismet/class.akismet-admin.php
@@ -1019,7 +1019,7 @@ class Akismet_Admin {
 
 	public static function display_status() {
 		if ( ! self::get_server_connectivity() ) {
-			Akismet::view( 'notice', compact( 'servers-be-down' ) );
+			Akismet::view( 'notice', array( 'type' => 'servers-be-down' ) );
 		}
 		else if ( ! empty( self::$notices ) ) {
 			foreach ( self::$notices as $index => $type ) {

--- a/akismet/class.akismet.php
+++ b/akismet/class.akismet.php
@@ -914,6 +914,15 @@ class Akismet {
 			return $approved;
 		}
 
+		if ( 'trash' === $approved ) {
+			// If the last comment we checked has had its approval set to 'trash',
+			// then it failed the comment blacklist check. Let that blacklist override
+			// the spam check, since users have the (valid) expectation that when
+			// they fill out their blacklists, comments that match it will always
+			// end up in the trash.
+			return $approved;
+		}
+
 		// bump the counter here instead of when the filter is added to reduce the possibility of overcounting
 		if ( $incr = apply_filters('akismet_spam_count_incr', 1) )
 			update_option( 'akismet_spam_count', get_option('akismet_spam_count') + $incr );
@@ -1198,7 +1207,7 @@ p {
 	 * @param mixed $akismet_debug The data to log.
 	 */
 	public static function log( $akismet_debug ) {
-		if ( apply_filters( 'akismet_debug_log', defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) ) {
+		if ( apply_filters( 'akismet_debug_log', defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG && defined( 'AKISMET_DEBUG' ) && AKISMET_DEBUG ) ) {
 			error_log( print_r( compact( 'akismet_debug' ), true ) );
 		}
 	}

--- a/akismet/readme.txt
+++ b/akismet/readme.txt
@@ -2,8 +2,8 @@
 Contributors: matt, ryan, andy, mdawaffe, tellyworth, josephscott, lessbloat, eoigal, cfinke, automattic, jgs
 Tags: akismet, comments, spam, antispam, anti-spam, anti spam, comment moderation, comment spam, contact form spam, spam comments
 Requires at least: 3.7
-Tested up to: 4.8
-Stable tag: 3.3.3
+Tested up to: 4.8.1
+Stable tag: 3.3.4
 License: GPLv2 or later
 
 Akismet checks your comments and contact form submissions against our global database of spam to protect you and your site from malicious content.
@@ -29,6 +29,13 @@ Upload the Akismet plugin to your blog, Activate it, then enter your [Akismet.co
 1, 2, 3: You're done!
 
 == Changelog ==
+
+= 3.3.4 =
+
+* Disabled Akismet's debug log output by default unless AKISMET_DEBUG is defined.
+* URL previews now begin preloading when the mouse moves near them in the comments section of wp-admin.
+* When a comment is caught by the Comment Blacklist, Akismet will always allow it to stay in the trash even if it is spam as well.
+* Fixed a bug that was preventing an error from being shown when a site can't reach Akismet's servers.
 
 = 3.3.3 =
 *Release Date - 13 July 2017*

--- a/akismet/views/notice.php
+++ b/akismet/views/notice.php
@@ -46,8 +46,8 @@
 </div>
 <?php elseif ( $type == 'servers-be-down' ) :?>
 <div class="akismet-alert akismet-critical">
-	<h3 class="akismet-key-status failed"><?php esc_html_e("Akismet can&#8217;t connect to your site.", 'akismet'); ?></h3>
-	<p class="akismet-description"><?php printf( __('Your firewall may be blocking Akismet. Please contact your host and refer to <a href="%s" target="_blank">our guide about firewalls</a>.', 'akismet'), 'https://blog.akismet.com/akismet-hosting-faq/'); ?></p>
+	<h3 class="akismet-key-status failed"><?php esc_html_e("Your site can&#8217;t connect to the Akismet servers.", 'akismet'); ?></h3>
+	<p class="akismet-description"><?php printf( __('Your firewall may be blocking Akismet from connecting to its API. Please contact your host and refer to <a href="%s" target="_blank">our guide about firewalls</a>.', 'akismet'), 'https://blog.akismet.com/akismet-hosting-faq/'); ?></p>
 </div>
 <?php elseif ( $type == 'active-dunning' ) :?>
 <div class="akismet-alert akismet-critical">


### PR DESCRIPTION
- Disabled Akismet’s debug log output by default unless AKISMET_DEBUG is defined.
- URL previews now begin preloading when the mouse moves near them in the comments section of wp-admin.
- When a comment is caught by the Comment Blacklist, Akismet will always allow it to stay in the trash even if it is spam as well.
- Fixed a bug that was preventing an error from being shown when a site can’t reach Akismet’s servers.