### PR TITLE
Don't call WPCOM_VIP_Cache_Manager::purge_site_cache() when saving posts under WP_IMPORTING

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -63,7 +63,7 @@ class WPCOM_VIP_Cache_Manager {
 		$button_html .= '</p><p><span class="button"><a href="' . esc_url( $url ) . '"><strong>';
 		$button_html .= esc_html__( 'Purge Page Cache' );
 		$button_html .= '</strong></a></span>';
-		
+
 		echo "<p>$button_html</p>\n";
 	}
 
@@ -267,11 +267,6 @@ class WPCOM_VIP_Cache_Manager {
 	public function queue_post_purge( $post_id ) {
 		if ( $this->site_cache_purged )
 			return false;
-
-		if ( defined( 'WP_IMPORTING' ) ) {
-			$this->purge_site_cache();
-			return false;
-		}
 
 		$post = get_post( $post_id );
 		if ( empty( $post ) ||

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -268,6 +268,10 @@ class WPCOM_VIP_Cache_Manager {
 		if ( $this->site_cache_purged )
 			return false;
 
+		if ( defined( 'WP_IMPORTING' ) ) {
+			return false;
+		}
+
 		$post = get_post( $post_id );
 		if ( empty( $post ) ||
 		     'revision' === $post->post_type ||


### PR DESCRIPTION
WP_IMPORTING can be set under a number of conditions, such as
syndication via REST apis, and shouldn’t end up BAN-ing the entire site.

Question - what impact will this have on CLI-based imports? Lots of extra code below the removed block could end up running, which could really slow things down. Needs some thought.

Fixes #705