### PR TITLE
Move New Relic separate file + Track WP_CLI and Cron

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -62,6 +62,7 @@ require_once( __DIR__ . '/000-debug/0-load.php' );
 
 // Load our development and environment helpers
 require_once( __DIR__ . '/vip-helpers/vip-utils.php' );
+require_once( __DIR__ . '/vip-helpers/vip-newrelic.php' );
 require_once( __DIR__ . '/vip-helpers/vip-caching.php' );
 require_once( __DIR__ . '/vip-helpers/vip-roles.php' );
 require_once( __DIR__ . '/vip-helpers/vip-permastructs.php' );

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -58,7 +58,8 @@ function wpcom_vip_cron_for_newrelic() {
 		&& function_exists( 'newrelic_add_custom_parameter' )
 		&& function_exists( 'newrelic_name_transaction' ) ) {
 		newrelic_name_transaction( 'wp-cron' );
-		newrelic_add_custom_parameter( 'wp-cron', 'true' );
+		// N.B. VIP Go sites execute cron events through WP CLI, so the event
+		// can be determined in the New Relic 'wp-cli-cmd-args' custom parameter
 		newrelic_ignore_apdex();
 	}
 }

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -21,8 +21,8 @@ function wpcom_vip_disable_new_relic_js() {
 /**
  * Add the exact URI to NewRelic tracking but only if we're not in the admin
  */
-function wpcom_vip_add_URI_to_newrelic(){
-	if ( ! is_admin() && function_exists( 'newrelic_add_custom_parameter' ) ){
+function wpcom_vip_add_uri_to_newrelic() {
+	if ( ! is_admin() && function_exists( 'newrelic_add_custom_parameter' ) ) {
 		newrelic_capture_params();
 		newrelic_add_custom_parameter( 'HTTP_REFERER', isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '' );
 		newrelic_add_custom_parameter( 'HTTP_USER_AGENT', isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' );
@@ -36,29 +36,29 @@ add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
  *
  * We don't want to count cron as part of the apdex because it is not a user facing function and if cron tasks are slow it doesn't imply that the site's performance is impacted. Without removing these, long running cron tasks could flag the site as having performance problems, which would cause false positives in the monitoring.
  */
-function wpcom_vip_cron_for_newrelic(){
-	if ( wp_doing_cron() && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
+function wpcom_vip_cron_for_newrelic() {
+	if ( wp_doing_cron() && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ) {
 		newrelic_name_transaction( 'wp-cron' );
 		newrelic_add_custom_parameter( 'wp-cron', 'true' );
 		newrelic_ignore_apdex();
 	}
 }
-add_action( 'muplugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); //We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10
+add_action( 'muplugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); // We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10
 
 /**
  * Name wp-cli correctly in New Relic and do not count it as part of the Apdex score
  *
  * We don't want to count ongoing WP-CLI requests as part of the apdex because it is not a user facing function and if a WP-CLI request is slow it doesn't imply that the site's performance is impacted. Without removing these WP-CLI requests from the apdex calculation it could flag the site as having performance problems, which would cause false positives in the monitoring.
  */
-function wpcom_vip_wpcli_for_newrelic(){
+function wpcom_vip_wpcli_for_newrelic() {
 	if ( defined( 'WP_CLI' )
 	     && WP_CLI
 	     && ! wp_doing_cron()  // Cron is going to be run via WP-CLI in the near term. We want to keep Cron and WP-CLI separated for better monitoring so we're not going to flag WP_CLI requests that are actually cron requests as WP-CLI.
 	     && function_exists( 'newrelic_ignore_apdex' )
-	     && function_exists( 'newrelic_name_transaction' ) ){
+	     && function_exists( 'newrelic_name_transaction' ) ) {
 		newrelic_name_transaction( 'wp-cli' );
 		newrelic_add_custom_parameter( 'wp-cli', 'true' );
 		newrelic_ignore_apdex();
 	}
 }
-add_action( 'muplugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 );  //We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10
+add_action( 'muplugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 );  // We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -95,23 +95,6 @@ function wpcom_vip_wpcli_for_newrelic() {
 		// e.g. `wp option get siteurl`
 		newrelic_add_custom_parameter( 'wp-cli-cmd', $cmd );
 
-		$assoc_args = \WP_CLI::get_runner()->assoc_args;
-		$config = \WP_CLI::get_runner()->config;
-		// Empty values clutter the result
-		foreach ( $config as $config_arg => $config_value ) {
-			if ( empty( $config_value ) ) {
-				unset( $config[$config_arg] );
-			}
-		}
-		$all_config = array_merge( $assoc_args, $config );
-		// Key sorting normalises the resultant string
-		ksort( $all_config );
-		// e.g. `allow-root=1&color=auto&format=json&skip-plugins=1` which is
-		// equivalent to `--allow-root --color=auto --format=json --skip-plugins`
-		// We have this format because building a query string is easy and understandable
-		// (and a hack) whereas rebuilding a WP CLI style command parameters is harder
-		newrelic_add_custom_parameter( 'wp-cli-cmd-args', urldecode(http_build_query( $all_config ) ) );
-
 		newrelic_ignore_apdex();
 	}
 }

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -26,6 +26,7 @@ function wpcom_vip_add_URI_to_newrelic(){
 		newrelic_capture_params();
 		newrelic_add_custom_parameter( 'HTTP_REFERER', isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '' );
 		newrelic_add_custom_parameter( 'HTTP_USER_AGENT', isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' );
+		newrelic_add_custom_parameter( 'HTTPS', isset( $_SERVER['HTTPS'] ) ? $_SERVER['HTTPS'] : '' );
 	}
 }
 add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -29,8 +29,11 @@ function wpcom_vip_disable_new_relic_js() {
 
 if ( extension_loaded( 'newrelic' ) ){
 	add_action( 'muplugins_loaded', 'wpcom_vip_add_uri_to_newrelic' );
-	add_action( 'muplugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); //We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10
-	add_action( 'muplugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 );  //We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10
+	// We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10
+	add_action( 'muplugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 );
+	// We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10
+	// This must be hooked later than wpcom_vip_cron_for_newrelic to allow values to be overwritten
+	add_action( 'muplugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 12 );
 	add_action( 'rest_dispatch_request', 'wpcom_vip_rest_routes_for_newrelic', 10,4);
 }
 

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -82,7 +82,16 @@ function wpcom_vip_wpcli_for_newrelic() {
 
 		newrelic_name_transaction( 'wp-cli' );
 
-		$cmd = 'wp ' . implode( ' ', \WP_CLI::get_runner()->arguments );
+		$wp_cli_arguments = \WP_CLI::get_runner()->arguments;
+		if ( empty( $wp_cli_arguments ) ) {
+			// Not much to do at this point
+			return;
+		}
+		if ( ! is_array( $wp_cli_arguments ) ) {
+			$wp_cli_arguments = [ $wp_cli_arguments ];
+		}
+		array_unshift( $wp_cli_arguments, 'wp' );
+		$cmd = implode( ' ', $wp_cli_arguments );
 		// e.g. `wp option get siteurl`
 		newrelic_add_custom_parameter( 'wp-cli-cmd', $cmd );
 

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Disable New Relic's browser metrics
+ *
+ * Removes NR's JavaScript for tracking browser metrics, including page load times, Apdex score, and more.
+ *
+ * Must be called at or before the `template_redirect` action.
+ */
+function wpcom_vip_disable_new_relic_js() {
+	if ( did_action( 'template_redirect' ) && ! doing_action( 'template_redirect' ) ) {
+		_doing_it_wrong( __FUNCTION__, 'New Relic&#8217;s browser tracking can only be disabled at or before the `template_redirect` action.', '1.0' );
+		return;
+	}
+
+	if ( function_exists( 'newrelic_disable_autorum' ) ) {
+		newrelic_disable_autorum();
+	}
+}
+
+/**
+ * Add the exact URI to NewRelic tracking but only if we're not in the admin
+ */
+function wpcom_vip_add_URI_to_newrelic(){
+	if ( ! is_admin() && function_exists( 'newrelic_add_custom_parameter' ) ){
+		newrelic_add_custom_parameter( 'REQUEST_URI', isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '' );
+		newrelic_add_custom_parameter( 'HTTP_REFERER', isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '' );
+		newrelic_add_custom_parameter( 'HTTP_USER_AGENT', isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' );
+	}
+}
+add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
+
+/**
+ * Name cron correctly in New Relic and do not count it as part of the Apdex score.
+ *
+ * We don't want to count cron as part of the apdex because it is not a user facing function and if cron tasks are slow it doesn't imply that the site's performance is impacted. Without removing these, long running cron tasks could flag the site as having performance problems, which would cause false positives in the monitoring.
+ */
+function wpcom_vip_cron_for_newrelic(){
+	if ( defined( 'DOING_CRON' ) && DOING_CRON && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
+		newrelic_name_transaction( 'wp-cron' );
+		newrelic_ignore_apdex();
+	}
+}
+add_action( 'plugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); //We are attaching this at plugins_loaded because it's possible for Cron-Control to trigger at plugins_loaded priority 10 (at the latest)
+
+/**
+ * Name wp-cli correctly in New Relic and do not count it as part of the Apdex score
+ *
+ * We don't want to count ongoing WP-CLI requests as part of the apdex because it is not a user facing function and if a WP-CLI request is slow it doesn't imply that the site's performance is impacted. Without removing these WP-CLI requests from the apdex calculation it could flag the site as having performance problems, which would cause false positives in the monitoring.
+ */
+function wpcom_vip_wpcli_for_newrelic(){
+	if ( defined( 'WP_CLI' )
+	     && WP_CLI
+	     && ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) // Cron is going to be run via WP-CLI in the near term. We want to keep Cron and WP-CLI separated for better monitoring so we're not going to flag WP_CLI requests that are actually cron requests as WP-CLI.
+	     && function_exists( 'newrelic_ignore_apdex' )
+	     && function_exists( 'newrelic_name_transaction' ) ){
+		newrelic_name_transaction( 'wp-cli' );
+		newrelic_ignore_apdex();
+	}
+}
+add_action( 'plugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 ); //We are attaching this at plugins_loaded because it's possible for Cron-Control to trigger at plugins_loaded priority 10 (at the latest), we therefore can't tell until then if this is a WP-CLI request that is also a cron request.

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -75,8 +75,30 @@ function wpcom_vip_wpcli_for_newrelic() {
 	     && function_exists( 'newrelic_ignore_apdex' )
 	     && function_exists( 'newrelic_add_custom_parameter' )
 	     && function_exists( 'newrelic_name_transaction' ) ) {
+
 		newrelic_name_transaction( 'wp-cli' );
-		newrelic_add_custom_parameter( 'wp-cli', 'true' );
+
+		$cmd = 'wp ' . implode( ' ', \WP_CLI::get_runner()->arguments );
+		// e.g. `wp option get siteurl`
+		newrelic_add_custom_parameter( 'wp-cli-cmd', $cmd );
+
+		$assoc_args = \WP_CLI::get_runner()->assoc_args;
+		$config = \WP_CLI::get_runner()->config;
+		// Empty values clutter the result
+		foreach ( $config as $config_arg => $config_value ) {
+			if ( empty( $config_value ) ) {
+				unset( $config[$config_arg] );
+			}
+		}
+		$all_config = array_merge( $assoc_args, $config );
+		// Key sorting normalises the resultant string
+		ksort( $all_config );
+		// e.g. `allow-root=1&color=auto&format=json&skip-plugins=1` which is
+		// equivalent to `--allow-root --color=auto --format=json --skip-plugins`
+		// We have this format because building a query string is easy and understandable
+		// (and a hack) whereas rebuilding a WP CLI style command parameters is harder
+		newrelic_add_custom_parameter( 'wp-cli-cmd-args', urldecode(http_build_query( $all_config ) ) );
+
 		newrelic_ignore_apdex();
 	}
 }

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -41,7 +41,7 @@ function wpcom_vip_cron_for_newrelic(){
 		newrelic_ignore_apdex();
 	}
 }
-add_action( 'plugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); //We are attaching this at plugins_loaded because it's possible for Cron-Control to trigger at plugins_loaded priority 10 (at the latest)
+add_action( 'muplugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); //We are attaching this at plugins_loaded because it's possible for Cron-Control to trigger at plugins_loaded priority 10 (at the latest)
 
 /**
  * Name wp-cli correctly in New Relic and do not count it as part of the Apdex score
@@ -58,4 +58,4 @@ function wpcom_vip_wpcli_for_newrelic(){
 		newrelic_ignore_apdex();
 	}
 }
-add_action( 'plugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 ); //We are attaching this at plugins_loaded because it's possible for Cron-Control to trigger at plugins_loaded priority 10 (at the latest), we therefore can't tell until then if this is a WP-CLI request that is also a cron request.
+add_action( 'muplugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 ); //We are attaching this at plugins_loaded because it's possible for Cron-Control to trigger at plugins_loaded priority 10 (at the latest), we therefore can't tell until then if this is a WP-CLI request that is also a cron request.

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -36,7 +36,7 @@ add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
  * We don't want to count cron as part of the apdex because it is not a user facing function and if cron tasks are slow it doesn't imply that the site's performance is impacted. Without removing these, long running cron tasks could flag the site as having performance problems, which would cause false positives in the monitoring.
  */
 function wpcom_vip_cron_for_newrelic(){
-	if ( defined( 'DOING_CRON' ) && DOING_CRON && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
+	if ( wp_doing_cron() && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
 		newrelic_name_transaction( 'wp-cron' );
 		newrelic_ignore_apdex();
 	}
@@ -51,7 +51,7 @@ add_action( 'muplugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); //We are at
 function wpcom_vip_wpcli_for_newrelic(){
 	if ( defined( 'WP_CLI' )
 	     && WP_CLI
-	     && ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) // Cron is going to be run via WP-CLI in the near term. We want to keep Cron and WP-CLI separated for better monitoring so we're not going to flag WP_CLI requests that are actually cron requests as WP-CLI.
+	     && ! wp_doing_cron()  // Cron is going to be run via WP-CLI in the near term. We want to keep Cron and WP-CLI separated for better monitoring so we're not going to flag WP_CLI requests that are actually cron requests as WP-CLI.
 	     && function_exists( 'newrelic_ignore_apdex' )
 	     && function_exists( 'newrelic_name_transaction' ) ){
 		newrelic_name_transaction( 'wp-cli' );

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -37,7 +37,10 @@ add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
  * We don't want to count cron as part of the apdex because it is not a user facing function and if cron tasks are slow it doesn't imply that the site's performance is impacted. Without removing these, long running cron tasks could flag the site as having performance problems, which would cause false positives in the monitoring.
  */
 function wpcom_vip_cron_for_newrelic() {
-	if ( wp_doing_cron() && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ) {
+	if ( wp_doing_cron()
+		&& function_exists( 'newrelic_ignore_apdex' )
+		&& function_exists( 'newrelic_add_custom_parameter' )
+		&& function_exists( 'newrelic_name_transaction' ) ) {
 		newrelic_name_transaction( 'wp-cron' );
 		newrelic_add_custom_parameter( 'wp-cron', 'true' );
 		newrelic_ignore_apdex();
@@ -55,6 +58,7 @@ function wpcom_vip_wpcli_for_newrelic() {
 	     && WP_CLI
 	     && ! wp_doing_cron()  // Cron is going to be run via WP-CLI in the near term. We want to keep Cron and WP-CLI separated for better monitoring so we're not going to flag WP_CLI requests that are actually cron requests as WP-CLI.
 	     && function_exists( 'newrelic_ignore_apdex' )
+	     && function_exists( 'newrelic_add_custom_parameter' )
 	     && function_exists( 'newrelic_name_transaction' ) ) {
 		newrelic_name_transaction( 'wp-cli' );
 		newrelic_add_custom_parameter( 'wp-cli', 'true' );

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -23,7 +23,7 @@ function wpcom_vip_disable_new_relic_js() {
  */
 function wpcom_vip_add_URI_to_newrelic(){
 	if ( ! is_admin() && function_exists( 'newrelic_add_custom_parameter' ) ){
-		newrelic_add_custom_parameter( 'REQUEST_URI', isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '' );
+		newrelic_capture_params();
 		newrelic_add_custom_parameter( 'HTTP_REFERER', isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '' );
 		newrelic_add_custom_parameter( 'HTTP_USER_AGENT', isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' );
 	}

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -41,7 +41,7 @@ function wpcom_vip_cron_for_newrelic(){
 		newrelic_ignore_apdex();
 	}
 }
-add_action( 'muplugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); //We are attaching this at plugins_loaded because it's possible for Cron-Control to trigger at plugins_loaded priority 10 (at the latest)
+add_action( 'muplugins_loaded', 'wpcom_vip_cron_for_newrelic', 11 ); //We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10
 
 /**
  * Name wp-cli correctly in New Relic and do not count it as part of the Apdex score
@@ -58,4 +58,4 @@ function wpcom_vip_wpcli_for_newrelic(){
 		newrelic_ignore_apdex();
 	}
 }
-add_action( 'muplugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 ); //We are attaching this at plugins_loaded because it's possible for Cron-Control to trigger at plugins_loaded priority 10 (at the latest), we therefore can't tell until then if this is a WP-CLI request that is also a cron request.
+add_action( 'muplugins_loaded', 'wpcom_vip_wpcli_for_newrelic', 11 );  //We are attaching this at muplugins_loaded because Cron-Control is loaded at muplugins_loaded priority 10

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -26,7 +26,7 @@ function wpcom_vip_add_uri_to_newrelic() {
 		newrelic_capture_params();
 		newrelic_add_custom_parameter( 'HTTP_REFERER', isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '' );
 		newrelic_add_custom_parameter( 'HTTP_USER_AGENT', isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' );
-		newrelic_add_custom_parameter( 'HTTPS', isset( $_SERVER['HTTPS'] ) ? $_SERVER['HTTPS'] : '' );
+		newrelic_add_custom_parameter( 'HTTPS', is_ssl() );
 	}
 }
 add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -39,6 +39,7 @@ add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
 function wpcom_vip_cron_for_newrelic(){
 	if ( wp_doing_cron() && function_exists( 'newrelic_ignore_apdex' ) && function_exists( 'newrelic_name_transaction' ) ){
 		newrelic_name_transaction( 'wp-cron' );
+		newrelic_add_custom_parameter( 'wp-cron', 'true' );
 		newrelic_ignore_apdex();
 	}
 }
@@ -56,6 +57,7 @@ function wpcom_vip_wpcli_for_newrelic(){
 	     && function_exists( 'newrelic_ignore_apdex' )
 	     && function_exists( 'newrelic_name_transaction' ) ){
 		newrelic_name_transaction( 'wp-cli' );
+		newrelic_add_custom_parameter( 'wp-cli', 'true' );
 		newrelic_ignore_apdex();
 	}
 }

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1200,36 +1200,6 @@ function is_proxied_automattician() {
 }
 
 /**
- * Disable New Relic's browser metrics
- *
- * Removes NR's JavaScript for tracking browser metrics, including page load times, Apdex score, and more.
- *
- * Must be called at or before the `template_redirect` action.
- */
-function wpcom_vip_disable_new_relic_js() {
-	if ( did_action( 'template_redirect' ) && ! doing_action( 'template_redirect' ) ) {
-		_doing_it_wrong( __FUNCTION__, 'New Relic&#8217;s browser tracking can only be disabled at or before the `template_redirect` action.', '1.0' );
-		return;
-	}
-
-	if ( function_exists( 'newrelic_disable_autorum' ) ) {
-		newrelic_disable_autorum();
-	}
-}
-
-/**
- * Add the exact URI to NewRelic tracking but only if we're not in the admin
- */
-function wpcom_vip_add_URI_to_newrelic(){
-	if ( ! is_admin() && function_exists( 'newrelic_add_custom_parameter' ) ){
-		newrelic_add_custom_parameter( 'REQUEST_URI', isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '' );
-		newrelic_add_custom_parameter( 'HTTP_REFERER', isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '' );
-		newrelic_add_custom_parameter( 'HTTP_USER_AGENT', isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' );
-	}
-}
-add_action( 'muplugins_loaded', 'wpcom_vip_add_URI_to_newrelic' );
-
-/**
  * Send a message to IRC
  *
  * $level can be an int of one of the following


### PR DESCRIPTION
Move all New Relic logic to one file and add logging of Cron and WP_CLI as separate transactions that don't impact the Apdex score of the site (since those transactions don't impact what users get in terms of performance)