### PR TITLE
Add analytics tracking to vip_powered_wpcom_url to match wordpress.co…

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -120,7 +120,7 @@ function vip_powered_wpcom( $display = 'text', $before_text = 'Powered by ' ) {
  * @return string
  */
 function vip_powered_wpcom_url() {
-	return 'https://vip.wordpress.com/';
+	return 'https://vip.wordpress.com/?utm_source=vip_powered_wpcom&utm_medium=web&utm_campaign=VIP%20Footer%20Credit&utm_term=' . $_SERVER['HTTP_HOST'];
 }
 
 /**

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -120,7 +120,14 @@ function vip_powered_wpcom( $display = 'text', $before_text = 'Powered by ' ) {
  * @return string
  */
 function vip_powered_wpcom_url() {
-	return 'https://vip.wordpress.com/?utm_source=vip_powered_wpcom&utm_medium=web&utm_campaign=VIP%20Footer%20Credit&utm_term=' . $_SERVER['HTTP_HOST'];
+	$args = array(
+		'utm_source' => 'vip_powered_wpcom',
+		'utm_medium' => 'web',
+		'utm_campaign' => 'VIP Footer Credit',
+		'utm_term' => sanitize_text_field( $_SERVER['HTTP_HOST'] ),
+	);
+
+	return add_query_arg( $args, 'https://vip.wordpress.com/' );
 }
 
 /**


### PR DESCRIPTION
…m. Additionally, add the hostname as a tracked variable.

Fixes #731. 

Note: I've not sanitized the `$_SERVER` var since it isn't being stored, relying on any usage of this to escape the output URL properly. But happy to change that to sanitize and/or escape if it makes sense.