### PR TITLE
Correct `WPCOM_VIP_PRIVATE_DIR` path for CLI containers

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -33,6 +33,7 @@ if ( ! defined( 'WPCOM_IS_VIP_ENV' ) ) {
 }
 
 define( 'WPCOM_SANDBOXED', false !== strpos( gethostname(), '_web_dev_' ) );
+define( 'VIP_GO_IS_JOBS_HOST', false !== strpos( gethostname(), '_wpcli_' ) );
 
 // Used to verify emails sent via our SMTP servers
 if ( ! defined( 'WPCOM_VIP_MAIL_TRACKING_KEY' ) ) {
@@ -41,7 +42,7 @@ if ( ! defined( 'WPCOM_VIP_MAIL_TRACKING_KEY' ) ) {
 
 // Define constants for custom VIP Go paths
 define( 'WPCOM_VIP_CLIENT_MU_PLUGIN_DIR', WP_CONTENT_DIR . '/client-mu-plugins' );
-define( 'WPCOM_VIP_PRIVATE_DIR', WPCOM_SANDBOXED ? '/chroot/private' : '/private' );
+define( 'WPCOM_VIP_PRIVATE_DIR', WPCOM_SANDBOXED || VIP_GO_IS_JOBS_HOST ? '/chroot/private' : '/private' );
 
 // Define these values just in case
 defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) or define( 'WPCOM_VIP_MACHINE_USER_LOGIN', 'vip' );


### PR DESCRIPTION
CLI containers execute PHP via php-cli, rather than php-fpm; php-fpm provides the chroot used in web containers, therefore it isn't present in CLI containers. `/private` also isn't symlinked to `/chroot/private`, so references to `/private` will fail, but clients should be using `WPCOM_VIP_PRIVATE_DIR` anyway.

I used the `VIP_GO` prefix to avoid any confusion with WP.com's async jobs system and its constants.