### PR TITLE
Bypass Woocommerce file creation

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -148,6 +148,4 @@ add_filter( 'wp_link_query_args', 'wpcom_vip_wp_link_query_args', 10, 1 );
 /**
  * Stop Woocommerce from trying to create files on read-only filesystem
  */
-if ( false !== VIP_GO_ENV ) {
-	add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
-}
+add_filter( 'woocommerce_install_skip_create_files', '__return_true' );

--- a/misc.php
+++ b/misc.php
@@ -129,7 +129,7 @@ if ( defined( 'WPCOM_VIP_QUERY_LOG' ) && WPCOM_VIP_QUERY_LOG ) {
  *
  * The WordPress core is currently not setting `no_found_rows` inside the `_WP_Editors::wp_link_query`
  * See https://core.trac.wordpress.org/ticket/38784
- * 
+ *
  * Since the `_WP_Editors::wp_link_query` method is not using the `found_posts` nor `max_num_pages`
  * properties of `WP_Query` class, the `SQL_CALC_FOUND_ROWS` in produced SQL query is extra and
  * useless.
@@ -144,3 +144,10 @@ function wpcom_vip_wp_link_query_args( $query ) {
 }
 
 add_filter( 'wp_link_query_args', 'wpcom_vip_wp_link_query_args', 10, 1 );
+
+/**
+ * Stop Woocommerce from trying to create files on read-only filesystem
+ */
+if ( false !== VIP_GO_ENV ) {
+	add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
+}


### PR DESCRIPTION
Prevents Woocommerce from trying to create files where they can't be created, which just leads to lots of `mkdir(): Read-only file system` errors.

Fixes #736