### PR TITLE
Normalize URLs before adding them to purge list

### DIFF
--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -1,0 +1,48 @@
+
+<?php
+
+class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
+	public $cache_manager;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->cache_manager = WPCOM_VIP_Cache_Manager::instance();
+	}
+
+	public function get_data_for_queue_purge_url() {
+		return [
+			// 1: input URL
+			// 2: expected response from method
+			// 3: expected purge_urls list
+
+			'normal_url' => [
+				'https://example.com/path/to/file?query',
+				true,
+				[ 'https://example.com/path/to/file?query' ],
+			],
+
+			'invalid_url' => [
+				'badscheme://example.com/path',
+				false,
+				[],
+			],
+
+			'strip_fragment_from_url' => [
+				'https://example.com/post#fragment',
+				true,
+				[ 'https://example.com/post' ],
+			],
+		];
+	}
+
+	/**
+ 	 * @dataProvider get_data_for_queue_purge_url
+ 	 */ 
+	public function test__queue_purge_url( $queue_url, $expected_output, $expected_urls ) {
+		$actual_output = $this->cache_manager->queue_purge_url( $queue_url );
+
+		$this->assertEquals( $expected_output, $actual_output, 'Return value from `queue_purge_url` does not match.' );
+		$this->assertEquals( $expected_urls, $this->cache_manager->get_queued_purge_urls(), 'List of queued purge urls do not match' );
+	}
+}

--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -8,6 +8,7 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->cache_manager = WPCOM_VIP_Cache_Manager::instance();
+		$this->cache_manager->clear_queued_purge_urls();
 	}
 
 	public function get_data_for_queue_purge_url() {

--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -1,4 +1,3 @@
-
 <?php
 
 class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
@@ -11,39 +10,56 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 		$this->cache_manager->clear_queued_purge_urls();
 	}
 
-	public function get_data_for_queue_purge_url() {
+	public function get_data_for_valid_queue_purge_url_test() {
 		return [
 			// 1: input URL
-			// 2: expected response from method
-			// 3: expected purge_urls list
+			// 2: array of expected purge_urls list
 
 			'normal_url' => [
 				'https://example.com/path/to/file?query',
-				true,
 				[ 'https://example.com/path/to/file?query' ],
-			],
-
-			'invalid_url' => [
-				'badscheme://example.com/path',
-				false,
-				[],
 			],
 
 			'strip_fragment_from_url' => [
 				'https://example.com/post#fragment',
-				true,
 				[ 'https://example.com/post' ],
 			],
 		];
 	}
 
+	public function get_data_for_invalid_queue_purge_url_test() {
+		return [
+			'invalid_scheme' => [
+				'badscheme://example.com/path',
+			],
+		];
+	}
+
 	/**
- 	 * @dataProvider get_data_for_queue_purge_url
- 	 */ 
-	public function test__queue_purge_url( $queue_url, $expected_output, $expected_urls ) {
+	 * Tests valid URL inputs for `queue_purge_url`
+	 *
+	 * @dataProvider get_data_for_valid_queue_purge_url_test
+	 */
+	public function test__valid__queue_purge_url( $queue_url, $expected_urls ) {
 		$actual_output = $this->cache_manager->queue_purge_url( $queue_url );
 
-		$this->assertEquals( $expected_output, $actual_output, 'Return value from `queue_purge_url` does not match.' );
+		$this->assertTrue( $actual_output, 'Return value from `queue_purge_url` does not match.' );
 		$this->assertEquals( $expected_urls, $this->cache_manager->get_queued_purge_urls(), 'List of queued purge urls do not match' );
+	}
+
+	/**
+	 * Tests invalid URL inputs for `queue_purge_url`
+	 *
+	 * They are all expected to return false, queue nothing, and throw a warning.
+	 *
+	 * @dataProvider get_data_for_invalid_queue_purge_url_test
+	 */
+	public function test__invalid__queue_purge_url( $queue_url ) {
+		$this->setExpectedExceptionRegExp( 'PHPUnit_Framework_Error_Warning' );
+
+		$actual_output = $this->cache_manager->queue_purge_url( $queue_url );
+
+		$this->assertFalse( $actual_output, 'Return value from `queue_purge_url` should be false.' );
+		$this->assertEmpty( $this->cache_manager->get_queued_purge_urls(), 'List of queued purge urls should be empty' );
 	}
 }

--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -16,12 +16,22 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 			// 2: array of expected purge_urls list
 
 			'normal_url' => [
-				'https://example.com/path/to/file?query',
-				[ 'https://example.com/path/to/file?query' ],
+				'http://example.com/path/to/files',
+				[ 'http://example.com/path/to/files' ],
 			],
 
-			'strip_fragment_from_url' => [
+			'strip_querystring' => [
+				'https://example.com/path/to/file?query',
+				[ 'https://example.com/path/to/file' ],
+			],
+
+			'strip_fragment' => [
 				'https://example.com/post#fragment',
+				[ 'https://example.com/post' ],
+			],
+
+			'strip_querystring_and_fragment' => [
+				'https://example.com/post?query#fragment',
 				[ 'https://example.com/post' ],
 			],
 		];

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -564,16 +564,15 @@ class WPCOM_VIP_Cache_Manager {
 	}
 
 	protected function normalize_purge_url( $url ) {
-		$url = esc_url_raw( $url );
+		$normalized_url = esc_url_raw( $url );
 
-		$parsed_url = parse_url( $url );
-
-		// Strip off any URL fragments (i.e. `#search=xyz`) since that is ignored by the cache
-		if ( isset( $parsed_url['fragment'] ) ) {
-			unset( $parsed_url['fragment'] );
+		// Easy way to strip off any fragments since we don't have access to `http_build_url`.
+		$fragment_index = mb_strpos( $normalized_url, '#' );
+		if ( false !== $fragment_index ) {
+			$normalized_url = mb_substr( $normalized_url, 0, $fragment_index );
 		}
 
-		return http_build_url( $parsed_url );
+		return $normalized_url;
 	}
 
 	protected function is_valid_purge_url( $url ) {

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -52,6 +52,10 @@ class WPCOM_VIP_Cache_Manager {
 		add_action( 'shutdown', array( $this, 'execute_purges' ) );
 	}
 
+	public function get_queued_purge_urls() {
+		return $this->purge_urls;
+	}
+
 	public function get_manual_purge_link() {
 		if ( ! $this->can_purge_cache() ) {
 			return;

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -56,6 +56,10 @@ class WPCOM_VIP_Cache_Manager {
 		return $this->purge_urls;
 	}
 
+	public function clear_queued_purge_urls() {
+		$this->purge_urls = [];
+	}
+
 	public function get_manual_purge_link() {
 		if ( ! $this->can_purge_cache() ) {
 			return;

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -570,7 +570,12 @@ class WPCOM_VIP_Cache_Manager {
 	protected function normalize_purge_url( $url ) {
 		$normalized_url = esc_url_raw( $url );
 
-		// Easy way to strip off any fragments since we don't have access to `http_build_url`.
+		// Easy way to strip off query params and fragments since we don't have access to `http_build_url`.
+		$query_index = mb_strpos( $normalized_url, '?' );
+		if ( false !== $query_index ) {
+			$normalized_url = mb_substr( $normalized_url, 0, $query_index );
+		}
+
 		$fragment_index = mb_strpos( $normalized_url, '#' );
 		if ( false !== $fragment_index ) {
 			$normalized_url = mb_substr( $normalized_url, 0, $fragment_index );


### PR DESCRIPTION
Mostly, we want to strip off the fragment off any URLs since servers don't care about them.

So, a URL like `https://example.com/#q1` is added to the PURGE list as `https://example.com/` instead.