### PR TITLE
Don't try to block an already-blocked event

### DIFF
--- a/performance/do-pings.php
+++ b/performance/do-pings.php
@@ -4,6 +4,11 @@ namespace Automattic\VIP\Performance;
 
 // Disable pings by default
 function disable_pings( $event ) {
+	// Already blocked, carry on
+	if ( ! is_object( $event ) ) {
+		return $event;
+	}
+
 	if ( 'do_pings' === $event->hook ) {
 		return false;
 	}


### PR DESCRIPTION
If the event was already blocked, either by Core or other code, `$event` won't be an object. Checking for this resolves a "trying to get property of non-object" notice.