### PR TITLE
Importer: Suspend cache

### DIFF
--- a/wordpress-importer.php
+++ b/wordpress-importer.php
@@ -12,3 +12,12 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 */
 
 require( __DIR__ . '/wordpress-importer/wordpress-importer.php' );
+
+add_action( 'import_start', function() {
+	wp_suspend_cache_addition( true );
+	wp_cache_flush();
+});
+
+add_action( 'import_end', function() {
+	wp_cache_flush();
+});


### PR DESCRIPTION
Since sandboxes may not be in the origin datacenter, memcached
operations during imports might be slow. Suspending the cache and then
flush it afterwards may be faster than using the cache.