### PR TITLE
Temporarily disable force two-step auth

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -75,7 +75,8 @@ function wpcom_enable_two_factor_plugin() {
 		add_action( 'set_current_user', 'wpcom_vip_enforce_two_factor_plugin' );
 	}
 }
-add_action( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
+// TODO: Enable this :)
+//add_action( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
 
 /**
  * Filter Caps


### PR DESCRIPTION
There was previously a bug causing this not to work. When that was fixed, it caused some confusion about why two-step authentication was suddenly being enabled. Anyone who still wants to force two-step auth can do so by enabling `jetpack-force-2fa` or `two-factor` in their site repository with the `wpcom_vip_load_plugin` helper function.