### PR TITLE
Load vip-secrets.php in wp-config

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -9,10 +9,6 @@
  * good reason not to.
  */
 
-if ( file_exists( __DIR__ . '/.secrets/vip-secrets.php' ) ) {
-	require __DIR__ . '/.secrets/vip-secrets.php';
-}
-
 if ( ! defined( 'A8C_PROXIED_REQUEST' ) ) {
 	/**
 	 * @var constant A8C_PROXIED_REQUEST Set to true if the current request is made via the Automattic proxy, which is only available to Automatticians.


### PR DESCRIPTION
Loading secrets is moved to wp-config, so loading here is now redundant.