### PR TITLE
Add ability to specify TTL in wpcom_vip_wp_oembed_get

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -910,17 +910,16 @@ function wpcom_vip_bulk_user_management_whitelist( $users ) {
  *
  * @param string $url The URL that should be embedded
  * @param array $args Addtional arguments and parameters the embed
- * @param int $ttl How long to cache for in seconds , minimum 18000 (5 Hours)
+ * @param int $ttl How long to cache for in seconds; minimum 18000 (5 Hours)
  * @return string
  */
 function wpcom_vip_wp_oembed_get( $url, $args = array(), $ttl = false ) {
-
-	//Set a Minimum of 5H (1800seconds)
-	//let's get a bit of variation in here to prevent stampedes.
-	//Set a max of 30 days after which memcache thinks you're giving it a timestamp.
-	if ( $ttl && $ttl > 5 * HOUR_IN_SECONDS && ( $ttl < MONTH_IN_SECONDS ) ){
+	// We want a min ttl of 5 hours (1800s).
+	// And a max of 30 days (after which memcache thinks you're giving it a timestamp).
+	// Let's also add a bit of variation to prevent stampedes.
+	if ( $ttl && $ttl > 5 * HOUR_IN_SECONDS && ( $ttl < MONTH_IN_SECONDS ) ) {
 		$ttl = $ttl + rand( 0, HOUR_IN_SECONDS );
-	}else{
+	} else {
 		$ttl = rand( 5 * HOUR_IN_SECONDS, 6 * HOUR_IN_SECONDS );
 	}
 

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -918,7 +918,7 @@ function wpcom_vip_wp_oembed_get( $url, $args = array(), $ttl = false ) {
 	//Set a Minimum of 5H (1800seconds)
 	//let's get a bit of variation in here to prevent stampedes.
 	//Set a max of 30 days after which memcache thinks you're giving it a timestamp.
-	if ( $ttl && $ttl > 5 * HOUR_IN_SECONDS && ( $ttl < (30 * MONTH_IN_MINUTES * 60) ) ){
+	if ( $ttl && $ttl > 5 * HOUR_IN_SECONDS && ( $ttl < MONTH_IN_SECONDS ) ){
 		$ttl = $ttl + rand( 0, HOUR_IN_SECONDS );
 	}else{
 		$ttl = rand( 5 * HOUR_IN_SECONDS, 6 * HOUR_IN_SECONDS );

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -917,7 +917,9 @@ function wpcom_vip_wp_oembed_get( $url, $args = array(), $ttl = false ) {
 	// We want a min ttl of 5 hours (1800s).
 	// And a max of 30 days (after which memcache thinks you're giving it a timestamp).
 	// Let's also add a bit of variation to prevent stampedes.
-	if ( $ttl && $ttl > 5 * HOUR_IN_SECONDS && ( $ttl < MONTH_IN_SECONDS ) ) {
+	if ( $ttl
+		&& $ttl > ( 5 * HOUR_IN_SECONDS )
+		&& $ttl < ( MONTH_IN_SECONDS - HOUR_IN_SECONDS ) ) {
 		$ttl = $ttl + rand( 0, HOUR_IN_SECONDS );
 	} else {
 		$ttl = rand( 5 * HOUR_IN_SECONDS, 6 * HOUR_IN_SECONDS );


### PR DESCRIPTION
matches r316138-wpcom
limit of 1 month and minimum of 5h