### PR TITLE
setExpectedExceptionRegExp => expectException

### DIFF
--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -65,7 +65,7 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 	 * @dataProvider get_data_for_invalid_queue_purge_url_test
 	 */
 	public function test__invalid__queue_purge_url( $queue_url ) {
-		$this->setExpectedExceptionRegExp( 'PHPUnit_Framework_Error_Warning' );
+		$this->expectException( PHPUnit_Framework_Error_Warning::class );
 
 		$actual_output = $this->cache_manager->queue_purge_url( $queue_url );
 


### PR DESCRIPTION
Newer versions of PHPUnit note this is the preferred way to test for an explicit exception.

Should hopefully address the failing tests we're seeing on Travis:

```
1) VIP_Go_Cache_Manager_Test::test__invalid__queue_purge_url with data set "invalid_scheme" ('badscheme://example.com/path')
PHPUnit_Framework_Exception: Invalid expected exception message regex given: ''
```