### PR TITLE
Fix for "undefined index" notice in jetpack.php

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -30,7 +30,14 @@ function wpcom_vip_log_updating_jetpack_version() {
 			break;
 		}
 	}
-	error_log('updating_jetpack_version from ' . $jetpack_version  . ' | ' . $_SERVER['REQUEST_URI'] . '  (action: ' . $_REQUEST['action'] . ') ' . ' by ' . $caller . ': ' . print_r( func_get_args(), 1 ) );
+	error_log( sprintf(
+		"updating_jetpack_version from %s | %s  (action: %s)  by %s: %s",
+		$jetpack_version,
+		$_SERVER['REQUEST_URI'],
+		isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : '',
+		$caller,
+		print_r( func_get_args(), 1 )
+	) );
 }
 if ( defined( 'WPCOM_VIP_JETPACK_LOG' ) && WPCOM_VIP_JETPACK_LOG ) {
 	add_action( 'updating_jetpack_version', 'wpcom_vip_log_updating_jetpack_version', 10, 2 );


### PR DESCRIPTION
As `$_REQUEST` doesn't always have an `action` key, the logging code
would trigger an error, which is visibly annoying in local development
environments.

This change takes that into account while also make the code more
readable by breaking it out onto multiple lines.