### PR TITLE
Add check for WPCOM_VIP_DISABLE_SHARED_PLUGINS to /plugins api endpoint

### DIFF
--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -306,6 +306,9 @@ class WPCOM_VIP_REST_API_Endpoints {
 			$all_plugins['vip-shared-ui'] = $tmp_ui_plugins;
 		}
 
+		// add constant to endpoint
+		$all_plugins['disable-shared-plugins'] = ( defined( 'WPCOM_VIP_DISABLE_SHARED_PLUGINS' ) && true === WPCOM_VIP_DISABLE_SHARED_PLUGINS ) ? true : false;
+
 		return $all_plugins;
 	}
 }


### PR DESCRIPTION
For quickly checking if any sites are missing the constant.