### PR TITLE
Hotfix: Correctly handle Akismet API response order

### DIFF
--- a/akismet/class.akismet-admin.php
+++ b/akismet/class.akismet-admin.php
@@ -1061,8 +1061,8 @@ class Akismet_Admin {
 		if ( !$xml->isError() ) {
 			$responses = $xml->getResponse();
 			if ( count( $responses ) > 1 ) {
-				$api_key = array_shift( $responses[0] );
-				$user_id = (int) array_shift( $responses[1] );
+				$user_id = (int) array_shift( $responses[0] );
+				$api_key = array_shift( $responses[1] );
 				return compact( 'api_key', 'user_id' );
 			}
 		}


### PR DESCRIPTION
Swap the order of the response processing for get_jetpack_user to match the order of the API calls.

This fix is being reviewed for the next version of Akismet but we're pushing through now so we can make use of the underlying code.

See `pZbK5-54x`