### PR TITLE
Ignore the ip-utils lib

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,8 @@
 	<exclude-pattern>drop-ins/*</exclude-pattern>
 	<exclude-pattern>http-concat/*</exclude-pattern>
 	<exclude-pattern>jetpack/*</exclude-pattern>
+	<exclude-pattern>lib/proxy/ip-utils.php</exclude-pattern>
+	<exclude-pattern>tests/test-lib-proxy-ip-utils.php</exclude-pattern>
 	<exclude-pattern>query-monitor/*</exclude-pattern>
 	<exclude-pattern>rewrite-rules-inspector/*</exclude-pattern>
 	<exclude-pattern>shared-plugins/*</exclude-pattern>


### PR DESCRIPTION
This is an external library, so for the sake of future updates, we
shouldn't report errors or automatically fix PHPCS issues.