### PR TITLE
deploy.sh: Update the reference to the deploy repo

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -35,7 +35,7 @@ set -x
 
 cp ${TRAVIS_BUILD_DIR}/ci/known_hosts ~/.ssh/known_hosts
 
-git clone git@github.com:Automattic/vip-mu-plugins-public.git /tmp/target
+git clone git@github.com:Automattic/vip-go-mu-plugins-built.git /tmp/target
 
 mkdir -p ${DEPLOY_BUILD_DIR}
 


### PR DESCRIPTION
Was renamed to `vip-go-mu-plugins-built` (https://github.com/automattic/vip-go-mu-plugins-built)