### PR TITLE
Only enable the VIP Cache Manager in VIP environments.

### DIFF
--- a/vip-cache-manager.php
+++ b/vip-cache-manager.php
@@ -9,4 +9,10 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 */
 
 require_once( __DIR__ . '/vip-cache-manager/vip-cache-manager.php' );
+require_once( __DIR__ . '/vip-cache-manager/api.php' );
 require_once( __DIR__ . '/vip-cache-manager/ttl-manager.php' );
+
+if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV === true ) {
+	WPCOM_VIP_Cache_Manager::instance();
+	Automattic\VIP\Cache\TTL_Manager\init();
+}

--- a/vip-cache-manager/ttl-manager.php
+++ b/vip-cache-manager/ttl-manager.php
@@ -55,6 +55,3 @@ function enforce_rest_api_read_ttl( $response, $rest_server, $request ) {
 function set_rest_response_ttl( \WP_REST_Response $response, $ttl ) {
 	$response->header( 'Cache-Control', sprintf( 'max-age=%d', $ttl ) );
 }
-
-// Let's do it!
-init();

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -8,8 +8,6 @@ Version: 1.1
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-require_once( __DIR__ . '/api.php' );
-
 class WPCOM_VIP_Cache_Manager {
 	const MAX_PURGE_URLS = 100;
 	const MAX_BAN_URLS   = 10;
@@ -646,5 +644,3 @@ class WPCOM_VIP_Cache_Manager {
 		return is_proxied_automattician();
 	}
 }
-
-WPCOM_VIP_Cache_Manager::instance();


### PR DESCRIPTION
The Cache Manager breaks unit tests, and is useless on local.

By loading the files, the API is still publicly exposed. This avoids breaking code that uses these functions are extends them.

However the initialisation only happens in VIP environments.