### PR TITLE
VIP Plugins: Remove empty() checks for sites without plugins active

### DIFF
--- a/tests/test-vip-plugins.php
+++ b/tests/test-vip-plugins.php
@@ -13,21 +13,21 @@ class VIP_Go_Plugins_Test extends \WP_UnitTestCase {
 
 		// emulate the active plugins option
 		$this->option_active_plugins = [
-			'hello.php',
 			'airplane-mode/airplane-mode.php',
-			'msm-sitemap/msm-sitemap.php',
 			'gutenberg/gutenberg.php',
+			'hello.php',
 			'liveblog/liveblog.php',
-			'wp-instagram-widget/wp-instagram-widget.php',
+			'msm-sitemap/msm-sitemap.php',
 			'shortcake/shortcode-ui.php',
+			'wp-instagram-widget/wp-instagram-widget.php',
 		];
 
 		sort( $this->option_active_plugins );
 
 		// emulate the network active plugins option
 		$this->option_active_sitewide_plugins = [
-			'hello.php' => 1507904134,
 			'akismet/akismet.php' => 1507904154,
+			'hello.php' => 1507904134,
 			'msm-sitemap/msm-sitemap.php' => 1507904154,
 			'shortcake/shortcode-ui.php' => 1507904134,
 		];

--- a/tests/test-vip-plugins.php
+++ b/tests/test-vip-plugins.php
@@ -92,7 +92,7 @@ class VIP_Go_Plugins_Test extends \WP_UnitTestCase {
 		/**
 		 * Check that the returned option matches a merge of the filtered loaded plugins and active plugins
 		 */
-		$merged_plugins = array_merge( $this->option_active_plugins, wpcom_vip_get_filtered_loaded_plugins() );
+		$merged_plugins = array_unique( array_merge( $this->option_active_plugins, wpcom_vip_get_filtered_loaded_plugins() ) );
 		sort( $merged_plugins );
 		$this->assertEquals( $merged_plugins, get_option( 'active_plugins' ), 'The value of `$merged_plugins` does not match the returned value of `get_option( \'active_plugins\')`.' );
 
@@ -108,6 +108,11 @@ class VIP_Go_Plugins_Test extends \WP_UnitTestCase {
 		 */
 		$option_db = $wpdb->get_var( "SELECT option_value FROM $wpdb->options WHERE option_name = 'active_plugins' LIMIT 1" );
 		$option_db = maybe_unserialize( $option_db );
+		$plugin_change = array_merge( $this->option_active_plugins, array( 'amp-wp/amp.php' ) );
+		// because this was a dupe plugin we will be smart enough to remove it from the option
+		if ( ( $key = array_search( 'msm-sitemap/msm-sitemap.php', $plugin_change, true ) ) !== false ) {
+			unset( $plugin_change[ $key ] );
+		}
 		sort( $plugin_change );
 		$this->assertEquals( $plugin_change, $option_db, 'The database value `$option_db` does not match `$plugin_change`.' );
 
@@ -157,7 +162,7 @@ class VIP_Go_Plugins_Test extends \WP_UnitTestCase {
 		/**
 		 * Check that the returned option matches a merge of the filtered loaded plugins and active plugins
 		 */
-		$merged_plugins = array_merge( wpcom_vip_get_network_filtered_loaded_plugins(), $this->option_active_sitewide_plugins );
+		$merged_plugins = array_merge( $this->option_active_sitewide_plugins, wpcom_vip_get_network_filtered_loaded_plugins() );
 		ksort( $merged_plugins );
 		$this->assertEquals( $merged_plugins, get_site_option( 'active_sitewide_plugins' ), 'The value of `$merged_plugins` does not match the returned value of `get_site_option( \'active_sitewide_plugins\')`.' );
 
@@ -179,7 +184,7 @@ class VIP_Go_Plugins_Test extends \WP_UnitTestCase {
 		/**
 		 * Check that the option still makes sense again
 		 */
-		$saved_plugins = array_merge( wpcom_vip_get_network_filtered_loaded_plugins(), $plugin_change );
+		$saved_plugins = array_merge( $plugin_change, wpcom_vip_get_network_filtered_loaded_plugins() );
 		ksort( $saved_plugins );
 		$this->assertEquals( $saved_plugins, get_site_option( 'active_sitewide_plugins' ), 'The value of `$merged_plugins` does not match the returned value of `get_site_option( \'active_sitewide_plugins\')`.' );
 	}

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -173,7 +173,7 @@ function wpcom_vip_option_active_plugins( $value, $option ) {
 		$value = array();
 	}
 
-	$value = array_merge( $value, $code_plugins );
+	$value = array_unique( array_merge( $value, $code_plugins ) );
 
 	sort( $value );
 
@@ -195,14 +195,7 @@ function wpcom_vip_site_option_active_sitewide_plugins( $value, $option ) {
 		$value = array();
 	}
 
-	// removes duplicates
-	foreach ( $code_plugins as $key => $plugin ) {
-		if ( array_key_exists( $key, $value ) ) {
-			unset( $code_plugins[ $key ] );
-		}
-	}
-
-	$value = array_merge( $value, $code_plugins );
+	$value = array_unique( array_merge( $value, $code_plugins ) );
 
 	ksort( $value );
 
@@ -224,13 +217,6 @@ function wpcom_vip_pre_update_option_active_plugins( $value, $old_value, $option
 
 	if ( false === is_array( $value ) ) {
 		$value = array();
-	}
-
-	// removes duplicates
-	foreach ( $code_plugins as $key => $plugin ) {
-		if ( in_array( $plugin, $value, true ) ) {
-			unset( $code_plugins[ $key ] );
-		}
 	}
 
 	$value = array_diff( $value, $code_plugins );
@@ -255,13 +241,6 @@ function wpcom_vip_pre_update_site_option_active_sitewide_plugins( $value, $old_
 
 	if ( false === is_array( $value ) ) {
 		$value = array();
-	}
-
-	// removes duplicates
-	foreach ( $code_plugins as $key => $plugin ) {
-		if ( array_key_exists( $key, $value ) ) {
-			unset( $code_plugins[ $key ] );
-		}
 	}
 
 	$value = array_diff( $value, $code_plugins );

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -169,13 +169,13 @@ add_filter( 'network_admin_plugin_action_links', 'wpcom_vip_plugin_action_links'
 function wpcom_vip_option_active_plugins( $value, $option ) {
 	$code_plugins = wpcom_vip_get_filtered_loaded_plugins();
 
-	if ( ! empty( $value ) && ! empty( $code_plugins ) ) {
-		$value = array_merge( $value, $code_plugins );
+	if ( empty( $value ) ) {
+		$value = array();
 	}
 
-	if ( ! empty( $value ) ) {
-		sort( $value );
-	}
+	$value = array_merge( $value, $code_plugins );
+
+	sort( $value );
 
 	return $value;
 }
@@ -191,7 +191,11 @@ add_filter( 'option_active_plugins', 'wpcom_vip_option_active_plugins', 10, 2 );
 function wpcom_vip_site_option_active_sitewide_plugins( $value, $option ) {
 	$code_plugins = wpcom_vip_get_network_filtered_loaded_plugins();
 
-	if ( ! empty( $value ) && ! empty( $code_plugins ) ) {
+	if ( empty( $value ) ) {
+		$value = array();
+	}
+
+	if ( ! empty( $code_plugins ) ) {
 		// removes duplicates
 		foreach ( $code_plugins as $key => $plugin ) {
 			if ( array_key_exists( $key, $value ) ) {
@@ -202,9 +206,7 @@ function wpcom_vip_site_option_active_sitewide_plugins( $value, $option ) {
 		$value = array_merge( $value, $code_plugins );
 	}
 
-	if ( ! empty( $value ) ) {
-		ksort( $value );
-	}
+	ksort( $value );
 
 	return $value;
 
@@ -222,7 +224,11 @@ add_filter( 'site_option_active_sitewide_plugins', 'wpcom_vip_site_option_active
 function wpcom_vip_pre_update_option_active_plugins( $value, $old_value, $option ) {
 	$code_plugins = wpcom_vip_get_filtered_loaded_plugins();
 
-	if ( ! empty( $value ) && ! empty( $code_plugins ) ) {
+	if ( empty( $value ) ) {
+		$value = array();
+	}
+
+	if ( ! empty( $code_plugins ) ) {
 		// removes duplicates
 		foreach ( $code_plugins as $key => $plugin ) {
 			if ( in_array( $plugin, $value, true ) ) {
@@ -233,9 +239,7 @@ function wpcom_vip_pre_update_option_active_plugins( $value, $old_value, $option
 		$value = array_diff( $value, $code_plugins );
 	}
 
-	if ( ! empty( $value ) ) {
-		sort( $value );
-	}
+	sort( $value );
 
 	return $value;
 }
@@ -253,7 +257,11 @@ add_filter( 'pre_update_option_active_plugins', 'wpcom_vip_pre_update_option_act
 function wpcom_vip_pre_update_site_option_active_sitewide_plugins( $value, $old_value, $option, $network_id ) {
 	$code_plugins = wpcom_vip_get_network_filtered_loaded_plugins();
 
-	if ( ! empty( $value ) && ! empty( $code_plugins ) ) {
+	if ( empty( $value ) ) {
+		$value = array();
+	}
+
+	if ( ! empty( $code_plugins ) ) {
 		// removes duplicates
 		foreach ( $code_plugins as $key => $plugin ) {
 			if ( array_key_exists( $key, $value ) ) {
@@ -264,9 +272,7 @@ function wpcom_vip_pre_update_site_option_active_sitewide_plugins( $value, $old_
 		$value = array_diff( $value, $code_plugins );
 	}
 
-	if ( ! empty( $value ) ) {
-		ksort( $value );
-	}
+	ksort( $value );
 
 	return $value;
 }

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -195,7 +195,7 @@ function wpcom_vip_site_option_active_sitewide_plugins( $value, $option ) {
 		$value = array();
 	}
 
-	$value = array_unique( array_merge( $value, $code_plugins ) );
+	$value = array_merge( $value, $code_plugins );
 
 	ksort( $value );
 

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -169,7 +169,7 @@ add_filter( 'network_admin_plugin_action_links', 'wpcom_vip_plugin_action_links'
 function wpcom_vip_option_active_plugins( $value, $option ) {
 	$code_plugins = wpcom_vip_get_filtered_loaded_plugins();
 
-	if ( empty( $value ) ) {
+	if ( false === is_array( $value ) ) {
 		$value = array();
 	}
 
@@ -191,20 +191,18 @@ add_filter( 'option_active_plugins', 'wpcom_vip_option_active_plugins', 10, 2 );
 function wpcom_vip_site_option_active_sitewide_plugins( $value, $option ) {
 	$code_plugins = wpcom_vip_get_network_filtered_loaded_plugins();
 
-	if ( empty( $value ) ) {
+	if ( false === is_array( $value ) ) {
 		$value = array();
 	}
 
-	if ( ! empty( $code_plugins ) ) {
-		// removes duplicates
-		foreach ( $code_plugins as $key => $plugin ) {
-			if ( array_key_exists( $key, $value ) ) {
-				unset( $code_plugins[ $key ] );
-			}
+	// removes duplicates
+	foreach ( $code_plugins as $key => $plugin ) {
+		if ( array_key_exists( $key, $value ) ) {
+			unset( $code_plugins[ $key ] );
 		}
-
-		$value = array_merge( $value, $code_plugins );
 	}
+
+	$value = array_merge( $value, $code_plugins );
 
 	ksort( $value );
 
@@ -224,20 +222,18 @@ add_filter( 'site_option_active_sitewide_plugins', 'wpcom_vip_site_option_active
 function wpcom_vip_pre_update_option_active_plugins( $value, $old_value, $option ) {
 	$code_plugins = wpcom_vip_get_filtered_loaded_plugins();
 
-	if ( empty( $value ) ) {
+	if ( false === is_array( $value ) ) {
 		$value = array();
 	}
 
-	if ( ! empty( $code_plugins ) ) {
-		// removes duplicates
-		foreach ( $code_plugins as $key => $plugin ) {
-			if ( in_array( $plugin, $value, true ) ) {
-				unset( $code_plugins[ $key ] );
-			}
+	// removes duplicates
+	foreach ( $code_plugins as $key => $plugin ) {
+		if ( in_array( $plugin, $value, true ) ) {
+			unset( $code_plugins[ $key ] );
 		}
-
-		$value = array_diff( $value, $code_plugins );
 	}
+
+	$value = array_diff( $value, $code_plugins );
 
 	sort( $value );
 
@@ -257,20 +253,18 @@ add_filter( 'pre_update_option_active_plugins', 'wpcom_vip_pre_update_option_act
 function wpcom_vip_pre_update_site_option_active_sitewide_plugins( $value, $old_value, $option, $network_id ) {
 	$code_plugins = wpcom_vip_get_network_filtered_loaded_plugins();
 
-	if ( empty( $value ) ) {
+	if ( false === is_array( $value ) ) {
 		$value = array();
 	}
 
-	if ( ! empty( $code_plugins ) ) {
-		// removes duplicates
-		foreach ( $code_plugins as $key => $plugin ) {
-			if ( array_key_exists( $key, $value ) ) {
-				unset( $code_plugins[ $key ] );
-			}
+	// removes duplicates
+	foreach ( $code_plugins as $key => $plugin ) {
+		if ( array_key_exists( $key, $value ) ) {
+			unset( $code_plugins[ $key ] );
 		}
-
-		$value = array_diff( $value, $code_plugins );
 	}
+
+	$value = array_diff( $value, $code_plugins );
 
 	ksort( $value );
 


### PR DESCRIPTION
* Remove empty checks to ensure we always merge code activated plugins with our options. 
* Stop code activated plugins being saved to the DB.

Closes #790 
Closes #791 