### PR TITLE
Apply DB schema changes on cleanup

### DIFF
--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -52,6 +52,7 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 				WP_CLI::runcommand( $cmd );
 			}
 
+			// Apply
 			return;
 		}
 
@@ -85,6 +86,9 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 				OR option_name LIKE '\_site\_transient\_%'"
 			);
 		}
+		
+		// Apply any necessary database schema changes
+		dbDelta( 'all', true );
 
 		/**
 		 * Fires on migration cleanup


### PR DESCRIPTION
Run dbDelta on `wp vip migration cleanup` to ensure all the indexes are created properly.

**Note:** We need to wait for WP CLI commands to be async. Schema changes can be slow and blocking VIPd is bad.