### PR TITLE
Fix cache manager in PHPUnit

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@ if ( ! $_tests_dir ) {
 
 require_once $_tests_dir . '/includes/functions.php';
 
-define( 'VIP_GO_PHPUNIT_RUNNING', true );
+remove_action( 'init', array( 'VIP_Cache_Manager', 'init' ) );
 
 // Constant configs
 // Ideally we'd have a way to mock these

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,8 @@ if ( ! $_tests_dir ) {
 
 require_once $_tests_dir . '/includes/functions.php';
 
+define( 'VIP_GO_PHPUNIT_RUNNING', true );
+
 // Constant configs
 // Ideally we'd have a way to mock these
 define( 'FILES_CLIENT_SITE_ID', 123 );

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -212,6 +212,10 @@ class WPCOM_VIP_Cache_Manager {
 			return;
 		}
 
+		if ( defined( 'VIP_GO_PHPUNIT_RUNNING' ) && VIP_GO_PHPUNIT_RUNNING ) {
+			return;
+		}
+
 		$this->ban_urls = array_unique( $this->ban_urls );
 		$this->purge_urls = array_unique( $this->purge_urls );
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -212,10 +212,6 @@ class WPCOM_VIP_Cache_Manager {
 			return;
 		}
 
-		if ( defined( 'VIP_GO_PHPUNIT_RUNNING' ) && VIP_GO_PHPUNIT_RUNNING ) {
-			return;
-		}
-
 		$this->ban_urls = array_unique( $this->ban_urls );
 		$this->purge_urls = array_unique( $this->purge_urls );
 


### PR DESCRIPTION
Tests can modify a lot of data, which causes lots of cache purges,
which generates an error. This bails before the errors are generated.

See #784