### PR TITLE
Add Lightweight term counting plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "drop-ins/object-cache"]
 	path = drop-ins/object-cache
 	url = git@github.com:Automattic/wp-memcached.git
+[submodule "lightweight-term-count-update"]
+	path = lightweight-term-count-update
+	url = https://github.com/Automattic/lightweight-term-count-update

--- a/vip-light-term-count.php
+++ b/vip-light-term-count.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Plugin Name:     Lightweight Term Count Update
+ * Plugin URI:      https://github.com/Automattic/lightweight-term-count-update
+ * Description:     Makes the _update_term_count_on_transition_post_status action very fast
+ * Author:          Automattic, Alley Interactive
+ * Author URI:      https://automattic.com/
+ * Text Domain:     lightweight-term-count-update
+ * Domain Path:     /languages
+ * Version:         0.1.0
+ *
+ * @package 		Lightweight_Term_Count_Update
+ */
+
+require_once( __DIR__ . '/lightweight-term-count-update/lightweight-term-count-update.php' );


### PR DESCRIPTION
Some sites are having performance problems caused by term counting.
Term counting is slow and on WordPress.com is either sent to the jobs system or uses this plugin.

The plugin has been enabled on WordPress.com for around 8 months now and has proven stable.

This was tested on vip-test.go-vip.co by creating new tags, adding posts to them, removing posts from them and making sure the count matched.