### PR TITLE
Use HTTPS for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,27 @@
 [submodule "vip-dashboard"]
 	path = vip-dashboard
-	url = git@github.com:Automattic/vip-dashboard.git
+	url = https://github.com/Automattic/vip-dashboard.git
 [submodule "vip-support"]
 	path = vip-support
-	url = git@github.com:Automattic/vip-support.git
+	url = https://github.com/Automattic/vip-support.git
 [submodule "advanced-post-cache"]
 	path = advanced-post-cache
-	url = git@github.com:Automattic/advanced-post-cache.git
+	url = https://github.com/Automattic/advanced-post-cache.git
 [submodule "jetpack"]
 	path = jetpack
-	url = git@github.com:Automattic/jetpack.git
+	url = https://github.com/Automattic/jetpack.git
 [submodule "rewrite-rules-inspector"]
 	path = rewrite-rules-inspector
-	url = git@github.com:Automattic/rewrite-rules-inspector
+	url = https://github.com/Automattic/rewrite-rules-inspector
 [submodule "http-concat"]
 	path = http-concat
-	url = git@github.com:Automattic/nginx-http-concat.git
+	url = https://github.com/Automattic/nginx-http-concat.git
 [submodule "query-monitor"]
 	path = query-monitor
-	url = git@github.com:johnbillion/query-monitor.git
+	url = https://github.com/johnbillion/query-monitor.git
 [submodule "cron-control"]
 	path = cron-control
-	url = git@github.com:Automattic/Cron-Control.git
+	url = https://github.com/Automattic/Cron-Control.git
 [submodule "debug-bar-cron"]
 	path = debug-bar-cron
 	url = https://github.com/tollmanz/debug-bar-cron.git
@@ -33,7 +33,7 @@
 	url = https://github.com/georgestephanis/two-factor.git
 [submodule "drop-ins/object-cache"]
 	path = drop-ins/object-cache
-	url = git@github.com:Automattic/wp-memcached.git
+	url = https://github.com/Automattic/wp-memcached.git
 [submodule "lightweight-term-count-update"]
 	path = lightweight-term-count-update
 	url = https://github.com/Automattic/lightweight-term-count-update


### PR DESCRIPTION
SSH submodules require a Github account and associated SSH key. Since all of these submodules are public, we can use HTTPS instead to avoid requiring a Github account to clone the repo.