### PR TITLE
Jetpack: Enforce some modules.

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -62,6 +62,16 @@ if ( defined( 'WPCOM_VIP_JETPACK_LOG' ) && WPCOM_VIP_JETPACK_LOG ) {
 	add_action( 'pre_update_jetpack_option_version', 'wpcom_vip_log_updating_jetpack_version_option', 10, 2 );
 }
 
+/**
+ * Ensure some Jetpack modules are always enabled.
+ */
+function wpcom_vip_jetpack_active_modules( $active_modules ) {
+    return array_merge( $active_modules, [
+        'vaultpress',
+    ] );
+}
+add_filter( 'jetpack_active_modules', 'wpcom_vip_jetpack_active_modules' );
+
 
 if ( ! @constant( 'WPCOM_IS_VIP_ENV' ) ) {
 	add_filter( 'jetpack_is_staging_site', '__return_true' );


### PR DESCRIPTION
The `jetpack_active_modules` filter allows developers to enable/disable some modules in code. We might need to ensure some modules are always enabled/disabled and so we hook in to that filter ourselves.

At the moment, this just forces Vaultpress to be enabled. It won't have any effect until https://github.com/Automattic/jetpack/pull/8465 is merged and released.

I'm not sure this is the finished code...

* Do we want to force-enable other modules?
* Should we put a ridiculous priority on the filter to try and make sure we're last?
* Do we want to force disable any modules?
