### PR TITLE
Allow Debug Bar when sandboxed

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -9,7 +9,7 @@
  Text Domain: debug-bar
  */
 add_filter( 'debug_bar_enable', function( $enable ) {
-	$enable = is_automattician();
+	$enable = is_automattician() || WPCOM_SANDBOXED;
 
 	return $enable;
 }, 99 );


### PR DESCRIPTION
Regardles of `is_automattician()`, Debug Bar should be enabled when user has site sandboxed

Fixes #831