### PR TITLE
Don't override results of unique_filename_callback

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -258,6 +258,12 @@ class A8C_Files {
 	 * Filter's the return value of `wp_unique_filename()`
 	 */
 	public function filter_unique_filename( $filename, $ext, $dir, $unique_filename_callback ) {
+		// If a unique filename callback was used, let's just use its results.
+		// `wp_unique_filename` has fired this already so we don't need to actually call it.
+		if ( $unique_filename_callback && is_callable( $unique_filename_callback ) ) {
+			return $filename;
+		}
+
 		if ( '.tmp' === $ext || '/tmp/' === $dir ) {
 			return $filename;
 		}


### PR DESCRIPTION
`wp_unique_filename` allows passing in a custom callback as an added level of customization. In our filter for `wp_unique_filename`, we're just passing through the results as-is if the custom callback is used. Otherwise we can end up modifying the results, which may be undesirable.

One use case is when we want to override an existing file. We can use the custom callback to set the existing file's name. Without this change, our mu-plugins unique filename check runs and modifies the filename, which is not what we want.