### PR TITLE
Moving the sprintf to act on `$paging_endpoint` only

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -514,8 +514,7 @@ class WPCOM_VIP_Cache_Manager {
 			$term_purge_urls[] = $maybe_purge_url;
 			// Now add the pages for the archive we're clearing
 			for( $i = 2; $i <= $max_pages; $i++ ) {
-				$maybe_purge_url_page = rtrim( $maybe_purge_url, '/' ) . '/' . ltrim( $paging_endpoint, '/' );
-				$maybe_purge_url_page = sprintf( $maybe_purge_url_page, $i );
+				$maybe_purge_url_page = rtrim( $maybe_purge_url, '/' ) . '/' . ltrim( sprintf( $paging_endpoint, $i ), '/' );
 				$term_purge_urls[] = user_trailingslashit( $maybe_purge_url_page, 'paged' );
 			}
 		}


### PR DESCRIPTION
In case the slug contains some percentage signs, for instance due to encoding non-ascii chars, the `sprintf` call fails.

Instead of proposed str_replace escaping ( #823 ), this approach does no mess up with the URL, but only calls sprintf with `$paging_endpoint` as a param - that variable is supposed to contain  single `%d` conversion specifier and thus the `sprintf` should not fail due to the confusion over missing params.

Fixes #823