### PR TITLE
Jetpack Start: Make args for `connect_site` optional

### DIFF
--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -105,7 +105,7 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 		}
 	}
 
-	private function connect_site( $assoc_args ) {
+	private function connect_site( $assoc_args = [] ) {
 		if ( Jetpack::is_active() ) {
 			WP_CLI::line( '- Jetpack is already connected' );
 


### PR DESCRIPTION
Since we don't use them heavily in the method anyway. This also fixes compatibility issues with PHP 7.1 because we have at least one call to the method that doesn't pass in the arg.

Fixes #853