### PR TITLE
Add VIP Go stats pixel

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -154,5 +154,5 @@ add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
  * Record WordPress pageviews for VIP Go
  */
 add_action( 'wp_footer', function() {
-	echo '<img src="//pixel.wp.com/g.gif?v=wpcom-no-pv&x_vip-go-stats/wordpress" />';
+	echo '<img id="vip-go-stats-pixel" src="//pixel.wp.com/g.gif?v=wpcom-no-pv&x_vip-go-stats/wordpress" />';
 } );

--- a/misc.php
+++ b/misc.php
@@ -154,5 +154,10 @@ add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
  * Record WordPress pageviews for VIP Go
  */
 add_action( 'wp_footer', function() {
+	// Don't track logged in views
+	if ( is_user_logged_in() ) {
+		return;
+	}
+	
 	echo '<img id="vip-go-stats-pixel" src="//pixel.wp.com/g.gif?v=wpcom-no-pv&x_vip-go-stats/wordpress" />';
 } );

--- a/misc.php
+++ b/misc.php
@@ -149,3 +149,10 @@ add_filter( 'wp_link_query_args', 'wpcom_vip_wp_link_query_args', 10, 1 );
  * Stop Woocommerce from trying to create files on read-only filesystem
  */
 add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
+
+/**
+ * Record WordPress pageviews for VIP Go
+ */
+add_action( 'wp_footer', function() {
+	echo '<img src="//pixel.wp.com/g.gif?v=wpcom-no-pv&x_vip-go-stats/wordpress" />';
+} );


### PR DESCRIPTION
Right now we aggregate Jetpack stats, but this has some flaws. Namely:

* Stats are tracked per day, but ideally we'd want per hour stats
* Stats are only tracked for WordPress, we can extend this to other types of apps
* We miss stats for sites that don't have Jetpack

Note: When we deploy this, we should consider the current stats aggregation. Ideally we should
wait until just after the stats aggregation runs at 00:00 UTC, shift everything back a day (because
right now the stats are actually off by 1 day), and then turn this on to avoid double counting.

Alternatively, it would be much easier to disable the stats aggregation job before 00:00 and then deploy
this as close to 00:00 as possible. We'll technically be missing a day of stats, but that might be fine.