### PR TITLE
Drop PHP 7 & PHP 7.1 from Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ git:
   submodules: false
 
 php:
-  - 7
-  - 7.1
   - 7.2
 
 env:


### PR DESCRIPTION
VIP Go is on 7.2 everywhere.