### PR TITLE
Don't use Photon for `wpcom_vip_get_resized_attachment_url()`

### DIFF
--- a/tests/vip-helpers/test-vip-utils.php
+++ b/tests/vip-helpers/test-vip-utils.php
@@ -1,0 +1,25 @@
+<?php
+
+class WPCOM_VIP_Get_Resized_Attachment_Url_Test extends \WP_UnitTestCase {
+	public function test__invalid_attachment() {
+		$attachment_id = 99999999;
+
+		$actual_url = wpcom_vip_get_resized_attachment_url( $attachment_id, 100, 101 );
+
+		$this->assertFalse( $actual_url );
+	}
+
+	public function test__valid_attachment() {
+		$expected_end_of_url = '/image.jpg?w=100&h=101';
+
+		$attachment_id = $this->factory->attachment->create_object( [
+			'file' => 'image.jpg',
+		] );
+
+		$actual_url = wpcom_vip_get_resized_attachment_url( $attachment_id, 100, 101 );
+
+		$actual_end_of_url = substr( $actual_url, strrpos( $actual_url, '/' ) );
+
+		$this->assertEquals( $expected_end_of_url, $actual_end_of_url );
+	}
+}

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -178,14 +178,14 @@ function wpcom_vip_get_resized_attachment_url( $attachment_id, $width, $height, 
 		return false;
 	}
 
-	$args = array(
+	$resized_url = add_query_arg( [
 		'w' => intval( $width ),
 		'h' => intval( $height ),
-	);
+	], $url );
 
 	// @todo crop handling?
 
-	return jetpack_photon_url( $url, $args, '//' );
+	return $resized_url;
 }
 
 /**


### PR DESCRIPTION
The VIP Go Files services has the same capabilities and fewer issues on sites with restricted access.