### PR TITLE
WP_Filesystem_VIP:  Add naive implementation of `is_dir` 

### DIFF
--- a/files/class-wp-filesystem-vip-uploads.php
+++ b/files/class-wp-filesystem-vip-uploads.php
@@ -217,7 +217,6 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 * @return bool Whether $file is readable.
 	 */
 	public function is_readable( $file ) {
-
 		// If the file exists, we can read it.
 		return $this->exists( $file );
 	}
@@ -231,6 +230,26 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 */
 	public function is_writable( $file ) {
 		// This method is technically not implemented but we're returning true since we think most use cases would be to check if a file is writeable and then write to it. Given that most of the times the write will be successful there's not much to gain by implementing logic here.
+		return true;
+	}
+
+	/**
+	 * Create a directory.
+	 *
+	 * @param string $path Path for new directory.
+	 * @param mixed $chmod Optional. The permissions as octal number, (or False to skip chmod)
+	 *                      Default false.
+	 * @param mixed $chown Optional. A user name or number (or False to skip chown)
+	 *                      Default false.
+	 * @param mixed $chgrp Optional. A group name or number (or False to skip chgrp).
+	 *                      Default false.
+	 *
+	 * @return bool False if directory cannot be created, true otherwise.
+	 */
+	public function mkdir( $path, $chmod = false, $chown = false, $chgrp = false ) {
+		// We don't have an API for managing directories.
+		// Let's just assume we can create files on all paths.
+		// And pretend that this dir was created.
 		return true;
 	}
 
@@ -316,23 +335,6 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 * @return bool Whether operation was successful or not.
 	 */
 	public function touch( $file, $time = 0, $atime = 0 ) {
-		return $this->handle_unimplemented_method( __METHOD__ );
-	}
-
-	/**
-	 * Unimplemented - Create a directory.
-	 *
-	 * @param string $path Path for new directory.
-	 * @param mixed $chmod Optional. The permissions as octal number, (or False to skip chmod)
-	 *                      Default false.
-	 * @param mixed $chown Optional. A user name or number (or False to skip chown)
-	 *                      Default false.
-	 * @param mixed $chgrp Optional. A group name or number (or False to skip chgrp).
-	 *                      Default false.
-	 *
-	 * @return bool False if directory cannot be created, true otherwise.
-	 */
-	public function mkdir( $path, $chmod = false, $chown = false, $chgrp = false ) {
 		return $this->handle_unimplemented_method( __METHOD__ );
 	}
 

--- a/files/class-wp-filesystem-vip-uploads.php
+++ b/files/class-wp-filesystem-vip-uploads.php
@@ -171,7 +171,12 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	public function exists( $file ) {
 		$uploads_path = $this->sanitize_uploads_path( $file );
 
-		// TODO: should we return false for directories?
+		// We don't have an API for managing directories.
+		// Let's just assume we can create files on all paths.
+		if ( $this->is_dir( $file ) ) {
+			return true;
+		}
+
 		return $this->api->is_file( $uploads_path );
 	}
 
@@ -184,7 +189,24 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 */
 	public function is_file( $file ) {
 		// The API only deals with files, so we can just check for existence.
-		return $this->exists( $file );
+		return $this->exists( $uploads_path );
+	}
+
+	/**
+	 * Check if resource is a directory.
+	 *
+	 * We just naively check to see if the path has an extension.
+	 *
+	 * @param string $path Directory path.
+	 *
+	 * @return bool Whether $path is a directory.
+	 */
+	public function is_dir( $path ) {
+		$uploads_path = $this->sanitize_uploads_path( $path );
+
+		$pathinfo = pathinfo( $path );
+
+		return false === isset( $pathinfo['extension'] );
 	}
 
 	/**
@@ -195,6 +217,7 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 * @return bool Whether $file is readable.
 	 */
 	public function is_readable( $file ) {
+
 		// If the file exists, we can read it.
 		return $this->exists( $file );
 	}
@@ -255,17 +278,6 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 		trigger_error( $error_msg, E_USER_WARNING );
 
 		return false;
-	}
-
-	/**
-	 * Unimplemented - Check if resource is a directory.
-	 *
-	 * @param string $path Directory path.
-	 *
-	 * @return bool Whether $path is a directory.
-	 */
-	public function is_dir( $path ) {
-		return $this->handle_unimplemented_method( __METHOD__ );
 	}
 
 	/**

--- a/files/class-wp-filesystem-vip-uploads.php
+++ b/files/class-wp-filesystem-vip-uploads.php
@@ -173,7 +173,7 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 
 		// We don't have an API for managing directories.
 		// Let's just assume we can create files on all paths.
-		if ( $this->is_dir( $file ) ) {
+		if ( $this->is_dir( $uploads_path ) ) {
 			return true;
 		}
 
@@ -189,7 +189,7 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 */
 	public function is_file( $file ) {
 		// The API only deals with files, so we can just check for existence.
-		return $this->exists( $uploads_path );
+		return $this->exists( $file );
 	}
 
 	/**
@@ -204,7 +204,7 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	public function is_dir( $path ) {
 		$uploads_path = $this->sanitize_uploads_path( $path );
 
-		$pathinfo = pathinfo( $path );
+		$pathinfo = pathinfo( $uploads_path );
 
 		return false === isset( $pathinfo['extension'] );
 	}

--- a/tests/files/test-wp-filesystem-vip-uploads.php
+++ b/tests/files/test-wp-filesystem-vip-uploads.php
@@ -205,6 +205,11 @@ class WP_Filesystem_VIP_Uploads_Test extends \WP_UnitTestCase {
 				'/wp-content/uploads/folder',
 				true,
 			],
+
+			'directory with trailing slash' => [
+				'/wp-content/uploads/folder/',
+				true,
+			],
 		];
 	}
 

--- a/tests/files/test-wp-filesystem-vip-uploads.php
+++ b/tests/files/test-wp-filesystem-vip-uploads.php
@@ -183,4 +183,37 @@ class WP_Filesystem_VIP_Uploads_Test extends \WP_UnitTestCase {
 		$tmp_file_exists = file_exists( $tmp_file );
 		$this->assertFalse( $tmp_file_exists, 'Temp file was not deleted' );
 	}
+
+	public function get_test_data__is_dir() {
+		return [
+			'file' => [
+				'/wp-content/uploads/file.jpg',
+				false,
+			],
+
+			'file with trailing period' => [
+				'/wp-content/uploads/file.',
+				false,
+			],
+
+			'file with leading period' => [
+				'/wp-content/uploads/.file',
+				false,
+			],
+
+			'directory' => [
+				'/wp-content/uploads/folder',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__is_dir
+	 */
+	public function test__is_dir( $test_path, $expected_result ) {
+		$actual_result = $this->filesystem->is_dir( $test_path );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
 }


### PR DESCRIPTION
We don't have an API for managing directories so let's just assume we can create files on all paths.