### PR TITLE
Fix WPCOM_VIP_PRIVATE_DIR

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -82,7 +82,17 @@ if ( ! defined( 'WPCOM_VIP_MAIL_TRACKING_KEY' ) ) {
 
 // Define constants for custom VIP Go paths
 define( 'WPCOM_VIP_CLIENT_MU_PLUGIN_DIR', WP_CONTENT_DIR . '/client-mu-plugins' );
-define( 'WPCOM_VIP_PRIVATE_DIR', '/private' );
+
+$private_dir_path = WP_CONTENT_DIR . '/private'; // Local fallback
+if ( false !== VIP_GO_ENV ) {
+	if ( is_dir( '/private' ) ) {
+		$private_dir_path = '/private';
+	} elseif ( is_dir( '/chroot/private' ) ) {
+		$private_dir_path = '/chroot/private';
+	}
+}
+define( 'WPCOM_VIP_PRIVATE_DIR', $private_dir_path );
+unset( $private_dir_path );
 
 // Define these values just in case
 defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) or define( 'WPCOM_VIP_MACHINE_USER_LOGIN', 'vip' );

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -82,7 +82,7 @@ if ( ! defined( 'WPCOM_VIP_MAIL_TRACKING_KEY' ) ) {
 
 // Define constants for custom VIP Go paths
 define( 'WPCOM_VIP_CLIENT_MU_PLUGIN_DIR', WP_CONTENT_DIR . '/client-mu-plugins' );
-define( 'WPCOM_VIP_PRIVATE_DIR', WPCOM_SANDBOXED || VIP_GO_IS_CLI_CONTAINER ? '/chroot/private' : '/private' );
+define( 'WPCOM_VIP_PRIVATE_DIR', '/private' );
 
 // Define these values just in case
 defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) or define( 'WPCOM_VIP_MACHINE_USER_LOGIN', 'vip' );


### PR DESCRIPTION
The private dir is only prefixed with `/chroot` if you're running a sandbox as root, which shouldn't really happen anymore. As it is, this can break some sites when sandboxed because web requests are never root.

Fixes #858