### PR TITLE
Disable email sharing when recaptcha is not set-up

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -114,8 +114,9 @@ add_filter( 'jetpack_sync_listener_should_load', 'wpcom_vip_disable_jetpack_sync
 /**
  * Disable Email Sharing if Recaptcha is not setup.
  *
- * To prevent spam and abuse, we should only allow sharing via e-mail when Recaptcha is enabled.
- * @see https://jetpack.com/support/sharing/#captcha Instructions on how to set up reCaptcha for your site
+ * To prevent spam and abuse, we should only allow sharing via e-mail when reCAPTCHA is enabled.
+ *
+ * @see https://jetpack.com/support/sharing/#captcha Instructions on how to set up reCAPTCHA for your site
  *
  * @param  bool $is_enabled Current value.
  * @return bool              Whether (true) or not (false) email sharing is enabled.
@@ -126,6 +127,5 @@ function wpcom_vip_disable_jetpack_email_no_recaptcha( $is_enabled ) {
 	}
 
 	return defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' );
-
 }
 add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recaptcha' );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -114,7 +114,8 @@ add_filter( 'jetpack_sync_listener_should_load', 'wpcom_vip_disable_jetpack_sync
 /**
  * Disable Email Sharing if Recaptcha is not setup.
  *
- * To prevent spam and abuse, we should only allow sharing via e-mail when recapatcha is enabled.
+ * To prevent spam and abuse, we should only allow sharing via e-mail when Recaptcha is enabled.
+ * @see https://jetpack.com/support/sharing/#captcha Instructions on how to set up reCaptcha for your site
  *
  * @param  bool $is_enabled Current value.
  * @return bool              Whether (true) or not (false) email sharing is enabled.

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -121,8 +121,8 @@ add_filter( 'jetpack_sync_listener_should_load', 'wpcom_vip_disable_jetpack_sync
  */
 function wpcom_vip_disable_jetpack_email_no_recaptcha( $is_enabled ) {
 	if ( ! $is_enabled ) {
-	        return $enabled;
-	    }
+			return $is_enabled;
+	}
 
 	return defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' );
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -110,3 +110,21 @@ function wpcom_vip_disable_jetpack_sync_for_frontend_get_requests( $should_load 
 
 }
 add_filter( 'jetpack_sync_listener_should_load', 'wpcom_vip_disable_jetpack_sync_for_frontend_get_requests' );
+
+/**
+ * Disable Email Sharing if Recaptcha is not setup.
+ *
+ * To prevent spam and abuse, we should only allow sharing via e-mail when recapatcha is enabled.
+ *
+ * @param  bool $is_enabled Current value.
+ * @return bool              Whether (true) or not (false) email sharing is enabled.
+ */
+function wpcom_vip_disable_jetpack_email_no_recaptcha( $is_enabled ) {
+	if ( ! $is_enabled ) {
+	        return $enabled;
+	    }
+
+	return defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' );
+
+}
+add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recaptcha' );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -121,7 +121,7 @@ add_filter( 'jetpack_sync_listener_should_load', 'wpcom_vip_disable_jetpack_sync
  */
 function wpcom_vip_disable_jetpack_email_no_recaptcha( $is_enabled ) {
 	if ( ! $is_enabled ) {
-			return $is_enabled;
+		return $is_enabled;
 	}
 
 	return defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' );


### PR DESCRIPTION
As per #826, we should only allow [email sharing](https://jetpack.com/support/sharing/) if recaptcha is set-up.

## Testing

1) If it's not enabled already, go to Settings > Sharing and drag & drop the "Email" button into "Enabled Services"
2) Assuming recaptcha isn't set-up yet, go to a post and you should see the email sharing icon not visible.
3) [Set-up recapatcha](https://jetpack.com/tag/recaptcha/)
4) Go back to post and you should see that the email sharing icon is visible.

props @mjangda 

Fixes #826 