### PR TITLE
Added a call to remove the `vaultpress` option from the db prior to plugin registration

### DIFF
--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -63,7 +63,7 @@ function connect_vaultpress() {
 	    // Remove the VaultPress option from the db to prevent site registration from failing
         \WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
 	    // Register VaultPress
-		\WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
+        \WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
 	} else {
 		trigger_error( 'Cannot connect VaultPress outside of a WP_CLI context, skipping', E_USER_WARNING );
 	}

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -59,10 +59,11 @@ function connect_jetpack() {
 }
 
 function connect_vaultpress() {
-	if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) )
-	    // Remove the VaultPress option from the db to prevent site registration from failing
+	if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
+		// Remove the VaultPress option from the db to prevent site registration from failing
 		\WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
-	    // Register VaultPress
+		
+		// Register VaultPress
 		\WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
 	} else {
 		trigger_error( 'Cannot connect VaultPress outside of a WP_CLI context, skipping', E_USER_WARNING );

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -61,7 +61,7 @@ function connect_jetpack() {
 function connect_vaultpress() {
 	if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) )
 	    // Remove the VaultPress option from the db to prevent site registration from failing
-        \WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
+	    \WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
 	    // Register VaultPress
         \WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
 	} else {

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -61,8 +61,8 @@ function connect_jetpack() {
 function connect_vaultpress() {
 	if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 		// Remove the VaultPress option from the db to prevent site registration from failing
-		\WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
-		
+		delete_option( 'vaultpress' );
+
 		// Register VaultPress
 		\WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
 	} else {

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -60,6 +60,9 @@ function connect_jetpack() {
 
 function connect_vaultpress() {
 	if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
+	    \\ Remove the VaultPress option from the db to prevent site registration from failing
+        \WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
+	    \\ Register VaultPress
 		\WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
 	} else {
 		trigger_error( 'Cannot connect VaultPress outside of a WP_CLI context, skipping', E_USER_WARNING );

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -59,10 +59,10 @@ function connect_jetpack() {
 }
 
 function connect_vaultpress() {
-	if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
-	    \\ Remove the VaultPress option from the db to prevent site registration from failing
+	if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) )
+	    // Remove the VaultPress option from the db to prevent site registration from failing
         \WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
-	    \\ Register VaultPress
+	    // Register VaultPress
 		\WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
 	} else {
 		trigger_error( 'Cannot connect VaultPress outside of a WP_CLI context, skipping', E_USER_WARNING );

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -61,9 +61,9 @@ function connect_jetpack() {
 function connect_vaultpress() {
 	if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) )
 	    // Remove the VaultPress option from the db to prevent site registration from failing
-	    \WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
+		\WP_CLI::runcommand( sprintf( 'option delete vaultpress --url=%s', home_url() ) );
 	    // Register VaultPress
-        \WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
+		\WP_CLI::runcommand( sprintf( 'vaultpress register_via_jetpack --url=%s', home_url() ) );
 	} else {
 		trigger_error( 'Cannot connect VaultPress outside of a WP_CLI context, skipping', E_USER_WARNING );
 	}


### PR DESCRIPTION
This is to avoid a VaultPress fatal during the sync, which is caused by
the `vaultpress` option being present in the child site db.