### PR TITLE
Plugin Fixes Plugin

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -1,0 +1,40 @@
+<?php
+/*
+Plugin Name: VIP GO Plugin Fixes
+Description: Handles Plugin Specific Fixes for VIP GO Environments
+Author: Automattic
+Version: 1.0
+License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+*/
+
+// Make sure the `amp` query var has an explicit value.
+// Avoids issues when filtering the deprecated `query_string` hook.
+function vip_go_amp_force_query_var_value( $query_vars ) {
+
+	if ( isset( $query_vars[ AMP_QUERY_VAR ] ) ) {
+		if ( '' === $query_vars[ AMP_QUERY_VAR ] ) {
+			$query_vars[ AMP_QUERY_VAR ] = 1;
+
+			// Allow for some fuzziness on string/integer type matching.
+		} else if ( '1' !== $query_vars[ AMP_QUERY_VAR ] && 1 !== $query_vars[ AMP_QUERY_VAR ] ) {
+			global $wp_rewrite;
+
+			// If there is something after /amp/, pretend we didn't hit that rewrite rule.
+			if ( $wp_rewrite->use_trailing_slashes && '' !== $query_vars[ AMP_QUERY_VAR ] ) {
+
+				// Check for extra-long slugs, which will truncate and remove the /amp/* part.
+				if ( strlen( $query_vars['name'] ) > 190 ) {
+					// Give WP_Query an improbable string to get a 404.
+					$query_vars['name'] = substr( $query_vars['name'], 0, - 20 ) . substr( md5( $query_vars['name'] ), 0, 20 );
+				} else {
+					$query_vars['name'] = $query_vars['name'] . "/amp/" . $query_vars[ AMP_QUERY_VAR ];
+				}
+				unset( $query_vars[ AMP_QUERY_VAR ] );
+			}
+		}
+	}
+	return $query_vars;
+}
+
+
+add_filter( 'request', 'vip_go_amp_force_query_var_value', 9, 1 );

--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -1,7 +1,7 @@
 <?php
 /*
-Plugin Name: VIP GO Plugin Fixes
-Description: Handles Plugin Specific Fixes for VIP GO Environments
+Plugin Name: VIP Go Plugin Fixes
+Description: A collection of fixes for various plugins.
 Author: Automattic
 Version: 1.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -9,14 +9,13 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 
 // Make sure the `amp` query var has an explicit value.
 // Avoids issues when filtering the deprecated `query_string` hook.
+// Copy of upstream fix: https://github.com/Automattic/amp-wp/pull/910
 function vip_go_amp_force_query_var_value( $query_vars ) {
 
 	if ( isset( $query_vars[ AMP_QUERY_VAR ] ) ) {
 		if ( '' === $query_vars[ AMP_QUERY_VAR ] ) {
 			$query_vars[ AMP_QUERY_VAR ] = 1;
-
-			// Allow for some fuzziness on string/integer type matching.
-		} else if ( '1' !== $query_vars[ AMP_QUERY_VAR ] && 1 !== $query_vars[ AMP_QUERY_VAR ] ) {
+		} else if ( '1' !== $query_vars[ AMP_QUERY_VAR ] && 1 !== $query_vars[ AMP_QUERY_VAR ] ) { // Allow for some fuzziness on string/integer type matching.
 			global $wp_rewrite;
 
 			// If there is something after /amp/, pretend we didn't hit that rewrite rule.
@@ -33,8 +32,7 @@ function vip_go_amp_force_query_var_value( $query_vars ) {
 			}
 		}
 	}
+
 	return $query_vars;
 }
-
-
 add_filter( 'request', 'vip_go_amp_force_query_var_value', 9, 1 );

--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -11,7 +11,11 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 // Avoids issues when filtering the deprecated `query_string` hook.
 // Copy of upstream fix: https://github.com/Automattic/amp-wp/pull/910
 function vip_go_amp_force_query_var_value( $query_vars ) {
-
+	// Don't bother if AMP is not active
+	if ( ! defined( 'AMP_QUERY_VAR' ) ) {
+		return $query_vars;	
+	}
+	
 	if ( isset( $query_vars[ AMP_QUERY_VAR ] ) ) {
 		if ( '' === $query_vars[ AMP_QUERY_VAR ] ) {
 			$query_vars[ AMP_QUERY_VAR ] = 1;


### PR DESCRIPTION
Intended for addition of modifications to known plugins to resolve platform level issues while fixes get integrated back up to core repos.

Modified AMP Query Var filter to handle relative links. Existing AMP-WP plugin causes the AMP page to be rendered regardless of what comes after the /AMP/ portion of the link. To ensure that we don't get in infinite indexing loops we are enforcing that AMP triggers 404s appropriately instead of re-rendering the page. This is temporary until merged into core.