### PR TITLE
add Gutenberg loading functionality to Go

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "lightweight-term-count-update"]
 	path = lightweight-term-count-update
 	url = https://github.com/Automattic/lightweight-term-count-update
+[submodule "ramp-for-gutenberg"]
+	path = ramp-for-gutenberg
+	url = https://github.com/Automattic/ramp-for-gutenberg.git

--- a/ramp-for-gutenberg.php
+++ b/ramp-for-gutenberg.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Plugin Name: Gutenberg Ramp
+ * Description: Allows theme authors to control the circumstances under which the Gutenberg editor loads. Options include "load" (1 loads all the time, 0 loads never) "post_ids" (load for particular posts) "post_types" (load for particular posts types.)
+ * Version:     0.1
+ * Author:      Automattic, Inc.
+ * License:     GPL-2.0+
+ * License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: ramp-for-gutenberg
+ */
+
+// This file loads Ramp, and modifies behaviors for Gutenberg on VIP Go
+
+/** load Gutenberg Ramp **/
+if ( file_exists( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' ) ) {
+	require_once( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' );
+}
+
+/** Turn off the UI for Ramp **/
+add_action( 'plugins_loaded', function() {
+	remove_action( 'admin_init', 'ramp_for_gutenberg_initialize_admin_ui' );
+} );
+
+/** Loading helper **/
+function wpcom_vip_load_gutenberg( $criteria ) {
+	if ( ! function_exists( 'ramp_for_gutenberg_load_gutenberg' ) ) {
+		return;
+	}
+	ramp_for_gutenberg_load_gutenberg( $criteria );
+}

--- a/vip-plugins.php
+++ b/vip-plugins.php
@@ -10,3 +10,23 @@
  */
 
 require_once( __DIR__ . '/vip-plugins/vip-plugins.php' );
+
+/** loading helper and behaviors for Gutenberg on VIP Go **/
+
+/** load Gutenberg Ramp **/
+if ( file_exists( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' ) ) {
+	require_once( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' );
+}
+
+/** Turn off the UI for Ramp **/
+add_action( 'plugins_loaded', function() {
+	remove_action( 'admin_init', 'ramp_for_gutenberg_initialize_admin_ui' );
+} );
+
+/** Loading helper **/
+function wpcom_vip_load_gutenberg( $criteria ) {
+	if ( !function_exists( 'ramp_for_gutenberg_load_gutenberg' ) ) {
+		return;
+	}
+	ramp_for_gutenberg_load_gutenberg( $criteria );
+}

--- a/vip-plugins.php
+++ b/vip-plugins.php
@@ -10,23 +10,3 @@
  */
 
 require_once( __DIR__ . '/vip-plugins/vip-plugins.php' );
-
-/** loading helper and behaviors for Gutenberg on VIP Go **/
-
-/** load Gutenberg Ramp **/
-if ( file_exists( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' ) ) {
-	require_once( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' );
-}
-
-/** Turn off the UI for Ramp **/
-add_action( 'plugins_loaded', function() {
-	remove_action( 'admin_init', 'ramp_for_gutenberg_initialize_admin_ui' );
-} );
-
-/** Loading helper **/
-function wpcom_vip_load_gutenberg( $criteria ) {
-	if ( !function_exists( 'ramp_for_gutenberg_load_gutenberg' ) ) {
-		return;
-	}
-	ramp_for_gutenberg_load_gutenberg( $criteria );
-}


### PR DESCRIPTION
This PR allows VIPs to load Gutenberg conditionally from their themes using a helper called `wpcom_vip_load_gutenberg`.  This function is a wrapper for `ramp_for_gutenberg_load_gutenberg` and accepts the same parameters.  In order to use this function pre-5.0, VIPs will need to separately install the Gutenberg plugin in the `/plugins` directory of their repos.

Included in this PR:
- submodule for the Gutenberg Ramp plugin.
- provide a wrapper for `ramp_for_gutenberg_load_gutenberg` called `wpcom_vip_load_gutenberg`
- turn off Ramp UI by default