### PR TITLE
Improve Gutenberg Ramp argument consistency

### DIFF
--- a/ramp-for-gutenberg.php
+++ b/ramp-for-gutenberg.php
@@ -23,7 +23,7 @@ add_action( 'plugins_loaded', function() {
 } );
 
 /** Loading helper **/
-function wpcom_vip_load_gutenberg( $criteria ) {
+function wpcom_vip_load_gutenberg( $criteria = false ) {
 	if ( ! function_exists( 'ramp_for_gutenberg_load_gutenberg' ) ) {
 		return;
 	}


### PR DESCRIPTION
`ramp_for_gutenberg_load_gutenberg` accepts a single argument and defaults to `false`

`wpcom_vip_load_gutenberg` should do the same to avoid accidental fatal errors. [The documentation](https://vip.wordpress.com/documentation/vip-go/loading-gutenberg/#examples) already demonstrates usage with no arguments passed to `wpcom_vip_load_gutenberg`