### PR TITLE
Allow Developers to Opt Out from Gutenberg Ramp

### DIFF
--- a/ramp-for-gutenberg.php
+++ b/ramp-for-gutenberg.php
@@ -2,30 +2,31 @@
 
 /**
  * Plugin Name: Gutenberg Ramp
- * Description: Allows theme authors to control the circumstances under which the Gutenberg editor loads. Options include "load" (1 loads all the time, 0 loads never) "post_ids" (load for particular posts) "post_types" (load for particular posts types.)
- * Version:     0.1
+ * Description: Control the circumstances under which the Gutenberg editor loads in code, using Gutenberg Ramp.
+ * Version:     0.2
  * Author:      Automattic, Inc.
  * License:     GPL-2.0+
  * License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text Domain: ramp-for-gutenberg
  */
 
-// This file loads Ramp, and modifies behaviors for Gutenberg on VIP Go
-
-/** load Gutenberg Ramp **/
-if ( file_exists( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' ) ) {
-	require_once( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' );
-}
-
-/** Turn off the UI for Ramp **/
-add_action( 'plugins_loaded', function() {
-	remove_action( 'admin_init', 'ramp_for_gutenberg_initialize_admin_ui' );
-} );
-
-/** Loading helper **/
+/**
+ * Load Gutenberg via the Gutenberg Ramp plugin.
+ *
+ * @param array $criteria Use [ 'load' => 1 ] to always load, [ 'load' => 0 ] to never load, [ 'post_ids' => [] ] to load for particular posts, and [ 'post_types' => [] ] to load for particular post types.
+ */
 function wpcom_vip_load_gutenberg( $criteria ) {
+	// Load Gutenberg Ramp.
+	if ( file_exists( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' ) ) {
+		require_once( __DIR__ . '/ramp-for-gutenberg/ramp-for-gutenberg.php' );
+	}
+
+	// Turn off the UI for Gutenberg Ramp.
+	remove_action( 'admin_init', 'ramp_for_gutenberg_initialize_admin_ui' );
+
 	if ( ! function_exists( 'ramp_for_gutenberg_load_gutenberg' ) ) {
 		return;
 	}
+
 	ramp_for_gutenberg_load_gutenberg( $criteria );
 }


### PR DESCRIPTION
This PR moves the Gutenberg Ramp loading inside of the `wpcom_vip_load_gutenberg()` function. This enables developers to opt out from loading Gutenberg Ramp.

Other changes include moving the usage information to the doc block of the loading function, making it easier for developers to understand the options that they have.

This was tested manually using the following scenarios:
- _Not_ calling the `wpcom_vip_load_gutenberg()` function does _not_ load Gutenberg Ramp.
- Calling the `wpcom_vip_load_gutenberg()` function _does_ load Gutenberg Ramp.
- The Gutenberg Ramp UI is not visible in the admin.