### PR TITLE
Privacy Compat Fixes

### DIFF
--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -13,7 +13,7 @@ use WP_Error;
  *
  * The code here replaces the core handlers with our own implementation, which does work on Go sites.
  */
-add_action( 'admin_init', __NAMESPACE__ . '\init_privacy_compat' );
+add_action( 'init', __NAMESPACE__ . '\init_privacy_compat' );
 
 function init_privacy_compat() {
 	// Replace core's privacy data export handler with a custom one.


### PR DESCRIPTION
Follow-up from #895 

- [x] Switch to init hook. The delete handler is triggered during cron and need to be initialized in that context, not just admin.
- [ ] ... 