### PR TITLE
Upgrade to Akismet 4.0.7

### DIFF
--- a/akismet.php
+++ b/akismet.php
@@ -4,7 +4,7 @@
 Plugin Name: Akismet Anti-Spam
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 4.0.3
+Version: 4.0.7
 Author: Automattic
 Author URI: https://automattic.com/wordpress-plugins/
 License: GPLv2 or later

--- a/akismet/_inc/akismet.css
+++ b/akismet/_inc/akismet.css
@@ -417,6 +417,10 @@ table.comments td.comment p a:after {
 	padding: 1.5rem;
 }
 
+.akismet-lower .notice {
+	margin-bottom: 2rem;
+}
+
 .akismet-card {
 	margin-top: 1rem;
 	margin-bottom: 0;

--- a/akismet/_inc/akismet.js
+++ b/akismet/_inc/akismet.js
@@ -273,4 +273,13 @@ jQuery( function ( $ ) {
 		var img = new Image();
 		img.src = akismet_mshot_url( linkUrl );
 	}
+
+	/**
+	 * Sets the comment form privacy notice display to hide when one clicks Core's dismiss button on the related admin notice.
+	 */
+	$( '#akismet-privacy-notice-admin-notice' ).on( 'click', '.notice-dismiss', function(){
+		$.ajax({
+                        url: './options-general.php?page=akismet-key-config&akismet_comment_form_privacy_notice=hide',
+		});
+	});
 });

--- a/akismet/akismet.php
+++ b/akismet/akismet.php
@@ -6,7 +6,7 @@
 Plugin Name: Akismet Anti-Spam
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 4.0.3
+Version: 4.0.7
 Author: Automattic
 Author URI: https://automattic.com/wordpress-plugins/
 License: GPLv2 or later
@@ -37,7 +37,7 @@ if ( !function_exists( 'add_action' ) ) {
 	exit;
 }
 
-define( 'AKISMET_VERSION', '4.0.3' );
+define( 'AKISMET_VERSION', '4.0.7' );
 define( 'AKISMET__MINIMUM_WP_VERSION', '4.0' );
 define( 'AKISMET__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'AKISMET_DELETE_LIMIT', 100000 );

--- a/akismet/readme.txt
+++ b/akismet/readme.txt
@@ -2,8 +2,8 @@
 Contributors: matt, ryan, andy, mdawaffe, tellyworth, josephscott, lessbloat, eoigal, cfinke, automattic, jgs, procifer, stephdau
 Tags: akismet, comments, spam, antispam, anti-spam, anti spam, comment moderation, comment spam, contact form spam, spam comments
 Requires at least: 4.0
-Tested up to: 4.9.1
-Stable tag: 4.0.3
+Tested up to: 4.9.6
+Stable tag: 4.0.7
 License: GPLv2 or later
 
 Akismet checks your comments and contact form submissions against our global database of spam to protect you and your site from malicious content.
@@ -29,6 +29,31 @@ Upload the Akismet plugin to your blog, Activate it, then enter your [Akismet.co
 1, 2, 3: You're done!
 
 == Changelog ==
+
+= 4.0.7 =
+*Release Date - 28 May 2018*
+
+* Based on user feedback, the link on "Learn how your comment data is processed." in the optional privacy notice now has a `target` of `_blank` and opens in a new tab/window.
+* Updated the in-admin privacy notice to use the term "comment" instead of "contact" in "Akismet can display a notice to your users under your comment forms."
+* Only show in-admin privacy notice if Akismet has an API Key configured
+
+= 4.0.6 =
+*Release Date - 26 May 2018*
+
+* Moved away from using `empty( get_option() )` to instantiating a variable to be compatible with older versions of PHP (5.3, 5.4, etc).  
+
+= 4.0.5 =
+*Release Date - 26 May 2018*
+
+* Corrected version number after tagging. Sorry...
+
+= 4.0.4 =
+*Release Date - 26 May 2018*
+
+* Added a hook to provide Akismet-specific privacy information for a site's privacy policy.
+* Added tools to control the display of a privacy related notice under comment forms.
+* Fixed HTML in activation failure message to close META and HEAD tag properly.
+* Fixed a bug that would sometimes prevent Akismet from being correctly auto-configured.
 
 = 4.0.3 =
 *Release Date - 19 February 2018*

--- a/akismet/views/config.php
+++ b/akismet/views/config.php
@@ -151,6 +151,17 @@
 										?>
 									</td>
 								</tr>
+								<tr>
+									<th class="comment-form-privacy-notice" align="left" scope="row"><?php esc_html_e('Privacy', 'akismet'); ?></th>
+									<td></td>
+									<td align="left">
+										<fieldset><legend class="screen-reader-text"><span><?php esc_html_e('Akismet privacy notice', 'akismet'); ?></span></legend>
+										<p><label for="akismet_comment_form_privacy_notice_display"><input type="radio" name="akismet_comment_form_privacy_notice" id="akismet_comment_form_privacy_notice_display" value="display" <?php checked('display', get_option('akismet_comment_form_privacy_notice')); ?> /> <?php esc_html_e('Display a privacy notice under your comment forms.', 'akismet'); ?></label></p>
+										<p><label for="akismet_comment_form_privacy_notice_hide"><input type="radio" name="akismet_comment_form_privacy_notice" id="akismet_comment_form_privacy_notice_hide" value="hide" <?php echo in_array( get_option('akismet_comment_form_privacy_notice'), array('display', 'hide') ) ? checked('hide', get_option('akismet_comment_form_privacy_notice'), false) : 'checked="checked"'; ?> /> <?php esc_html_e('Do not display privacy notice.', 'akismet'); ?></label></p>
+										</fieldset>
+										<span class="akismet-note"><?php esc_html_e( 'To help your site be compliant with GDPR and other laws requiring notification of tracking, Akismet can display a notice to your users on your contact form. This feature is disabled by default, however, if you or your audience is located in Europe, you need to turn it on.', 'akismet' );?></span>
+									</td>
+								</tr>
 							</tbody>
 						</table>
 						<div class="akismet-card-actions">

--- a/akismet/views/notice.php
+++ b/akismet/views/notice.php
@@ -15,7 +15,7 @@
 <?php elseif ( $type == 'spam-check' ) :?>
 <div class="notice notice-warning">
 	<p><strong><?php esc_html_e( 'Akismet has detected a problem.', 'akismet' );?></strong></p>
-	<p><?php printf( __( 'Some comments have not yet been checked for spam by Akismet. They have been temporarily held for moderation and will automatically be rechecked later.', 'akismet' ) ); ?></p>
+	<p><?php esc_html_e( 'Some comments have not yet been checked for spam by Akismet. They have been temporarily held for moderation and will automatically be rechecked later.', 'akismet' ); ?></p>
 	<?php if ( $link_text ) { ?>
 		<p><?php echo $link_text; ?></p>
 	<?php } ?>
@@ -131,5 +131,11 @@
 		<?php printf( __( 'Please <a href="%s" target="_blank">contact our support team</a> with any questions.', 'akismet' ), 'https://akismet.com/contact/'); ?>
 	</p>
 	<?php endif; ?>
+</div>
+<?php elseif ( $type == 'privacy' ) :?>
+<div class="notice notice-warning is-dismissible" id="akismet-privacy-notice-admin-notice">
+	<p><strong><?php esc_html_e( 'Akismet & Privacy.', 'akismet' );?></strong></p>
+	<p><?php esc_html_e( 'To help your site be compliant with GDPR and other laws requiring notification of tracking, Akismet can display a notice to your users under your comment forms. This feature is disabled by default, however, if you or your audience is located in Europe, you need to turn it on.', 'akismet' ); ?></p>
+	<p><?php printf( __(' Please <a href="%s">enable</a> or <a href="%s">disable</a> this feature. <a href="%s" id="akismet-privacy-notice-control-notice-info-link" target="_blank">More information</a>.', 'akismet' ), admin_url( apply_filters( 'akismet_comment_form_privacy_notice_url_display', 'options-general.php?page=akismet-key-config&akismet_comment_form_privacy_notice=display' ) ), admin_url( apply_filters( 'akismet_comment_form_privacy_notice_url_hide', 'options-general.php?page=akismet-key-config&akismet_comment_form_privacy_notice=hide' ) ), 'https://akismet.com/privacy/' ); ?></p>
 </div>
 <?php endif;?>


### PR DESCRIPTION
https://blog.akismet.com/2018/05/28/version-4-0-7-of-the-akismet-wordpress-plugin-is-now-available/

```
4.0.7
Release Date – 28 May 2018

Based on user feedback, the link on “Learn how your comment data is processed.” in the optional privacy notice now has a target of _blank and opens in a new tab/window.
Updated the in-admin privacy notice to use the term “comment” instead of “contact” in “Akismet can display a notice to your users under your comment forms.”
Only show in-admin privacy notice if Akismet has an API Key configured
4.0.6
Release Date – 26 May 2018

Moved away from using empty( get_option() ) to instantiating a variable to be compatible with older versions of PHP (5.3, 5.4, etc).
4.0.5
Release Date – 26 May 2018

Corrected version number after tagging. Sorry…
4.0.4
Release Date – 26 May 2018

Added a hook to provide Akismet-specific privacy information for a site’s privacy policy.
Added tools to control the display of a privacy related notice under comment forms.
Fixed HTML in activation failure message to close META and HEAD tag properly.
Fixed a bug that would sometimes prevent Akismet from being correctly auto-configured.
```