### PR TITLE
Deprecates `wpcom_vip_load_wp_rest_api`

### DIFF
--- a/vip-helpers/vip-deprecated.php
+++ b/vip-helpers/vip-deprecated.php
@@ -1,6 +1,15 @@
 <?php
 
 /**
+ * Loads the built-in WP REST API endpoints in WordPress.com VIP context.
+ *
+ * @deprecated Not applicable since VIP 2.0.0
+ */
+function wpcom_vip_load_wp_rest_api() {
+    _deprecated_function( __FUNCTION__, '2.0.0' );
+}
+
+/**
  * Loads the shared VIP helper file which defines some helpful functions.
  *
  * @deprecated Not applicable since VIP 2.0.0


### PR DESCRIPTION
This will better allow themes to be migrated from WordPress.com without causing a fatal error.