### PR TITLE
Update to Jetpack 6.2.1

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 6.2
+ * Version: 6.2.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack


### PR DESCRIPTION
> This point fix addresses a small bug that prevented stats from working on the AMP view for a site, as well as an uncommon issue with the VR shortcode.

https://jetpack.com/?p=31394
https://github.com/Automattic/jetpack/releases/tag/6.2.1