### PR TITLE
Only Enforce Restricted Usernames on VIP Environments

### DIFF
--- a/security.php
+++ b/security.php
@@ -41,7 +41,10 @@ add_action( 'wp_login', 'wpcom_vip_login_limiter_on_success', 10, 2 );
 
 function wpcom_vip_limit_logins_for_restricted_usernames( $user, $username, $password ) {
 	$is_restricted_username = wpcom_vip_is_restricted_username( $username );
-	if ( $is_restricted_username ) {
+	if (
+		( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV )
+		&& $is_restricted_username
+	) {
 		return new WP_Error( 'restricted-login', 'Logins are restricted for that user. Please try a different user account.' );
 	}
 

--- a/security.php
+++ b/security.php
@@ -39,6 +39,18 @@ function wpcom_vip_login_limiter_on_success( $username, $user ) {
 }
 add_action( 'wp_login', 'wpcom_vip_login_limiter_on_success', 10, 2 );
 
+/**
+ * Limits logins of usernames that are not allowed to be used on VIP environments.
+ *
+ * If a user attempts to login using one of the restricted usernames, this filter
+ * returns a WP_Error and prevents the login entirely.
+ *
+ * @param null|\WP_User|\WP_Error $user     WP_User if the user is authenticated.
+ *                                          WP_Error or null otherwise.
+ * @param string                  $username Username or email address.
+ * @param string                  $password User password
+ * @return \WP_Error|\WP_User
+ */
 function wpcom_vip_limit_logins_for_restricted_usernames( $user, $username, $password ) {
 	$is_restricted_username = wpcom_vip_is_restricted_username( $username );
 	if (


### PR DESCRIPTION
Currently, the restricted usernames functionality enforces usernames on every single environment that the mu-plugins library is used on, including local. However, quite a lot of local development environments use the admin username by default, which makes it impossible to login with a default configuration. Chassis, in particular, sets up WordPress with a super-admin `admin` user by default and it is a recommended local environment for developing on VIP.

This simple change only enforces the restricted usernames when on a WPCOM_VIP environment instead of doing so indiscriminately.

P.S. I know I opened this up without any discussion in an Issue, I'm happy to open one up for this topic if preferred as a first step.