### PR TITLE
Update to VaultPress 1.9.5

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: https://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>.
- * Version: 1.9.2
+ * Version: 1.9.5
  * Author: Automattic
  * Author URI: https://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+

--- a/vaultpress/class.vaultpress-ixr-ssl-client.php
+++ b/vaultpress/class.vaultpress-ixr-ssl-client.php
@@ -8,8 +8,11 @@ if ( !class_exists( 'IXR_Client' ) )
 
 class VaultPress_IXR_SSL_Client extends IXR_Client {
 	var $ssl = false;
-	function __construct( $server, $path = false, $port = 80, $timeout = false ) {
+	function __construct( $server, $path = false, $port = 80, $timeout = false, $useragent = false ) {
 		parent::__construct( $server, $path, $port, $timeout );
+		if ( ! empty( $useragent ) ) {
+			$this->useragent = $useragent;
+		}
 	}
 	function ssl( $port=443 ) {
 		if ( !extension_loaded( 'openssl' ) )

--- a/vaultpress/readme.txt
+++ b/vaultpress/readme.txt
@@ -2,8 +2,8 @@
 Contributors: automattic, apokalyptik, briancolinger, josephscott, shaunandrews, xknown, thingalon, annezazu, rachelsquirrel
 Tags: security, malware, virus, archive, back up, back ups, backup, backups, scanning, restore, wordpress backup, site backup, website backup
 Requires at least: 3.2
-Tested up to: 4.8
-Stable tag: 1.9.2
+Tested up to: 4.9
+Stable tag: 1.9.5
 License: GPLv2
 
 VaultPress is a subscription service offering real-time backup, automated security scanning, and support from WordPress experts.
@@ -47,6 +47,16 @@ A VaultPress subscription is for a single WordPress site. You can purchase addit
 Yes, VaultPress supports Multisite installs. Each site will require its own subscription.
 
 == Changelog ==
+= 1.9.5 - 2 February 2018
+* Removing activation notice
+
+= 1.9.4 - 15 November 2017
+* Error handling improvements in the scanner
+
+= 1.9.3 - 9 November 2017
+* Compatibility update
+* Send a better user-agent string to VaultPress servers
+
 = 1.9.2 - 6 July 2017 =
 * Compatibility update
 

--- a/vaultpress/vaultpress.php
+++ b/vaultpress/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href="http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">Need some help?</a>
- * Version: 1.9.2
+ * Version: 1.9.5
  * Author: Automattic
  * Author URI: http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+
@@ -18,7 +18,7 @@ class VaultPress {
 	var $option_name          = 'vaultpress';
 	var $auto_register_option = 'vaultpress_auto_register';
 	var $db_version           = 4;
-	var $plugin_version       = '1.9.2';
+	var $plugin_version       = '1.9.5';
 
 	function __construct() {
 		register_activation_hook( __FILE__, array( $this, 'activate' ) );
@@ -354,11 +354,6 @@ class VaultPress {
 		// key and secret already exist in db
 		} elseif ( $this->is_registered() ) {
 			if ( $this->check_connection() ) {
-				$message = sprintf(
-					__( 'VaultPress has been registered and is currently backing up your site. <a href="%1$s">View Backup Status</a>', 'vaultpress' ),
-					admin_url( 'admin.php?page=vaultpress' )
-				);
-				$this->ui_message( $message, 'registered',  __( 'VaultPress has been activated!', 'vaultpress' ) );
 			}
 		}
 
@@ -1760,7 +1755,8 @@ JS;
 
 		if ( !class_exists( 'VaultPress_IXR_SSL_Client' ) )
 			require_once( dirname( __FILE__ ) . '/class.vaultpress-ixr-ssl-client.php' );
-		$client = new VaultPress_IXR_SSL_Client( $hostname, '/xmlrpc.php', 80, $timeout );
+		$useragent = 'VaultPress/' . $this->plugin_version . '; ' . $this->site_url();
+		$client = new VaultPress_IXR_SSL_Client( $hostname, '/xmlrpc.php', 80, $timeout, $useragent );
 
 		if ( 'vaultpress.com' == $hostname )
 			$client->ssl();

--- a/vaultpress/vp-scanner.php
+++ b/vaultpress/vp-scanner.php
@@ -100,7 +100,10 @@ function vp_is_interesting_file($file) {
  * @return array An array with 3 arrays of lines
  */
 function split_file_to_php_html( $file ) {
-	$source = file_get_contents( $file );
+	$source = @file_get_contents( $file );
+	if ( $source === false ) {
+		$source = '';
+	}
 	return split_to_php_html( $source );
 }
 
@@ -112,7 +115,7 @@ function split_file_to_php_html( $file ) {
  * @return array An array with 3 arrays of lines
  */
 function split_to_php_html( $source ) {
-	$tokens = token_get_all( $source );
+	$tokens = @token_get_all( $source );
 
 	$ret = array( 'php' => array(), 'php-with-comments' => array(), 'html' => array() );
 	$current_line = 0;
@@ -252,7 +255,11 @@ function vp_scan_file( $file, $tmp_file = null, $use_parser = false ) {
 		// if there is no filename_regex, we assume it's the same of vp_is_interesting_file().
 		if ( empty( $signature->filename_regex ) || preg_match( '#' . addcslashes( $signature->filename_regex, '#' ) . '#i', $file ) ) {
 			if ( null === $file_content || !is_array( $file_content ) ) {
-				$file_content = file( $real_file );
+				$file_content = @file( $real_file );
+
+				if ( $file_content === false ) {
+					return false;
+				}
 
 				if ( $use_parser ) {
 					$file_parsed = split_file_to_php_html( $real_file );


### PR DESCRIPTION
```
= 1.9.5 - 2 February 2018
* Removing activation notice

= 1.9.4 - 15 November 2017
* Error handling improvements in the scanner

= 1.9.3 - 9 November 2017
* Compatibility update
* Send a better user-agent string to VaultPress servers
```