### PR TITLE
Remove Jetpack Monitor from mandatory modules

### DIFF
--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -18,8 +18,6 @@ class WPCOM_VIP_Jetpack_Mandatory {
 	 */
 	protected $mandatory_modules = array(
 		'manage',
-		'monitor',
-		// 'sso', // Disabled while we roll out force-2fa
 		'stats',
 		'vaultpress',
 	);


### PR DESCRIPTION
We rely on other monitoring systems instead.