### PR TITLE
replace deprecated wpcom_initiate_flush_rewrite_rules call

### DIFF
--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -24,7 +24,7 @@ add_filter( 'rri_parent_slug', function() { return 'vip-dashboard'; } );
  */
 add_action( 'switch_theme', 'rri_wpcom_action_switch_theme' );
 function rri_wpcom_action_switch_theme( $new_name ) {
-	wpcom_initiate_flush_rewrite_rules();
+	flush_rewrite_rules();
 }
 
 /**


### PR DESCRIPTION
replace wpcom_initiate_flush_rewrite_rules() with flush_rewrite_rules().

Fixes `PHP Notice:  wpcom_initiate_flush_rewrite_rules is <strong>deprecated</strong> since version 2.0.0! Use flush_rewrite_rules instead. in /srv/www/theundefeated/public_html/wp-includes/functions.php on line 3840`