### PR TITLE
Display bulk edit actions when total entries are less than 20

### DIFF
--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -25,9 +25,19 @@ add_action( 'load-edit.php', __NAMESPACE__ . '\defer_term_counting' );
 function bulk_editing_is_limited() {
 	$per_page = get_query_var( 'posts_per_page' );
 
+	// Get total number of entries
+	$post_type = get_query_var( 'post_type' );
+	$num_posts = wp_count_posts( $post_type, 'readable' );
+	$total_posts = array_sum( (array) $num_posts );
+
 	// Core defaults to 20 posts per page
 	// If requesting more--or all--entries, hide bulk actions
-	return $per_page > BULK_EDIT_LIMIT || -1 === $per_page;
+	// Except, do not hide bulk actions if less than 20 total entries
+	if ( BULK_EDIT_LIMIT > $total_posts ) {
+		return false;
+	} else {
+		return $per_page > BULK_EDIT_LIMIT || -1 === $per_page;
+	}
 }
 
 /**


### PR DESCRIPTION
When you navigate to this admin page: https://theundefeated.com/wp-admin/edit.php?post_type=page the following message is displayed, and the bulk edit actions are hidden:

>Bulk actions are disabled because more than 20 items were requested. To re-enable bulk edit, please adjust the "Number of items" setting under Screen Options. If you have a large number of posts to update, please get in touch as we may be able to help.

However, the number of items per page is set to 20 and the total entries for this post type is less than 20. I am seeing this on other themes as well. I checked the query variables and the 'posts_per_page' variable is set to -1 for this page.

I am submitting this PR to fix the above issue by checking if the number of total entries is less than 20. If so, do not hide bulk edit actions, even though the 'posts_per_page' query variable is -1.