### PR TITLE
Fix Query Monitor 3.0.1 notices

### DIFF
--- a/vip-helpers/vip-query-monitor.php
+++ b/vip-helpers/vip-query-monitor.php
@@ -73,7 +73,7 @@ class WPCOM_VIP_QM_Collector_DB_Queries extends QM_Collector_DB_Queries
 
 
 			$is_main_query = ( $request === $sql && ( false !== strpos( $stack, ' WP->main,' ) ) );
-			$row = compact('caller', 'caller_name', 'stack', 'sql', 'ltime', 'result', 'type', 'component', 'trace', 'has_main_query', 'is_main_query');
+			$row = compact('caller', 'caller_name', 'stack', 'sql', 'ltime', 'result', 'type', 'component', 'trace', 'is_main_query' );
 
 			if (is_wp_error($result)) {
 				$this->data['errors'][] = $row;

--- a/vip-helpers/vip-query-monitor.php
+++ b/vip-helpers/vip-query-monitor.php
@@ -4,11 +4,17 @@ class WPCOM_VIP_QM_Collector_DB_Queries extends QM_Collector_DB_Queries
 {
 	public function process_db_object($id, wpdb $db)
 	{
+		global $wp_the_query;
+		
 		$rows = array();
 		$types = array();
 		$total_time = 0;
 		$has_result = false;
 		$has_trace = false;
+		$request    = trim( $wp_the_query->request );
+		if ( method_exists( $db, 'remove_placeholder_escape' ) ) {
+			$request = $db->remove_placeholder_escape( $request );
+		}
 
 		foreach ((array)$db->queries as $query) {
 
@@ -65,7 +71,9 @@ class WPCOM_VIP_QM_Collector_DB_Queries extends QM_Collector_DB_Queries
 				$types[ $type ]['callers'][ $caller ]++;
 			}
 
-			$row = compact('caller', 'caller_name', 'stack', 'sql', 'ltime', 'result', 'type', 'component', 'trace');
+
+			$is_main_query = ( $request === $sql && ( false !== strpos( $stack, ' WP->main,' ) ) );
+			$row = compact('caller', 'caller_name', 'stack', 'sql', 'ltime', 'result', 'type', 'component', 'trace', 'has_main_query', 'is_main_query');
 
 			if (is_wp_error($result)) {
 				$this->data['errors'][] = $row;
@@ -83,10 +91,14 @@ class WPCOM_VIP_QM_Collector_DB_Queries extends QM_Collector_DB_Queries
 
 		$this->data['total_qs'] += $total_qs;
 		$this->data['total_time'] += $total_time;
+		
+		$has_main_query = wp_list_filter( $rows, array(
+			'is_main_query' => true,
+		) );
 
 		# @TODO put errors in here too:
 		# @TODO proper class instead of (object)
-		$this->data['dbs'][ $id ] = (object)compact('rows', 'types', 'has_result', 'has_trace', 'total_time', 'total_qs');
+		$this->data['dbs'][ $id ] = (object)compact('rows', 'types', 'has_result', 'has_trace', 'total_time', 'total_qs', 'has_main_query');
 
 	}
 }


### PR DESCRIPTION
**Problem**:
With PHP Errors enabled, Query Monitor was displaying notices that `is_main_query` and `has_main_query` were missing. 

**Reason**:
This is because VIP Go has a [custom DB Collector implementation](https://github.com/Automattic/vip-go-mu-plugins/blob/master/vip-helpers/vip-query-monitor.php) that's slightly outdated (last updated October 2016) but Query Monitor implemented the `is_main_query` functionality on Feb, 2017: https://github.com/johnbillion/query-monitor/commit/5a8dc9832427b187ce70acfee9a1ccf61457ec0a

**Solution**:
Copy & Paste the changes made to `process_db_object` method from https://github.com/johnbillion/query-monitor/commit/5a8dc9832427b187ce70acfee9a1ccf61457ec0a and https://github.com/johnbillion/query-monitor/commit/7e28e515d0f9d2f4e617ec424334929cf9a63fd2

**Testing**:
1. Open any site in a dev/sandbox environment
2. Look at the "Dashboard -> WP Toolbar -> Query Monitor -> Queries"
3. See something like this:
![screen](https://user-images.githubusercontent.com/988095/42223073-8f43a198-7edf-11e8-910f-9516c205241c.png)
4. Apply patch
5. No more notices 🎉 