### PR TITLE
Fix multisite not found error message

### DIFF
--- a/errors/site-not-found.html
+++ b/errors/site-not-found.html
@@ -144,7 +144,7 @@
 
 			<div class="col-right">
 				<h1>Site Not Found</h1>
-				<p>A site was not found at the requested URL. Please check the URL and try again.</p>
+				<p>This is a multisite, but a site was not found at the requested URL. Please check the URL and domain mapping and try again.</p>
 				<footer>
 					<span class="error">Error SITE_NOT_FOUND</span>
 				</footer>


### PR DESCRIPTION
The site not found page for multisites can be confusing. We should make it more clear that it's a multisite, but the domain is not mapped to a site.