### PR TITLE
Removed $screen check in plugin_action_links filter

### DIFF
--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -149,9 +149,7 @@ function wpcom_vip_plugin_action_links( $actions, $plugin_file, $plugin_data, $c
 		}
 		$actions['vip-code-activated-plugin'] = __( 'Enabled via code', 'vip-plugins-dashboard' );
 
-		if ( 'plugins' === $screen->id ) {
-			unset( $actions['network_active'] );
-		}
+		unset( $actions['network_active'] );
 	}
 
 	return $actions;

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -149,7 +149,9 @@ function wpcom_vip_plugin_action_links( $actions, $plugin_file, $plugin_data, $c
 		}
 		$actions['vip-code-activated-plugin'] = __( 'Enabled via code', 'vip-plugins-dashboard' );
 
-		unset( $actions['network_active'] );
+		if ( is_a( $screen, 'WP_Screen' ) && 'plugins' === $screen->id ) {
+			unset( $actions['network_active'] );
+		}
 	}
 
 	return $actions;


### PR DESCRIPTION
Right now, this conditional
```php
if ( 'plugins' === $screen->id ) {
	unset( $actions['network_active'] );
}
```
can cause [issues with Jetpack](https://wordpressvip.zendesk.com/agent/tickets/80336). The problem is that code is run on the `plugin_action_links` filter, which Jetpack does also call on `admin_init`. However, on `admin_init`, the `current_screen` is not yet defined, so `$screen` above ends up being `null`, of which we then try to fetch a property.

The issue is ultimately in Jetpack, which shouldn't call that filter on `admin_init`, and I have [sent a PR to their repo](https://github.com/Automattic/jetpack/pull/9960), BUT we can simply add a check to ensure that `$screen` is defined and is a `WP_Screen` object. This change would fix the ZD ticket, and it doesn't seem out of place anyway :)

I tested the change on the sandboxed client site, and it works fine. Any VIP Go site running Jetpack is potentially affected. Just visiting the admin plugins page on a VIP Go site running Jetpack should be enough to trigger the error. (I could not _see_ the error myself on the client site because of weird error logging settings, but I could see `$screen` being `null`).