### PR TITLE
Allow to fix intermediate images paths in backend editor

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -96,7 +96,7 @@ class A8C_Files {
 			return $content;
 		}, 9999999 ); // Jetpack hooks in at 6 9s (999999) so we do 7
 
-		// See https://vipsupportp2.wordpress.com/2018/06/27/intermediate-images-on-vip-go-sites/
+		// See https://github.com/Automattic/vip-go-mu-plugins/pull/944
 		if ( defined( 'WPCOM_VIP_USE_JETPACK_PHOTON' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON ) {
 
 			//Photon wouldn't run in the backend editor by default, need to enable it first
@@ -110,7 +110,7 @@ class A8C_Files {
 			add_filter( 'the_editor_content', function( $content ) {
 			  remove_filter( 'jetpack_photon_pre_image_url', [ 'A8C_Files_Utils', 'strip_dimensions_from_url_path' ] );
 			  return $content;
-			}, 9999999 );
+			}, 9999999 ); // Jetpack hooks in at 6 9s (999999) so we do 7
 
 		}
 

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -96,6 +96,24 @@ class A8C_Files {
 			return $content;
 		}, 9999999 ); // Jetpack hooks in at 6 9s (999999) so we do 7
 
+		// See https://vipsupportp2.wordpress.com/2018/06/27/intermediate-images-on-vip-go-sites/
+		if ( defined( 'VIP_GO_USE_JETPACK_PHOTON_BACKEND' ) && true === VIP_GO_USE_JETPACK_PHOTON_BACKEND ) {
+
+			//Photon wouldn't run in the backend editor by default, need to enable it first
+			add_filter( 'the_editor_content', array( 'Jetpack_Photon', 'filter_the_content' ) );
+
+			add_filter( 'the_editor_content', function( $content ) {
+			  add_filter( 'jetpack_photon_pre_image_url', [ 'A8C_Files_Utils', 'strip_dimensions_from_url_path' ] );
+			  return $content;
+			}, 0 );
+
+			add_filter( 'the_editor_content', function( $content ) {
+			  remove_filter( 'jetpack_photon_pre_image_url', [ 'A8C_Files_Utils', 'strip_dimensions_from_url_path' ] );
+			  return $content;
+			}, 9999999 );
+
+		}
+
 		// If Photon isn't active, we need to init the necessary filters.
 		// This takes care of rewriting intermediate images for us.
 		Jetpack_Photon::instance();

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -97,7 +97,7 @@ class A8C_Files {
 		}, 9999999 ); // Jetpack hooks in at 6 9s (999999) so we do 7
 
 		// See https://vipsupportp2.wordpress.com/2018/06/27/intermediate-images-on-vip-go-sites/
-		if ( defined( 'VIP_GO_USE_JETPACK_PHOTON_BACKEND' ) && true === VIP_GO_USE_JETPACK_PHOTON_BACKEND ) {
+		if ( defined( 'WPCOM_VIP_USE_JETPACK_PHOTON_BACKEND' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON_BACKEND ) {
 
 			//Photon wouldn't run in the backend editor by default, need to enable it first
 			add_filter( 'the_editor_content', array( 'Jetpack_Photon', 'filter_the_content' ) );

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -97,7 +97,7 @@ class A8C_Files {
 		}, 9999999 ); // Jetpack hooks in at 6 9s (999999) so we do 7
 
 		// See https://vipsupportp2.wordpress.com/2018/06/27/intermediate-images-on-vip-go-sites/
-		if ( defined( 'WPCOM_VIP_USE_JETPACK_PHOTON_BACKEND' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON_BACKEND ) {
+		if ( defined( 'WPCOM_VIP_USE_JETPACK_PHOTON' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON ) {
 
 			//Photon wouldn't run in the backend editor by default, need to enable it first
 			add_filter( 'the_editor_content', array( 'Jetpack_Photon', 'filter_the_content' ) );


### PR DESCRIPTION
This fixes #942.

**UPDATE:** tested this on a site that was having issues with backend images after an import, as per 78987-z, and works fine! Images are fixed and nothing bad seems to have happened!

When a site is migrated from a platform where intermediate images are used, we take care of using our own VIP Go Files Service to serve their images. This means that `image-600x300.jpg`-like files are never created nor read, but we generate them on the fly using a querystring like `image.jpg?resize=600,300`. This parsing is half done by our custom function `strip_dimensions_from_url_path()` and half by Jetpack Photon. Everything happens on the fly on `the_content` for frontend display.

However, exactly because things only happen on the fly on `the_content`, images can be broken in the admin editor, where the hard-coded intermediate path is still in the content. With these changes, if the new constant `WPCOM_VIP_USE_JETPACK_PHOTON_BACKEND` is defined and set to `true`, the routine that runs on the front-end will also run in the back-end. This will fix intermediate images not being shown in the back-end editor (at least when the cause is the one detailed above).

I have tested this on Tumbleweed and things work as expected for me. 
You can test it too by 
1. sandboxing Tumbleweed (68);
2. checking out this PR branch;
3. setting both `WPCOM_VIP_USE_JETPACK_PHOTON` and `WPCOM_VIP_USE_JETPACK_PHOTON_BACKEND` to true in `~/site-repo/vip-config/vip-config.php`;
4. visiting [this post edit page](https://tumbleweed.simonwheatley.co.uk/wp-admin/post.php?post=14774&action=edit) (refrain from making changes/saving something, as that would impact other testers);
5. you will correctly see the two images included there, even though they have an intermediate image hard-coded path like `<a href="https://tumbleweed.simonwheatley.co.uk/wp-content/uploads/2018/06/funny_mustache_and_sunglasses_face_classic_round_sticker-r1ab2fe2fbae04a4d8ddc960835afbafa_v9waf_8byvr_324-600x300.jpg"><img class="alignnone size-full wp-image-14779" src="https://tumbleweed.simonwheatley.co.uk/wp-content/uploads/2018/06/funny_mustache_and_sunglasses_face_classic_round_sticker-r1ab2fe2fbae04a4d8ddc960835afbafa_v9waf_8byvr_324-600x300.jpg" alt="" width="660" height="344" data-recalc-dims="1" /></a>`;
6. also confirm that nothing has changed in the [front-end page](https://tumbleweed.simonwheatley.co.uk/2018/06/25/ignore-test-for-intermediate-images/).

**_Caveat_**: if a post is saved with this flow active, then the updated image src will go into the database. In other words, the original hard-coded intermediate image path will vanish; the content itself will contain `image.jpg?resize=600,300`, and not `image-600x300.jpg` as it originally did. I worked to revert the changes we'd do in the editor content so that they would only be for display, but never really impact the post content. 

The idea was that if specifications ever change, or if a client leaves VIP, we don't want post contents to have those querystring appended. After all, it's easy to rebuild intermediate images and it'd be nice to have posts already ready to welcome them. However, I ultimately refrained from doing so. My code to revert changes on post save is [available for posterity here](https://github.com/Automattic/vip-go-mu-plugins/issues/942#issuecomment-408379631), but in the end
1. it was tricky, and difficult to foresee how those changes could break URLs/images on new posts. There were just too many things at play;
2. upon closer inspection, there did not seem to be any reason for it. I don't believe we should tie users to any platform, but it looks like it's already happening. For example, [this post](https://www.mercurynews.com/2018/04/28/bc-manrs-adv28-04-4/) on a client site has the following img tag:
`<img class="size-article_inline_third lazyautosizes lazyload" src="https://i1.wp.com/www.mercurynews.com/wp-content/uploads/2017/03/miss-manners.jpg?w=620&amp;crop=0%2C0px%2C100%2C9999px&amp;ssl=1" sizes="612px" srcset="https://i1.wp.com/www.mercurynews.com/wp-content/uploads/2017/03/miss-manners.jpg?w=620&amp;crop=0%2C0px%2C100%2C9999px&amp;ssl=1 620w,https://i1.wp.com/www.mercurynews.com/wp-content/uploads/2017/03/miss-manners.jpg?w=210&amp;crop=0%2C0px%2C100%2C9999px&amp;ssl=1 210w" alt="Judith Martin" width="612"  ... [cut] `
This is not only in their front-end content: it's in their actual post content. I've retrieved the raw post content and it contains `i1.wp.com` hard-coded in them. This is bad for portability. However, since we are already doing this, I really did not see the point of making an effort to prevent something like this on migrated sites, also given the task complexity, so I just dropped it :)