### PR TITLE
Add Must Use Plugins to general plugins page

### DIFF
--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -320,7 +320,7 @@ function wpcom_vip_include_active_plugins() {
 add_action( 'plugins_loaded', 'wpcom_vip_include_active_plugins', 5 );
 
 /**
- * Filter MU plugins and exclude some we wouldn't want to show (those for internal use).
+ * Filter MU plugins and exclude some that are not important to show.
  *
  * @return array MU plugins paths
  */
@@ -331,6 +331,7 @@ function wpcom_vip_get_mu_plugins_to_hide() {
 		'alloptions-limit.php',
 		'schema.php',
 		'stats.php',
+		'vip-cache-manager.php',
 		'vip-feed-cache.php',
 		'vip-light-term-count.php',
 		'vip-rest-api.php',

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -284,7 +284,7 @@ function wpcom_vip_plugins_list_add_must_use( $all_plugins ) {
 	}
 
 	$all_plugins = array_merge( (array) $all_plugins, $mu_plugins );
-var_dump($all_plugins);
+
 	asort( $all_plugins );
 
 	return $all_plugins;


### PR DESCRIPTION
This fixes #936.

This PR will make VIP Go Must Use plugins display in the Plugins page, as shown in the screenshot below:
![screenshot from 2018-07-31 14-58-51](https://user-images.githubusercontent.com/7880569/43464180-4b40b98c-94d2-11e8-9e17-2548390cbacd.png)

I have tested this on Tumbleweed and it all looks good to me. 

I have excluded some of the MU plugins from display because I felt they were just meaningless for customers, and would just clutter their Plugins page. The ones I have excluded are:
```php
$mu_plugins_to_hide = array(
	'000-vip-init.php',
	'001-core.php',
	'alloptions-limit.php',
	'schema.php',
	'stats.php',
	'vip-cache-manager.php',
	'vip-feed-cache.php',
	'vip-light-term-count.php',
	'vip-rest-api.php',
	'vip-wp-cli-to-cron.php',
	'wp-cli.php',
	'z-client-mu-plugins.php',
);
```
A bunch of others don't have a proper header so are displaying just with their slug at the moment (like `vip-performance.php`), but I have submitted PR #948 that addresses this (which should be approved first), so that the list is all nice and tidy. 

Finally, I must mention I did a bit of a hack to have this work all right: in `option_active_plugins` filter, we generate the backtrace of the call and bail if called from `validate_active_plugins()`. The _why_ this is needed is best explained with a lengthy explanation.

The first place where we want to hook is the `all_plugins` filter, which fires in the `prepare_items()` function of `class-wp-plugins-list-table.php`. This is responsible for the display of the plugin entries. There we do something along the lines of 
```php
$mu_plugins = get_mu_plugins();
$all_plugins = array_merge( (array) $all_plugins, $mu_plugins );
return $all_plugins;
```
This has the effect of including our MU plugins in the general plugin list, but they don't show up as active. The info on the status of a plugin is retrieved in [`single_row()` in that same file](https://core.trac.wordpress.org/browser/tags/4.9.6/src/wp-admin/includes/class-wp-plugins-list-table.php#L592), which uses [`is_plugin_active()`](https://core.trac.wordpress.org/browser/tags/4.9.6/src/wp-admin/includes/plugin.php#L432), which simply checks whether the given plugin slug is in the `active_plugins` option. No filtering allowed here.

Okay, so let's hook to `option_active_plugins` and edit the information that `get_option( 'active_plugins' )` would return. This can be done. But here comes the trouble: anything in that option has to be validated through `validate_active_plugins()`, and no filtering is allowed there. It will basically check if the plugin file exists _relative to the plugins folder_, and forbid any directory traversal (i.e. no `wp-content/plugins/../mu-plugins/`). Nothing bad happens, but an error message is then displayed for each of these MU Plugins:

![screenshot from 2018-07-31 11-39-45](https://user-images.githubusercontent.com/7880569/43477125-4cc10d0a-94f2-11e8-847a-ceffba979749.png)

And since no filtering is allowed there, the only way to avoid the MU plugins to be validated is to bail out when the caller is the validator function :)