### PR TITLE
Added/improved header section for some MU plugins 

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -1,8 +1,13 @@
 <?php
 
 /**
- * Initialisation for various VIP functionality
- *
+ * Plugin Name: VIP Init
+ * Description: Initialisation for various VIP functionality.
+ * Author: Automattic
+ * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
+/**
  * By virtue of the filename, this file is included first of
  * all the files in the VIP Go MU plugins directory. All
  * VIP code should be initialised here, unless there's a

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -2,9 +2,11 @@
 
 /**
  * Plugin Name: VIP Init
- * Description: Initialisation for various VIP functionality.
+ * Description: Initializes critical elements of the VIP environment.
  * Author: Automattic
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Remember vip-init.php? This is like that, but better! 
  */
 
 /**

--- a/001-core.php
+++ b/001-core.php
@@ -3,6 +3,8 @@
 /**
  * Plugin Name: VIP Go Core Modifications
  * Description: Changes to make WordPress core work better on VIP Go.
+ * Author: Automattic
+ * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */
 
 require_once( __DIR__ . '/001-core/privacy.php' );

--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Plugin Name: VIP All Options Limit
+ * Description: Provides warnings and notifications for wp_options exceeding limits.
+ * Author: Automattic
+ * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
 add_action( 'plugins_loaded', 'wpcom_vip_sanity_check_alloptions' );
 
 function wpcom_vip_sanity_check_alloptions() {

--- a/async-publish-actions.php
+++ b/async-publish-actions.php
@@ -1,7 +1,11 @@
 <?php
-/**
- * Allow for async processing of tasks normally hooked to certain `transition_post_status` calls.
- */
+
+/*
+Plugin Name: Async Publish Actions
+Description: Allow for async processing of tasks normally hooked to certain `transition_post_status` calls.
+Author: Automattic
+Author URI: http://automattic.com/
+*/
 
 namespace Automattic\VIP\Async_Publish_Actions;
 

--- a/performance.php
+++ b/performance.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+Plugin Name: VIP Performance
+Description: Various performance enhancements.
+Author: Automattic
+Version: 1.0
+License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+*/
+
 require_once( __DIR__ . '/performance/lastpostmodified.php' );
 require_once( __DIR__ . '/performance/bulk-edit.php' );
 require_once( __DIR__ . '/performance/vip-tweaks.php' );

--- a/schema.php
+++ b/schema.php
@@ -1,7 +1,10 @@
 <?php
 
-/*
- * Schema Customizations
+/**
+ * Plugin Name: VIP Schema
+ * Description: Provides VIP-specific database schema customizations.
+ * Author: Automattic
+ * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */
 
 namespace Automattic\VIP\Schema;

--- a/stats.php
+++ b/stats.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Plugin Name: VIP Stats
+ * Description: Basic VIP stats functions.
+ * Author: Automattic
+ * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
 namespace Automattic\VIP\Stats;
 
 // Limit tracking to production

--- a/two-factor.php
+++ b/two-factor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: VIP Force Two Factor
- * Description: Force Two Factor Auth
+ * Description: Force Two Factor Authentication for stronger security.
  * Author: Automattic
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */

--- a/vip-feed-cache.php
+++ b/vip-feed-cache.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * Plugin Name: VIP Feed Cache
+ * Description: Sets VIP Go Cache Class.
+ * Author: Automattic
+ * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+ 
 /**
  * Sets the SimplePie Cache Class to our custom VIP Go Class.
  *


### PR DESCRIPTION
Some MU plugins lack proper name/description and thus show up in the plugins view just with their slugs, as shown below:
![screenshot from 2018-08-01 09-13-44](https://user-images.githubusercontent.com/7880569/43509682-3a9df61e-956b-11e8-8a43-53ba24d8326c.png)

This PR aims at fixing them, providing all MU plugins with an apt header section. This is particularly important since we are going to show those in the general plugins view, as per #947. 