### PR TITLE
Don't override Cache-Control headers in REST API

### DIFF
--- a/tests/test-cache-ttl-manager-rest.php
+++ b/tests/test-cache-ttl-manager-rest.php
@@ -106,7 +106,7 @@ class TTL_Manager__REST_API__Test extends \WP_Test_REST_TestCase {
 		$this->assertArrayNotHasKey( 'Cache-Control', $response_headers );
 	}
 
-	public function test__skip_ttl_if_already_set() {
+	public function test__skip_ttl_if_already_set_via_rest_response() {
 		$request = new \WP_REST_Request( 'GET', '/tests/v1/endpoint' );
 		$response = $this->server->dispatch( $request );
 		$response->header( 'Cache-Control', 'max-age=666' );
@@ -114,6 +114,12 @@ class TTL_Manager__REST_API__Test extends \WP_Test_REST_TestCase {
 
 		$response_headers = $dispatched_response->get_headers();
 
-		$this->assertArraySubset( [ 'Cache-Control' => 'max-age=666' ], $response_headers );
+		$this->assertArraySubset( [
+			'Cache-Control' => 'max-age=666',
+		], $response_headers );
+	}
+
+	public function test__skip_ttl_if_already_set_via_php_header() {
+		$this->markTestSkipped( 'Cannot test since we cannot simulate `header()` or `header_list()` in PHPUnit.' );
 	}
 }

--- a/vip-cache-manager/ttl-manager.php
+++ b/vip-cache-manager/ttl-manager.php
@@ -27,6 +27,15 @@ function enforce_rest_api_read_ttl( $response, $rest_server, $request ) {
 		return $response;
 	}
 
+	// Don't override existing Cache-Control headers sent via PHP
+	$php_headers = headers_list();
+	foreach ( $php_headers as $header ) {
+		if ( 0 === stripos( $header, 'Cache-Control:' ) ) {
+			return $response;
+		}
+	}
+
+	// Don't override existing Cache-Control headers set via REST Response
 	$response_headers = $response->get_headers();
 	if ( isset( $response_headers['Cache-Control'] ) ) {
 		return $response;


### PR DESCRIPTION
If the header is set via `header()` we should not override it.

Previously, we were only checking if the Cache-Control header was set via the REST Response object. Now, we look at both.

## To Test

- Set `header( 'Cache-Control: max-age=404' );` somewhere in your pageload cycle and make a request to a `wp-json` endpoint.
- Verify that the `Cache-Control` header is set to `max-age=404`.

Then:

- Remove the `header()` call and make the request again. Verify that the `Cache-Control` header now has `max-age=60`.