### PR TITLE
Rewrite code that uses deprecated function each().

### DIFF
--- a/vaultpress/cron-tasks.php
+++ b/vaultpress/cron-tasks.php
@@ -108,7 +108,9 @@ class VP_Site_Scanner {
 			return false;
 
 		reset( $paths );
-		list( $type, $current ) = each( $paths );
+		$type    = key( $paths );
+		$current = current( $paths );
+		next( $paths );
 		if ( !is_object( $current ) || empty( $current->last_dir ) )
 			return $this->_scan_clean_up( $paths, $type );
 

--- a/vaultpress/vp-scanner.php
+++ b/vaultpress/vp-scanner.php
@@ -271,7 +271,8 @@ function vp_scan_file( $file, $tmp_file = null, $use_parser = false ) {
 			if ( is_array( $file_content ) && ( $signature->patterns ) && is_array( $signature->patterns ) ) {
 				if ( ! $use_parser ) {
 					reset( $signature->patterns );
-					while ( $is_vulnerable && list( , $pattern ) = each( $signature->patterns ) ) {
+					while ( $is_vulnerable && current( $signature->patterns ) ) {
+						next( $signature->patterns );
 						if ( ! $match = preg_grep( '#' . addcslashes( $pattern, '#' ) . '#im', $file_content ) ) {
 							$is_vulnerable = false;
 							break;
@@ -287,7 +288,8 @@ function vp_scan_file( $file, $tmp_file = null, $use_parser = false ) {
 					}
 					// same code as the '! $use_parser' branch above
 					reset( $signature->patterns );
-					while ( $is_vulnerable && list( , $pattern ) = each( $signature->patterns ) ) {
+					while ( $is_vulnerable && current( $signature->patterns ) ) {
+						next( $signature->patterns );
 						if ( ! $match = preg_grep( '#' . addcslashes( $pattern, '#' ) . '#im', $code ) ) {
 							$is_vulnerable = false;
 							break;


### PR DESCRIPTION
As of PHP 7.2, `each()` is a deprecated function, so it is being replaced with a similar but non-deprecated algorithm:
 - extract the first array key (`key()`)
 - extract the first array value (`current()`)
 - advance the array pointer (`next()`)

This is related to #867.