### PR TITLE
Change default behaviour of wpcom_vip_load_gutenberg() function.

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -34,7 +34,7 @@ remove_action( 'try_gutenberg_panel', 'wp_try_gutenberg_panel' );
 /**
  * Load Gutenberg via the Gutenberg Ramp plugin.
  */
-function wpcom_vip_load_gutenberg( $criteria = false ) {
+function wpcom_vip_load_gutenberg( $criteria = true ) {
 	if ( ! function_exists( 'gutenberg_ramp_load_gutenberg' ) ) {
 		return;
 	}


### PR DESCRIPTION
Currently, calling `wpcom_vip_load_gutenberg()` makes `$criteria` default to `false`. That means calling `wpcom_vip_load_gutenberg()` does not load Gutenberg. This needs to change.

The current state of the code has led to at least three instances of clients thinking they have enabled Gutenberg when they have not, and filing high priority support tickets.

The new version of this code sets `$criteria` to `true` by default, making for a more logical connection between function name and function behaviour.