### PR TITLE
Adding a filter to prevent async post status event from being scheduled

### DIFF
--- a/async-publish-actions.php
+++ b/async-publish-actions.php
@@ -122,6 +122,16 @@ function _queue_async_hooks( $new_status, $old_status, $post ) {
 		'old_status' => $old_status,
 	];
 
+	/**
+	 * Filter whether or not a cron event should be scheduled when the post transitions status.
+	 *
+	 * @param bool  $true Whether or not to schedule the cron event.
+	 * @param array $args Array of arguments containing the post_id, new_status, and old_status.
+	 */
+	if ( false === apply_filters( 'wpcom_async_transition_post_status_schedule_async', true, $args ) ) {
+		return;
+	}
+
 	if ( false !== wp_next_scheduled( ASYNC_TRANSITION_EVENT, $args ) ) {
 		return;
 	}


### PR DESCRIPTION
## Description
We have been having some issues with too many cron events being scheduled with posts getting published. This is happening because we use custom post types as a storage mechanism for various things that don't contain any public information.

To prevent this from happening I've added a filter here where we can conditionally set the value to `false` and it will prevent the cron event from being scheduled.

For our implementation, we plan on doing something like:
```php
add_filter( 'wpcom_async_transition_post_status_schedule_async', function( $value, $args ) {
    if ( 'my-post-type' === get_post_type( $args['post_id'] ) ) {
        $value = false;
    }
    return $value;
}, 10, 2 );
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
2. Add the above code (replacing CPT name with `page`)
3. Publish a new page
4. No event shout have gotten scheduled
5. 💰 
