### PR TITLE
Prevent Notice when calling `nocache_headers()` super early

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -15,7 +15,9 @@ add_filter( 'upload_mimes', function( $mimes ) {
 // Ensure we do not send the cache headers through to Varnish,
 // so responses obey the cache settings we have configured.
 function wpcom_vip_check_for_404_and_remove_cache_headers( $headers ) {
-	if ( is_404() ) {
+	global $wp_query;
+
+	if ( isset( $wp_query ) && is_404() ) {
 		unset( $headers['Expires'] );
 		unset( $headers['Cache-Control'] );
 		unset( $headers['Pragma'] );

--- a/tests/test-check-for-404-and-remove-cache-headers.php
+++ b/tests/test-check-for-404-and-remove-cache-headers.php
@@ -1,10 +1,15 @@
 <?php
 
-class VIP_Go_Misc_Test extends WP_UnitTestCase {
+class VIP_Go_Test_Check_For_404_And_Remove_Cache_Headers extends WP_UnitTestCase {
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 		require_once( __DIR__ . '/../misc.php' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		wp_reset_query();
 	}
 
 	/**
@@ -14,7 +19,7 @@ class VIP_Go_Misc_Test extends WP_UnitTestCase {
 	 * @param bool $is_wp_query_set Is the global $wp_query object set for a particular test case.
 	 * @param bool $is_404_set Is this page a 404.
 	 */
-	function test_check_for_404_and_remove_cache_headers( $is_wp_query_set, $is_404_set ) {
+	function test_check_for_404_and_remove_cache_headers( $is_wp_query_set, $is_404_set, $expected_headers ) {
 		global $wp_query;
 		$headers = array(
 			'Expires'       => 1,
@@ -22,20 +27,16 @@ class VIP_Go_Misc_Test extends WP_UnitTestCase {
 			'Pragma'        => 1,
 		);
 
-		$temp = null;
 		if ( $is_404_set ) {
 			$wp_query->set_404();
 		}
 		if ( ! $is_wp_query_set ) {
-			$temp     = $wp_query;
 			$wp_query = null;
 		}
 
 		$result = wpcom_vip_check_for_404_and_remove_cache_headers( $headers );
-		$this->assertEquals( empty( $result ), ( $is_404_set && $is_wp_query_set ) );
-		if ( ! isset( $wp_query ) ) {
-			$wp_query = $temp;
-		}
+		$this->assertEquals( $result, $expected_headers );
+
 	}
 
 	/**
@@ -45,21 +46,37 @@ class VIP_Go_Misc_Test extends WP_UnitTestCase {
 	 */
 	function data_provider() {
 		return array(
-			array(
+			'wp_query-set-and-is_404'         => array(
 				true,
 				true,
+				array(),
 			),
-			array(
+			'wp_query-set-and-not-is_404'     => array(
 				true,
 				false,
+				array(
+					'Expires'       => 1,
+					'Cache-Control' => 1,
+					'Pragma'        => 1,
+				),
 			),
-			array(
+			'wp_query-not-set-and-not-is_404' => array(
 				false,
 				false,
+				array(
+					'Expires'       => 1,
+					'Cache-Control' => 1,
+					'Pragma'        => 1,
+				),
 			),
-			array(
+			'wp_query-not-set-and-is_404'     => array(
 				false,
 				true,
+				array(
+					'Expires'       => 1,
+					'Cache-Control' => 1,
+					'Pragma'        => 1,
+				),
 			),
 		);
 	}

--- a/tests/test-misc.php
+++ b/tests/test-misc.php
@@ -1,0 +1,67 @@
+<?php
+
+class VIP_Go_Misc_Test extends WP_UnitTestCase {
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		require_once( __DIR__ . '/../misc.php' );
+	}
+
+	/**
+	 * Test cache headers removal if page is 404.
+	 *
+	 * @dataProvider data_provider
+	 * @param bool $is_wp_query_set Is the global $wp_query object set for a particular test case.
+	 * @param bool $is_404_set Is this page a 404.
+	 */
+	function test_check_for_404_and_remove_cache_headers( $is_wp_query_set, $is_404_set ) {
+		global $wp_query;
+		$headers = array(
+			'Expires'       => 1,
+			'Cache-Control' => 1,
+			'Pragma'        => 1,
+		);
+
+		$temp = null;
+		if ( $is_404_set ) {
+			$wp_query->set_404();
+		}
+		if ( ! $is_wp_query_set ) {
+			$temp     = $wp_query;
+			$wp_query = null;
+		}
+
+		$result = wpcom_vip_check_for_404_and_remove_cache_headers( $headers );
+		$this->assertEquals( empty( $result ), ( $is_404_set && $is_wp_query_set ) );
+		if ( ! isset( $wp_query ) ) {
+			$wp_query = $temp;
+		}
+	}
+
+	/**
+	 * The data provider method
+	 *
+	 * @return array
+	 */
+	function data_provider() {
+		return array(
+			array(
+				true,
+				true,
+			),
+			array(
+				true,
+				false,
+			),
+			array(
+				false,
+				false,
+			),
+			array(
+				false,
+				true,
+			),
+		);
+	}
+
+}


### PR DESCRIPTION
## Description

Added a check to see if `global $wp_query` is set before using `is_404()` to avoid the following notice:
```
Notice: is_404 was called incorrectly. Conditional query tags do not work before the query is run. Before then, they always return false. Please see <a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 3.1.0.)
```

Fixes #935

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
2. Add the following code snippet to a PHP file in `client-mu-plugins` directory in your sandbox
```
if ( isset( $_GET['dont-cache'] ) ) {
    nocache_headers();
}
```
3. Visit a page that you know will throw a 404 error with the following appended to the URL:
`/?dont-cache=1`
4. With the fix, the aforementioned notice will not be seen.
5. Also, confirm the contents of the `$headers` array in `misc.php`
