### PR TITLE
Add lost password limits

### DIFF
--- a/security.php
+++ b/security.php
@@ -143,6 +143,7 @@ function wpcom_vip_username_is_limited( $username, $cache_group = 'login_limit' 
 		switch( $cache_group ) {
 
 			case 'lost_password_limit':
+				do_action( 'password_reset_limit_exceeded', $username );
 				return new WP_Error( 'lost_password_limit_exceeded', __( 'You have exceeded the password reset limit.  Please wait a few minutes and try again.' ) );
 				break;
 			case 'login_limit':

--- a/security.php
+++ b/security.php
@@ -64,7 +64,7 @@ function wpcom_vip_login_limiter_authenticate( $user, $username, $password ) {
 	if ( empty( $username ) && empty( $password ) )
 		return $user;
 
-	$is_login_limited = wpcom_vip_login_is_limited( $username );
+	$is_login_limited = wpcom_vip_username_is_limited( $username );
 	if ( is_wp_error( $is_login_limited ) ) {
 		return $is_login_limited;
 	}
@@ -79,7 +79,7 @@ function wpcom_vip_login_limit_dont_show_login_form() {
 	}
 
 	$username = sanitize_user( $_POST['log'] );
-	if ( $error = wpcom_vip_login_is_limited( $username ) ) {
+	if ( $error = wpcom_vip_username_is_limited( $username ) ) {
 		login_header( __( 'Error' ), '', $error );
 		login_footer();
 		exit;
@@ -109,7 +109,7 @@ function wpcom_vip_lost_password_limit( $errors ) {
 	} else {
 		$username = sanitize_user( $username );
 	}
-	$is_login_limited = wpcom_vip_login_is_limited( $username, $cache_group );
+	$is_login_limited = wpcom_vip_username_is_limited( $username, $cache_group );
 
 	if ( is_wp_error( $is_login_limited ) ) {
 		$errors->add( $is_login_limited->get_error_code(), $is_login_limited->get_error_message() );
@@ -121,7 +121,7 @@ function wpcom_vip_lost_password_limit( $errors ) {
 }
 add_action( 'lostpassword_post', 'wpcom_vip_lost_password_limit' );
 
-function wpcom_vip_login_is_limited( $username, $cache_group = 'login_limit' ) {
+function wpcom_vip_username_is_limited( $username, $cache_group = 'login_limit' ) {
 	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 
 	$key1 = $ip . '|' . $username;

--- a/security.php
+++ b/security.php
@@ -139,7 +139,6 @@ function wpcom_vip_username_is_limited( $username, $cache_group = 'login_limit' 
 	$threshold2 = 50;
 
 	if ( $count1 >= $threshold1 || $count2 >= $threshold2 ) {
-		do_action( 'login_limit_exceeded', $username );
 
 		switch( $cache_group ) {
 
@@ -147,6 +146,7 @@ function wpcom_vip_username_is_limited( $username, $cache_group = 'login_limit' 
 				return new WP_Error( 'lost_password_limit_exceeded', __( 'You have exceeded the password reset limit.  Please wait a few minutes and try again.' ) );
 				break;
 			case 'login_limit':
+				do_action( 'login_limit_exceeded', $username );
 				return new WP_Error( 'login_limit_exceeded', __( 'You have exceeded the login limit.  Please wait a few minutes and try again.' ) );
 				break;
 

--- a/security.php
+++ b/security.php
@@ -131,20 +131,19 @@ add_action( 'lostpassword_post', 'wpcom_vip_lost_password_limit' );
 function wpcom_vip_username_is_limited( $username, $cache_group = 'login_limit' ) {
 	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 
-	$key1 = $ip . '|' . $username;
-	$key2 = $ip;
-	$count1 = wp_cache_get( $key1, $cache_group );
-
+	$key1                   = $ip . '|' . $username;
+	$key2                   = $ip;
+	$count1                 = wp_cache_get( $key1, $cache_group );
 	$is_restricted_username = wpcom_vip_is_restricted_username( $username );
+	$threshold2             = 50;
 
-	if ( $is_restricted_username ) {
-		$threshold1 = 2;
-	} elseif ( 'lost_password_limit' === $cache_group ) {
+	if ( 'lost_password_limit' === $cache_group ) {
 		$threshold1 = 3;
 		$threshold2 = 3;
+	} elseif ( $is_restricted_username ) {
+		$threshold1 = 2;
 	} else {
 		$threshold1 = 5;
-		$threshold2 = 50;
 	}
 
 	$count2 = wp_cache_get( $key2, $cache_group );

--- a/security.php
+++ b/security.php
@@ -21,7 +21,7 @@ function wpcom_vip_is_restricted_username( $username ) {
  * @param string $cache_group The cache group to track the $username to.
  */
 function wpcom_vip_limiter( $username, $cache_group ) {
-	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
+	$ip   = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 	$key1 = $ip . '|' . $username; // IP + username
 	$key2 = $ip; // IP only
 
@@ -35,7 +35,7 @@ function wpcom_vip_limiter( $username, $cache_group ) {
 	}
 
 	wp_cache_add( $key1, 0, $cache_group, $is_restricted_username ? HOUR_IN_SECONDS : ( MINUTE_IN_SECONDS * $unrestricted_username_lockout_multiplier ) );
-	wp_cache_add( $key2, 0, $cache_group,  HOUR_IN_SECONDS );
+	wp_cache_add( $key2, 0, $cache_group, HOUR_IN_SECONDS );
 	wp_cache_incr( $key1, 1, $cache_group );
 	wp_cache_incr( $key2, 1, $cache_group );
 }
@@ -151,7 +151,7 @@ function wpcom_vip_username_is_limited( $username, $cache_group = 'login_limit' 
 
 	if ( $count1 >= $threshold1 || $count2 >= $threshold2 ) {
 
-		switch( $cache_group ) {
+		switch ( $cache_group ) {
 
 			case 'lost_password_limit':
 				do_action( 'password_reset_limit_exceeded', $username );


### PR DESCRIPTION
This adds rate limits to lost password requests using similar logic to our login limiter. It generalizes a few of the existing functions used in limiting login attempts so the logic could be applied to multiple contexts. We're limiting lost password requests to 3 attempts. I've also added two tests related to the new functionality.

## Steps to Test

1. Check out PR.
1. Go to `/wp-login.php?action=lostpassword`
1. Fill out and submit the form.
1. Verify that an error message is returned after the third attempt.
1. Verify that no password reset email is received after the third attempt.
