### PR TITLE
Fix hash_equals() php warning

### DIFF
--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -159,8 +159,8 @@ function get_proxy_verification_key() {
 		return (string) WPCOM_VIP_PROXY_VERIFICATION;
 	}
 
-	// If not properly defined for some reason, return a string of random numbers to avoid guessing the key.
-	return (string) rand();
+	// If not properly defined for some reason, return a string of random chars to avoid guessing the key.
+	return bin2hex( random_bytes( 32 ) );
 }
 
 /**

--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -156,7 +156,7 @@ function set_remote_address( $ip ) {
  */
 function get_proxy_verification_key() {
 	if ( defined( 'WPCOM_VIP_PROXY_VERIFICATION' ) && ! empty( WPCOM_VIP_PROXY_VERIFICATION ) ) {
-		return WPCOM_VIP_PROXY_VERIFICATION;
+		return (string) WPCOM_VIP_PROXY_VERIFICATION;
 	}
 
 	// If not properly defined for some reason, return a string of random numbers to avoid guessing the key.

--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -152,15 +152,15 @@ function set_remote_address( $ip ) {
 /**
  * Return the defined verification key for a site
  *
- * @return string|int The verification key if available, or a random integer if no key is configured.
+ * @return string The verification key if available, or a string of random numbers if no key is configured.
  */
 function get_proxy_verification_key() {
 	if ( defined( 'WPCOM_VIP_PROXY_VERIFICATION' ) && ! empty( WPCOM_VIP_PROXY_VERIFICATION ) ) {
 		return WPCOM_VIP_PROXY_VERIFICATION;
 	}
 
-	// If not properly defined for some reason, return a random number to avoid guessing the key.
-	return rand();
+	// If not properly defined for some reason, return a string of random numbers to avoid guessing the key.
+	return (string) rand();
 }
 
 /**

--- a/tests/test-lib-proxy-ip-forward.php
+++ b/tests/test-lib-proxy-ip-forward.php
@@ -226,8 +226,8 @@ class IP_Forward__Get_Proxy_Verification_Key__Test extends \PHPUnit_Framework_Te
 
 		$actual_key = get_proxy_verification_key();
 
-		$this->assertNotEmpty( $actual_key );
-		$this->assertTrue( is_string( $actual_key ) );
+		$this->assertNotEmpty( $actual_key, 'The Proxy Verification Key is empty' );
+		$this->assertTrue( is_string( $actual_key ), 'The Proxy Verification Key is not a string' );
 	}
 
 	/**
@@ -239,7 +239,19 @@ class IP_Forward__Get_Proxy_Verification_Key__Test extends \PHPUnit_Framework_Te
 
 		$actual_key = get_proxy_verification_key();
 
-		$this->assertNotEmpty( $actual_key );
+		$this->assertNotEmpty( $actual_key, 'The Proxy Verification Key is empty' );
+		$this->assertTrue( is_string( $actual_key ), 'The Proxy Verification Key is not a string' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__defined_but_integer() {
+		define( 'WPCOM_VIP_PROXY_VERIFICATION', 1234 );
+
+		$actual_key = get_proxy_verification_key();
+
 		$this->assertTrue( is_string( $actual_key ) );
 	}
 

--- a/tests/test-lib-proxy-ip-forward.php
+++ b/tests/test-lib-proxy-ip-forward.php
@@ -227,6 +227,7 @@ class IP_Forward__Get_Proxy_Verification_Key__Test extends \PHPUnit_Framework_Te
 		$actual_key = get_proxy_verification_key();
 
 		$this->assertNotEmpty( $actual_key );
+		$this->assertTrue( is_string( $actual_key ) );
 	}
 
 	/**
@@ -239,6 +240,7 @@ class IP_Forward__Get_Proxy_Verification_Key__Test extends \PHPUnit_Framework_Te
 		$actual_key = get_proxy_verification_key();
 
 		$this->assertNotEmpty( $actual_key );
+		$this->assertTrue( is_string( $actual_key ) );
 	}
 
 	/**

--- a/tests/test-lib-proxy-ip-forward.php
+++ b/tests/test-lib-proxy-ip-forward.php
@@ -226,7 +226,7 @@ class IP_Forward__Get_Proxy_Verification_Key__Test extends \PHPUnit_Framework_Te
 
 		$actual_key = get_proxy_verification_key();
 
-		$this->assertTrue( is_numeric( $actual_key ) );
+		$this->assertNotEmpty( $actual_key );
 	}
 
 	/**
@@ -238,7 +238,7 @@ class IP_Forward__Get_Proxy_Verification_Key__Test extends \PHPUnit_Framework_Te
 
 		$actual_key = get_proxy_verification_key();
 
-		$this->assertTrue( is_numeric( $actual_key ) );
+		$this->assertNotEmpty( $actual_key );
 	}
 
 	/**


### PR DESCRIPTION
This solves #977

`hash_equals()` expects both values passed into it to be strings. However `get_proxy_verification_key()` may return an integer when `WPCOM_VIP_PROXY_VERIFICATION` is undefined, triggering a PHP warning. Casting `rand()` to a  string prevents this.

phpunit tests updated to reflect string instead of integer. Added `assertNotEmpty()` to verify that the string of numbers are properly returned when `WPCOM_VIP_PROXY_VERIFICATION` undefined or blank.