### PR TITLE
Disable `display_errors` for wp-cli

### DIFF
--- a/wp-cli.php
+++ b/wp-cli.php
@@ -45,7 +45,29 @@ function maybe_toggle_is_ssl() {
 	}
 }
 
+/**
+ * Disable `display_errors` for all wp-cli interactions on production servers.
+ *
+ * Warnings and notices can break things like JSON output,
+ * especially for critical plugins like cron-control.
+ *
+ * Only do this on production servers to allow local and sandbox debugging.
+ */
+function disable_display_errors() {
+	if ( true !== WPCOM_IS_VIP_ENV ) {
+		return;
+	}
+
+	if ( true === WPCOM_SANDBOXED ) {
+		return;
+	}
+
+	ini_set( 'display_errors', 0 );
+}
+
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	disable_display_errors();
+
 	init_is_ssl_toggle();
 
 	foreach ( glob( __DIR__ . '/wp-cli/*.php' ) as $command ) {


### PR DESCRIPTION
Warnings and notices can break things like JSON output, especially for critical plugins like cron-control.

Only do this on production servers to allow local and sandbox debugging.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Add a call to `trigger_error( 'boo', E_USER_WARNING )` in `client-mu-plugins`
1. On local, sandbox, and production, run a wp-cli command.
1. Verify that the warning shows up on local and sandbox, but now on production.
