### PR TITLE
Impliment concatention whitelist for Ramp

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -41,7 +41,7 @@ function wpcom_vip_load_gutenberg( $criteria = true ) {
 
 	gutenberg_ramp_load_gutenberg( $criteria );
 
-	add_action( 'admin_init', 'wpcom_vip_disable_gutenberg_concat' );	
+	add_action( 'admin_init', 'wpcom_vip_disable_gutenberg_concat' );
 }
 
 /**
@@ -61,6 +61,20 @@ function wpcom_vip_disable_gutenberg_concat() {
 
 	// Disable HTTP Concat plugin when Gutenberg will load
 	if ( $gutenberg_will_load ) {
-		add_filter( 'js_do_concat', '__return_false' );
+		add_filter( 'js_do_concat', gutenberg_concat_filter() );
 	}
+
+}
+
+function gutenberg_concat_filter( $do_concat, $handle ) {
+    switch ( $handle ) {
+        case 'lodash':
+        case 'editor':
+        case 'wp-api-fetch':
+        case 'wp-data':
+        case 'wp-element':
+            return false;
+        default:
+            return $do_concat;
+    }
 }

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -59,13 +59,14 @@ function wpcom_vip_disable_gutenberg_concat() {
 		( $gutenberg_ramp->gutenberg_should_load() && $gutenberg_ramp->gutenberg_will_load() )
 	);
 
-	// Disable HTTP Concat plugin when Gutenberg will load
+
 	if ( $gutenberg_will_load ) {
-		add_filter( 'js_do_concat', gutenberg_concat_filter() );
+		add_filter( 'js_do_concat', 'gutenberg_concat_filter', 10, 2 );
 	}
 
 }
 
+// skip concatenation for these whitelisted files since they may break Gutenberg if concatenated
 function gutenberg_concat_filter( $do_concat, $handle ) {
     switch ( $handle ) {
         case 'lodash':


### PR DESCRIPTION
## Description
When certain js files are run through the existing concatenation on VIP, some are not properly rendered which breaks things in the Gutenberg editor. This fix whitelists a subset of files so that the functionality works correctly.

## Pros
Gutenberg works

## Cons
Performance can be slightly affected if not all files aren't concatenated

## Steps to Test

1. Enable Gutenberg for the Go site if not enabled already
2. Set `vip-go-mu-plugins` on the site to one that does not include any concat fixes (https://github.com/Automattic/vip-go-mu-plugins/commit/8335bb772bf5784b453df2634e5aa187489054ae or older)
3. Verify that the Gutenberg editor does not load for a Gutenberg-enabled post in wp-admin (the post are will be white space and you will see JavaScript errors in the console like: `TypeError: f is undefined`)
4. Update the `vip-go-mu-plugins` on the site to this version.
5. Verify that the Gutenberg-editor does load for a Gutenberg-enabled post in wp-admin
6. To ensure concatenation is working but excluding the files in the whitelist, use the Network tab in the browser console. Set the filter to show just the JS files, and you should see `lodash.js`, `editor.js` and about 20 or so `/_static/??`... files. (With the original concat fix (#957) the Gutenberg editor works but this list is 100+ files.)
