### PR TITLE
WPCOM Compat: 'plugins' means the default plugin location

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -955,6 +955,17 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 		}
 	}
 
+	/**
+	 * wpcom compat
+	 *
+	 * Lots of themes set $folder to the default location so they can
+	 * load a release candidate. We should interpret 'plugins' to mean
+	 * the plugin is in the default place.
+	 */
+	if ( $folder === 'plugins' ) {
+		$folder = false;
+	}
+
 	// Shared plugins are being deprecated.
 	// This can be removed once shared plugins have all been removed.
 	// https://vip.wordpress.com/documentation/vip-go/deprecating-shared-plugins-on-vip-go/

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -964,6 +964,7 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 	 */
 	if ( $folder === 'plugins' ) {
 		$folder = false;
+		_doing_it_wrong( __FUNCTION__, 'The specified $folder should not be "plugins", which is the default location', '2.0.0' );
 	}
 
 	// Shared plugins are being deprecated.


### PR DESCRIPTION
In order to allow themes to be more easily copied as-is from
WordPress.com, this makes wpcom_vip_load_plugin interpret 'plugins'
as the default plugin location. This is because it really is the default
location, but WordPress.com themes commonly set it anyway because they
need to set a release candidate version. When we copy the theme to VIP
Go, it tries to load the theme from wp-content/plugins/plugins.