### PR TITLE
Connect akismet during migration cleanup

### DIFF
--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -41,6 +41,8 @@ function run_after_data_migration_cleanup() {
 	
 	if ( class_exists( 'Akismet_Admin' ) && method_exists( 'Akismet_Admin', 'connect_jetpack_user' ) ) {
 		Akismet_Admin::connect_jetpack_user();
+	} else {
+		trigger_error( sprintf( '%s: Failed to call `Akismet_Admin::connect_jetpack_user` as it does not exist; Akismet will need to be connected manually', __FUNCTION__ ), E_USER_WARNING );
 	}
 }
 

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -38,6 +38,7 @@ function run_after_data_migration_cleanup() {
 
 	connect_jetpack();
 	connect_vaultpress();
+	Akismet_Admin::connect_jetpack_user()
 }
 
 function delete_db_transients() {

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -38,7 +38,7 @@ function run_after_data_migration_cleanup() {
 
 	connect_jetpack();
 	connect_vaultpress();
-	Akismet_Admin::connect_jetpack_user()
+	Akismet_Admin::connect_jetpack_user();
 }
 
 function delete_db_transients() {

--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -38,7 +38,10 @@ function run_after_data_migration_cleanup() {
 
 	connect_jetpack();
 	connect_vaultpress();
-	Akismet_Admin::connect_jetpack_user();
+	
+	if ( class_exists( 'Akismet_Admin' ) && method_exists( 'Akismet_Admin', 'connect_jetpack_user' ) ) {
+		Akismet_Admin::connect_jetpack_user();
+	}
 }
 
 function delete_db_transients() {


### PR DESCRIPTION
### Test:

First, in a sandbox:

```
wp --allow-root cron event schedule vip_after_data_migration
```

After the command has finished, verify Akismet is connected:

```
wp --allow-root shell
wp> Akismet_Admin::display_status();
<div class="akismet-alert akismet-active">
	<h3 class="akismet-key-status">Akismet is now protecting your site from spam. Happy blogging!</h3>
	</div>
```