### PR TITLE
Run dbDelta during migration cleanup

### DIFF
--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -7,6 +7,9 @@ add_action( 'vip_after_data_migration', 'Automattic\VIP\Migration\after_data_mig
 function after_data_migration() {
 	if ( is_multisite() ) {
 		$sites = get_sites();
+		
+		// Update global tables
+		dbDelta( 'global' );
 
 		foreach( $sites as $site ) {
 			switch_to_blog( $site->blog_id );
@@ -33,6 +36,8 @@ function run_after_data_migration_cleanup() {
 	do_action( 'vip_go_migration_cleanup' );
 
 	delete_db_transients();
+	
+	dbDelta( 'blog' );
 
 	wp_cache_flush();
 


### PR DESCRIPTION
If it's a multisite, ensure we update the global tables. For each blog, update the blog tables.

### Test:

First, in a sandbox:

```
wp --allow-root cron event schedule vip_after_data_migration
```

After the command has finished, verify the schema is correct:

```
$ vipgo db <site>
mysql> show indexes from wp_postmeta;
```

Ensure the `vip_meta_key_value` index exists.