### PR TITLE
Block wp_mail if VIP_BLOCK_WP_MAIL is set

### DIFF
--- a/vip-mail.php
+++ b/vip-mail.php
@@ -8,6 +8,19 @@ Version: 1.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
+/**
+ * No-Op wp_mail
+ *
+ * If VIP_BLOCK_WP_MAIL is set, we want to ensure wp_mail is not
+ * sending any emails. Since wp_mail is a pluggable function, we
+ * can redefine it here to do nothing.
+ */
+if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL && ! function_exists( 'wp_mail' ) ) {
+	function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
+		// no-op
+	}
+}
+
 class VIP_SMTP {
 	function init() {
 		add_action( 'phpmailer_init',    array( $this, 'phpmailer_init' ) );

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -8,16 +8,9 @@ Version: 1.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-/**
- * No-Op wp_mail
- *
- * If VIP_BLOCK_WP_MAIL is set, we want to ensure wp_mail is not
- * sending any emails. Since wp_mail is a pluggable function, we
- * can redefine it here to do nothing.
- */
-if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL && ! function_exists( 'wp_mail' ) ) {
-	function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
-		// no-op
+class VIP_NoOp_Mailer {
+	function send() {
+		trigger_error( sprintf( 'No-Op wp_mail: <%s> %s', $this->to ?? '', $this->Subject ?? ''), E_USER_NOTICE );
 	}
 }
 
@@ -30,6 +23,11 @@ class VIP_SMTP {
 	}
 
 	function phpmailer_init( $phpmailer ) {
+		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL ) {
+			$phpmailer = new VIP_NoOp_Mailer;
+			return;
+		}
+
 		global $all_smtp_servers;
 
 		if ( ! is_array( $all_smtp_servers ) || empty( $all_smtp_servers ) ) {

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -15,7 +15,7 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
  * sending any emails. Since wp_mail is a pluggable function, we
  * can redefine it here to do nothing.
  */
-if ( defined( 'WPCOM_VIP_BLOCK_WP_MAIL' ) && WPCOM_VIP_BLOCK_WP_MAIL && ! function_exists( 'wp_mail' ) ) {
+if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL && ! function_exists( 'wp_mail' ) ) {
 	function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
 		// no-op
 	}

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -15,7 +15,7 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
  * sending any emails. Since wp_mail is a pluggable function, we
  * can redefine it here to do nothing.
  */
-if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL && ! function_exists( 'wp_mail' ) ) {
+if ( defined( 'WPCOM_VIP_BLOCK_WP_MAIL' ) && WPCOM_VIP_BLOCK_WP_MAIL && ! function_exists( 'wp_mail' ) ) {
 	function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
 		// no-op
 	}

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -9,8 +9,12 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 */
 
 class VIP_NoOp_Mailer {
+	function __construct( $phpmailer ) {
+		$this->Subject = $phpmailer->Subject;
+	}
+
 	function send() {
-		trigger_error( sprintf( 'No-Op wp_mail: <%s> %s', $this->to ?? '', $this->Subject ?? ''), E_USER_NOTICE );
+		trigger_error( sprintf( 'No-Op wp_mail: %s', $this->Subject ?? '' ) );
 	}
 }
 
@@ -24,7 +28,7 @@ class VIP_SMTP {
 
 	function phpmailer_init( $phpmailer ) {
 		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL ) {
-			$phpmailer = new VIP_NoOp_Mailer;
+			$phpmailer = new VIP_NoOp_Mailer( $phpmailer );
 			return;
 		}
 

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -26,7 +26,7 @@ class VIP_SMTP {
 		add_filter( 'wp_mail_from', array( $this, 'filter_wp_mail_from' ), 1 );
 	}
 
-	function phpmailer_init( $phpmailer ) {
+	function phpmailer_init( &$phpmailer ) {
 		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL ) {
 			$phpmailer = new VIP_NoOp_Mailer( $phpmailer );
 			return;

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -10,11 +10,12 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 
 class VIP_Noop_Mailer {
 	function __construct( $phpmailer ) {
-		$this->Subject = $phpmailer->Subject;
+		$this->subject = $phpmailer->Subject ?? '[No Subject]';
+		$this->recipients = implode( ', ', array_keys( $phpmailer->getAllRecipientAddresses() ) );
 	}
 
 	function send() {
-		trigger_error( sprintf( 'No-Op wp_mail: %s', $this->Subject ?? '' ) );
+		trigger_error( sprintf( '%s: skipped sending email with subject `%s` to %s', __METHOD__, $this->subject, $this->recipients ), E_USER_NOTICE );
 	}
 }
 

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -28,7 +28,7 @@ class VIP_SMTP {
 	}
 
 	function phpmailer_init( &$phpmailer ) {
-		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL ) {
+		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && true === VIP_BLOCK_WP_MAIL ) {
 			$phpmailer = new VIP_Noop_Mailer( $phpmailer );
 			return;
 		}

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -8,7 +8,7 @@ Version: 1.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-class VIP_NoOp_Mailer {
+class VIP_Noop_Mailer {
 	function __construct( $phpmailer ) {
 		$this->Subject = $phpmailer->Subject;
 	}
@@ -28,7 +28,7 @@ class VIP_SMTP {
 
 	function phpmailer_init( &$phpmailer ) {
 		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && VIP_BLOCK_WP_MAIL ) {
-			$phpmailer = new VIP_NoOp_Mailer( $phpmailer );
+			$phpmailer = new VIP_Noop_Mailer( $phpmailer );
 			return;
 		}
 


### PR DESCRIPTION
In some cases (usually migrations before the site is ready) we want
to ensure wp_mail isn't sending out emails. This allows us to set
VIP_BLOCK_WP_MAIL, which will redefine wp_mail to do nothing.

Fixes #991 

### Test

1. Load the code on a sandbox
2. Set `VIP_BLOCK_WP_MAIL` to `true`
3. Run `wp_mail( $to, $subject, $message )` in `wp shell`

`wp_mail` should return NULL and you should not get an email. (Normally `wp_mail` returns `true` on success.)