### PR TITLE
Remove concatenation fixes from Ramp. Use fixes in http_concat plugin instead.

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -40,27 +40,4 @@ function wpcom_vip_load_gutenberg( $criteria = true ) {
 	}
 
 	gutenberg_ramp_load_gutenberg( $criteria );
-
-	add_action( 'admin_init', 'wpcom_vip_disable_gutenberg_concat' );	
-}
-
-/**
- * Disable HTTP Concat plugin in admin
- */
-function wpcom_vip_disable_gutenberg_concat() {
-
-	$gutenberg_ramp = Gutenberg_Ramp::get_instance();
-
-	$gutenberg_will_load = (
-		// Ramp has decided to load Gutenberg
-		true === $gutenberg_ramp->load_gutenberg
-		||
-		// or Ramp will allow Gutenberg to load, and Gutenberg is about to be loaded (probably because the plugin is active)
-		( $gutenberg_ramp->gutenberg_should_load() && $gutenberg_ramp->gutenberg_will_load() )
-	);
-
-	// Disable HTTP Concat plugin when Gutenberg will load
-	if ( $gutenberg_will_load ) {
-		add_filter( 'js_do_concat', '__return_false' );
-	}
 }


### PR DESCRIPTION
## Description
When certain js files are run through the existing concatenation on VIP, some are not properly rendered which breaks things in the Gutenberg editor. We have implemented a fix in the http_concat_plugin to bypass files that have inline scripts. See:
https://github.com/Automattic/nginx-http-concat/pull/42

## Pros
Gutenberg works

## Cons
Performance can be slightly affected if not all files aren't concatenated

## Steps to Test

1. Enable Gutenberg for the Go site if not enabled already
2. Set `vip-go-mu-plugins` on the site to one that does not include any concat fixes (https://github.com/Automattic/vip-go-mu-plugins/commit/8335bb772bf5784b453df2634e5aa187489054ae or older)
3. Verify that the Gutenberg editor does not load for a Gutenberg-enabled post in wp-admin (the post are will be white space and you will see JavaScript errors in the console like: `TypeError: f is undefined`)
4. Update the `vip-go-mu-plugins` on the site to this version.
5. Verify that the Gutenberg-editor does load for a Gutenberg-enabled post in wp-admin
6. To ensure concatenation is working but excluding a subset of files, use the Network tab in the browser console. Set the filter to show just the JS files, and compare the total number of js files served in steps 3 and 5 (With this fix implemented, it should server about half the # of files it does in step 3).
