### PR TITLE
Changed group metric calculation 

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -61,19 +61,18 @@ class Concat_Metrics {
 	}
 
 	private function calculate_efficiency_ratio( $scripts ) {
-		$total_scripts = count( $scripts );
 
-		$concats_multiple = array_filter( $scripts, function ( $var ) {
+		$groups = array_reduce( $scripts, function ( $groups, $var ) {
 			if ( 'concat' === $var['type'] ) {
-				return count( $var['paths'] ) > 1;
+				$num_scripts = count( $var['paths'] );
+				$groups['total'] += $num_scripts;
+				array_push( $groups['size'],  $num_scripts );
 			}
+			return $groups;
+		}, ['total' => 0, 'size' => []] );
 
-			return false;
-		});
 
-		$total_concats_multiple = count( $concats_multiple );
-
-		return ( $total_concats_multiple / $total_scripts );
+		return ( array_sum( $groups['size'] ) / count( $groups['size'] ) ) / $groups['total'];
 	}
 
 	private function send_efficiency_stat( $ratio ) {

--- a/stats.php
+++ b/stats.php
@@ -67,7 +67,7 @@ class Concat_Metrics {
 				$num_scripts = count( $var['paths'] );
 				$groups['total'] += $num_scripts;
 				array_push( $groups['size'], $num_scripts );
-			} elseif ( 'do_item' === $var['do_item'] ) {
+			} elseif ( 'do_item' === $var['type'] ) {
 				// do_item are individual scripts
 				$groups['total'] += 1;
 				array_push( $groups['size'], 1 );

--- a/stats.php
+++ b/stats.php
@@ -66,7 +66,11 @@ class Concat_Metrics {
 			if ( 'concat' === $var['type'] ) {
 				$num_scripts = count( $var['paths'] );
 				$groups['total'] += $num_scripts;
-				array_push( $groups['size'],  $num_scripts );
+				array_push( $groups['size'], $num_scripts );
+			} elseif ( 'do_item' === $var['do_item'] ) {
+				// do_item are individual scripts
+				$groups['total'] += 1;
+				array_push( $groups['size'], 1 );
 			}
 			return $groups;
 		}, ['total' => 0, 'size' => []] );


### PR DESCRIPTION
## Description
Changed our concatenation stats metric to calculate the  efficiency ratio based on the average group size relative to the number of scripts in all groups:

 `average_groupsize`/`total_number_scripts_in_groups`:
1) 1 group of 10 scripts:   10/10 = 100%
2) 2 groups, one of 5, one of 15 = 10/20 = 50%
2) 3 groups of 3 scripts each : 3/9 = 33%
3)  10 groups of 1 script each = 1/10 = 10%

Also see: https://github.com/Automattic/vip-go-mu-plugins/pull/997