### PR TITLE
Use named function to allow re-enabling filename media searches

### DIFF
--- a/performance/media.php
+++ b/performance/media.php
@@ -2,8 +2,8 @@
 
 // Prevent core from doing filename lookups for media search.
 // https://core.trac.wordpress.org/ticket/39358
-if( ! ( defined( 'VIP_GO_ENABLE_FILENAMES_SEARCH' ) && VIP_GO_ENABLE_FILENAMES_SEARCH ) ) {
-	add_action( 'pre_get_posts', function() {
-		remove_filter( 'posts_clauses', '_filter_query_attachment_filenames' );
-	} );
+function vip_go_filter_query_attachment_filenanes ( ){
+    remove_filter( 'posts_clauses', '_filter_query_attachment_filenames' );
 }
+
+add_action( 'pre_get_posts', 'vip_go_filter_query_attachment_filenanes' );

--- a/performance/media.php
+++ b/performance/media.php
@@ -2,6 +2,8 @@
 
 // Prevent core from doing filename lookups for media search.
 // https://core.trac.wordpress.org/ticket/39358
-add_action( 'pre_get_posts', function() {
-	remove_filter( 'posts_clauses', '_filter_query_attachment_filenames' );
-} );
+if( ! ( defined( 'VIP_GO_ENABLE_FILENAMES_SEARCH' ) && VIP_GO_ENABLE_FILENAMES_SEARCH ) ) {
+	add_action( 'pre_get_posts', function() {
+		remove_filter( 'posts_clauses', '_filter_query_attachment_filenames' );
+	} );
+}

--- a/performance/media.php
+++ b/performance/media.php
@@ -2,8 +2,8 @@
 
 // Prevent core from doing filename lookups for media search.
 // https://core.trac.wordpress.org/ticket/39358
-function vip_go_filter_query_attachment_filenanes ( ){
+function vip_filter_query_attachment_filenames ( ){
     remove_filter( 'posts_clauses', '_filter_query_attachment_filenames' );
 }
 
-add_action( 'pre_get_posts', 'vip_go_filter_query_attachment_filenanes' );
+add_action( 'pre_get_posts', 'vip_filter_query_attachment_filenames' );


### PR DESCRIPTION
## Description

Currently Filename searches are disabled for performance reasons. However clients have requested this functionality be enabled. (see Ticket 81547 in Zendesk). This update names the anonymous function so that clients can remove it if needed.

I'm not sure if we want to have documentation on this feature as it is a performance concern.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Go to `wp-admin` > `Media`
1. Perform a search for a filename
1. Verify expected media is *not* returned.
1. Add `remove_action( 'pre_get_posts', 'vip_filter_query_attachment_filenames');` to a themes functions.php file.
1. Go to `wp-admin` > `Media`
1. Perform a search for a filename
1. Verify expected media *is* returned.
