### PR TITLE
Jetpack: Globally remove Photon CDN support

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -19,7 +19,11 @@ require_once( __DIR__ . '/jetpack-mandatory.php' );
  * Blocks access to certain functionality that isn't compatible with the platform.
  */
 add_filter( 'jetpack_get_available_modules', function( $modules ) {
+	// The Photon service is not necessary on VIP Go since the same features are built-in.
+	// Note that we do utilize some of the Photon module's code with our own Files Service.
 	unset( $modules['photon'] );
+	unset( $modules['photon-cdn'] );
+
 	unset( $modules['site-icon'] );
 	unset( $modules['protect'] );
 


### PR DESCRIPTION
VIP Go has a built-in Content Acceleration Network, so the Photon CDN functionality is not necessary (it just adds another HTTP layer and limits the capability of our concat functionality).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

CLI:

1. Update to Jetpack 6.7.
1. Check out PR.
1. `wp jetpack module list`.
1. Verify that photon-cdn is not in the list.
1. `wp jetpack module activate photon-cdn`.
1. Verify that this fails.

UI:

1. Update to Jetpack 6.7.
1. Check out PR.
1. Verify Site Accelerator is not available in the Jetpack Settings page.