### PR TITLE
Jetpack: Make Protect a mandatory module

### DIFF
--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -20,6 +20,7 @@ class WPCOM_VIP_Jetpack_Mandatory {
 		'manage',
 		'stats',
 		'vaultpress',
+		'protect',
 	);
 
 	/**

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -21,7 +21,6 @@ require_once( __DIR__ . '/jetpack-mandatory.php' );
 add_filter( 'jetpack_get_available_modules', function( $modules ) {
 	unset( $modules['photon'] );
 	unset( $modules['site-icon'] );
-	unset( $modules['protect'] );
 
 	return $modules;
 }, 999 );


### PR DESCRIPTION
This was disabled earlier due to login issues with reverse proxies. Those have since been fixed and we can restore this.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Go to `wp-admin` > `Jetpack`
1. Verify that Protect is turned on.
