### PR TITLE
Add support for basic auth to internal API endpoints

### DIFF
--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -45,7 +45,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 			'methods'             => 'GET',
 			'callback'            => array( $this, 'list_sites' ),
 			'permission_callback' => function() {
-				return wpcom_vip_go_rest_api_request_allowed( $this->namespace );
+				return wpcom_vip_go_rest_api_request_allowed( $this->namespace, 'manage_sites' );
 			},
 		) );
 

--- a/tests/test-vip-rest-api.php
+++ b/tests/test-vip-rest-api.php
@@ -142,7 +142,7 @@ class VIP_Go_REST_API_Test extends \WP_UnitTestCase {
 		unset( $_SERVER['PHP_AUTH_USER'] );
 		unset( $_SERVER['PHP_AUTH_PW'] );
 
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 401, $response->get_status() );
 	}
 
 	public function test__insufficient_basic_auth_credentials() {
@@ -161,7 +161,7 @@ class VIP_Go_REST_API_Test extends \WP_UnitTestCase {
 		unset( $_SERVER['PHP_AUTH_USER'] );
 		unset( $_SERVER['PHP_AUTH_PW'] );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 401, $response->get_status() );
 	}
 
 	public function test__valid_basic_auth_credentials() {

--- a/tests/test-vip-rest-api.php
+++ b/tests/test-vip-rest-api.php
@@ -129,4 +129,58 @@ class VIP_Go_REST_API_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( 401, $response->get_status() );
 	}
+
+	public function test__invalid_basic_auth_credentials() {
+		$request = new \WP_REST_Request( 'GET', '/' . self::VALID_NAMESPACE . '/sites' );
+
+		// $request->add_header() doesn't populate the vars our endpoint checks
+		$_SERVER['PHP_AUTH_USER'] = '';
+		$_SERVER['PHP_AUTH_PW'] = '';
+
+		$response = $this->server->dispatch( $request );
+
+		unset( $_SERVER['PHP_AUTH_USER'] );
+		unset( $_SERVER['PHP_AUTH_PW'] );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	public function test__insufficient_basic_auth_credentials() {
+		$request = new \WP_REST_Request( 'GET', '/' . self::VALID_NAMESPACE . '/sites' );
+
+		$random_username = wp_generate_password( 12 );
+		$random_password = wp_generate_password( 12 );
+		$user_id = wp_create_user( $random_username, $random_password, $random_username . '@example.com' );
+
+		// $request->add_header() doesn't populate the vars our endpoint checks
+		$_SERVER['PHP_AUTH_USER'] = $random_username;
+		$_SERVER['PHP_AUTH_PW'] = $random_password;
+
+		$response = $this->server->dispatch( $request );
+
+		unset( $_SERVER['PHP_AUTH_USER'] );
+		unset( $_SERVER['PHP_AUTH_PW'] );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test__valid_basic_auth_credentials() {
+		$request = new \WP_REST_Request( 'GET', '/' . self::VALID_NAMESPACE . '/sites' );
+
+		$random_username = wp_generate_password( 12 );
+		$random_password = wp_generate_password( 12 );
+		$user_id = wp_create_user( $random_username, $random_password, $random_username . '@example.com' );
+		grant_super_admin( $user_id );
+
+		// $request->add_header() doesn't populate the vars our endpoint checks
+		$_SERVER['PHP_AUTH_USER'] = $random_username;
+		$_SERVER['PHP_AUTH_PW'] = $random_password;
+
+		$response = $this->server->dispatch( $request );
+
+		unset( $_SERVER['PHP_AUTH_USER'] );
+		unset( $_SERVER['PHP_AUTH_PW'] );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
 }

--- a/tests/test-vip-rest-api.php
+++ b/tests/test-vip-rest-api.php
@@ -170,7 +170,8 @@ class VIP_Go_REST_API_Test extends \WP_UnitTestCase {
 		$random_username = wp_generate_password( 12 );
 		$random_password = wp_generate_password( 12 );
 		$user_id = wp_create_user( $random_username, $random_password, $random_username . '@example.com' );
-		grant_super_admin( $user_id );
+		$user = get_user_by( 'id', $user_id );
+		$user->add_cap( 'vip_support' );
 
 		// $request->add_header() doesn't populate the vars our endpoint checks
 		$_SERVER['PHP_AUTH_USER'] = $random_username;

--- a/tests/test-vip-rest-api.php
+++ b/tests/test-vip-rest-api.php
@@ -148,8 +148,7 @@ class VIP_Go_REST_API_Test extends \WP_UnitTestCase {
 	public function test__insufficient_basic_auth_credentials() {
 		$request = new \WP_REST_Request( 'GET', '/' . self::VALID_NAMESPACE . '/sites' );
 
-		$random_username = wp_generate_password( 12 );
-		$random_password = wp_generate_password( 12 );
+		list( $random_username, $random_password ) = self::get_test_username_password();
 		$user_id = wp_create_user( $random_username, $random_password, $random_username . '@example.com' );
 
 		// $request->add_header() doesn't populate the vars our endpoint checks
@@ -167,8 +166,7 @@ class VIP_Go_REST_API_Test extends \WP_UnitTestCase {
 	public function test__valid_basic_auth_credentials() {
 		$request = new \WP_REST_Request( 'GET', '/' . self::VALID_NAMESPACE . '/sites' );
 
-		$random_username = wp_generate_password( 12 );
-		$random_password = wp_generate_password( 12 );
+		list( $random_username, $random_password ) = self::get_test_username_password();
 		$user_id = wp_create_user( $random_username, $random_password, $random_username . '@example.com' );
 		$user = get_user_by( 'id', $user_id );
 		$user->add_cap( 'vip_support' );
@@ -183,5 +181,12 @@ class VIP_Go_REST_API_Test extends \WP_UnitTestCase {
 		unset( $_SERVER['PHP_AUTH_PW'] );
 
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	// Helper function to generate random username and password
+	static function get_test_username_password() {
+		$username = 'testuser_' . mt_rand();
+		$password = wp_generate_password( 12 );
+		return array( $username, $password );
 	}
 }

--- a/tests/test-vip-rest-api.php
+++ b/tests/test-vip-rest-api.php
@@ -163,13 +163,33 @@ class VIP_Go_REST_API_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 401, $response->get_status() );
 	}
 
-	public function test__valid_basic_auth_credentials() {
+	public function test__valid__vip_support_basic_auth_credentials() {
 		$request = new \WP_REST_Request( 'GET', '/' . self::VALID_NAMESPACE . '/sites' );
 
 		list( $random_username, $random_password ) = self::get_test_username_password();
 		$user_id = wp_create_user( $random_username, $random_password, $random_username . '@example.com' );
 		$user = get_user_by( 'id', $user_id );
 		$user->add_cap( 'vip_support' );
+
+		// $request->add_header() doesn't populate the vars our endpoint checks
+		$_SERVER['PHP_AUTH_USER'] = $random_username;
+		$_SERVER['PHP_AUTH_PW'] = $random_password;
+
+		$response = $this->server->dispatch( $request );
+
+		unset( $_SERVER['PHP_AUTH_USER'] );
+		unset( $_SERVER['PHP_AUTH_PW'] );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test__valid_basic_auth_credentials() {
+		$request = new \WP_REST_Request( 'GET', '/' . self::VALID_NAMESPACE . '/sites' );
+
+		list( $random_username, $random_password ) = self::get_test_username_password();
+		$user_id = wp_create_user( $random_username, $random_password, $random_username . '@example.com' );
+		$user = get_user_by( 'id', $user_id );
+		$user->add_cap( 'manage_sites' );
 
 		// $request->add_header() doesn't populate the vars our endpoint checks
 		$_SERVER['PHP_AUTH_USER'] = $random_username;

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -68,7 +68,7 @@ function wpcom_vip_verify_go_rest_api_request_authorization( $namespace, $auth_h
  * @param  string $namespace RESET API route's namespace
  * @return bool
  */
-function wpcom_vip_go_rest_api_request_allowed( $namespace, $cap = 'manage_options' ) {
+function wpcom_vip_go_rest_api_request_allowed( $namespace, $cap = 'do_not_allow' ) {
 	if ( get_current_user_id() > 0 && ( current_user_can( 'vip_support' ) || current_user_can( $cap ) ) ) {
 		return true;
 	}

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -68,7 +68,11 @@ function wpcom_vip_verify_go_rest_api_request_authorization( $namespace, $auth_h
  * @param  string $namespace RESET API route's namespace
  * @return bool
  */
-function wpcom_vip_go_rest_api_request_allowed( $namespace ) {
+function wpcom_vip_go_rest_api_request_allowed( $namespace, $cap = 'manage_options' ) {
+	if ( get_current_user_id() > 0 && ( current_user_can( 'vip_support' ) || current_user_can( $cap ) ) ) {
+		return true;
+	}
+
 	// Do we have a header to check?
 	if ( ! isset( $_SERVER['HTTP_AUTHORIZATION'] ) || empty( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
 		return false;
@@ -76,6 +80,55 @@ function wpcom_vip_go_rest_api_request_allowed( $namespace ) {
 
 	return wpcom_vip_verify_go_rest_api_request_authorization( $namespace, $_SERVER['HTTP_AUTHORIZATION'] );
 }
+
+// https://github.com/WP-API/Basic-Auth
+function json_basic_auth_handler( $user ) {
+	global $wp_json_basic_auth_error;
+	$wp_json_basic_auth_error = null;
+
+	// Don't authenticate twice
+	if ( ! empty( $user ) ) {
+		return $user;
+	}
+
+	// Check that we're trying to authenticate
+	if ( !isset( $_SERVER['PHP_AUTH_USER'] ) ) {
+		return $user;
+	}
+
+	$username = $_SERVER['PHP_AUTH_USER'];
+	$password = $_SERVER['PHP_AUTH_PW'];
+
+	/**
+	 * In multi-site, wp_authenticate_spam_check filter is run on authentication. This filter calls
+	 * get_currentuserinfo which in turn calls the determine_current_user filter. This leads to infinite
+	 * recursion and a stack overflow unless the current function is removed from the determine_current_user
+	 * filter during authentication.
+	 */
+	remove_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+	$user = wp_authenticate( $username, $password );
+	add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+
+	if ( is_wp_error( $user ) ) {
+		$wp_json_basic_auth_error = $user;
+		return null;
+	}
+
+	$wp_json_basic_auth_error = true;
+	return $user->ID;
+}
+add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+
+function json_basic_auth_error( $error ) {
+	// Passthrough other errors
+	if ( ! empty( $error ) ) {
+		return $error;
+	}
+
+	global $wp_json_basic_auth_error;
+	return $wp_json_basic_auth_error;
+}
+add_filter( 'rest_authentication_errors', 'json_basic_auth_error' );
 
 /**
  * Include customizations

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -69,8 +69,15 @@ function wpcom_vip_verify_go_rest_api_request_authorization( $namespace, $auth_h
  * @return bool
  */
 function wpcom_vip_go_rest_api_request_allowed( $namespace, $cap = 'do_not_allow' ) {
-	if ( get_current_user_id() > 0 && ( current_user_can( 'vip_support' ) || current_user_can( $cap ) ) ) {
-		return true;
+	// First check basic auth
+	$basic_auth_user = wpcom_vip_basic_auth_user();
+	if ( $basic_auth_user && ! is_wp_error( $basic_auth_user ) &&
+		$basic_auth_user->ID && $basic_auth_user->ID > 0 ) {
+			$user_id = $basic_auth_user->ID;
+
+			if ( user_can( $user_id, 'vip_support' ) || user_can( $user_id, $cap ) ) {
+				return true;
+			}
 	}
 
 	// Do we have a header to check?
@@ -81,54 +88,16 @@ function wpcom_vip_go_rest_api_request_allowed( $namespace, $cap = 'do_not_allow
 	return wpcom_vip_verify_go_rest_api_request_authorization( $namespace, $_SERVER['HTTP_AUTHORIZATION'] );
 }
 
-// https://github.com/WP-API/Basic-Auth
-function json_basic_auth_handler( $user ) {
-	global $wp_json_basic_auth_error;
-	$wp_json_basic_auth_error = null;
-
-	// Don't authenticate twice
-	if ( ! empty( $user ) ) {
-		return $user;
-	}
-
-	// Check that we're trying to authenticate
+function wpcom_vip_basic_auth_user() {
 	if ( !isset( $_SERVER['PHP_AUTH_USER'] ) ) {
-		return $user;
+		return false;
 	}
 
 	$username = $_SERVER['PHP_AUTH_USER'];
 	$password = $_SERVER['PHP_AUTH_PW'];
 
-	/**
-	 * In multi-site, wp_authenticate_spam_check filter is run on authentication. This filter calls
-	 * get_currentuserinfo which in turn calls the determine_current_user filter. This leads to infinite
-	 * recursion and a stack overflow unless the current function is removed from the determine_current_user
-	 * filter during authentication.
-	 */
-	remove_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
-	$user = wp_authenticate( $username, $password );
-	add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
-
-	if ( is_wp_error( $user ) ) {
-		$wp_json_basic_auth_error = $user;
-		return null;
-	}
-
-	$wp_json_basic_auth_error = true;
-	return $user->ID;
+	return wp_authenticate( $username, $password );
 }
-add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
-
-function json_basic_auth_error( $error ) {
-	// Passthrough other errors
-	if ( ! empty( $error ) ) {
-		return $error;
-	}
-
-	global $wp_json_basic_auth_error;
-	return $wp_json_basic_auth_error;
-}
-add_filter( 'rest_authentication_errors', 'json_basic_auth_error' );
 
 /**
  * Include customizations

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -89,7 +89,7 @@ function wpcom_vip_go_rest_api_request_allowed( $namespace, $cap = 'do_not_allow
 }
 
 function wpcom_vip_basic_auth_user() {
-	if ( !isset( $_SERVER['PHP_AUTH_USER'] ) ) {
+	if ( ! isset( $_SERVER['PHP_AUTH_USER'] ) || ! isset( $_SERVER['PHP_AUTH_PW'] ) ) {
 		return false;
 	}
 

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -75,6 +75,10 @@ function wpcom_vip_go_rest_api_request_allowed( $namespace, $cap = 'do_not_allow
 		$basic_auth_user->ID && $basic_auth_user->ID > 0 ) {
 			$user_id = $basic_auth_user->ID;
 
+			// Check current user has `vip_support` or the required capability.
+			// VIP Support users should be able to do anything on the site, but
+			// this cap check runs before that plugin is loaded.
+			// https://github.com/Automattic/vip-support
 			if ( user_can( $user_id, 'vip_support' ) || user_can( $user_id, $cap ) ) {
 				return true;
 			}


### PR DESCRIPTION
Use case: We need to use the vip/v1/sites endpoint to get information
about multisites in the migration CLI. Rather than hardcoding a shared
secret in the CLI, we can create a user on the site and use that
username and password to authenticate for the API endpoints.

This uses the basic auth plugin (https://github.com/WP-API/Basic-Auth)
to populte the current user based on HTTP basic auth. We can then use
that current user to decide whether to authenticate the current request
for our internal endpoints.

Note: We're also checking `current_user_can( 'vip_support' )` here
because VIP Support users only have `read`, `subscriber`, and
`vip_support` in this context. We may just want to fix that instead.

Testing:

1. Load the PR on your sandbox
2. Create support user on a test site
3. curl -u 'username:password' https://&lt;domain>/wp-json/vip/v1/sites