### PR TITLE
Add blog ID to the /vip/v1/sites response

### DIFF
--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -165,6 +165,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 					}
 
 					$sites[] = array(
+						'ID' => $_site,
 						'domain_name' => $url,
 					);
 
@@ -178,6 +179,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 		} else {
 			// Provided for consistency, even though this provides no insightful response
 			$sites[] = array(
+				'ID' => $_site,
 				'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
 			);
 		}

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -179,7 +179,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 		} else {
 			// Provided for consistency, even though this provides no insightful response
 			$sites[] = array(
-				'ID' => null,
+				'ID' => 1,
 				'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
 			);
 		}

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -179,7 +179,7 @@ class WPCOM_VIP_REST_API_Endpoints {
 		} else {
 			// Provided for consistency, even though this provides no insightful response
 			$sites[] = array(
-				'ID' => $_site,
+				'ID' => null,
 				'domain_name' => parse_url( home_url(), PHP_URL_HOST ),
 			);
 		}


### PR DESCRIPTION
For migrations we want to use the /sites endpoint to figure out the domain name for a given subsite. In order to associate domains to blog IDs, we need to include the blog ID in the response here.

Testing:

Testing will be easier once https://github.com/Automattic/vip-go-mu-plugins/pull/1015 is merged so that we don't need to generate and pass an authorization token. You could hack `wpcom_vip_go_rest_api_request_allowed()` on your sandbox to always return true, though.

Then `curl https://<domain>/wp-json/vip/v1/sites` should return a list of sites with IDs.