### PR TITLE
Add PHPUnit test script

### DIFF
--- a/bin/download-wp-tests.sh
+++ b/bin/download-wp-tests.sh
@@ -1,0 +1,107 @@
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR="${WP_TESTS_DIR-/tmp/wordpress-tests-lib}/"
+WP_CORE_DIR="${WP_CORE_DIR-/tmp/wordpress}/"
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$WP_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$WP_VERSION"
+fi
+
+echo $WP_VERSION
+
+set -ex
+
+# Footle around to remove any trailing slashes, and then add
+# them back in again.
+# We're going to install WordPress and the WordPress test lib
+# to version specific directories, for greater control locally
+shopt -s extglob;
+WP_TESTS_DIR_ACTUAL="${WP_TESTS_DIR%%+(/)}-${WP_VERSION}/"
+WP_CORE_DIR_ACTUAL="${WP_CORE_DIR%%+(/)}-${WP_VERSION}/"
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR_ACTUAL ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR_ACTUAL
+
+	if [ $WP_VERSION == 'latest' ]; then
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR_ACTUAL
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR_ACTUAL/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR_ACTUAL ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR_ACTUAL
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR_ACTUAL/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR_ACTUAL/data
+	fi
+
+	cd $WP_TESTS_DIR_ACTUAL
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+	fi
+
+}
+
+install_wp
+install_test_suite
+
+# Create a symbolic link to the version specific directories
+# from a generic location
+rm -rf "${WP_CORE_DIR%%+(/)}"
+rm -rf "${WP_TESTS_DIR%%+(/)}"
+ln -s "${WP_CORE_DIR_ACTUAL%%+(/)}" "${WP_CORE_DIR%%+(/)}"
+ln -s "${WP_TESTS_DIR_ACTUAL%%+(/)}" "${WP_TESTS_DIR%%+(/)}"
+

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -12,7 +12,7 @@ DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-$DIR/download-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST $WP_VERSION
+$DIR/download-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION"
 
 install_db() {
 	# parse DB_HOST for port or socket references

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -11,91 +11,8 @@ DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 
-WP_TESTS_DIR="${WP_TESTS_DIR-/tmp/wordpress-tests-lib}/"
-WP_CORE_DIR="${WP_CORE_DIR-/tmp/wordpress}/"
-
-download() {
-    if [ `which curl` ]; then
-        curl -s "$1" > "$2";
-    elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
-    fi
-}
-
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
-	WP_TESTS_TAG="tags/$WP_VERSION"
-else
-	# http serves a single offer, whereas https serves multiple. we only want one
-	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
-	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
-	WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
-	if [[ -z "$WP_VERSION" ]]; then
-		echo "Latest WordPress version could not be found"
-		exit 1
-	fi
-	WP_TESTS_TAG="tags/$WP_VERSION"
-fi
-
-
-set -ex
-
-# Footle around to remove any trailing slashes, and then add
-# them back in again.
-# We're going to install WordPress and the WordPress test lib
-# to version specific directories, for greater control locally
-shopt -s extglob;
-WP_TESTS_DIR_ACTUAL="${WP_TESTS_DIR%%+(/)}-${WP_VERSION}/"
-WP_CORE_DIR_ACTUAL="${WP_CORE_DIR%%+(/)}-${WP_VERSION}/"
-
-install_wp() {
-
-	if [ -d $WP_CORE_DIR_ACTUAL ]; then
-		return;
-	fi
-
-	mkdir -p $WP_CORE_DIR_ACTUAL
-
-	if [ $WP_VERSION == 'latest' ]; then
-		local ARCHIVE_NAME='latest'
-	else
-		local ARCHIVE_NAME="wordpress-$WP_VERSION"
-	fi
-
-	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR_ACTUAL
-
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR_ACTUAL/wp-content/db.php
-
-}
-
-install_test_suite() {
-	# portable in-place argument for both GNU sed and Mac OSX sed
-	if [[ $(uname -s) == 'Darwin' ]]; then
-		local ioption='-i .bak'
-	else
-		local ioption='-i'
-	fi
-
-	# set up testing suite if it doesn't yet exist
-	if [ ! -d $WP_TESTS_DIR_ACTUAL ]; then
-		# set up testing suite
-		mkdir -p $WP_TESTS_DIR_ACTUAL
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR_ACTUAL/includes
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR_ACTUAL/data
-	fi
-
-	cd $WP_TESTS_DIR_ACTUAL
-
-	if [ ! -f wp-tests-config.php ]; then
-		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-	fi
-
-}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+$DIR/download-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST $WP_VERSION
 
 install_db() {
 	# parse DB_HOST for port or socket references
@@ -117,15 +34,5 @@ install_db() {
 	# create database
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
-
-install_wp
-install_test_suite
-
-# Create a symbolic link to the version specific directories
-# from a generic location
-rm -rf "${WP_CORE_DIR%%+(/)}"
-rm -rf "${WP_TESTS_DIR%%+(/)}"
-ln -s "${WP_CORE_DIR_ACTUAL%%+(/)}" "${WP_CORE_DIR%%+(/)}"
-ln -s "${WP_TESTS_DIR_ACTUAL%%+(/)}" "${WP_TESTS_DIR%%+(/)}"
 
 install_db

--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+WP_VERSION=${1-latest}
+
+MYSQL_ROOT_PASSWORD='wordpress'
+db=$(docker run -p 3306:3306 -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb)
+function cleanup() {
+	docker rm -f $db
+}
+trap cleanup EXIT
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root $MYSQL_ROOT_PASSWORD 127.0.0.1 $WP_VERSION)
+
+## Ensure there's a database connection for the rest of the steps
+until docker exec -it $db mysql -u root --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do
+	echo "Waiting for database connection..."
+	sleep 5
+done
+
+docker run \
+	-v $(pwd):/app \
+	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
+	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \
+	--network host \
+	--rm phpunit/phpunit \
+	--bootstrap /app/tests/bootstrap.php

--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -10,7 +10,7 @@ function cleanup() {
 trap cleanup EXIT
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root $MYSQL_ROOT_PASSWORD 127.0.0.1 $WP_VERSION)
+WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root "$MYSQL_ROOT_PASSWORD" "127.0.0.1" "$WP_VERSION")
 
 ## Ensure there's a database connection for the rest of the steps
 until docker exec -it $db mysql -u root --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do

--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -3,22 +3,25 @@
 WP_VERSION=${1-latest}
 
 MYSQL_ROOT_PASSWORD='wordpress'
-db=$(docker run -p 3306:3306 -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb)
+docker network create tests
+db=$(docker run -p 3306:3306 --network tests --name db -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb)
 function cleanup() {
 	docker rm -f $db
+	docker network rm tests
 }
 trap cleanup EXIT
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root "$MYSQL_ROOT_PASSWORD" "127.0.0.1" "$WP_VERSION")
+WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root "$MYSQL_ROOT_PASSWORD" "db" "$WP_VERSION")
 
 ## Ensure there's a database connection for the rest of the steps
-until docker exec -it $db mysql -u root --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do
+until docker exec -it $db mysql -u root -h db --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do
 	echo "Waiting for database connection..."
 	sleep 5
 done
 
 docker run \
+ 	--network tests \
 	-v $(pwd):/app \
 	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
 	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \

--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -4,7 +4,7 @@ WP_VERSION=${1-latest}
 
 MYSQL_ROOT_PASSWORD='wordpress'
 docker network create tests
-db=$(docker run -p 3306:3306 --network tests --name db -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb)
+db=$(docker run --network tests --name db -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb)
 function cleanup() {
 	docker rm -f $db
 	docker network rm tests
@@ -25,6 +25,5 @@ docker run \
 	-v $(pwd):/app \
 	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
 	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \
-	--network host \
 	--rm phpunit/phpunit \
 	--bootstrap /app/tests/bootstrap.php


### PR DESCRIPTION
```
usage: ./bin/phpunit-docker.sh [wp-version]
```

Adds a new script that uses docker to create a temporary database
container, installs the WP Unit Test dependencies, and runs the tests
in a phpunit container.

We're also splitting the existing install-wp-tests.sh script into two parts
so the applicable parts are reusable for this. The part that sets up a
local database is unnecessary here since we're using Docker for that.

The existing script still references the new download-wp-tests.sh script
internally, so that should continue to function the same as before.

Fixes #1017