### PR TITLE
Connect akismet during migration cleanup

### DIFF
--- a/vip-helpers/vip-migrations.php
+++ b/vip-helpers/vip-migrations.php
@@ -84,15 +84,16 @@ function connect_vaultpress() {
 }
 
 function connect_akismet() {
-	$user = get_current_user_id();
+	$original_user = get_current_user_id();
 
 	// Switch to wpcomvip -- Akismet connects the current user
-	$wpcomvip = get_user_by( 'login', 'wpcomvip' );
-	if ( ! $wpcomvip ) {
+	$wpcomvip_user = get_user_by( 'login', 'wpcomvip' );
+	if ( ! $wpcomvip_user ) {
 		trigger_error( sprintf( '%s: Failed to find wpcomvip user while attempting to connect Akismet; Akismet will need to be connected manually', __FUNCTION__ ), E_USER_WARNING );
+		return;
 	}
 
-	wp_set_current_user( $wpcomvip->ID );
+	wp_set_current_user( $wpcomvip_user->ID );
 
 	if ( class_exists( 'Akismet_Admin' ) && method_exists( 'Akismet_Admin', 'connect_jetpack_user' ) ) {
 		$connected = \Akismet_Admin::connect_jetpack_user();
@@ -104,5 +105,5 @@ function connect_akismet() {
 	}
 
 	// Switch back to current user
-	wp_set_current_user( $user );
+	wp_set_current_user( $original_user );
 }


### PR DESCRIPTION
## Description

Resolves the issue from #1023 by properly namespacing `\Akismet_Admin::connect_jetpack_user()` and adds some additional error checking.

Fixes #988, #1023

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR on a sandbox
2. `wp --allow-root cron event schedule vip_after_data_migration '+1 hour' && wp --allow-root cron event run vip_after_data_migration`
3. Check error logs and confirm Akismet is connected