### PR TITLE
Use mangle cache invalidation for file purges

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -454,19 +454,21 @@ class A8C_Files {
 		else
 			$file_uri = '/' . $url_parts['path'];
 
-		if ( in_array( $file_uri, $deleted_uris ) ) {
-			// This file has already been successfully deleted from the file service in this request
-			return;
-		}
-
 		$headers = array(
 					'X-Client-Site-ID: ' . constant( 'FILES_CLIENT_SITE_ID' ),
 					'X-Access-Token: ' . constant( 'FILES_ACCESS_TOKEN' ),
 				);
 
+		$delete_uri = $file_uri;
 		$service_url = $this->get_files_service_hostname() . '/' . $this->get_upload_path();
 		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
 			$service_url .= '/sites/' . get_current_blog_id();
+			$delete_uri = '/sites/' . get_current_blog_id() . $delete_uri;
+		}
+
+		if ( in_array( $delete_uri, $deleted_uris ) ) {
+			// This file has already been successfully deleted from the file service in this request
+			return;
 		}
 
 		$ch = curl_init( $service_url . $file_uri );
@@ -487,7 +489,7 @@ class A8C_Files {
 		}
 
 		// Set our static so we can later recall that this file has already been deleted and purged
-		$deleted_uris[] = $file_uri;
+		$deleted_uris[] = $delete_uri;
 
 		// We successfully deleted the file, purge the file from the caches
 		$invalidation_url = get_site_url() . '/' . $this->get_upload_path();

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -446,7 +446,7 @@ class A8C_Files {
 	function delete_file( $file_name ) {
 		// To ensure we don't needlessly fire off deletes for all sizes of the same image, of
 		// which all except the first result in 404's, keep accounting of what we've deleted.
-		static $deleted_uri;
+		static $deleted_uris = array();
 
 		$url_parts = parse_url( $file_name );
 		if ( false !== stripos( $url_parts['path'], constant( 'LOCAL_UPLOADS' ) ) )
@@ -454,7 +454,7 @@ class A8C_Files {
 		else
 			$file_uri = '/' . $url_parts['path'];
 
-		if ( isset( $deleted_uri ) && ( $deleted_uri == $file_uri ) ) {
+		if ( in_array( $file_uri, $deleted_uris ) ) {
 			// This file has already been successfully deleted from the file service in this request
 			return;
 		}
@@ -487,7 +487,7 @@ class A8C_Files {
 		}
 
 		// Set our static so we can later recall that this file has already been deleted and purged
-		$deleted_uri = $file_uri;
+		$deleted_uris[] = $file_uri;
 
 		// We successfully deleted the file, purge the file from the caches
 		$invalidation_url = get_site_url() . '/' . $this->get_upload_path();

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -546,8 +546,10 @@ class A8C_Files {
 			return;
 		}
 
-		if ( ! isset( $file_cache_servers ) || empty( $file_cache_servers ) )
+		if ( ! isset( $file_cache_servers ) || empty( $file_cache_servers ) ) {
+			error_log( sprintf( __( 'Error purging the file cache for %s: There are no file cache servers defined.' ), $url ) );
 			return $requests;
+		}
 
 		foreach ( $file_cache_servers as $server  ) {
 			$server = explode( ':', $server[0] );

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -510,10 +510,12 @@ class A8C_Files {
 		}
 
 		$uri = '/';
-		if ( isset( $parsed['path'] ) )
+		if ( isset( $parsed['path'] ) ) {
 			$uri = $parsed['path'];
-		if ( isset( $parsed['query'] ) )
+		}
+		if ( isset( $parsed['query'] ) ) {
 			$uri .= $parsed['query'];
+		}
 
 		$requests = array();
 

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -473,7 +473,7 @@ class A8C_Files {
 		curl_close( $ch );
 
 		if ( 200 != $http_code ) {
-			error_log( sprintf( __( 'Error deleting the file from the remote servers: Code %d' ), $http_code ) );
+			error_log( sprintf( __( 'Error deleting the file %s from the remote servers: Code %d' ), $file_uri, $http_code ) );
 			return;
 		}
 

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -484,7 +484,7 @@ class A8C_Files {
 		curl_close( $ch );
 
 		if ( 200 != $http_code ) {
-			error_log( sprintf( __( 'Error deleting the file %s from the remote servers: Code %d' ), $file_uri, $http_code ) );
+			trigger_error( sprintf( __( 'Error deleting the file %s from the remote servers: Code %d' ), $file_uri, $http_code ), E_USER_WARNING );
 			return;
 		}
 
@@ -541,13 +541,13 @@ class A8C_Files {
 			curl_close( $curl );
 
 			if ( 200 != $http_code ) {
-				error_log( sprintf( __( 'Error purging %s from the cache service: Code %d' ), $url, $http_code ) );
+				trigger_error( sprintf( __( 'Error purging %s from the cache service: Code %d' ), $url, $http_code ), E_USER_WARNING );
 			}
 			return;
 		}
 
 		if ( ! isset( $file_cache_servers ) || empty( $file_cache_servers ) ) {
-			error_log( sprintf( __( 'Error purging the file cache for %s: There are no file cache servers defined.' ), $url ) );
+			trigger_error( sprintf( __( 'Error purging the file cache for %s: There are no file cache servers defined.' ), $url ), E_USER_WARNING );
 			return $requests;
 		}
 


### PR DESCRIPTION
## Description

If the PURGE_SERVER_TYPE is configured for mangle, use it for files purges instead of direct calls to Varnish. Also, don't fire off deletes to the files service for every image size as this slows down the request needlessly.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally.
- [x] This change works and has been tested on a Go sandbox.
- [x] This change works and has been tested in production.

## Steps to Test

1. Set the purge server type constant on you sandbox to 'mangle'.
2. Delete a file.
3. Ask systems to check the DC LB host logs to ensure only a single DELETE hit the files service and only a single PURGE took place to the mangle cache invalidation service.

