### PR TITLE
Require the GUTENBERG_USE_PLUGIN constant

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1070,6 +1070,9 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 	// Without the constant in place, we skip loading the plugin and fallback to the core block editor.
 	// This will also facilitate the upgrade path where core disables the Gutenberg plugin as part of the upgrade.
 	if ( 'gutenberg' === $plugin ) {
+		$db_version = absint( get_option( 'db_version' ) );
+		$is_50_plus = $db_version >= 43764;
+
 		$should_load_gutenberg = true;
 		if ( ! defined( 'GUTENBERG_USE_PLUGIN' ) ) {
 			$should_load_gutenberg = false;
@@ -1077,7 +1080,7 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 			$should_load_gutenberg = false;
 		}
 
-		if ( ! $should_load_gutenberg ) {
+		if ( $is_50_plus && ! $should_load_gutenberg ) {
 			trigger_error( 'wpcom_vip_load_plugin: Skipped loading Gutenberg plugin. Please add `define( \'GUTENBERG_USE_PLUGIN\', true );` if you would like to use the plugin over the Core Block Editor. For details, see https://wp.me/p9nvA-7Xk', E_USER_WARNING );
 
 			return;

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1081,7 +1081,7 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 		}
 
 		if ( $is_50_plus && ! $should_load_gutenberg ) {
-			trigger_error( 'wpcom_vip_load_plugin: Skipped loading Gutenberg plugin. Please add `define( \'GUTENBERG_USE_PLUGIN\', true );` if you would like to use the plugin over the Core Block Editor. For details, see https://wp.me/p9nvA-7Xk', E_USER_WARNING );
+			trigger_error( 'wpcom_vip_load_plugin: Skipped loading Gutenberg plugin. Please add `define( \'GUTENBERG_USE_PLUGIN\', true );` if you would like to use the plugin over the Core Block Editor. For details, see https://vip.wordpress.com/documentation/vip-go/loading-gutenberg/', E_USER_WARNING );
 
 			return;
 		}

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1066,6 +1066,24 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 		}
 	}
 
+	// For WordPress 5.0+, any environments that want to use the Gutenberg plugin need to define a specific constant.
+	// Without the constant in place, we skip loading the plugin and fallback to the core block editor.
+	// This will also facilitate the upgrade path where core disables the Gutenberg plugin as part of the upgrade.
+	if ( 'gutenberg' === $plugin ) {
+		$should_load_gutenberg = true;
+		if ( ! defined( 'GUTENBERG_USE_PLUGIN' ) ) {
+			$should_load_gutenberg = false;
+		} elseif ( true !== GUTENBERG_USE_PLUGIN ) {
+			$should_load_gutenberg = false;
+		}
+
+		if ( ! $should_load_gutenberg ) {
+			trigger_error( 'wpcom_vip_load_plugin: Skipped loading Gutenberg plugin. Please add `define( \'GUTENBERG_USE_PLUGIN\', true );` if you would like to use the plugin over the Core Block Editor. For details, see https://wp.me/p9nvA-7Xk', E_USER_WARNING );
+
+			return;
+		}
+	}
+	
 	if ( $includepath && file_exists( $includepath ) ) {
 		wpcom_vip_add_loaded_plugin( "{$plugin_type}/{$plugin}/{$file}" );
 


### PR DESCRIPTION
For WordPress 5.0+, any environments that want to use the Gutenberg plugin need to define the `GUTENBERG_USE_PLUGIN` constant. This facilitates the upgrade path where core disables the Gutenberg plugin as part of the upgrade. Without the constant in place, the upgrade routine would fail to deactivate the plugin and continue using it.

If the constant is defined, any attempts to load the plugin via `wpcom_vip_load_plugin` will skip loading the plugin and just fallback to the core block editor.

We'll want to coordinate this with the 5.0 upgrade on Go sites.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Add Gutenberg plugin
1. Add `wpcom_vip_load_plugin( 'gutenberg' )` to a client-mu-plugin.
1. Upgrade to 5.0.
1. Verify that the plugin was deactivated and the core block editor is used.
1. Verify a warning is triggered about missing the constant.

Repeat with step 2 adding a `define( 'GUTENBERG_USE_PLUGIN', true )` as well. Verify that the plugin stays active, no warnings are triggered, and the plugin editor is used.
