### PR TITLE
Jetpack 6.8

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 6.7
+ * Version: 6.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack


### PR DESCRIPTION
https://jetpack.com/2018/11/27/jetpack-6-8-building-jetpack-for-the-new-wordpress-editor/

> Today, we’re introducing the first wave of Jetpack blocks built specifically for the new WordPress editor, Gutenberg. The features you’ve come to rely on have been adapted for this new experience: payment buttons, forms, maps, and markdown.

To be deployed today (December 5, 2018) around 2000 UTC.