### PR TITLE
Modify the 5.0 about page to be more VIP-specific

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -41,3 +41,54 @@ function wpcom_vip_load_gutenberg( $criteria = true ) {
 
 	gutenberg_ramp_load_gutenberg( $criteria );
 }
+
+// Modify the the post-upgrade screen (about.php) to be more VIP-specific
+// Don't mind that hacky CSS, please :)
+add_action( 'all_admin_notices', function() {
+	global $pagenow;
+	if ( 'about.php' !== $pagenow ) {
+		return;
+	}
+
+	// Only on 5.0+
+	$db_version = absint( get_option( 'db_version' ) );
+	if ( $db_version < 43764 ) {
+		return;
+	}
+
+?>
+<style>
+#classic-editor,
+#classic-editor + div.full-width,
+#classic-editor + div.full-width + div.feature-section {
+	display: none;
+}
+
+.about-text {
+	display: none;
+}
+
+#vip-upgrade-message {
+	margin: 20px 200px 20px 0;
+	padding: 0;
+
+	background: none;
+	border: none;
+	box-shadow: none;
+}
+
+#vip-upgrade-message p {
+	font-weight: 400;
+    line-height: 1.6em;
+    font-size: 19px;
+}
+</style>
+<div id="vip-upgrade-message" class="notice notice-success" style="display: block !important">
+	<p>Thank you for updating to the latest version! WordPress 5.0 introduces a robust new content creation experience.</p>
+
+	<p><strong>Your editor of choice has not been changed</strong>.</p>
+
+	<p>Read more about the new editor below, learn about <a href="https://vip.wordpress.com/documentation/gutenberg-at-vip/" rel="noopener noreferrer" target="_blank">how it's configured on VIP</a>, or <a href="https://testgutenberg.com/" rel="noopener noreferrer" target="_blank">try it out in your browser</a>.</p>
+</div>
+<?php
+} );

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -56,6 +56,11 @@ add_action( 'all_admin_notices', function() {
 		return;
 	}
 
+	$is_using_gutenberg = false;
+	if ( class_exists( 'Gutenberg_Ramp' ) ) {
+		$is_using_gutenberg = Gutenberg_Ramp::get_instance()->active;
+	}
+
 ?>
 <style>
 #classic-editor,
@@ -89,6 +94,10 @@ add_action( 'all_admin_notices', function() {
 	<p><strong>Your editor of choice has not been changed</strong>.</p>
 
 	<p>Read more about the new editor below, learn about <a href="https://vip.wordpress.com/documentation/gutenberg-at-vip/" rel="noopener noreferrer" target="_blank">how it's configured on VIP</a>, or <a href="https://testgutenberg.com/" rel="noopener noreferrer" target="_blank">try it out in your browser</a>.</p>
+
+	<?php if ( ! $is_using_gutenberg ) : ?>
+		<p>Need help planning your transition? The <a href="<?php echo admin_url( 'admin.php?page=vip-dashboard' ); ?>">VIP Support team is ready to help</a>!</p>
+	<?php endif; ?>
 </div>
 <?php
 } );


### PR DESCRIPTION
Remove Classic Editor references since we have Ramp in place. Add links and references to VIP docs and resources instead.

![2018-12-06 at 5 42 pm](https://user-images.githubusercontent.com/86105/49616594-59597d80-f97f-11e8-911d-70460e820842.png)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Upgrade to 5.0.
1. Check out PR.
1. Go to `wp-admin/about.php`
1. Verify you don't see the Classic Editor references.
1. Verify you get VIP specific messaging at the top.

Repeat with 4.9.8 and make sure the About page isn't modified.
