### PR TITLE
Retain < 5.0 behaviour for tinyMCE scripts.

### DIFF
--- a/http-concat.php
+++ b/http-concat.php
@@ -12,6 +12,20 @@ if ( true === WPCOM_IS_VIP_ENV ) {
 	// Activate concatenation
 	if ( ! isset( $_GET['concat_js'] ) || 'yes' === $_GET['concat_js'] ) {
 		require __DIR__ .'/http-concat/jsconcat.php';
+
+		add_filter( 'js_do_concat', function( $do_concat, $handle ) {
+			// Retain < 5.0 behaviour for tinyMCE scripts.
+			// These used to be output individually and bypass concat.
+			// 5.0 registers them as scripts which gets them picked up by out concat.
+			// However, tinymce.min.js (root) does not handle that situation well.
+			// It ends up initializing with the baseURL set to that of the script.
+			// Which then leads to problems loading additional dependencies.
+			if ( 'wp-tinymce-root' === $handle || 'wp-tinymce' === $handle ) {
+				$do_concat = false;
+			}
+
+			return $do_concat;
+		}, 10, 2 );
 	}
 
 	if ( ! isset( $_GET['concat_css'] ) || 'yes' === $_GET['concat_css'] ) {


### PR DESCRIPTION
These used to be output individually and bypass concat. 5.0 registers
them as scripts which gets them picked up by our concat.

However, tinymce.min.js (root) does not handle that situation well.
It ends up initializing with the baseURL set to that of the script.

Which then leads to problems loading additional dependencies and
everything breaks.

By skipping concat, we restore earlier behaviour and keep sites working.

## Steps to Test

1. Apply PR
1. Load classic editor on 5.0 
1. Verify it works