### PR TITLE
Migration: Reset all the site roles if the core roles doesn't exist.

### DIFF
--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -70,6 +70,12 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 			}
 		}
 
+		// Cleanup roles
+		if ( get_role( 'administrator' ) === null ) {
+			// If the `administrator` role is not present, it's required to reset the default roles.
+			WP_CLI::runcommand( 'role reset --all' );
+		}
+
 		WP_CLI::line( 'Calling Automattic\VIP\Migration\run_after_data_migration_cleanup()' );
 
 		if ( ! $dry_run ) {


### PR DESCRIPTION
## Description

When importing sites from WordPress.com, since it doesn't store the roles in the database, the default core roles are not presented on the target site, requiring to run `wp role reset --all` after the database import.

This PR wants to remove that need and automate that step as part of the migration cleanup script. It will check for the existence of the `administrator` role. In case it isn't available on the site, it will run the `wp role reset --all` command.

I have decided on calling the command directly instead of duplicating the logic in the [`role reset` command](https://github.com/wp-cli/role-command/blob/master/src/Role_Command.php#L271-L283), as it allows reusing that code, making the cleanup command less complex, but I'm open to different approaches!

Ref: #1040 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out the PR.
2. Run `wp role list` in a Go site with a fresh import from WordPress.com, and check if the default roles exist.
3. Run `wp vip migration cleanup` and if there are no default roles, you should see them being reseted and created; if the roles exist you shouldn't see anything.
4. Check if the roles exist with `wp role list`
