### PR TITLE
Improving the filesystem experience on VIP Go multisite

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -232,14 +232,14 @@ class A8C_Files {
 	function get_upload_dir( $upload ) {
 
 		// Maybe fix paths for multisite
-		if ( ! is_multisite() || ( is_main_network() && is_main_site() ) ) {
-			// If we're not on multisite, do nothing
-			$sites_path = '';
-		} elseif ( false !== stripos( $upload['subdir'], '/sites/' ) ) {
-			// If we maybe already have `/sites/` in the path, do nothing
-			$sites_path = '';
-		} else {
-			$sites_path = '/sites/' . get_current_blog_id();
+		$sites_path = '';
+		if (
+			// We only want to manipulate the paths if...
+			is_multisite() && // we're on multisite
+			1 !== get_current_blog_id() && // the blog ID is NOT 1, the uploads path for blog ID 1 doesn't need to include the site ID
+			false === stripos( $upload['subdir'], '/sites/' ) // the `subdir` hasn't already been updated to include /sites/{site_id}
+			) {
+				$sites_path = '/sites/' . get_current_blog_id();
 		}
 
 		$upload['path'] = constant( 'LOCAL_UPLOADS' ) . $sites_path . $upload['subdir'];

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -230,8 +230,20 @@ class A8C_Files {
 	}
 
 	function get_upload_dir( $upload ) {
-		$upload['path'] = constant( 'LOCAL_UPLOADS' ) . $upload['subdir'];
-		$upload['basedir'] = constant( 'LOCAL_UPLOADS' );
+
+		// Maybe fix paths for multisite
+		if ( ! is_multisite() || ( is_main_network() && is_main_site() ) ) {
+			// If we're not on multisite, do nothing
+			$sites_path = '';
+		} elseif ( false !== stripos( $path, '/sites/' ) ) {
+			// If we maybe already have `/sites/` in the path, do nothing
+			$sites_path = '';
+		} else {
+			$sites_path = '/sites/' . get_current_blog_id();
+		}
+
+		$upload['path'] = constant( 'LOCAL_UPLOADS' ) . $sites_path . $upload['subdir'];
+		$upload['basedir'] = constant( 'LOCAL_UPLOADS' ) . $sites_path;
 
 		return $upload;
 	}

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -235,7 +235,7 @@ class A8C_Files {
 		if ( ! is_multisite() || ( is_main_network() && is_main_site() ) ) {
 			// If we're not on multisite, do nothing
 			$sites_path = '';
-		} elseif ( false !== stripos( $path, '/sites/' ) ) {
+		} elseif ( false !== stripos( $upload['subdir'], '/sites/' ) ) {
 			// If we maybe already have `/sites/` in the path, do nothing
 			$sites_path = '';
 		} else {

--- a/files/class-wp-filesystem-vip-uploads.php
+++ b/files/class-wp-filesystem-vip-uploads.php
@@ -29,21 +29,20 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 		$upload_dir = wp_get_upload_dir();
 		$upload_basedir = $upload_dir['basedir'];
 
-		// If not multisite OR the $path already contains `/sites/` do nothing
-		if ( ! is_multisite() || ( is_main_network() && is_main_site() && false === stripos( $sanitized_path, '/sites/' ) ) ) {
-			$sites_path = '';
-		} else {
-			$sites_path = '/sites/' . get_current_blog_id();
+		// Leave everything alone if we're not on multisite or the $upload_basedir doesn't include '/sites/'
+		if ( is_multisite() && false !== stripos( $upload_basedir, '/sites/' ) ) {
+			// Strip the $upload_basedir back down to /tmp/uploads so we can write to any folder we'd like
+			$upload_basedir = implode( '/', array_slice( explode( '/', $upload_basedir ), 0, 3 ) );
 		}
 
 		// WP_CONTENT_DIR and wp_get_upload_dir() may not be the same.
 		// So we handle them separately.
 		if ( 0 === stripos( $sanitized_path, $upload_basedir ) ) {
 			$sanitized_path = str_ireplace( $upload_basedir, '', $sanitized_path );
-			$sanitized_path = '/wp-content/uploads' . $sites_path . $sanitized_path;
+			$sanitized_path = '/wp-content/uploads' . $sanitized_path;
 		} elseif ( 0 === stripos( $sanitized_path, $wp_content_dir ) ) {
 			$sanitized_path = str_ireplace( $wp_content_dir, '', $sanitized_path );
-			$sanitized_path = '/wp-content' . $sites_path . $sanitized_path;
+			$sanitized_path = '/wp-content' . $sanitized_path;
 		}
 
 		// TODO: Should we fail for other paths?

--- a/files/class-wp-filesystem-vip-uploads.php
+++ b/files/class-wp-filesystem-vip-uploads.php
@@ -29,14 +29,21 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 		$upload_dir = wp_get_upload_dir();
 		$upload_basedir = $upload_dir['basedir'];
 
+		// If not multisite OR the $path already contains `/sites/` do nothing
+		if ( ! is_multisite() || ( is_main_network() && is_main_site() && false === stripos( $sanitized_path, '/sites/' ) ) ) {
+			$sites_path = '';
+		} else {
+			$sites_path = '/sites/' . get_current_blog_id();
+		}
+
 		// WP_CONTENT_DIR and wp_get_upload_dir() may not be the same.
 		// So we handle them separately.
 		if ( 0 === stripos( $sanitized_path, $upload_basedir ) ) {
 			$sanitized_path = str_ireplace( $upload_basedir, '', $sanitized_path );
-			$sanitized_path = '/wp-content/uploads' . $sanitized_path;
+			$sanitized_path = '/wp-content/uploads' . $sites_path . $sanitized_path;
 		} elseif ( 0 === stripos( $sanitized_path, $wp_content_dir ) ) {
 			$sanitized_path = str_ireplace( $wp_content_dir, '', $sanitized_path );
-			$sanitized_path = '/wp-content' . $sanitized_path;
+			$sanitized_path = '/wp-content' . $sites_path . $sanitized_path;
 		}
 
 		// TODO: Should we fail for other paths?

--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -68,10 +68,11 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 	}
 
 	private function is_uploads_path( $file_path ) {
-		$upload_dir  = wp_get_upload_dir();
-		$upload_base = $upload_dir['basedir'];
+		// This probably needs to be more robust as I'm not sure if there are ever scenarios where the uploads directory would _not_ be /tmp/uploads on VIP Go
+		// We just need to look for /tmp/uploads here - we don't really care about the /sites/{site_id} part to determine if it's an uploads path or not
+		$upload_path = trailingslashit( get_temp_dir() ) . 'uploads';
 
-		return 0 === strpos( $file_path, $upload_base );
+		return 0 === strpos( $file_path, $upload_path );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Working with the filesystem on VIP Go multisite is difficult to work with. In my testing, I was unable to place a file in `/wp-content/uploads/sites/{site_id}` and instead all files were placed in `/wp-content/uploads`. This makes storing site-specific files impossible on VIP Go. Plugins like Beaver Builder rely on being able to write to those folders to avoid potentially overwriting files from other sites on the network. Plugins like the newest version of Multilingual Press needs to be able to copy media files from one site on the network to another but are unable to do so.

I've updated the `upload_dir` filter in a8c-files.php respect multisite by adding in the `/sites/{site_id}` portion of the paths. By standardizing the output of `wp_get_upload_dir()`, I need to update `WP_Filesystem_VIP_Uploads->sanitize_uploads_path()` to allow access to both `/tmp/uploads` as well as `/tmp/uploads/sites/{any_site_id}`. Finally, `WP_Filesystem_VIP->is_uploads_path()` also needed to be updated to correctly determine the transport class that should be used for a given file path.

This code should be a good starting point for discussion about what needs to happen to improve the filesystem experience on VIP Go multisite.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR
1. Sandbox a VIP Go Multisite
1. Use the example code from the [VIP Documentation](https://vip.wordpress.com/documentation/using-wp_filesystem-instead-of-direct-file-access-functions/#example) to create new or copy existing files.
1. Verify that the created or copied files are in the expected location
