### PR TITLE
Prevent the JSON response from the `file_exists` call from being echoed.

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -248,7 +248,7 @@ class A8C_Files {
 
 		$ch = curl_init( $post_url );
 
-		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
+		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
 		curl_setopt( $ch, CURLOPT_HEADER, false );
 		curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
 		curl_setopt( $ch, CURLOPT_TIMEOUT, 10 );


### PR DESCRIPTION
There is no reason to echo the output from the call, especially since we now need to send additional information back from the check to the upcoming stream wrapper implementation.