### PR TITLE
Only init VIP Filesystem with FILES constants

### DIFF
--- a/vip-filesystem.php
+++ b/vip-filesystem.php
@@ -38,8 +38,11 @@ use Automattic\VIP\Files\VIP_Filesystem;
  * @since    1.0.0
  */
 function run_vip_filesystem() {
-	$plugin = new VIP_Filesystem();
-	$plugin->run();
+	// Only init if we have the necessary constants
+	if ( defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' ) ) {
+		$plugin = new VIP_Filesystem();
+		$plugin->run();
+	}
 }
 
 run_vip_filesystem();


### PR DESCRIPTION
To prevent breaking local environments where those are not set. The notices with WP_DEBUG can break uploads.

Temp fix until we deploy #1052