### PR TITLE
Only run phpcs once on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ php:
 
 env:
   matrix:
-    - WP_VERSION=latest WP_MULTISITE=0 DEPLOY_BRANCH=master
-    - WP_VERSION=latest WP_MULTISITE=1 DEPLOY_BRANCH=master
+    - WP_VERSION=latest WP_MULTISITE=0 DEPLOY_BRANCH=master RUN_PHPCS=1
+    - WP_VERSION=latest WP_MULTISITE=1 DEPLOY_BRANCH=master RUN_PHPCS=0
 
 addons:
   apt:
@@ -29,7 +29,9 @@ before_script:
 
 script:
   # Linting and unit tests
-  - make test
+  - make lint
+  - if [[ "$RUN_PHPCS" == "1" ]]; then make sniff; fi
+  - make phpunit
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 test: lint phpunit phpcs
 
+sniff: phpcs
+
 lint:
 	find . -name \*.php -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -d display_errors=stderr -l > /dev/null
 


### PR DESCRIPTION
No need to run multiple times for each separate test env which is a waste of time.

Fixes #1055 

## Verification

- Check Travis results
- Verify that only single site test has PHPCS run