### PR TITLE
Add filetype check to Stream Wrappers 

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -198,9 +198,9 @@ class API_Client {
 	 * @return string|WP_Error New unique filename
 	 */
 	public function get_unique_filename( $file_path ) {
-		$response = $this->call_api( $file_path, 'get', [
+		$response = $this->call_api( $file_path, 'GET', [
 			'headers' => [
-				'x-action' => 'unique_filename',
+				'X-Action' => 'unique_filename',
 			],
 		] );
 

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -188,4 +188,21 @@ class API_Client {
 		/* translators: 1: file path 2: HTTP status code */
 		return new WP_Error( 'is_file-failed', sprintf( __( 'Failed to check if file `%1$s` exists (response code: %2$d)' ), $file_path, $response_code ) );
 	}
+
+	public function get_unique_name( $file_path ) {
+		$response = $this->call_api( $file_path, 'get', [
+			'headers' => [
+				'x-action' => 'unique_filename',
+			],
+		] );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		$content = wp_remote_retrieve_body( $response );
+
+		return compact( 'response_code', 'content' );
+	}
 }

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -22,10 +22,10 @@ class VIP_Filesystem_Stream_Wrapper {
 	 * The VIP Files API Client
 	 *
 	 * @since   1.0.0
-	 * @access  protected
+	 * @access  public
 	 * @var     API_Client  VIP Files API Client
 	 */
-	protected $client;
+	public $client;
 
 	/**
 	 * The file resource fetched through the VIP Files API

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -177,17 +177,9 @@ class VIP_Filesystem {
 	 * @return  bool        True if filetype is supported. Else false
 	 */
 	private function check_filetype_with_backend( $filename ) {
-		$uploads = wp_upload_dir();
+		$upload_path = $this->get_upload_path();
 
-		$url_parts = wp_parse_url( $uploads['url'] . '/' . $filename );
-		$file_path = $url_parts['path'];
-		if ( is_multisite() ) {
-			$sanitized_file_path = Path_Utils::trim_leading_multisite_directory( $file_path, $this->get_upload_path() );
-			if ( false !== $sanitized_file_path ) {
-				$file_path = $sanitized_file_path;
-				unset( $sanitized_file_path );
-			}
-		}
+		$file_path = $upload_path . $filename;
 
 		$result = $this->stream_wrapper->client->get_unique_filename( $file_path );
 
@@ -202,10 +194,7 @@ class VIP_Filesystem {
 	}
 
 	private function get_upload_path() {
-		$upload_path = trim( get_option( 'upload_path' ) );
-		if ( empty( $upload_path ) )
-			return 'wp-content/uploads';
-		else
-			return $upload_path;
+		$upload_dir_path = wp_get_upload_dir()['path'];
+		return ltrim( $upload_dir_path. self::PROTOCOL . '://' );
 	}
 }

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -93,6 +93,18 @@ class VIP_Filesystem {
 	}
 
 	/**
+	 * Remove the registered filters.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function remove_filters() {
+
+		remove_filter( 'upload_dir', [ $this, 'filter_upload_dir' ], 10 );
+		remove_filter( 'wp_check_filetype_and_ext', array( $this, 'filter_filetype_check' ), 10 );
+	}
+
+	/**
 	 * Filter the result of `wp_upload_dir` function
 	 *
 	 * @since 1.0.0
@@ -170,13 +182,13 @@ class VIP_Filesystem {
 	 * by the VIP Filesystem.
 	 *
 	 * @since   1.0.0
-	 * @access  private
+	 * @access  protected
 	 *
 	 * @param   string      $filename
 	 *
 	 * @return  bool        True if filetype is supported. Else false
 	 */
-	private function check_filetype_with_backend( $filename ) {
+	protected function check_filetype_with_backend( $filename ) {
 		$upload_path = $this->get_upload_path();
 
 		$file_path = $upload_path . $filename;

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -153,7 +153,7 @@ class VIP_Filesystem {
 
 		// Setting `ext` and `type` to empty will fail the upload because Go doesn't allow unfiltered uploads
 		// See `_wp_handle_upload()`
-		if ( $this->check_filetype_with_backend( $filename ) ) {
+		if ( ! $this->check_filetype_with_backend( $filename ) ) {
 			$filetype_data['ext']             = '';
 			$filetype_data['type']            = '';
 			// Never set this true, which leaves filename changing to dedicated methods in this class

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -132,9 +132,9 @@ class VIP_Filesystem {
 	}
 
 	/**
-	 * Check filetype support against Mogile
+	 * Check filetype support against VIP Filesystem API
 	 *
-	 * Leverages Mogile backend, which will return a 406 or other non-200 code if the filetype is unsupported
+	 * Leverages VIP Filesystem API, which will return a 406 or other non-200 code if the filetype is unsupported
 	 *
 	 * @since   1.0.0
 	 * @access  public
@@ -164,7 +164,8 @@ class VIP_Filesystem {
 	}
 
 	private function check_uniqueness_with_backend( $filename ) {
-		if ( ! ( ( $uploads = wp_upload_dir() ) && false === $uploads['error'] ) ) {
+		$uploads = wp_upload_dir();
+		if ( ! (  $uploads && false === $uploads['error'] ) ) {
 			$file['error'] = $uploads['error'];
 			return $file;
 		}
@@ -179,6 +180,8 @@ class VIP_Filesystem {
 			}
 		}
 
-		$result = $this->stream_wrapper->client->get_file( $file_path );
+		$result = $this->stream_wrapper->client->get_unique_name( $file_path );
+
+		return $result;
 	}
 }

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -178,10 +178,6 @@ class VIP_Filesystem {
 	 */
 	private function check_filetype_with_backend( $filename ) {
 		$uploads = wp_upload_dir();
-		if ( ! (  $uploads && false === $uploads[ 'error' ] ) ) {
-			trigger_error( $uploads[ 'error' ], E_USER_WARNINNG );
-			return false;
-		}
 
 		$url_parts = wp_parse_url( $uploads['url'] . '/' . $filename );
 		$file_path = $url_parts['path'];

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -195,6 +195,6 @@ class VIP_Filesystem {
 
 	private function get_upload_path() {
 		$upload_dir_path = wp_get_upload_dir()['path'];
-		return ltrim( $upload_dir_path. self::PROTOCOL . '://' );
+		return substr( $upload_dir_path, strlen( self::PROTOCOL . '://' ) );
 	}
 }

--- a/tests/files/test-api-client.php
+++ b/tests/files/test-api-client.php
@@ -454,4 +454,41 @@ class API_Client_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $upload_path, $actual_result );
 	}
 
+	public function get_test_data__get_unique_filename() {
+		return [
+			'new-unique-filename' => [
+				[
+					'response' => [
+						'code' => 200,
+					],
+					'body' => '{"filename":"uniquename.jpg"}',
+				],
+				'uniquename.jpg'
+			],
+			'invalid-type' => [
+				[
+					'response' => [
+						'code' => 406,
+					]
+				],
+				new WP_Error('invalid-file-type',
+					'Failed to generate new unique file name `/wp-content/uploads/file.jpg` (response code: 406)'),
+			],
+			'WP_Error' => [
+				new WP_Error( 'oh-no', 'Oh no!' ),
+				new WP_Error( 'oh-no', 'Oh no!' ),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__get_unique_filename
+	 */
+	public function test__get_unique_filename( $mocked_response, $expected_result ) {
+		$this->mock_http_response( $mocked_response );
+
+		$actual_result = $this->api_client->get_unique_filename( '/wp-content/uploads/file.jpg' );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
 }

--- a/tests/files/test-api-client.php
+++ b/tests/files/test-api-client.php
@@ -491,4 +491,18 @@ class API_Client_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected_result, $actual_result );
 	}
+
+	public function test__get_unique_filename__validate_request() {
+		$this->mock_http_response( [] ); // don't care about the response
+
+		$this->api_client->get_unique_filename( '/wp-content/uploads/file.jpg' );
+
+		$actual_http_request = reset( $this->http_requests );
+
+		$this->assertEquals( 'https://files.go-vip.co/wp-content/uploads/file.jpg', $actual_http_request['url'], 'Incorrect API URL' );
+		$this->assertEquals( 'GET', $actual_http_request['args']['method'], 'Incorrect HTTP method' );
+		$this->assertArraySubset( [
+			'X-Action' => 'unique_filename'
+		], $actual_http_request['args']['headers'], 'Missing `X-Action` header' );
+	}
 }

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Automattic\VIP\Files;
+
+use WP_Error;
+use WP_UnitTestCase;
+
+class VIP_Filesystem_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var     VIP_Filesystem
+	 */
+	protected $vip_filesystem;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once( __DIR__ . '/../../files/class-vip-filesystem.php' );
+
+		// make sure needed constants are defined
+		if ( ! defined( 'LOCAL_UPLOADS' ) ) {
+			define( 'LOCAL_UPLOADS', '/tmp/uploads' );
+		}
+		if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+			define( 'WP_CONTENT_DIR', '/tmp/wordpress/wp-content' );
+		}
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->vip_filesystem = new VIP_Filesystem();
+
+		// add the filters for upload dir tests
+		$add_filters = self::get_method( 'add_filters' );
+		$add_filters->invoke( $this->vip_filesystem );
+	}
+
+	public function tearDown() {
+		// remove the filters
+		$remove_filters = self::get_method( 'remove_filters' );
+		$remove_filters->invoke( $this->vip_filesystem );
+
+		$this->vip_filesystem = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper function for accessing protected methods.
+	 */
+	protected static function get_method( $name ) {
+		$class = new \ReflectionClass( __NAMESPACE__ . '\VIP_Filesystem' );
+		$method = $class->getMethod( $name );
+		$method->setAccessible( true );
+		return $method;
+	}
+
+	public function get_test_data__filter_upload_dir() {
+		return [
+			'local-uploads' => [
+				[
+					'path' => LOCAL_UPLOADS . '/2019/1',
+					'url' => 'http://test.com/wp-content/uploads/2019/1',
+					'subdir' => '/2019/1',
+					'basedir' => LOCAL_UPLOADS,
+				],
+				[
+					'path' => 'vip://wp-content/uploads/2019/1',
+					'url' => 'http://test.com/wp-content/uploads/2019/1',
+					'subdir' => '/2019/1',
+					'basedir' => 'vip://wp-content/uploads'
+				],
+			],
+			'wp-content' => [
+				[
+					'path' => WP_CONTENT_DIR . '/uploads/2019/1',
+					'url' => 'http://test.com/wp-content/uploads/2019/1',
+					'subdir' => '/2019/1',
+					'basedir' => WP_CONTENT_DIR . '/uploads'
+				],
+				[
+					'path' => 'vip://wp-content/uploads/2019/1',
+					'url' => 'http://test.com/wp-content/uploads/2019/1',
+					'subdir' => '/2019/1',
+					'basedir' => 'vip://wp-content/uploads'
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__filter_upload_dir
+	 */
+	public function test__filter_upload_dir( $params, $expected ) {
+		$actual = $this->vip_filesystem->filter_upload_dir( $params );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test__filter_filetype_check() {
+		$stub = $this->getMockBuilder( VIP_Filesystem::class )
+				->setMethods( [ 'check_filetype_with_backend' ] )
+				->getMock();
+
+		$stub->expects( $this->once() )
+				->method( 'check_filetype_with_backend' )
+				->with( 'somefile.jpg' )
+				->will( $this->returnValue( true ) );
+
+		$expected = [
+			'ext' => '.jpg',
+			'type' => 'image/jpeg',
+			'proper_filename' => true,
+		];
+		$actual = $stub->filter_filetype_check( $expected, '/path/to/somefile.jpg', 'somefile.jpg', [] );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test__filter_filetype_check__invalid_file() {
+		$stub = $this->getMockBuilder( VIP_Filesystem::class )
+		             ->setMethods( [ 'check_filetype_with_backend' ] )
+		             ->getMock();
+
+		$stub->expects( $this->once() )
+		     ->method( 'check_filetype_with_backend' )
+		     ->with( 'somefile.jpg' )
+		     ->will( $this->returnValue( false ) );
+
+		$data = [
+			'ext' => '.jpg',
+			'type' => 'image/jpeg',
+			'proper_filename' => true,
+		];
+		$expected = [
+			'ext' => '',
+			'type' => '',
+			'proper_filename' => false,
+		];
+		$actual = $stub->filter_filetype_check( $data, '/path/to/somefile.jpg', 'somefile.jpg', [] );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test__get_upload_path() {
+		$get_upload_path = self::get_method( 'get_upload_path' );
+
+		$actual = $get_upload_path->invoke( $this->vip_filesystem );
+
+		$this->assertNotContains( 'vip://', $actual );
+	}
+}


### PR DESCRIPTION
## Description

Add the required filter hooks for the new Filesystem Stream Wrapper plugin
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
