### PR TITLE
Enable srcset for all VIP Go Production sites

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -881,7 +881,7 @@ function is_vip_go_srcset_enabled() {
 		return '0' === $_GET['disable_vip_srcset'];
 	}
 
-	$enabled = 1;
+	$enabled = true;
 
 	/**
 	 * Filters the default state of VIP Go File Service compatible srcset solution.

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -877,12 +877,11 @@ function wpcom_intermediate_sizes( $sizes ) {
  */
 function is_vip_go_srcset_enabled() {
 	// Allow override via querystring for easy testing
-	if ( isset( $_GET['enable_vip_srcset'] ) ) {
-		return '1' === $_GET['enable_vip_srcset'];
+	if ( isset( $_GET['disable_vip_srcset'] ) ) {
+		return '0' === $_GET['disable_vip_srcset'];
 	}
 
-	// For now, default to enabled on non-production environments only.
-	$enabled = ( defined( 'VIP_GO_ENV' ) && 'production' !== constant( 'VIP_GO_ENV' ) );
+	$enabled = 1;
 
 	/**
 	 * Filters the default state of VIP Go File Service compatible srcset solution.


### PR DESCRIPTION
## Description
Lobby Post: https://lobby.vip.wordpress.com/2018/09/13/call-for-testing-responsive-images-coming-to-vip-go/

After a lengthy testing period, we are going to enable `srcset` for all production sites.

For testing purposes, you can now optionally disable `srcset` using the `disable_vip_srcset` query string.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Update the `a8c-files.php` on your Sandbox.
2. Check images on your sandbox and make sure they look as expected
3. Inspect the source of the images to make sure the `srcset` sizes are present.
4. Add `?disable_image_sizes` to your URL to check to see if disabling works.