### PR TITLE
Don't process images with missing metadata

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -911,6 +911,13 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 		return $data;
 	}
 
+	// Missing some critical data we need to determine sizes, so bail
+	if ( ! isset( $data['file'] )
+	    || ! isset( $data['width'] )
+	    || ! isset( $data['height'] ) {
+		return $data;    
+	}
+	
 	$mime_type = get_post_mime_type( $attachment_id );
 	$attachment_is_image = preg_match( '!^image/!', $mime_type );
 

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -900,6 +900,10 @@ function is_vip_go_srcset_enabled() {
  * @return array Attachment metadata.
  */
 function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
+	// Can't do much if data is empty
+	if ( empty( $data ) ) {
+		return $data;
+	}
 
 	$sizes_already_exist = (
 		true === is_array( $data )

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -914,7 +914,7 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 	// Missing some critical data we need to determine sizes, so bail
 	if ( ! isset( $data['file'] )
 	    || ! isset( $data['width'] )
-	    || ! isset( $data['height'] ) {
+	    || ! isset( $data['height'] ) ) {
 		return $data;    
 	}
 	


### PR DESCRIPTION
If an attachment doesn't have the appropriate meta (width/height/file), we can't really resize it, and we should skip attempting to process it anyway.

Prevents warnings that are triggering because of this:

```
Warning: Illegal string offset 'width' in /var/www/wp-content/mu-plugins/files/class-image.php on line 48 [wp-content/mu-plugins/files/class-image-sizes.php:31 Automattic\VIP\Files\Image->__construct(), wp-content/mu-plugins/a8c-files.php:918 Automattic\VIP\Files\ImageSizes->__construct(), wp-includes/class-wp-hook.php:286 a8c_files_maybe_inject_image_sizes() ... ]
```