### PR TITLE
Add Stream Wrapper purge cache on delete

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -286,7 +286,9 @@ class VIP_Filesystem {
 }
 
 	/**
-	 * Strip query string to avoid attempting to delete the aforementioned image sizes
+	 * Get the file path URI
+	 *
+	 * Strip query string and `vip` protocol to avoid attempting to delete the aforementioned image sizes
 	 *
 	 * @since   1.0.0
 	 * @access  private
@@ -296,7 +298,7 @@ class VIP_Filesystem {
 	 * @return  string
 	 */
 	private function get_file_uri_path( $file_path ) {
-		$url      = wp_parse_url( $file_path );
+		$url = wp_parse_url( $file_path );
 
 		// Adding the leading slash because `wp_parse_url` reads the `wp-content` part
 		// of the path as `host` without any slashes

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -243,8 +243,7 @@ class VIP_Filesystem {
 			return;
 		}
 
-		if (! unlink( $file_path ) ) {
-			// failed deleting
+		if ( ! unlink( $file_path ) ) {
 			return;
 		}
 
@@ -254,7 +253,8 @@ class VIP_Filesystem {
 		// We successfully deleted the file, purge the file from the caches
 		$this->purge_file_cache( $file_uri );
 
-		// Don't return anything so that `wp_delete_file()` won't try to `unlink` again
+		// Return empty value so that `wp_delete_file()` won't try to `unlink` again
+		return false;
 	}
 
 	/**

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -238,7 +238,7 @@ class VIP_Filesystem {
 
 		$file_path = $this->clean_file_path( $file_path );
 
-		$file_uri  = $this->strip_query_args( $file_path );
+		$file_uri  = $this->get_file_uri_path( $file_path );
 
 		if ( in_array( $file_uri, $deleted_uris, true ) ) {
 			// This file has already been successfully deleted from the file service in this request
@@ -295,8 +295,11 @@ class VIP_Filesystem {
 	 *
 	 * @return  string
 	 */
-	private function strip_query_args( $file_path ) {
+	private function get_file_uri_path( $file_path ) {
 		$url      = wp_parse_url( $file_path );
+
+		// Adding the leading slash because `wp_parse_url` reads the `wp-content` part
+		// of the path as `host` without any slashes
 		$file_uri = sprintf( '/%s%s', $url['host'], $url['path'] );
 
 		return $file_uri;

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -102,7 +102,8 @@ class VIP_Filesystem {
 	private function remove_filters() {
 
 		remove_filter( 'upload_dir', [ $this, 'filter_upload_dir' ], 10 );
-		remove_filter( 'wp_check_filetype_and_ext', array( $this, 'filter_filetype_check' ), 10 );
+		remove_filter( 'wp_check_filetype_and_ext', [ $this, 'filter_filetype_check' ], 10 );
+		remove_filter( 'wp_delete_file', [ $this, 'filter_delete_file' ], 20 );
 	}
 
 	/**

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -311,11 +311,7 @@ class VIP_Filesystem {
 	 * @param   string  $file_uri
 	 */
 	private function purge_file_cache( $file_uri ) {
-		$invalidation_url = get_site_url();
-		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
-			$invalidation_url .= '/sites/' . get_current_blog_id();
-		}
-		$invalidation_url .= $file_uri;
+		$invalidation_url = get_site_url() . $file_uri;
 
 		if ( ! \WPCOM_VIP_Cache_Manager::instance()->queue_purge_url( $invalidation_url ) ) {
 			trigger_error( sprintf( __( 'Error purging %s from the cache service' ), $invalidation_url ),

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -89,8 +89,8 @@ class VIP_Filesystem {
 	private function add_filters() {
 
 		add_filter( 'upload_dir', [ $this, 'filter_upload_dir' ], 10, 1 );
-		add_filter( 'wp_check_filetype_and_ext', array( $this, 'filter_filetype_check' ), 10, 4 );
-		add_filter( 'wp_delete_file', array( &$this, 'filter_delete_file' ), 20, 1 );
+		add_filter( 'wp_check_filetype_and_ext', [ $this, 'filter_filetype_check' ], 10, 4 );
+		add_filter( 'wp_delete_file', [ $this, 'filter_delete_file' ], 20, 1 );
 	}
 
 	/**

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -227,7 +227,9 @@ class VIP_Filesystem {
 	 * @since   1.0.0
 	 * @access  public
 	 *
-	 * @param   string      $file_path
+	 * @param   string $file_path
+	 *
+	 * @return  string
 	 */
 	public function filter_delete_file( $file_path ) {
 		// To ensure we don't needlessly fire off deletes for all sizes of the same image, of
@@ -240,11 +242,11 @@ class VIP_Filesystem {
 
 		if ( in_array( $file_uri, $deleted_uris, true ) ) {
 			// This file has already been successfully deleted from the file service in this request
-			return;
+			return '';
 		}
 
 		if ( ! unlink( $file_path ) ) {
-			return;
+			return '';
 		}
 
 		// Set our static so we can later recall that this file has already been deleted and purged
@@ -254,7 +256,7 @@ class VIP_Filesystem {
 		$this->purge_file_cache( $file_uri );
 
 		// Return empty value so that `wp_delete_file()` won't try to `unlink` again
-		return false;
+		return '';
 	}
 
 	/**

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -262,7 +262,7 @@ class VIP_Filesystem {
 		$deleted_uris[] = $file_uri;
 
 		// We successfully deleted the file, purge the file from the caches
-		$invalidation_url = get_site_url() . '/' . $this->get_upload_path();
+		$invalidation_url = get_site_url();
 		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
 			$invalidation_url .= '/sites/' . get_current_blog_id();
 		}

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -150,4 +150,52 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 
 		$this->assertNotContains( 'vip://', $actual );
 	}
+
+	public function get_test_data__clean_file_path() {
+		return [
+			'dirty path' => [
+				'vip://wp-content/uploads/vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768',
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768'
+			],
+			'clean path' => [
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768',
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768'
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__clean_file_path
+	 */
+	public function test__clean_file_path( $file_path, $expected ) {
+		$clean_file_path = self::get_method( 'clean_file_path' );
+
+		$actual = $clean_file_path->invokeArgs( $this->vip_filesystem, [ $file_path ] );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function get_test_data__get_file_uri_path() {
+		return [
+			'with query args' => [
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768',
+				'/wp-content/uploads/2019/01/IMG_4115.jpg'
+			],
+			'clean path' => [
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg',
+				'/wp-content/uploads/2019/01/IMG_4115.jpg'
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__get_file_uri_path
+	 */
+	public function test__get_file_uri_path( $file_path, $expected ) {
+		$get_file_uri_path = self::get_method( 'get_file_uri_path' );
+
+		$actual = $get_file_uri_path->invokeArgs( $this->vip_filesystem, [ $file_path ] );
+
+		$this->assertEquals( $expected, $actual );
+	}
 }


### PR DESCRIPTION
## Description

Add a filter to purge file from cache on delete.

Branched off of changes in #1061 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
