### PR TITLE
PHP 7.3 Compat: continue 3 for consistency

### DIFF
--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -814,7 +814,7 @@ class WPCOM_elasticsearch {
 
 						case 'month':
 							if ( empty( $_GET['year'] ) || empty( $_GET['monthnum'] ) ) {
-								continue;
+								continue 3;
 							}
 
 							$filters[] = array(
@@ -828,7 +828,7 @@ class WPCOM_elasticsearch {
 						case 'day':
 
 							if ( empty( $_GET['year'] ) || empty( $_GET['monthnum'] ) || empty( $_GET['day'] ) ) {
-								continue;
+								continue 3;
 							}
 
 							$filters[] = array(


### PR DESCRIPTION
`continue` is deprecated inside switch without a numeric identifier. Switch to `continue 3` to match the `year` case in `date_histogram`.

Fixes #1064 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).