### PR TITLE
Fix --yes flag on wp vip migration cleanup

### DIFF
--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -20,9 +20,10 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 		global $wpdb;
 
 		$dry_run = Utils\get_flag_value( $assoc_args, 'dry-run' );
+		$yes = Utils\get_flag_value( $assoc_args, 'yes' );
 		if ( $dry_run ) {
 			WP_CLI::log( 'Performing a dry run, with no database modification.' );
-		} else {
+		} else if ( ! $yes ) {
 			$env = defined( 'VIP_GO_ENV' ) ? VIP_GO_ENV : 'unknown';
 			WP_CLI::confirm( sprintf( 'Are you sure you want to run cleanup on the %s environment?', $env ) , $assoc_args );
 		}

--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -13,17 +13,17 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 	 * [--dry-run]
 	 * : Show changes without updating
 	 *
-	 * [--yes]
+	 * [--skip-confirm]
 	 * : Skip the confirmation prompt
 	 */
 	function cleanup( $args, $assoc_args ) {
 		global $wpdb;
 
 		$dry_run = Utils\get_flag_value( $assoc_args, 'dry-run' );
-		$yes = Utils\get_flag_value( $assoc_args, 'yes' );
+		$skip_confirm = Utils\get_flag_value( $assoc_args, 'skip-confirm' );
 		if ( $dry_run ) {
 			WP_CLI::log( 'Performing a dry run, with no database modification.' );
-		} else if ( ! $yes ) {
+		} else if ( ! $skip_confirm ) {
 			$env = defined( 'VIP_GO_ENV' ) ? VIP_GO_ENV : 'unknown';
 			WP_CLI::confirm( sprintf( 'Are you sure you want to run cleanup on the %s environment?', $env ) , $assoc_args );
 		}


### PR DESCRIPTION
This wires up the --yes option.

The documentation says --yes skips the confirmation, but it
didn't do anything before now.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Sandbox a site
1. Checkout this PR in mu-plugins
1. wp vip migration cleanup --yes
1. Verify the confirmation step is skipped