### PR TITLE
Prepare for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ git:
 
 php:
   - 7.2
+  - 7.3
 
 env:
   matrix:


### PR DESCRIPTION
Start testing against PHP 7.3 in Travis to prep for upgrade on Go.