### PR TITLE
Add file upload & delete stats

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -57,9 +57,10 @@ function track_file_upload() {
 	$stat_group = $using_streams ? 'stream' : 'a8c-files';
 
 	$pixel = add_query_arg( array(
-		'v'                     => 'wpcom-no-pv',
-		'x_vip-go-upload-via' => $stat_group,
-		'x_vip-go-upload-site' => FILES_CLIENT_SITE_ID,
+		'v' => 'wpcom-no-pv',
+		'x_vip-go-file-upload-via' => $stat_group,
+		'x_vip-go-file-upload' => FILES_CLIENT_SITE_ID,
+		'x_vip-go-file-action' => 'upload',
 	), 'http://pixel.wp.com/b.gif' );
 
 	wp_remote_get( $pixel, array(
@@ -86,9 +87,10 @@ function track_file_delete() {
 	$stat_group = $using_streams ? 'stream' : 'a8c-files';
 
 	$pixel = add_query_arg( array(
-		'v'                     => 'wpcom-no-pv',
-		'x_vip-go-delete-via' => $stat_group,
-		'x_vip-go-delete-site' => FILES_CLIENT_SITE_ID,
+		'v' => 'wpcom-no-pv',
+		'x_vip-go-file-delete-via' => $stat_group,
+		'x_vip-go-file-delete' => FILES_CLIENT_SITE_ID,
+		'x_vip-go-file-action' => 'delete',
 	), 'http://pixel.wp.com/b.gif' );
 
 	wp_remote_get( $pixel, array(

--- a/stats.php
+++ b/stats.php
@@ -12,8 +12,8 @@ namespace Automattic\VIP\Stats;
 // Limit tracking to production
 if ( true === WPCOM_IS_VIP_ENV && false === WPCOM_SANDBOXED ) {
 	add_action( 'async_transition_post_status', __NAMESPACE__ . '\track_publish_post', 9999, 2 );
-	add_action( 'wp_handle_upload', __NAMESPACE__ . '\track_file_upload', 9999, 2 );
-	add_action( 'wp_delete_file', __NAMESPACE__ . '\track_file_delete', 9999, 1 );
+	add_filter( 'wp_handle_upload', __NAMESPACE__ . '\handle_file_upload', 9999, 2 );
+	add_filter( 'wp_delete_file', __NAMESPACE__ . '\handle_file_delete', 9999, 1 );
 }
 
 /**
@@ -42,7 +42,13 @@ function track_publish_post( $new_status, $old_status ) {
 /**
  * Count uploaded files
  */
-function track_file_upload( $upload, $context ) {
+function handle_file_upload( $upload, $context ) {
+	track_file_upload();
+
+	return $upload;
+}
+
+function track_file_upload() {
 	$using_streams = false;
 	if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) ) {
 		$using_streams = (bool) VIP_FILESYSTEM_USE_STREAM_WRAPPER;
@@ -62,10 +68,16 @@ function track_file_upload( $upload, $context ) {
 	) );
 }
 
+function handle_file_delete( $file ) {
+	track_file_delete();
+
+	return $file;
+}
+
 /**
  * Count deleted files
  */
-function track_file_delete( $file ) {
+function track_file_delete() {
 	$using_streams = false;
 	if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) ) {
 		$using_streams = (bool) VIP_FILESYSTEM_USE_STREAM_WRAPPER;


### PR DESCRIPTION
## Description

Add new functions to track file uploads and deletes in MC Stats.

Should be able to track between the new Stream Wrapper file uploads and the older a8c-files uploads.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
