### PR TITLE
WP_Filesystem: Switch `uploads` paths to use WP_Filesystem_Direct

### DIFF
--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -42,7 +42,13 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 	 * @return WP_Filesystem_VIP_Uploads|bool|mixed|WP_Filesystem_Direct
 	 */
 	private function get_transport_for_path( $filename, $context = 'read' ) {
+		// Uploads paths can just use PHP functions when stream wrapper is enabled.
+		// This is because wp_upload_dir will return a vip:// path.
 		if ( $this->is_uploads_path( $filename ) ) {
+			if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER ) {
+				return $this->direct;
+			}
+
 			return $this->uploads;
 		} elseif ( $this->is_tmp_path( $filename ) ) {
 			return $this->direct;


### PR DESCRIPTION
When stream wrapper is enabled, we can just use PHP core functions for media. This is because wp_upload_dir will return a vip:// path.

## Checklist

- N/A This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- N/A This change has relevant unit tests (if applicable).
- N/A This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Sandbox a site.
1. Enable stream wrapper with `define( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER', true );`
1. `wp shell`
1. `wp_filesystem( request_filesystem_credentials( site_url() ) );
1. `$GLOBALS['wp_filesystem']->put_contents( 'vip://wp-content/uploads/testing.txt', 'Hello world' );`
1. `$GLOBALS['wp_filesystem']->get_contents( 'vip://wp-content/uploads/testing.txt' );` (should output "Hello World")
1. Disable stream wrapper.
1. Verify that earlier filesystem interactions continue to work.
