### PR TITLE
wp vip migration cleanup: Skip confirm for subsites

### DIFF
--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -42,7 +42,7 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 			$it = new \WP_CLI\Iterators\Table( $iterator_args );
 			foreach ( $it as $blog ) {
 				$url = $blog->domain . $blog->path;
-				$cmd = "--url={$url} vip migration cleanup";
+				$cmd = "--url={$url} vip migration cleanup --skip-confirm";
 
 				if ( $dry_run ) {
 					$cmd .= ' --dry-run';


### PR DESCRIPTION
We prompt for confirmation (or --skip-confirm is passed) when the command is first run. We shouldn't prompt for confirmation of every subsite as well.

## Testing

1. Sandbox a multisite
1. Run `wp vip migration cleanup`
1. Confirm that subsites don't prompt for additional confirmation