### PR TITLE
Set shorter timeouts for low-cost API calls

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -167,7 +167,9 @@ class API_Client {
 	}
 
 	public function delete_file( $file_path ) {
-		$response = $this->call_api( $file_path, 'DELETE' );
+		$response = $this->call_api( $file_path, 'DELETE', [
+			'timeout' => 2,
+		] );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -186,6 +188,7 @@ class API_Client {
 
 	public function is_file( $file_path, &$info = null ) {
 		$response = $this->call_api( $file_path, 'GET', [
+			'timeout' => 2,
 			'headers' => [
 				'X-Action' => 'file_exists',
 			],
@@ -220,6 +223,7 @@ class API_Client {
 	 */
 	public function get_unique_filename( $file_path ) {
 		$response = $this->call_api( $file_path, 'GET', [
+			'timeout' => 2,
 			'headers' => [
 				'X-Action' => 'unique_filename',
 			],


### PR DESCRIPTION
We don't need to use the default 10s timeout for all API calls. Some of them like `is_file` and `unique_filename` should be fast and we should set those timeouts accordingly.

Fixes #1089 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.