### PR TITLE
Add to file cache on get file request

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -163,7 +163,12 @@ class API_Client {
 			return new WP_Error( 'get_file-failed', sprintf( __( 'Failed to get file `%1$s` (response code: %2$d)' ), $file_path, $response_code ) );
 		}
 
-		return wp_remote_retrieve_body( $response );
+		$body = wp_remote_retrieve_body( $response );
+
+		// save to cache
+		$this->cache->cache_file( $file_path, $body );
+
+		return $body;
 	}
 
 	public function delete_file( $file_path ) {


### PR DESCRIPTION
## Description

Add file to local file cache on a `get_file` request to the Fileservice API

Fixes #1097 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
