### PR TITLE
Don't update the $wp_user_roles global

### DIFF
--- a/vip-helpers/vip-roles.php
+++ b/vip-helpers/vip-roles.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * Helper functions that make it easy to add roles for WordPress.com sites.
- *
- * We use the core API functions as well as modifying the $wp_user_roles global
- * in case roles are re-initialized and our mods are lost.
+ * Helper functions that make it easy to add roles for VIP sites.
  */
 
 /**
@@ -32,19 +29,10 @@ function wpcom_vip_get_role_caps( $role ) {
  * @param array $capabilities Key/value array of capabilities for the role
  */
 function wpcom_vip_add_role( $role, $name, $capabilities ) {
-	global $wp_user_roles;
-
 	$role_obj = get_role( $role );
 
 	if ( ! $role_obj ) {
 		add_role( $role, $name, $capabilities );
-
-		if ( ! isset( $wp_user_roles[ $role ] ) ) {
-			$wp_user_roles[ $role ] = array(
-				'name' => $name,
-				'capabilities' => $capabilities,
-			);
-		}
 
 		_wpcom_vip_maybe_refresh_current_user_caps( $role );
 	} else {
@@ -61,8 +49,6 @@ function wpcom_vip_add_role( $role, $name, $capabilities ) {
  * @param array $caps Key/value array of capabilities for this role
  */
 function wpcom_vip_merge_role_caps( $role, $caps ) {
-	global $wp_user_roles;
-
 	$role_obj = get_role( $role );
 
 	if ( ! $role_obj )
@@ -78,10 +64,6 @@ function wpcom_vip_merge_role_caps( $role, $caps ) {
 			$role_obj->remove_cap( $cap );
 	}
 
-	if ( isset( $wp_user_roles[ $role ] ) ) {
-		$wp_user_roles[ $role ][ 'capabilities' ] = array_merge( $current_caps, (array) $caps );
-	}
-
 	_wpcom_vip_maybe_refresh_current_user_caps( $role );
 }
 
@@ -94,18 +76,12 @@ function wpcom_vip_merge_role_caps( $role, $caps ) {
  * @param array $caps Key/value array of capabilities for this role
  */
 function wpcom_vip_override_role_caps( $role, $caps ) {
-	global $wp_user_roles;
-
 	$role_obj = get_role( $role );
 
 	if ( ! $role_obj )
 		return;
 
 	$role_obj->capabilities = (array) $caps;
-
-	if ( isset( $wp_user_roles[ $role ] ) ) {
-		$wp_user_roles[ $role ][ 'capabilities' ] = (array) $caps;
-	}
 
 	_wpcom_vip_maybe_refresh_current_user_caps( $role );
 }


### PR DESCRIPTION
This should be on the core / lower-level functions to do. Usage is also very rare.

Us overriding the global can lead to unexpected behaviour in multisite  contexts like switching blogs and overriding/removing core roles.

Updating it is not actually necessary since core tracks changes to role objects in the `wp_roles()` global instead.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).

## Steps to Test / Verify

- Start by verifying that the VIP Support roles are still there with the PR in place (`wp role list`).
- Add the `$wp_user_roles` global with some custom roles to `vip-config` and verify that the VIP Support roles are still there (again, `wp role list`).

Next, verify the previously broken flow doesn't break:

1. On a multisite install, make sure you have two sites.
1. Verify initial roles for both sites via `wp role list`
1. `wp shell`
1. Add a new role using our helper: ` wpcom_vip_add_role( 'testing-2', 'Testing 2', [] )`
1. Verify role was added successfully (can inspect `wp_roles()`).
1. Switch to different subsite: `switch_to_blog( 2 )` // where `2` is the ID
1. Add a new role using our helper: ` wpcom_vip_add_role( 'testing-3', 'Testing 3', [] )`
1. Verify role was added successfully and existing roles were retained (can inspect `wp_roles()` or run `wp role list`).

Repeat with `$wp_user_roles` global set.