### PR TITLE
Optimize Stream_Wrapper::stream_open

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -158,7 +158,10 @@ class API_Client {
 		}
 
 		$response_code = wp_remote_retrieve_response_code( $response );
-		if ( 200 !== $response_code ) {
+		if ( 404 === $response_code ) {
+			/* translators: 1: file path */
+			return new WP_Error( 'file-not-found', sprintf( __( 'The requested file `%1$s` does not exist (response code: 404)' ), $file_path ) );
+		} elseif ( 200 !== $response_code ) {
 			/* translators: 1: file path 2: HTTP status code */
 			return new WP_Error( 'get_file-failed', sprintf( __( 'Failed to get file `%1$s` (response code: %2$d)' ), $file_path, $response_code ) );
 		}

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -123,10 +123,10 @@ class VIP_Filesystem_Stream_Wrapper {
 	public function stream_open( $path, $mode, $options, &$opened_path ) {
 		$path = $this->trim_path( $path );
 
-		if ( $this->client->is_file( $path ) ) {
-			$result = $this->client->get_file( $path );
+		$result = $this->client->get_file( $path );
 
-			if ( is_wp_error( $result ) ) {
+		if ( is_wp_error( $result ) ) {
+			if ( 'file-not-found' !== $result->get_error_code() ) {
 				trigger_error(
 					sprintf( 'stream_open failed for %s with error: %s #vip-go-streams', $path, $result->get_error_message() ),
 					E_USER_WARNING
@@ -134,13 +134,12 @@ class VIP_Filesystem_Stream_Wrapper {
 				return false;
 			}
 
-			// Converts file contents into stream resource
-			$file = $this->string_to_resource( $result );
-		} else {
 			// File doesn't exist on File service so create new file
-			$file = $this->string_to_resource( '' );
+			$result = '';
 		}
 
+		// Converts file contents into stream resource
+		$file = $this->string_to_resource( $result );
 
 		// Get meta data
 		$meta = stream_get_meta_data( $file );

--- a/tests/files/test-api-client.php
+++ b/tests/files/test-api-client.php
@@ -283,7 +283,17 @@ class API_Client_Test extends \WP_UnitTestCase {
 					],
 					'body' => null,
 				],
-				new WP_Error( 'get_file-failed', 'Failed to get file `/wp-content/uploads/file.jpg` (response code: 404)' ),
+				new WP_Error( 'file-not-found', 'The requested file `/wp-content/uploads/file.jpg` does not exist (response code: 404)' ),
+			],
+
+			'other-bad-status' => [
+				[
+					'response' => [
+						'code' => 500,
+					],
+					'body' => null,
+				],
+				new WP_Error( 'get_file-failed', 'Failed to get file `/wp-content/uploads/file.jpg` (response code: 500)' ),
 			],
 
 			'file-exists' => [


### PR DESCRIPTION
Instead of doing two separate API calls (is_file and get_file), just do one and use the signal from get_file to determine if the file exists.

In the case where files don't exist, we'll still do 1 call as previously, but in the case where they do, we drop down the count from 2 to 1.

Fixes #1105

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

1. Check out PR.
1. `wp shell`
1. `file_put_contents( 'vip://wp-content/uploads/file-' . time() '.txt', 'testing ' . time() );`
1. Verify that works and that fetching the file returns the correct content.