### PR TITLE
Fix `wp --skip-plugins`

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -956,6 +956,10 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 		}
 	}
 
+	if ( ! wpcom_vip_should_load_plugins() ) {
+		return;
+	}
+
 	/**
 	 * wpcom compat
 	 *

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1138,6 +1138,29 @@ function wpcom_vip_can_use_shared_plugin( $plugin ) {
 }
 
 /**
+ * Helper function to check if we can load plugins or not.
+ */
+function wpcom_vip_should_load_plugins() {
+	static $should_load_plugins;
+
+	if ( isset( $should_load_plugins ) ) {
+		return $should_load_plugins;
+	}
+
+	$should_load_plugins = true;
+
+	// WP-CLI loaded with --skip-plugins flag
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		$skipped_plugins = \WP_CLI::get_runner()->config['skip-plugins'];
+		if ( $skipped_plugins ) {
+			$should_load_plugins = false;
+		}
+	}
+
+	return $should_load_plugins;
+}
+
+/**
  * Store the name of a VIP plugin that will be loaded
  *
  * @param string $plugin Plugin name and folder
@@ -1187,6 +1210,10 @@ function wpcom_vip_load_helpers_for_network_active_plugins() {
 		return;
 	}
 
+	if ( ! wpcom_vip_should_load_plugins() ) {
+		return;
+	}
+
 	foreach ( wp_get_active_network_plugins() as $plugin ) {
 		_wpcom_vip_include_plugin( $plugin );
 	}
@@ -1199,6 +1226,10 @@ add_action( 'muplugins_loaded', 'wpcom_vip_load_helpers_for_network_active_plugi
  * Technically tries to include the main plugin file again, but we don't care, because it uses `include_once()` and is called after Core loads the plugin
  */
 function wpcom_vip_load_helpers_for_sites_core_plugins() {
+	if ( ! wpcom_vip_should_load_plugins() ) {
+		return;
+	}
+
 	foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
 		_wpcom_vip_include_plugin( $plugin );
 	}

--- a/z-client-mu-plugins.php
+++ b/z-client-mu-plugins.php
@@ -112,8 +112,11 @@ function wpcom_vip_filter_client_mu_plugins_url( $url, $url_path, $plugin_path )
 }
 add_filter( 'plugins_url', 'wpcom_vip_filter_client_mu_plugins_url', 10, 3 );
 
-// Let's load the plugins
-foreach ( wpcom_vip_get_client_mu_plugins() as $client_mu_plugin ) {
-	include_once( $client_mu_plugin );
+
+if ( wpcom_vip_should_load_plugins() ) {
+	// Let's load the plugins
+	foreach ( wpcom_vip_get_client_mu_plugins() as $client_mu_plugin ) {
+		include_once( $client_mu_plugin );
+	}
+	unset( $client_mu_plugin );
 }
-unset( $client_mu_plugin );


### PR DESCRIPTION
Leads to unnecessarily loading plugins which can sometimes break WP-CLI because of unexpected fatals. This also defeats the purpose of the skip-plugins flag.

We're now preventing breaking WP-CLI by skipping plugin loading when that context is set.

Fixes #1069 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

*Scenario 1: UI-activated plugin with fatal*

1. Add a plugin and activate via UI (wp-admin > Plugins)
1. Add a fatal to the main plugin file (e.g. `poop();`)
1. Call `wp shell --skip-plugins`.and verify that shell loads without error. Previously, this would fatal.
1. Call `wp shell` and verify that it fatals.

*Scenario 2: client-mu-plugin with fatal*

1. Add a client-mu-plugin file.
1. Add a fatal to the plugin file (e.g. `poop();`)
1. Call `wp shell --skip-plugins` and verify that shell loads without error. Previously, this would fatal.
1. Call `wp shell` and verify that it fatals.

*Scenario 1: UI-activated plugin with fatal*

1. Add a plugin and activate via code (`wpcom_vip_load_plugin( 'my-plugin' );`)
1. Add a fatal to the main plugin file (e.g. `poop();`)
1. Call `wp shell --skip-plugins` and verify that shell loads without error. Previously, this would fatal.
1. Call `wp shell` and verify that it fatals.