### PR TITLE
Register Stream Wrapper `init` hook earlier

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -935,7 +935,7 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 
 if ( defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' ) ) {
 	// Kick things off
-	add_action( 'init', 'a8c_files_init' );
+	add_action( 'muplugins_loaded', 'a8c_files_init' );
 
 	// Disable automatic creation of intermediate image sizes.
 	// We generate them on-the-fly on VIP.

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -935,7 +935,7 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 
 if ( defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' ) ) {
 	// Kick things off
-	add_action( 'muplugins_loaded', 'a8c_files_init' );
+	a8c_files_init();
 
 	// Disable automatic creation of intermediate image sizes.
 	// We generate them on-the-fly on VIP.


### PR DESCRIPTION
## Description

Move a8c files init to use the `muplugins_loaded` hook instead of `init`.

Fixes #1104 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
