### PR TITLE
Disable stream wrapper on AMS

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -39,9 +39,9 @@ class A8C_Files {
 
 		// Conditionally load either the new Stream Wrapper implementation or old school a8c-files.
 		// The old school implementation will be phased out soon.
-		// NOTE: Temporarily disable Stream Wrapper loading for sites on AMS
-		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER &&
-				'ams-files.vipv2.net' !== FILE_SERVICE_ENDPOINT ) {
+		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER
+			// NOTE: Temporarily disable Stream Wrapper loading for sites on AMS as it's not ready for use there
+			&& 'ams-files.vipv2.net' !== FILE_SERVICE_ENDPOINT ) {
 			$this->init_vip_filesystem();
 		} else {
 			$this->init_legacy_filesystem();

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -39,7 +39,9 @@ class A8C_Files {
 
 		// Conditionally load either the new Stream Wrapper implementation or old school a8c-files.
 		// The old school implementation will be phased out soon.
-		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER ) {
+		// NOTE: Temporarily disable Stream Wrapper loading for sites on AMS
+		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER &&
+				'ams-files.vipv2.net' !== FILE_SERVICE_ENDPOINT ) {
 			$this->init_vip_filesystem();
 		} else {
 			$this->init_legacy_filesystem();


### PR DESCRIPTION
## Description

Don't allow use of Stream Wrappers for sites hosted on AMS.

Fixes #1103 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
