### PR TITLE
Add debug log for API client

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -264,8 +264,8 @@ class API_Client {
 	private function log_request( $path, $method, $rquest_args ): void {
 		$x_action = '';
 
-		if ( isset( $rquest_args['headers'] ) && isset( $rquest_args['headers']['X-Action'] ) ) {
-			$x_action = $rquest_args['headers']['X-Action'];
+		if ( isset( $request_args['headers'] ) && isset( $request_args['headers']['X-Action'] ) ) {
+			$x_action = $request_args['headers']['X-Action'];
 		}
 
 		trigger_error(

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -76,6 +76,13 @@ class API_Client {
 
 		$response = wp_remote_request( $request_url, $request_args );
 
+		// Debug log
+		if ( defined( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) ||
+		     true === constant( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) )
+		{
+			$this->log_request( $path, $method, $request_args );
+		}
+
 		return $response;
 	}
 
@@ -252,5 +259,21 @@ class API_Client {
 		$obj = json_decode( $content );
 
 		return $obj->filename;
+	}
+
+	private function log_request( $path, $method, $rquest_args ): void {
+		$x_action = '';
+
+		if ( isset( $rquest_args['headers'] ) && isset( $rquest_args['headers']['X-Action'] ) ) {
+			$x_action = $rquest_args['headers']['X-Action'];
+		}
+
+		trigger_error(
+			sprintf( 'method:%s, path:%s, X-Action:%s #vip-go-streams-debug',
+				$method,
+				$path,
+				$x_action
+			), E_USER_NOTICE
+		);
 	}
 }

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -77,7 +77,7 @@ class API_Client {
 		$response = wp_remote_request( $request_url, $request_args );
 
 		// Debug log
-		if ( defined( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) ||
+		if ( defined( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) &&
 		     true === constant( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) )
 		{
 			$this->log_request( $path, $method, $request_args );

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -261,7 +261,7 @@ class API_Client {
 		return $obj->filename;
 	}
 
-	private function log_request( $path, $method, $rquest_args ): void {
+	private function log_request( $path, $method, $request_args ) {
 		$x_action = '';
 
 		if ( isset( $request_args['headers'] ) && isset( $request_args['headers']['X-Action'] ) ) {


### PR DESCRIPTION
## Description

Debug log for the VIP Filesystem API Client. Depends on the `VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG` constant to be set to `true`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
