### PR TITLE
Allow E_USER_NOTICE for debugging in API Client

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -261,7 +261,19 @@ class API_Client {
 		return $obj->filename;
 	}
 
+	// Allow E_USER_NOTICE to be logged since WP blocks it by default.
+	private function allow_E_USER_NOTICE() {
+		static $updated_error_reporting = false;
+		if ( ! $updated_error_reporting ) {
+			$current_reporting_level = error_reporting();
+			error_reporting( $current_reporting_level | E_USER_NOTICE );
+			$updated_error_reporting = true;
+		}
+	}
+
 	private function log_request( $path, $method, $request_args ) {
+		$this->allow_E_USER_NOTICE();
+
 		$x_action = '';
 
 		if ( isset( $request_args['headers'] ) && isset( $request_args['headers']['X-Action'] ) ) {

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -277,11 +277,11 @@ class API_Client {
 		$x_action = '';
 
 		if ( isset( $request_args['headers'] ) && isset( $request_args['headers']['X-Action'] ) ) {
-			$x_action = $request_args['headers']['X-Action'];
+			$x_action = ' | X-Action:' . $request_args['headers']['X-Action'];
 		}
 
 		trigger_error(
-			sprintf( 'method:%s, path:%s, X-Action:%s #vip-go-streams-debug',
+			sprintf( 'method:%s | path:%s%s #vip-go-streams-debug',
 				$method,
 				$path,
 				$x_action


### PR DESCRIPTION
By default, WordPress skips them via error_reporting, which is causing our trigger_error calls to be useless. If debugging is enabled for stream wrappers, we're now allowing E_USER_NOTICE so the debug gets tracked properly.

Previously #1114 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

1. With `define( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG', false )`, verify that nothing is logged when browsing attachment pages and uploading and deleting files.
1. With `define( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG', true )` and `define( 'WP_DEBUG', false );`, verify that nothing is logged when browsing attachment pages and uploading and deleting files.
1. With `define( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG', true )` and `define( 'WP_DEBUG', true );` verify that API client actions are logged as notices.