### PR TITLE
Store the filesize in meta on upload

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -302,14 +302,23 @@ class VIP_Filesystem {
 		// Append the filesize if not already set to avoid continued dynamic API calls.
 		// The filesize doesn't change so it's okay to store it in meta.
 		if ( ! isset( $metadata['filesize'] ) ) {
-			$file = get_attached_file( $attachment_id );
-
-			if ( file_exists( $file ) ) {
-				$metadata['filesize'] = filesize( $file );
+			$filesize = $this->get_filesize_from_file( $attachment_id );
+			if ( false !== $filesize ) {
+				$metadata['filesize'] = $filesize;
 			}
 		}
 
 		return $metadata;
+	}
+
+	private function get_filesize_from_file( $attachment_id ) {
+		$file = get_attached_file( $attachment_id );
+
+		if ( ! file_exists( $file ) ) {
+			return false;
+		}
+
+		return filesize( $file );
 	}
 
 	/**

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -92,6 +92,7 @@ class VIP_Filesystem {
 		add_filter( 'wp_check_filetype_and_ext', [ $this, 'filter_filetype_check' ], 10, 4 );
 		add_filter( 'wp_delete_file', [ $this, 'filter_delete_file' ], 20, 1 );
 		add_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20, 2 );
+		add_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ], 10, 2 );
 	}
 
 	/**
@@ -106,6 +107,7 @@ class VIP_Filesystem {
 		remove_filter( 'wp_check_filetype_and_ext', [ $this, 'filter_filetype_check' ], 10 );
 		remove_filter( 'wp_delete_file', [ $this, 'filter_delete_file' ], 20 );
 		remove_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20 );
+		remove_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ] );
 	}
 
 	/**
@@ -289,7 +291,26 @@ class VIP_Filesystem {
 		}
 
 		return $file_path;
-}
+	}
+
+	/**
+	 * Filters the generated attachment metdata
+	 *
+	 * @return array
+	 */
+	public function filter_wp_generate_attachment_metadata( $metadata, $attachment_id ) {
+		// Append the filesize if not already set to avoid continued dynamic API calls.
+		// The filesize doesn't change so it's okay to store it in meta.
+		if ( ! isset( $metadata['filesize'] ) ) {
+			$file = get_attached_file( $attachment_id );
+
+			if ( file_exists( $file ) ) {
+				$metadata['filesize'] = filesize( $file );
+			}
+		}
+
+		return $metadata;
+	}
 
 	/**
 	 * Get the file path URI

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -6,6 +6,7 @@ use WP_Error;
 use WP_UnitTestCase;
 
 class VIP_Filesystem_Test extends WP_UnitTestCase {
+	const TEST_IMAGE_PATH = VIP_GO_MUPLUGINS_TESTS__DIR__ . '/fixtures/image.jpg';
 
 	/**
 	 * @var     VIP_Filesystem
@@ -226,5 +227,41 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		$actual = $this->vip_filesystem->filter_get_attached_file( $args[ 'file' ], $args[ 'attachment_id' ] );
 
 		$this->assertEquals( $expected, $actual );
+	}
+
+	public function get_test_data__filter_wp_generate_attachment_metadata() {
+		return [
+			'filesize-not-set' => [
+				[],
+				[
+					'filesize' => 6941712,
+				],
+			],
+
+			'filesize-already-set' => [
+				[
+					'filesize' => 1234,
+				],
+				[
+					'filesize' => 1234,
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__filter_wp_generate_attachment_metadata
+	 */
+	public function test__filter_wp_generate_attachment_metadata( $initial_metadata, $expected_metadata ) {
+		// Remove filters as they conflict with the logic in our filter function below.
+		// We don't have a test-specific wrapper that we can fall back to.
+		$remove_filters = self::get_method( 'remove_filters' );
+		$remove_filters->invoke( $this->vip_filesystem );
+
+		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+
+		$actual_metadata = $this->vip_filesystem->filter_wp_generate_attachment_metadata( $initial_metadata, $attachment_id );
+
+		$this->assertEquals( $expected_metadata, $actual_metadata );
 	}
 }


### PR DESCRIPTION
To avoid the need to do repeated checks against the API anytime the filesize for an attachment is needed.

With stream wrappers, we end up making lots of API calls for `filesize` because core functions (like `prepare_attachment_for_js` will attempt to use it). This cuts down the load on the API quite a bit.

Fixes #695

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests

## Steps to Test

1. Enable stream wrapper: `define( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER', true );`
1. Upload a file
1. Verify that the edit attachment page displays the filesize but not HTTP calls are triggered.
1. Call `wp_get_attachment_metadata` for the metadata and verify that the filesize is stored.