### PR TITLE
Vary Cache: Simplify logic for is_user_in_group

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -96,29 +96,42 @@ class Vary_Cache {
 	}
 
 	/**
-	 * Checks if the request has some in with agroup cookie matching a given group and optionally a value
+	 * Checks if the request has a group cookie matching a given group, regardless of segment value.
 	 *
 	 * @param  string $group Group name.
-	 * @param  string $value (optional) Which segment within the group to check? Omit to check if the user is in the group at all.
 	 *
 	 * @return bool   True on success. False on failure.
 	 */
-	public static function is_user_in_group( $group, $value = null ) {
+	public static function is_user_in_group( $group ) {
 		self::parse_group_cookie();
 
 		// The group isn't defined, or the user isn't in it.
-		if ( ! isset( self::$groups[ $group ] ) || null === self::$groups[ $group ] ) {
+		if ( ! array_key_exists( $group, self::$groups ) ) {
 			return false;
 		}
 
-		// The user is the group, and we don't care about the specific segment.
-		if ( null === $value ) {
-			return true;
+		return true;
+	}
+
+	/**
+	 * Checks if the request has a group cookie matching a given group and segment. e.g. 'dev-group', 'yes'
+	 *
+	 * @param  string $group Group name.
+	 * @param  string $segment Which segment within the group to check.
+	 *
+	 * @return bool   True on success. False on failure.
+	 */
+	public static function is_user_in_group_segment( $group, $segment ) {
+		self::parse_group_cookie();
+
+		if ( ! self::is_user_in_group( $group ) ) {
+			return false;
 		}
 
 		// Check for a specific group segment.
-		return self::$groups[ $group ] === $value;
+		return self::$groups[ $group ] === $segment;
 	}
+
 
 	/**
 	 * Returns the associated groups for the request.

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -116,7 +116,6 @@ class Vary_Cache {
 	public static function is_user_in_group( $group ) {
 		self::parse_group_cookie();
 
-		//var_dump( $group, self::$groups );
 		// The group isn't defined, or the user isn't in it.
 		if ( ! array_key_exists( $group, self::$groups ) ) {
 			return false;

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -61,7 +61,6 @@ class Vary_Cache {
 	 * @param  array $groups  One or more groups to vary on.
 	 */
 	public static function register_groups( $groups ) {
-		self::$groups = [];
 		if ( is_array( $groups ) ) {
 			foreach ( $groups as $group ) {
 				self::$groups[ $group ] = '';

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -107,7 +107,7 @@ class Vary_Cache {
 		self::parse_group_cookie();
 
 		// The group isn't defined, or the user isn't in it.
-		if ( empty( self::$groups[ $group ] ) ) {
+		if ( ! isset( self::$groups[ $group ] ) || null === self::$groups[ $group ] ) {
 			return false;
 		}
 

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -98,18 +98,26 @@ class Vary_Cache {
 	/**
 	 * Checks if the request has some in with agroup cookie matching a given group and optionally a value
 	 *
-	 * @param  string $group  Group name.
-	 * @param  string $value Optional - A value for the group.
+	 * @param  string $group Group name.
+	 * @param  string $value (optional) Which segment within the group to check? Omit to check if the user is in the group at all.
 	 *
 	 * @return bool   True on success. False on failure.
 	 */
-	public static function is_user_in_group( $group, $value ) {
+	public static function is_user_in_group( $group, $value = null ) {
 		self::parse_group_cookie();
-		if ( ! isset( self::$groups[ $group ] ) ) {
+
+		// The group isn't defined, or the user isn't in it.
+		if ( empty( self::$groups[ $group ] ) ) {
 			return false;
 		}
 
-		return ( null === $value ) || ( self::$groups[ $group ] === $value );
+		// The user is the group, and we don't care about the specific segment.
+		if ( null === $value ) {
+			return true;
+		}
+
+		// Check for a specific group segment.
+		return self::$groups[ $group ] === $value;
 	}
 
 	/**

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -61,6 +61,7 @@ class Vary_Cache {
 	 * @param  array $groups  One or more groups to vary on.
 	 */
 	public static function register_groups( $groups ) {
+		self::$groups = [];
 		if ( is_array( $groups ) ) {
 			foreach ( $groups as $group ) {
 				self::$groups[ $group ] = '';
@@ -70,6 +71,16 @@ class Vary_Cache {
 		}
 
 		self::parse_group_cookie();
+	}
+
+	/**
+	 * Clears out the groups and values
+	 *
+	 * @since   1.0.0
+	 * @access  public
+	 */
+	public static function clear_groups() {
+		self::$groups = [];
 	}
 
 	/**
@@ -105,6 +116,7 @@ class Vary_Cache {
 	public static function is_user_in_group( $group ) {
 		self::parse_group_cookie();
 
+		//var_dump( $group, self::$groups );
 		// The group isn't defined, or the user isn't in it.
 		if ( ! array_key_exists( $group, self::$groups ) ) {
 			return false;

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -30,7 +30,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		return $method;
 	}
 
-	public function get_test_data__is_user_in_group() {
+	public function get_test_data__is_user_in_group_segment() {
 		return [
 			'group-not-defined' => [
 				[],
@@ -45,14 +45,26 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 					'vip-go-seg' => 'design-group_--_yes',
 				],
 				[
-					'dev-group'
+					'dev-group',
 				],
 				'dev-group',
 				'yes',
 				false,
 			],
 
-			'user-in-group-and-any-segment' => [
+			'user-in-group-with-empty-segment' => [
+				[
+					'vip-go-seg' => 'dev-group_--_',
+				],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				'',
+				true,
+			],
+
+			'user-in-group-segment-but-searching-for-null' => [
 				[
 					'vip-go-seg' => 'dev-group_--_maybe',
 				],
@@ -61,7 +73,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				],
 				'dev-group',
 				null,
-				true,
+				false,
 			],
 
 			'user-in-group-but-different-segment' => [
@@ -102,14 +114,61 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		];
 	}
 
+	public function get_test_data__is_user_in_group() {
+		return [
+			'user-not-in-group' => [
+				[
+					'vip-go-seg' => 'design-group_--_yes',
+				],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				false,
+			],
+			'user-not-in-group' => [
+				[
+					'vip-go-seg' => 'dev-group_--_yes',
+				],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				true,
+			],
+			'user-in-group-and-empty-segment' => [
+				[
+					'vip-go-seg' => 'dev-group_--_',
+				],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				true,
+			],
+		];
+	}
+
 	/**
- 	 * @dataProvider get_test_data__is_user_in_group
+ 	 * @dataProvider get_test_data__is_user_in_group_segment
  	 */
-	public function test__is_user_in_group( $initial_cookie, $initial_groups, $test_group, $test_value, $expected_result ) {
+	public function test__is_user_in_group_segment( $initial_cookie, $initial_groups, $test_group, $test_value, $expected_result ) {
 		$_COOKIE = $initial_cookie;
 		Vary_Cache::register_groups( $initial_groups );
 
-		$actual_result = Vary_Cache::is_user_in_group( $test_group, $test_value );
+		$actual_result = Vary_Cache::is_user_in_group_segment( $test_group, $test_value );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	/**
+	 * @dataProvider get_test_data__is_user_in_group
+	 */
+	public function test__is_user_in_group( $initial_cookie, $initial_groups, $test_group, $expected_result ) {
+		$_COOKIE = $initial_cookie;
+		Vary_Cache::register_groups( $initial_groups );
+
+		$actual_result = Vary_Cache::is_user_in_group( $test_group );
 
 		$this->assertEquals( $expected_result, $actual_result );
 	}

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -11,7 +11,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-
+		Vary_Cache::clear_groups();
 		$this->original_COOKIE = $_COOKIE;
 	}
 
@@ -116,6 +116,12 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 	public function get_test_data__is_user_in_group() {
 		return [
+			'group-not-defined' => [
+				[],
+				[],
+				'dev-group',
+				false,
+			],
 			'user-not-in-group' => [
 				[
 					'vip-go-seg' => 'design-group_--_yes',

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Automattic\VIP\Cache;
+
+class Vary_Cache_Test extends \WP_UnitTestCase {
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once( __DIR__ . '/../../cache/class-vary-cache.php' );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->original_COOKIE = $_COOKIE;
+	}
+
+	public function tearDown() {
+		$_COOKIE = $this->original_COOKIE;
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper function for accessing protected methods.
+	 */
+	protected static function get_method( $name ) {
+		$class = new \ReflectionClass( __NAMESPACE__ . '\API_Client' );
+		$method = $class->getMethod( $name );
+		$method->setAccessible( true );
+		return $method;
+	}
+
+	public function get_test_data__is_user_in_group() {
+		return [
+			'group-not-defined' => [
+				[],
+				[],
+				'dev-group',
+				'yes',
+				false,
+			],
+
+			'user-not-in-group' => [
+				[
+					'vip-go-seg' => 'design-group_--_yes',
+				],
+				[
+					'dev-group'
+				],
+				'dev-group',
+				'yes',
+				false,
+			],
+
+			'user-in-group-and-any-segment' => [
+				[
+					'vip-go-seg' => 'dev-group_--_maybe',
+				],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				null,
+				true,
+			],
+
+			'user-in-group-but-different-segment' => [
+				[
+					'vip-go-seg' => 'dev-group_--_maybe',
+				],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				'yes',
+				false,
+			],
+
+			'user-in-group-and-same-segment' => [
+				[
+					'vip-go-seg' => 'dev-group_--_yes',
+				],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				'yes',
+				true,
+			],
+		];
+	}
+
+	/**
+ 	 * @dataProvider get_test_data__is_user_in_group
+ 	 */
+	public function test__is_user_in_group( $initial_cookie, $initial_groups, $test_group, $test_value, $expected_result ) {
+		$_COOKIE = $initial_cookie;
+		Vary_Cache::register_groups( $initial_groups );
+
+		$actual_result = Vary_Cache::is_user_in_group( $test_group, $test_value );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+}

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -45,7 +45,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 					'vip-go-seg' => 'design-group_--_yes',
 				],
 				[
-					'dev-group',
+					'design-group',
 				],
 				'dev-group',
 				'yes',
@@ -127,7 +127,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 					'vip-go-seg' => 'design-group_--_yes',
 				],
 				[
-					'dev-group',
+					'design-group',
 				],
 				'dev-group',
 				false,
@@ -160,6 +160,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
  	 */
 	public function test__is_user_in_group_segment( $initial_cookie, $initial_groups, $test_group, $test_value, $expected_result ) {
 		$_COOKIE = $initial_cookie;
+		Vary_Cache::clear_groups();
 		Vary_Cache::register_groups( $initial_groups );
 
 		$actual_result = Vary_Cache::is_user_in_group_segment( $test_group, $test_value );
@@ -172,6 +173,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 */
 	public function test__is_user_in_group( $initial_cookie, $initial_groups, $test_group, $expected_result ) {
 		$_COOKIE = $initial_cookie;
+		Vary_Cache::clear_groups();
 		Vary_Cache::register_groups( $initial_groups );
 
 		$actual_result = Vary_Cache::is_user_in_group( $test_group );

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -126,7 +126,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				'dev-group',
 				false,
 			],
-			'user-not-in-group' => [
+			'user-in-group' => [
 				[
 					'vip-go-seg' => 'dev-group_--_yes',
 				],

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -87,6 +87,18 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				'yes',
 				true,
 			],
+
+			'user-in-group-and-segment-with-zero-value' => [
+				[
+					'vip-go-seg' => 'dev-group_--_0',
+				],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				'0',
+				true,
+			],
 		];
 	}
 


### PR DESCRIPTION
By making the value optional and add some tests.

See #1122 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

Adds new unit tests for the method.