### PR TITLE
Enable Vary Cache with encrypted groups/data

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -12,6 +12,7 @@ class Vary_Cache {
 	// Allowed values in cookie are alphanumerics (A-Za-z0-9) and underscore (_) and hyphen (-).
 	private const GROUP_SEPARATOR = '__';
 	private const VALUE_SEPARATOR = '_--_';
+	private const VERSION_PREFIX = 'vc-v1__';
 
 	/**
 	 * Flag to indicate if this an encrypted group request
@@ -214,10 +215,10 @@ class Vary_Cache {
 		if ( isset( $_COOKIE[ self::COOKIE_SEGMENT ] ) || isset( $_COOKIE[ self::COOKIE_AUTH ] ) ) {
 
 			if ( self::is_encryption_enabled() ) {
-				$cookie_value = $_COOKIE[ self::COOKIE_AUTH ];
+				$cookie_value = str_replace( self::VERSION_PREFIX, '', $_COOKIE[ self::COOKIE_AUTH ] );
 				$cookie_value = self::decrypt_cookie_value( $cookie_value );
 			} else {
-				$cookie_value = $_COOKIE[ self::COOKIE_SEGMENT ];
+				$cookie_value = str_replace( self::VERSION_PREFIX, '', $_COOKIE[ self::COOKIE_SEGMENT ] );
 			}
 
 			$groups = explode( self::GROUP_SEPARATOR, $cookie_value );
@@ -281,7 +282,7 @@ class Vary_Cache {
 	 */
 	private static function set_cookie( $name, $value ) {
 		$expiry = time() + self::$cookie_expiry;
-		setcookie( $name, $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( $name, self::VERSION_PREFIX . $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
 	}
 
 	/**

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -243,21 +243,23 @@ class Vary_Cache {
 	 * @access  private
 	 */
 	private static function parse_group_cookie() {
-		if ( isset( $_COOKIE[ self::COOKIE_SEGMENT ] ) || isset( $_COOKIE[ self::COOKIE_AUTH ] ) ) {
-
-			if ( self::is_encryption_enabled() ) {
-				$cookie_value = str_replace( self::VERSION_PREFIX, '', $_COOKIE[ self::COOKIE_AUTH ] );
-				$cookie_value = self::decrypt_cookie_value( $cookie_value );
-			} else {
-				$cookie_value = str_replace( self::VERSION_PREFIX, '', $_COOKIE[ self::COOKIE_SEGMENT ] );
-			}
-
-			$groups = explode( self::GROUP_SEPARATOR, $cookie_value );
-			foreach ( $groups as $group ) {
-				list( $group_name, $group_value ) = explode( self::VALUE_SEPARATOR, $group );
-				self::$groups[ $group_name ] = $group_value ?? '';
-			}
+		if ( self::is_encryption_enabled() && ! empty( $_COOKIE[ self::COOKIE_AUTH ] ) ) {
+			$cookie_value = self::decrypt_cookie_value( $_COOKIE[ self::COOKIE_AUTH ] );
+		} elseif ( ! empty( $_COOKIE[ self::COOKIE_SEGMENT ] ) ) {
+			$cookie_value = $_COOKIE[ self::COOKIE_SEGMENT ];
 		}
+
+		if ( empty( $cookie_value ) ) {
+			return;
+		}
+
+		$cookie_value = str_replace( self::VERSION_PREFIX, '', $cookie_value );
+		$groups = explode( self::GROUP_SEPARATOR, $cookie_value );
+		foreach ( $groups as $group ) {
+			list( $group_name, $group_value ) = explode( self::VALUE_SEPARATOR, $group );
+			self::$groups[ $group_name ] = $group_value ?? '';
+		}
+
 	}
 
 

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -214,10 +214,10 @@ class Vary_Cache {
 		if ( isset( $_COOKIE[ self::COOKIE_SEGMENT ] ) || isset( $_COOKIE[ self::COOKIE_AUTH ] ) ) {
 
 			if ( self::is_encryption_enabled() ) {
-				$cookie_value = sanitize_text_field( wp_unslash( $_COOKIE[ self::COOKIE_AUTH ] ) );
+				$cookie_value = $_COOKIE[ self::COOKIE_AUTH ];
 				$cookie_value = self::decrypt_cookie_value( $cookie_value );
 			} else {
-				$cookie_value = sanitize_text_field( wp_unslash( $_COOKIE[ self::COOKIE_SEGMENT ] ) );
+				$cookie_value = $_COOKIE[ self::COOKIE_SEGMENT ];
 			}
 
 			$groups = explode( self::GROUP_SEPARATOR, $cookie_value );


### PR DESCRIPTION
## Description

Implement the encrypted cookie approach to allow encrypted segmentation.

See #1122 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

Example:

1. Start with the [GDPR example](https://github.com/wpcomvip/vip-vary-cache-testing)
2. Set `VIP_GO_AUTH_COOKIE_KEY` and `VIP_GO_AUTH_COOKIE_IV` constants for the site
3. Enable encryption by setting `Vary_Cache::set_encryption( true );` before the register_groups call
4. Ensure that the segmentation functionality works as expected
