### PR TITLE
Vary_Cache: Add single version of register_group

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -177,7 +177,7 @@ class Vary_Cache {
 	 *
 	 * @return array  user's group-value pairs
 	 */
-	public static function get_user_groups() {
+	public static function get_groups() {
 		self::parse_group_cookie();
 		return self::$groups;
 	}

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -54,7 +54,7 @@ class Vary_Cache {
 	}
 
 	/**
-	 * Set request to indicate the request will vary on a group
+	 * Set request to indicate the request will vary on one or more groups.
 	 *
 	 * @since   1.0.0
 	 * @access  public
@@ -62,27 +62,34 @@ class Vary_Cache {
 	 * @param  array $groups  One or more groups to vary on.
 	 * @return boolean
 	 */
-	public static function register_groups( $groups ) {
-		if ( is_array( $groups ) ) {
-			foreach ( $groups as $group ) {
-				if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ) {
-					trigger_error( sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
-					return false;
-				}
-
-				self::$groups[ $group ] = '';
-			}
-		} else {
-			if ( strpos( $groups, self::GROUP_SEPARATOR ) !== false || strpos( $groups, self::VALUE_SEPARATOR ) !== false ) {
-				trigger_error( sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
-				return false;
+	public static function register_groups( array $groups ) {
+		foreach ( $groups as $group ) {
+			if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ) {
+				trigger_error( sprintf( 'Failed to register group (%s); cannot use the delimiter values (`%s` or `%s`) in the group name', $group, self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
+				continue;
 			}
 
-			self::$groups[ $groups ] = '';
+			self::$groups[ $group ] = '';
 		}
 
 		self::parse_group_cookie();
+
 		return true;
+	}
+
+	/**
+	 * Set request to indicate the request will vary on a group.
+	 *
+	 * Convenience version of `register_groups`.
+	 *
+	 * @since   1.0.0
+	 * @access  public
+	 *
+	 * @param  string $groups A group to vary on.
+	 * @return boolean
+	 */
+	public static function register_group( string $group ) {
+		return self::register_groups( [ $group ] );
 	}
 
 	/**

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -191,17 +191,6 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_result, $actual_result );
 	}
 
-	public function get_test_data__register_groups_valid() {
-		return [
-			'valid-group-array' => [
-				[ 'dev-group', 'design-group' ],
-			],
-			'valid-group' => [
-				'dev-group',
-			],
-		];
-	}
-
 	public function get_test_data__register_groups_invalid() {
 		return [
 			'invalid-group-array' => [
@@ -215,13 +204,30 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider get_test_data__register_groups_valid
-	 */
-	public function test__register_groups_valid( $valid_groups ) {
-		$actual_result = Vary_Cache::register_groups( $valid_groups );
+	public function test__register_group_valid() {
+		$expected_groups = [
+			'dev-group' => '',
+		];
 
-		$this->assertTrue( $actual_result );
+		$actual_result = Vary_Cache::register_group( 'dev-group' );
+
+		$this->assertTrue( $actual_result, 'register_group returned false' );
+		$this->assertEquals( $expected_groups, $this->get_groups() );
+	}
+
+	public function test__register_groups_valid() {
+		$expected_groups = [
+			'dev-group' => '',
+			'design-group' => '',
+		];
+
+		$actual_result = Vary_Cache::register_groups( [
+			'dev-group',
+			'design-group',
+		] );
+
+		$this->assertTrue( $actual_result, 'register_groups returned false' );
+		$this->assertEquals( $expected_groups, $this->get_groups() );
 	}
 
 	/**
@@ -232,6 +238,12 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		$actual_result = Vary_Cache::register_groups( $invalid_groups );
 		
 		$this->assertFalse( $actual_result );
+	}
+
+	public function test__register_group() {
+		$actual_result = Vary_Cache::register_groups( $valid_groups );
+
+		$this->assertTrue( $actual_result );
 	}
 
 	public function get_test_data__set_group_for_user_valid() {

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -191,6 +191,44 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_result, $actual_result );
 	}
 
+	public function test__register_group() {
+		$expected_groups = [
+			'dev-group' => '',
+		];
+
+		$actual_result = Vary_Cache::register_group( 'dev-group' );
+
+		$this->assertTrue( $actual_result, 'register_group returned false' );
+		$this->assertEquals( $expected_groups, Vary_Cache::get_groups() );
+	}
+
+	public function test__register_groups__valid() {
+		$expected_groups = [
+			'dev-group' => '',
+			'design-group' => '',
+		];
+
+		$actual_result = Vary_Cache::register_groups( [
+			'dev-group',
+			'design-group',
+		] );
+
+		$this->assertTrue( $actual_result, 'Valid register_groups call did not return true' );
+		$this->assertEquals( $expected_groups, Vary_Cache::get_groups(), 'Registered groups do not match expected.' );
+	}
+
+	public function test__register_groups__multiple_calls() {
+		$expected_groups = [
+			'dev-group' => '',
+			'design-group' => '',
+		];
+
+		Vary_Cache::register_groups( [ 'dev-group' ] );
+		Vary_Cache::register_groups( [ 'design-group' ] );
+
+		$this->assertEquals( $expected_groups, Vary_Cache::get_groups(), 'Multiple register_groups did not result in expected groups' );
+	}
+
 	public function get_test_data__register_groups_invalid() {
 		return [
 			'invalid-group-array' => [
@@ -204,46 +242,15 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		];
 	}
 
-	public function test__register_group_valid() {
-		$expected_groups = [
-			'dev-group' => '',
-		];
-
-		$actual_result = Vary_Cache::register_group( 'dev-group' );
-
-		$this->assertTrue( $actual_result, 'register_group returned false' );
-		$this->assertEquals( $expected_groups, $this->get_groups() );
-	}
-
-	public function test__register_groups_valid() {
-		$expected_groups = [
-			'dev-group' => '',
-			'design-group' => '',
-		];
-
-		$actual_result = Vary_Cache::register_groups( [
-			'dev-group',
-			'design-group',
-		] );
-
-		$this->assertTrue( $actual_result, 'register_groups returned false' );
-		$this->assertEquals( $expected_groups, $this->get_groups() );
-	}
-
 	/**
 	 * @dataProvider get_test_data__register_groups_invalid
 	 */
-	public function test__register_groups_invalid( $invalid_groups, $expected_error_code ) {
+	public function test__register_groups__invalid( $invalid_groups, $expected_error_code ) {
 		$this->expectException( \PHPUnit_Framework_Error_Warning::class );
 		$actual_result = Vary_Cache::register_groups( $invalid_groups );
-		
-		$this->assertFalse( $actual_result );
-	}
 
-	public function test__register_group() {
-		$actual_result = Vary_Cache::register_groups( $valid_groups );
-
-		$this->assertTrue( $actual_result );
+		$this->assertFalse( $actual_result, 'Invalid register_groups call did not return false' );
+		$this->assertEquals( [], Vary_Cache::get_groups(), 'Registered groups was not empty.' );
 	}
 
 	public function get_test_data__set_group_for_user_valid() {


### PR DESCRIPTION
Much cleaner than remembering to wrap your value in an array.

```
Vary_Cache::register_groups( [ 'gdpr' ] );

# vs

Vary_Cache::register_group( 'gdpr' );
```

See #1122 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

TODO
