### PR TITLE
Vary Cache: Set group separator to be more unique 

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -59,21 +59,25 @@ class Vary_Cache {
 	 * @access  public
 	 *
 	 * @param  array $groups  One or more groups to vary on.
+	 * @return WP_error|boolean
 	 */
 	public static function register_groups( $groups ) {
 		if ( is_array( $groups ) ) {
 			foreach ( $groups as $group ) {
 				if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ) {
-					trigger_error( sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
-					return;
+					return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ) );
 				}
 				self::$groups[ $group ] = '';
 			}
 		} else {
+			if ( strpos( $groups, self::GROUP_SEPARATOR ) !== false || strpos( $groups, self::VALUE_SEPARATOR ) !== false ) {
+				return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ) );
+			}
 			self::$groups[ $groups ] = '';
 		}
 
 		self::parse_group_cookie();
+		return true;
 	}
 
 	/**
@@ -101,10 +105,10 @@ class Vary_Cache {
 		// TODO: only send header if we added or changed things
 		// TODO: don't set the cookie if was already set on the request
 		if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ) {
-			return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
+			return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ) );
 		}
 		if ( strpos( $value, self::GROUP_SEPARATOR ) !== false || strpos( $value, self::VALUE_SEPARATOR ) !== false ) {
-			return new WP_Error( 'invalid_vary_group_segment', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group segment', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
+			return new WP_Error( 'invalid_vary_group_segment', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group segment', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ) );
 		}
 		self::$groups[ $group ] = $value;
 		if ( self::is_encryption_enabled() ) {

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -10,7 +10,7 @@ class Vary_Cache {
 	private const COOKIE_AUTH = 'vip-go-auth';
 
 	// Allowed values in cookie are alphanumerics (A-Za-z0-9) and underscore (_) and hyphen (-).
-	private const GROUP_SEPARATOR = '__';
+	private const GROUP_SEPARATOR = '---__';
 	private const VALUE_SEPARATOR = '_--_';
 
 	/**
@@ -63,6 +63,10 @@ class Vary_Cache {
 	public static function register_groups( $groups ) {
 		if ( is_array( $groups ) ) {
 			foreach ( $groups as $group ) {
+				if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ) {
+					trigger_error( 'Cannot use the group separator text in the group name', E_USER_WARNING );
+					return;
+				}
 				self::$groups[ $group ] = '';
 			}
 		} else {
@@ -86,6 +90,11 @@ class Vary_Cache {
 		// TODO: only send header if we added or changed things
 		// TODO: don't set the cookie if was already set on the request
 		// validate, process $group, etc.
+		if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ||
+			strpos( $value, self::GROUP_SEPARATOR ) !== false || strpos( $value, self::VALUE_SEPARATOR ) !== false ) {
+				trigger_error( 'Cannot use the group or value separator text in the group/value name', E_USER_WARNING );
+			return;
+		}
 		self::$groups[ $group ] = $value;
 		if ( self::is_encryption_enabled() ) {
 			$cookie_value = self::encrypt_cookie_value( self::stringify_groups() );

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -94,16 +94,17 @@ class Vary_Cache {
 	 *
 	 * @param  string $group  Group name to vary the request on.
 	 * @param  string $value A value for the group.
+	 * @return WP_Error|boolean
 	 */
 	public static function set_group_for_user( $group, $value ) {
 		// TODO: make sure headers aren't already sent
 		// TODO: only send header if we added or changed things
 		// TODO: don't set the cookie if was already set on the request
-		// validate, process $group, etc.
-		if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ||
-			strpos( $value, self::GROUP_SEPARATOR ) !== false || strpos( $value, self::VALUE_SEPARATOR ) !== false ) {
-				trigger_error( 'Cannot use the group or value separator text in the group/value name', E_USER_WARNING );
-			return;
+		if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ) {
+			return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
+		}
+		if ( strpos( $value, self::GROUP_SEPARATOR ) !== false || strpos( $value, self::VALUE_SEPARATOR ) !== false ) {
+			return new WP_Error( 'invalid_vary_group_segment', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group segment', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
 		}
 		self::$groups[ $group ] = $value;
 		if ( self::is_encryption_enabled() ) {
@@ -112,6 +113,7 @@ class Vary_Cache {
 		} else {
 			self::set_cookie( self::COOKIE_SEGMENT, self::stringify_groups() );
 		}
+		return true;
 	}
 
 	/**

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -65,13 +65,13 @@ class Vary_Cache {
 		if ( is_array( $groups ) ) {
 			foreach ( $groups as $group ) {
 				if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ) {
-					return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ) );
+					trigger_error( sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
 				}
 				self::$groups[ $group ] = '';
 			}
 		} else {
 			if ( strpos( $groups, self::GROUP_SEPARATOR ) !== false || strpos( $groups, self::VALUE_SEPARATOR ) !== false ) {
-				return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ) );
+				trigger_error( sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
 			}
 			self::$groups[ $groups ] = '';
 		}

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -59,20 +59,24 @@ class Vary_Cache {
 	 * @access  public
 	 *
 	 * @param  array $groups  One or more groups to vary on.
-	 * @return WP_error|boolean
+	 * @return boolean
 	 */
 	public static function register_groups( $groups ) {
 		if ( is_array( $groups ) ) {
 			foreach ( $groups as $group ) {
 				if ( strpos( $group, self::GROUP_SEPARATOR ) !== false || strpos( $group, self::VALUE_SEPARATOR ) !== false ) {
 					trigger_error( sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
+					return false;
 				}
+
 				self::$groups[ $group ] = '';
 			}
 		} else {
 			if ( strpos( $groups, self::GROUP_SEPARATOR ) !== false || strpos( $groups, self::VALUE_SEPARATOR ) !== false ) {
 				trigger_error( sprintf( 'Failed to register group; cannot use the delimiter values (`%s` or `%s`) in the group name', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ), E_USER_WARNING );
+				return false;
 			}
+
 			self::$groups[ $groups ] = '';
 		}
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 7.0
+ * Version: 7.0.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -187,11 +187,9 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		return [
 			'valid-group-array' => [
 				[ 'dev-group', 'design-group' ],
-				true,
 			],
 			'valid-group' => [
 				'dev-group',
-				true,
 			],
 		];
 	}
@@ -212,11 +210,11 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	/**
 	 * @dataProvider get_test_data__register_groups_valid
 	 */
-	public function test__register_groups_valid( $valid_groups, $expected_result ) {
+	public function test__register_groups_valid( $valid_groups ) {
 		Vary_Cache::clear_groups();
-		$actual_result  = Vary_Cache::register_groups( $valid_groups );
+		$actual_result = Vary_Cache::register_groups( $valid_groups );
 
-		$this->assertEquals( $expected_result, $actual_result );
+		$this->assertTrue( $actual_result );
 	}
 
 	/**
@@ -224,8 +222,11 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 */
 	public function test__register_groups_invalid( $invalid_groups, $expected_error_code ) {
 		Vary_Cache::clear_groups();
+
 		$this->expectException( \PHPUnit_Framework_Error_Warning::class );
-		Vary_Cache::register_groups( $invalid_groups );
+		$actual_result = Vary_Cache::register_groups( $invalid_groups );
+		
+		$this->assertFalse( $actual_result );
 	}
 
 	public function get_test_data__set_group_for_user_valid() {

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Cache;
 
+use WP_Error;
+
 class Vary_Cache_Test extends \WP_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -180,4 +182,111 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected_result, $actual_result );
 	}
+
+	public function get_test_data__register_groups_valid() {
+		return [
+			'valid-group-array' => [
+				[ 'dev-group', 'design-group' ],
+				true,
+			],
+			'valid-group' => [
+				'dev-group',
+				true,
+			],
+		];
+	}
+
+	public function get_test_data__register_groups_invalid() {
+		return [
+			'invalid-group-array' => [
+				[ 'dev-group', 'dev-group---__' ],
+				'invalid_vary_group_name',
+			],
+			'invalid-group-name' => [
+				[ 'dev-group---__' ],
+				'invalid_vary_group_name',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__register_groups_valid
+	 */
+	public function test__register_groups_valid( $valid_groups, $expected_result ) {
+		Vary_Cache::clear_groups();
+		$actual_result  = Vary_Cache::register_groups( $valid_groups );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	/**
+	 * @dataProvider get_test_data__register_groups_invalid
+	 */
+	public function test__register_groups_invalid( $invalid_groups, $expected_error_code ) {
+		Vary_Cache::clear_groups();
+		$actual_result  = Vary_Cache::register_groups( $invalid_groups );
+
+		$this->assertWPError( $actual_result, 'Not WP_Error object' );
+
+		$actual_error_code = $actual_result->get_error_code();
+		$this->assertEquals( $expected_error_code, $actual_error_code, 'Incorrect error code' );
+	}
+
+	public function get_test_data__set_group_for_user_valid() {
+		return [
+			'valid-group-' => [
+				'dev-group',
+				'yes',
+				true,
+			],
+		];
+	}
+
+	public function get_test_data__set_group_for_user_invalid() {
+		return [
+			'invalid-group-name-group-separator' => [
+				'dev-group---__',
+				'yes',
+				'invalid_vary_group_name',
+			],
+			'invalid-group-segment-group-separator' => [
+				'dev-group',
+				'yes---__',
+				'invalid_vary_group_segment',
+			],
+			'invalid-group-name-value-separator' => [
+				'dev-group_--_',
+				'yes',
+				'invalid_vary_group_name',
+			],
+			'invalid-group-segment-value-separator' => [
+				'dev-group',
+				'yes_--_',
+				'invalid_vary_group_segment',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__set_group_for_user_valid
+	 */
+	public function test__set_group_for_user_valid( $group, $value, $expected_result ) {
+		$this->markTestSkipped('Skip for now until cookie is set in hook');
+		$actual_result  = Vary_Cache::set_group_for_user( $group, $value );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	/**
+	 * @dataProvider get_test_data__set_group_for_user_invalid
+	 */
+	public function test__set_group_for_user_invalid( $group, $value, $expected_error_code ) {
+		$actual_result  = Vary_Cache::set_group_for_user( $group, $value );
+
+		$this->assertWPError( $actual_result, 'Not WP_Error object' );
+
+		$actual_error_code = $actual_result->get_error_code();
+		$this->assertEquals( $expected_error_code, $actual_error_code, 'Incorrect error code' );
+	}
+
 }

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -224,12 +224,8 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 */
 	public function test__register_groups_invalid( $invalid_groups, $expected_error_code ) {
 		Vary_Cache::clear_groups();
-		$actual_result  = Vary_Cache::register_groups( $invalid_groups );
-
-		$this->assertWPError( $actual_result, 'Not WP_Error object' );
-
-		$actual_error_code = $actual_result->get_error_code();
-		$this->assertEquals( $expected_error_code, $actual_error_code, 'Incorrect error code' );
+		$this->expectException( \PHPUnit_Framework_Error_Warning::class );
+		Vary_Cache::register_groups( $invalid_groups );
 	}
 
 	public function get_test_data__set_group_for_user_valid() {

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -13,8 +13,10 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		Vary_Cache::clear_groups();
+
 		$this->original_COOKIE = $_COOKIE;
+
+		Vary_Cache::clear_groups();
 	}
 
 	public function tearDown() {
@@ -162,7 +164,6 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
  	 */
 	public function test__is_user_in_group_segment( $initial_cookie, $initial_groups, $test_group, $test_value, $expected_result ) {
 		$_COOKIE = $initial_cookie;
-		Vary_Cache::clear_groups();
 		Vary_Cache::register_groups( $initial_groups );
 
 		$actual_result = Vary_Cache::is_user_in_group_segment( $test_group, $test_value );
@@ -175,7 +176,6 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 */
 	public function test__is_user_in_group( $initial_cookie, $initial_groups, $test_group, $expected_result ) {
 		$_COOKIE = $initial_cookie;
-		Vary_Cache::clear_groups();
 		Vary_Cache::register_groups( $initial_groups );
 
 		$actual_result = Vary_Cache::is_user_in_group( $test_group );
@@ -211,7 +211,6 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 * @dataProvider get_test_data__register_groups_valid
 	 */
 	public function test__register_groups_valid( $valid_groups ) {
-		Vary_Cache::clear_groups();
 		$actual_result = Vary_Cache::register_groups( $valid_groups );
 
 		$this->assertTrue( $actual_result );
@@ -221,8 +220,6 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 * @dataProvider get_test_data__register_groups_invalid
 	 */
 	public function test__register_groups_invalid( $invalid_groups, $expected_error_code ) {
-		Vary_Cache::clear_groups();
-
 		$this->expectException( \PHPUnit_Framework_Error_Warning::class );
 		$actual_result = Vary_Cache::register_groups( $invalid_groups );
 		


### PR DESCRIPTION
## Description
Set separator value to be more Unique and also make sure that the seprator values aren't used in the group name or segment 

Fixes #1129 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
