### PR TITLE
Fix group check logic to return false for groups with empty segments

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -114,9 +114,8 @@ class Vary_Cache {
 	 */
 	public static function is_user_in_group( $group ) {
 		self::parse_group_cookie();
-
 		// The group isn't defined, or the user isn't in it.
-		if ( ! array_key_exists( $group, self::$groups ) ) {
+		if ( ! array_key_exists( $group, self::$groups ) || null == self::$groups[ $group ] ) {
 			return false;
 		}
 

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -115,7 +115,7 @@ class Vary_Cache {
 	public static function is_user_in_group( $group ) {
 		self::parse_group_cookie();
 		// The group isn't defined, or the user isn't in it.
-		if ( ! array_key_exists( $group, self::$groups ) || null == self::$groups[ $group ] ) {
+		if ( ! array_key_exists( $group, self::$groups ) || '' === trim( self::$groups[ $group ] ) ) {
 			return false;
 		}
 

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -61,7 +61,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				],
 				'dev-group',
 				'',
-				true,
+				false,
 			],
 
 			'user-in-group-segment-but-searching-for-null' => [
@@ -150,7 +150,15 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 					'dev-group',
 				],
 				'dev-group',
-				true,
+				false,
+			],
+			'user-not-yet-assigned' => [
+				[],
+				[
+					'dev-group',
+				],
+				'dev-group',
+				false,
 			],
 		];
 	}


### PR DESCRIPTION
## Description

Fixes an issue where checking if the user is in a group will return true if user hasn't been assigned a segment in that group yet.

We'll have to be clear in the documentation that the user must set a non-empty value for the segment for the user to be considered in the group.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

