### PR TITLE
Vary Cache: Fix version prefix

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -296,7 +296,7 @@ class Vary_Cache {
 		};
 		$flattened = array_map( $flatten, array_keys( self::$groups ), self::$groups );
 
-		return implode( self::GROUP_SEPARATOR, $flattened );
+		return self::VERSION_PREFIX . implode( self::GROUP_SEPARATOR, $flattened );
 	}
 
 	/**
@@ -333,7 +333,7 @@ class Vary_Cache {
 	 */
 	private static function set_cookie( $name, $value ) {
 		$expiry = time() + self::$cookie_expiry;
-		setcookie( $name, self::VERSION_PREFIX . $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( $name, $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
 	}
 
 	/**


### PR DESCRIPTION
Should only set it when stringifying groups. Previously we were appending it to the value which meant that encrypted cookies and cb cookies were getting incorrect values set.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).

## Steps to Test

1. Using the GDPR example, verify that all things work.
1. Enable encryption for the GDPR example; make sure that the cookie value does not have the version prefix visible.
1. Call `Vary_Cache::set_no_cache_for_user()` on a page; verify that the `vip-go-cb` cookie is set with a value of `1`.