### PR TITLE
Vary Cache: Group WP hooks / callbacks together

### DIFF
--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -31,7 +31,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 * Helper function for accessing protected methods.
 	 */
 	protected static function get_method( $name ) {
-		$class = new \ReflectionClass( __NAMESPACE__ . '\Vary_Cache' );
+		$class = new \ReflectionClass( __NAMESPACE__ . '\API_Client' );
 		$method = $class->getMethod( $name );
 		$method->setAccessible( true );
 		return $method;

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -16,11 +16,14 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 		$this->original_COOKIE = $_COOKIE;
 
-		Vary_Cache::clear_groups();
+		Vary_Cache::load();
 	}
 
 	public function tearDown() {
+		Vary_Cache::unload();
+
 		$_COOKIE = $this->original_COOKIE;
+
 		parent::tearDown();
 	}
 
@@ -28,7 +31,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 * Helper function for accessing protected methods.
 	 */
 	protected static function get_method( $name ) {
-		$class = new \ReflectionClass( __NAMESPACE__ . '\API_Client' );
+		$class = new \ReflectionClass( __NAMESPACE__ . '\Vary_Cache' );
 		$method = $class->getMethod( $name );
 		$method->setAccessible( true );
 		return $method;
@@ -173,6 +176,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	public function test__is_user_in_group_segment( $initial_cookie, $initial_groups, $test_group, $test_value, $expected_result ) {
 		$_COOKIE = $initial_cookie;
 		Vary_Cache::register_groups( $initial_groups );
+		Vary_Cache::parse_group_cookie();
 
 		$actual_result = Vary_Cache::is_user_in_group_segment( $test_group, $test_value );
 
@@ -185,6 +189,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	public function test__is_user_in_group( $initial_cookie, $initial_groups, $test_group, $expected_result ) {
 		$_COOKIE = $initial_cookie;
 		Vary_Cache::register_groups( $initial_groups );
+		Vary_Cache::parse_group_cookie();
 
 		$actual_result = Vary_Cache::is_user_in_group( $test_group );
 
@@ -290,5 +295,4 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		$actual_error_code = $actual_result->get_error_code();
 		$this->assertEquals( $expected_error_code, $actual_error_code, 'Incorrect error code' );
 	}
-
 }


### PR DESCRIPTION
- Moves the `send_headers` call into the class alongside other WP hooks
- Rather than re-parsing the cookie every time a method is called, which is a bit of a waste, parse it once on init.

Fixes #1132
See #1122

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

With the GDPR example, make sure that the 3 different states work as expected and get correctly cached values on multiple refreshes.