### PR TITLE
Vary Cache: Send a debug header if WP_DEBUG enabled

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -322,6 +322,10 @@ class Vary_Cache {
 			} else {
 				header( 'Vary: X-VIP-Go-Segmentation' );
 			}
+
+			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
+				header( 'X-VIP-Go-Segmentation-Debug: ' . self::stringify_groups() );
+			}
 		}
 	}
 


### PR DESCRIPTION
To simplify debugging, it can be helpful to see which groups we're varying on.

#1123

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).

## Steps to Test

1. Enable WP_DEBUG.
1. Go to the GDPR example. Verify that requests show the `X-VIP-Go_Segementation_Debug` response header.
1. Turn off WP_DEBUG; verify that requests no longer have the header.