### PR TITLE
Add skipped tests back in now that PHPUnit versions are in sync

### DIFF
--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -251,7 +251,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 * @dataProvider get_test_data__register_groups_invalid
 	 */
 	public function test__register_groups__invalid( $invalid_groups ) {
-		$this->expectException( \PHPUnit_Framework_Error_Warning::class );
+		$this->expectException( \PHPUnit\Framework\Error\Warning::class );
 		$actual_result = Vary_Cache::register_groups( $invalid_groups );
 
 		$this->assertFalse( $actual_result, 'Invalid register_groups call did not return false' );
@@ -330,7 +330,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 */
 	public function test__enable_encryption_invalid() {
 		$this->markTestSkipped('Skip for now until PHPUnit is updated in Travis');
-		$this->expectException( \PHPUnit_Framework_Error_Error::class );
+		$this->expectException( \PHPUnit\Framework\Error\Error::class );
 		$actual_result = Vary_Cache::enable_encryption( );
 		$this->assertNull( $actual_result );
 	}
@@ -341,7 +341,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 */
 	public function test__enable_encryption_invalid_empty_constants() {
 		$this->markTestSkipped('Skip for now until PHPUnit is updated in Travis');
-		$this->expectException( \PHPUnit_Framework_Error_Error::class );
+		$this->expectException( \PHPUnit\Framework\Error\Error::class );
 
 		define( 'VIP_GO_AUTH_COOKIE_KEY', '' );
 		define( 'VIP_GO_AUTH_COOKIE_IV', '');

--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -65,7 +65,7 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 	 * @dataProvider get_data_for_invalid_queue_purge_url_test
 	 */
 	public function test__invalid__queue_purge_url( $queue_url ) {
-		$this->expectException( PHPUnit_Framework_Error_Warning::class );
+		$this->expectException( \PHPUnit\Framework\Error\Warning::class );
 
 		$actual_output = $this->cache_manager->queue_purge_url( $queue_url );
 


### PR DESCRIPTION
## Description

Re-nable to tests that check for PHP errors now that the PHPUnit version in Travis has been bumped up
