### PR TITLE
Add send_headers checks

### DIFF
--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Note: you can pass in additional phpunit args
+# Test a specific file: ./bin/phpunit-docker.sh tests/path/to/test.php
+# Stop on failures: ./bin/phpunit-docker.sh --stop-on-failure
+# etc.
+
 WP_VERSION=${1-latest}
 
 MYSQL_ROOT_PASSWORD='wordpress'
@@ -26,4 +31,4 @@ docker run \
 	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
 	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \
 	--rm phpunit/phpunit \
-	--bootstrap /app/tests/bootstrap.php
+	--bootstrap /app/tests/bootstrap.php "$@"

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -5,7 +5,7 @@ namespace Automattic\VIP\Cache;
 use WP_Error;
 
 class Vary_Cache {
-	private const COOKIE_NO_CACHE = 'vip-go-cb';
+	private const COOKIE_NOCACHE = 'vip-go-cb';
 	private const COOKIE_SEGMENT = 'vip-go-seg';
 	private const COOKIE_AUTH = 'vip-go-auth';
 
@@ -50,16 +50,34 @@ class Vary_Cache {
 	 */
 	private static $cookie_expiry = MONTH_IN_SECONDS;
 
-	/** Nocache */
-	public static function set_no_cache_for_user() {
-		self::set_cookie( self::COOKIE_NO_CACHE, 1 );
+	/**
+	 * Add nocache cookie for the user.
+	 *
+	 * This bypasses all requests from the VIP Cache.
+	 */
+	public static function set_nocache_for_user() {
+		if ( self::did_send_headers() ) {
+			return new WP_Error( 'did_send_headers', 'Failed to set nocache cookie; cannot be called after the `send_headers` hook has fired.' );
+		}
+
+		self::set_cookie( self::COOKIE_NOCACHE, 1 );
+
+		return true;
 	}
 
-	/** Clears the cache-busting flag */
-	public static function remove_no_cache_for_user() {
-		if ( isset( $_COOKIE[ self::COOKIE_NO_CACHE ] ) ) {
-			self::unset_cookie( self::COOKIE_NO_CACHE );
+	/**
+	 * Clears the nocache cookie for the user.
+	 *
+	 * Restores caching behaviour for all future requests.
+	 */
+	public static function remove_nocache_for_user() {
+		if ( self::did_send_headers() ) {
+			return new WP_Error( 'did_send_headers', 'Failed to remove nocache cookie; cannot be called after the `send_headers` hook has fired.' );
 		}
+
+		self::unset_cookie( self::COOKIE_NOCACHE );
+
+		return true;
 	}
 
 	public static function load() {

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -408,9 +408,11 @@ class Vary_Cache {
 		if ( preg_match( '/[^_0-9a-zA-Z-]+/', $value ) > 0 ) {
 			return new WP_Error( 'vary_cache_group_invalid_chars', 'Invalid character(s). Can only use alphanumerics, dash and underscore' );
 		}
+
 		if ( strpos( $value, self::VALUE_SEPARATOR ) !== false || strpos( $value, self::GROUP_SEPARATOR ) !== false ) {
 			return new WP_Error( 'vary_cache_group_cannot_use_delimiter', sprintf( 'Cannot use the delimiter values (`%s` or `%s`)', self::GROUP_SEPARATOR, self::VALUE_SEPARATOR ) );
 		}
+
 		return true;
 	}
 }

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -24,6 +24,15 @@ class Vary_Cache {
 	private static $encryption_enabled = false;
 
 	/**
+	 * Flag to indicate if the send_headers action was triggered
+	 *
+	 * @since   1.0.0
+	 * @access  private
+	 * @var     bool  true if headers were sent
+	 */
+	private static $did_send_headers = false;
+
+	/**
 	 * Member variable to store the parsed group values.
 	 *
 	 * @since   1.0.0
@@ -58,19 +67,24 @@ class Vary_Cache {
 		self::add_filters();
 	}
 
+	/**
+	 * Convenience function for resetting state in tests
+	 */
 	public static function unload() {
-		self::clear_groups();
 		self::remove_filters();
+
+		self::clear_groups();
+		self::$did_send_headers = false;
 	}
 
 	protected static function add_filters() {
 		add_action( 'init', [ Vary_Cache::class, 'parse_group_cookie' ] );
-		add_action( 'send_headers', [ Vary_Cache::class, 'add_vary_headers' ] );
+		add_action( 'send_headers', [ Vary_Cache::class, 'send_headers' ], PHP_INT_MAX ); // run late to catch any changes that may happen earlier in send_headers
 	}
 
 	protected static function remove_filters() {
 		remove_action( 'init', [ Vary_Cache::class, 'parse_group_cookie' ] );
-		remove_action( 'send_headers', [ Vary_Cache::class, 'add_vary_headers' ] );
+		remove_action( 'send_headers', [ Vary_Cache::class, 'send_headers' ], PHP_INT_MAX );
 	}
 
 	/**
@@ -83,6 +97,11 @@ class Vary_Cache {
 	 * @return boolean
 	 */
 	public static function register_groups( array $groups ) {
+		if ( self::did_send_headers() ) {
+			trigger_error( sprintf( 'Failed to register_groups (%s); cannot be called after the `send_headers` hook has fired.', implode( ', ', $groups ) ), E_USER_WARNING );
+			return false;
+		}
+
 		foreach ( $groups as $group ) {
 			$validate_result = self::validate_cookie_value( $group );
 			if ( is_wp_error( $validate_result ) ) {
@@ -132,13 +151,15 @@ class Vary_Cache {
 	 * @return WP_Error|boolean
 	 */
 	public static function set_group_for_user( $group, $value ) {
-		// TODO: make sure headers aren't already sent
-		// TODO: only send header if we added or changed things
-		// TODO: don't set the cookie if was already set on the request
+		if ( self::did_send_headers() ) {
+			return new WP_Error( 'did_send_headers', sprintf( 'Failed to set group (%s => %s) for user; cannot be called after the `send_headers` hook has fired.', $group, $value ) );
+		}
+
 		$validate_group_result = self::validate_cookie_value( $group );
 		if ( is_wp_error( $validate_group_result ) ) {
 			return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group (%s): %s', $group, $validate_group_result->get_error_message() ) );
 		}
+
 		$validate_value_result = self::validate_cookie_value( $value );
 		if ( is_wp_error( $validate_value_result ) ) {
 			return new WP_Error( 'invalid_vary_group_segment', sprintf( 'Failed to register group segment (%s): %s', $group, $validate_value_result->get_error_message() ) );
@@ -331,10 +352,16 @@ class Vary_Cache {
 		self::$cookie_expiry = $expiry;
 	}
 
+	public static function send_headers() {
+		self::$did_send_headers = true;
+
+		self::send_vary_headers();
+	}
+
 	/**
 	 * Add the vary cache headers to indicate that the response should be cached
 	 */
-	public static function add_vary_headers() {
+	private static function send_vary_headers() {
 		if ( ! empty( self::$groups ) ) {
 			if ( self::is_encryption_enabled() ) {
 				header( 'Vary: X-VIP-Go-Auth' );
@@ -346,6 +373,10 @@ class Vary_Cache {
 				header( 'X-VIP-Go-Segmentation-Debug: ' . self::stringify_groups() );
 			}
 		}
+	}
+
+	private static function did_send_headers() {
+		return self::$did_send_headers;
 	}
 
 	/**

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -234,6 +234,20 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_groups, Vary_Cache::get_groups(), 'Multiple register_groups did not result in expected groups' );
 	}
 
+	public function test__register_groups__did_send_headers() {
+		do_action( 'send_headers' );
+
+		$this->expectException( \PHPUnit\Framework\Error\Warning::class );
+
+		$actual_result = Vary_Cache::register_groups( [
+			'dev-group',
+			'design-group',
+		] );
+
+		$this->assertFalse( $actual_result, 'register_groups after send_headers did not return false' );
+		$this->assertEquals( [], Vary_Cache::get_groups(), 'Registered groups are not empty.' );
+	}
+
 	public function get_test_data__register_groups_invalid() {
 		return [
 			'invalid-group-array' => [
@@ -326,8 +340,19 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_error_code, $actual_error_code, 'Incorrect error code' );
 	}
 
-	/**
-	 */
+	public function test__set_group_for_user__did_send_headers() {
+		do_action( 'send_headers' );
+
+		$expected_error_code = 'did_send_headers';
+
+		$actual_result = Vary_Cache::set_group_for_user( 'group', 'segment' );
+
+		$this->assertWPError( $actual_result, 'Not WP_Error object' );
+
+		$actual_error_code = $actual_result->get_error_code();
+		$this->assertEquals( $expected_error_code, $actual_error_code, 'Incorrect error code' );
+	}
+
 	public function test__enable_encryption_invalid() {
 		$this->markTestSkipped('Skip for now until PHPUnit is updated in Travis');
 		$this->expectException( \PHPUnit_Framework_Error_Error::class );
@@ -398,7 +423,6 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	}
 
 	public function test__validate_cookie_value_valid( ) {
-
 		$get_validate_cookie_value_method = self::get_method( 'validate_cookie_value' );
 
 		$actual_result = $get_validate_cookie_value_method->invokeArgs(null, [

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -476,4 +476,54 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		$this->assertNotContains( 'Vary: X-VIP-Go-Segmentation', xdebug_get_headers(), 'Response should not include Vary: X-VIP-Go-Segmentation header' );
 		$this->assertNotContains( 'Vary: X-VIP-Go-Auth', xdebug_get_headers(), 'Response should not include Vary: X-VIP-Go-Auth header' );
 	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__set_nocache_for_user__did_send_headers() {
+		do_action( 'send_headers' );
+
+		$actual_result = Vary_Cache::set_nocache_for_user();
+
+		$this->assertWPError( $actual_result, 'Not WP_Error object' );
+		$this->assertEquals( 'did_send_headers', $actual_result->get_error_code(), 'Incorrect error code' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__set_nocache_for_user() {
+		$actual_result = Vary_Cache::set_nocache_for_user();
+
+		$this->assertTrue( $actual_result, 'Result was not true' );
+
+		// TODO: verify cookie was set
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__remove_nocache_for_user__did_send_headers() {
+		do_action( 'send_headers' );
+
+		$actual_result = Vary_Cache::remove_nocache_for_user();
+
+		$this->assertWPError( $actual_result, 'Not WP_Error object' );
+		$this->assertEquals( 'did_send_headers', $actual_result->get_error_code(), 'Incorrect error code' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__remove_nocache_for_user() {
+		$actual_result = Vary_Cache::set_nocache_for_user();
+
+		$this->assertTrue( $actual_result, 'Result was not true' );
+
+		// TODO: verify cookie was removed
+	}
 }


### PR DESCRIPTION
Fail when changes are attempted after send_headers.

We can't set cookies or the vary header after headers have already been sent and should warn users when they attempt to do that.

Fixes #1130

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

1. Check out PR.
1. Add `add_action( 'template_redirect', function() { Vary_Cache::register_group( 'dev-group' ); } );`
1. Verify warning is thrown.
1. Add `add_action( 'template_redirect', function() { var_dump( Vary_Cache::set_group_for_user( 'dev-group', 'yay' ) ); } );`
1. Verify WP_Error is output.