### PR TITLE
Vary Cache: Set cookies only once

### DIFF
--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -343,6 +343,8 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 		// Trigger headers to verify assertions
 		do_action( 'send_headers' );
+
+		$this->assertEquals( 1, did_action( 'vip_vary_cache_did_send_headers' ) );
 	}
 
 	/**
@@ -523,6 +525,8 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 		// Trigger headers to verify assertions
 		do_action( 'send_headers' );
+
+		$this->assertEquals( 1, did_action( 'vip_vary_cache_did_send_headers' ) );
 	}
 
 	/**
@@ -558,5 +562,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 		// Trigger headers to verify assertions
 		do_action( 'send_headers' );
+
+		$this->assertEquals( 1, did_action( 'vip_vary_cache_did_send_headers' ) );
 	}
 }


### PR DESCRIPTION
Only send the cookie once instead of calling setcookie every time a change is triggered. This also allows for easier testing and organizes the code a bit more cleanly.

Also introduces a new action `vip_vary_cache_did_send_headers` that must be used for early exits. We attempted falling back to `shutdown` for those cases, but can't reliably do so since output has already been sent in many cases by the time our shutdown callback fires.

Fixes #1133 

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

Make sure the GDPR example works (just pushed an update to work with this PR).