### PR TITLE
Migrations CLI: Use cURL multi for attachements validation

### DIFF
--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -241,6 +241,8 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 					$log_request = false;
 
 					$response_code = curl_getinfo( $handle, CURLINFO_HTTP_CODE );
+					$url = curl_getinfo( $handle, CURLINFO_EFFECTIVE_URL );
+					
 					curl_multi_remove_handle( $mh, $handle );
 
 					if ( 200 === $response_code ) {

--- a/wp-cli/vip-migrations.php
+++ b/wp-cli/vip-migrations.php
@@ -166,7 +166,7 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 	 * Iterate over attachments and check to see if they actually exist.
 	 *
 	 * @subcommand validate-attachments
-	 * @synopsis <csv-filename> [--log-found-files]
+	 * @synopsis <csv-filename> [--log-found-files] [--start_date=<start_date>] [--end_date=<end_date>]
 	 */
 	public function validate_attachments( $args, $assoc_args ) {
 		$log_found_files = WP_CLI\Utils\get_flag_value( $assoc_args, 'log-found-files', false );
@@ -174,10 +174,8 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 
 		$offset = 0;
 		$limit = 500;
-		$output = array();
-
-		$attachment_count = array_sum( (array) wp_count_posts( 'attachment' ) );
-		$progress = \WP_CLI\Utils\make_progress_bar( 'Checking ' . number_format( $attachment_count ) . ' attachments', $attachment_count );
+		$threads = 10;
+		$output = array( array('url', 'status' ) );
 
 		$file_descriptor = fopen( $output_file, 'w' );
 		if ( false === $file_descriptor ) {
@@ -185,37 +183,82 @@ class VIP_Go_Migrations_Command extends WPCOM_VIP_CLI_Command {
 		}
 
 		global $wpdb;
+
+		$date_query = "";
+		if ( isset( $assoc_args['start_date'] ) ) {
+			$date_query .= $wpdb->prepare(" AND post_date > '%s' ", $assoc_args['start_date'] );
+		}
+
+		if ( isset( $assoc_args['end_date'] ) ) {
+			$date_query .= $wpdb->prepare(" AND post_date < '%s' ", $assoc_args['end_date'] );
+		}
+
+		$count_sql = 'SELECT COUNT(*) FROM ' . $wpdb->posts . ' WHERE post_type = "attachment" ' . $date_query;
+		$attachment_count = $wpdb->get_row( $count_sql, ARRAY_N )[0];
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Checking ' . number_format( $attachment_count ) . ' attachments', $attachment_count );
+
 		do {
-			$sql = $wpdb->prepare( 'SELECT guid FROM ' . $wpdb->posts . ' WHERE post_type = "attachment" LIMIT %d,%d', $offset, $limit );
+			$sql = $wpdb->prepare( 'SELECT guid FROM ' . $wpdb->posts . ' WHERE post_type = "attachment" ' . $date_query . ' LIMIT %d,%d', $offset, $limit );
 			$attachments = $wpdb->get_results( $sql );
 
-			foreach ( $attachments as $attachment ) {
-				$log_request = false;
-				$url = $attachment->guid;
+			// Break the attachments into groups of maxiumum 10 elements
+			$attachments_arrays = array_chunk( $attachments , $threads );
 
-				/*
-				 * TODO: Switch over to `curl_multi` to do lookups in parallel
-				 * if this turns out to be too slow for large media libraries.
-				 */
-				$request = wp_remote_head( $url );
-				$response_code = wp_remote_retrieve_response_code( $request );
-				$response_message = wp_remote_retrieve_response_message( $request );
+			$mh = curl_multi_init();
+			// Loop through each block of 10 attachments
+			foreach ( $attachments_arrays as $attachments_array ) {
 
-				if ( 200 === $response_code ) {
-					$log_request = $log_found_files;
-				} else {
-					$log_request = true;
+				$ch = array();
+				$index = 0;
+
+				foreach( $attachments_array as $attachment ) {
+					$url = $attachment->guid;
+
+					// By switching the URLs from http:// to https>// we save a request, since it will be redirected to the SSL url
+					if ( is_ssl() ) {
+						$url = str_replace( 'http://', 'https://', $url );
+					}
+
+					$ch[ $index ] = curl_init();
+					curl_setopt( $ch[ $index ], CURLOPT_RETURNTRANSFER, true );
+					curl_setopt( $ch[ $index ], CURLOPT_URL, $url );
+					curl_setopt( $ch[ $index ], CURLOPT_FOLLOWLOCATION, true );
+					curl_setopt( $ch[ $index ], CURLOPT_NOBODY, true );
+
+					curl_multi_add_handle( $mh, $ch[ $index ] );
+					$index++;
 				}
 
-				if ( $log_request ) {
-					$output[] = array(
-						$url,
-						$response_code,
-						$response_message,
-					);
+				// Exec the cURL requests
+				$curl_active = null;
+				do {
+					$mrc = curl_multi_exec( $mh, $curl_active );
+				} while ( $curl_active > 0 );
+
+				// Process the responses
+				foreach( $ch as $index => $handle ) {
+					$log_request = false;
+
+					$response_code = curl_getinfo( $handle, CURLINFO_HTTP_CODE );
+					curl_multi_remove_handle( $mh, $handle );
+
+					if ( 200 === $response_code ) {
+						$log_request = $log_found_files;
+					} else {
+						$log_request = true;
+					}
+
+					if ( $log_request ) {
+						$output[] = array(
+							$url,
+							$response_code,
+						);
+					}
+
+					$progress->tick();
 				}
 
-				$progress->tick();
 			}
 
 			// Pause.


### PR DESCRIPTION
## Description

The `validate-attachments` command in the `vip migration` command was doing a synchronous HTTP request for each attachment, which was really slow for sites with a big amount of attachments.

I have implemented the HTTP status code validation using `curl_multi`, so it tests 10 URLs asynchronously. From my tests, I believe this change makes the process ~10x faster than the previous method using `wp_remote_get`.

Additionally, I have included two optional arguments: `--start_date` and `--end_date`, to time box the validation, which is useful when dealing with delta imports of media.

There was a problem with 301 redirections from http to https being included in the CSV, despite of the `--log-found-files` argument. This was addressing by having the cURL request follow any redirections that might exist.

There are a few breaking changes, though: the CSV file now includes an header (`url,status`), while the `$response_message` has been removed from the file - I couldn't find a good way to extract that information from the cURL request.

I'm open to any suggestions on how to improve the code.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
2. On the VIP Go sandbox, run `wp vip migration validate-attachments attachments.csv --start_date=2019-02-20`
3. You should be able to see all the missing (404) attachments in the `attachments.csv` file, otherwise it will be an empty file with just the header. 