### PR TITLE
Stats: Set default for context param for wp_handle_upload

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -44,7 +44,7 @@ function track_publish_post( $new_status, $old_status ) {
 /**
  * Count uploaded files
  */
-function handle_file_upload( $upload, $context ) {
+function handle_file_upload( $upload, $context = 'upload' ) {
 	track_file_upload();
 
 	return $upload;


### PR DESCRIPTION
Some plugins (like `enable-media-replace`) call the action manually but don't pass the correct number of params (1 instead of 2), which can result in fatals:

```
Uncaught ArgumentCountError: Too few arguments to function Automattic\VIP\Stats\handle_file_upload(), 1 passed in /var/www/wp-includes/class-wp-hook.php on line 286 and exactly 2 expected
```

Set a default to prevent those fatals.

## Checklist

Please make sure the items below have been covered before requesting a review:

- n/a This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Install enable-media-replace plugin
1. Upload a file and then replace it.
1. Verify both work as expected.
