### PR TITLE
Fix multicall to always return 429 once rate limit exceeded

### DIFF
--- a/security.php
+++ b/security.php
@@ -97,9 +97,13 @@ function wpcom_vip_login_limit_dont_show_login_form() {
 }
 add_action( 'login_form_login', 'wpcom_vip_login_limit_dont_show_login_form' );
 
+
 function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
-	if ( is_wp_error( $user ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED == $user->get_error_code() )
+	static $login_limit_error;
+	if ( ( is_wp_error( $user ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $user->get_error_code() ) || ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $login_limit_error ) {
+		$login_limit_error = ERROR_CODE_LOGIN_LIMIT_EXCEEDED;
 		return new IXR_Error( 503, $user->get_error_message() );
+	}
 
 	return $error;
 }

--- a/security.php
+++ b/security.php
@@ -105,7 +105,7 @@ function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
 			$login_limit_error = $user;
 	}
 
-	if ( ( is_wp_error( $login_limit_error ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $login_limit_error->get_error_code() ) ) {
+	if ( is_wp_error( $login_limit_error ) ) {
 		return new IXR_Error( 503, $login_limit_error->get_error_message() );
 	}
 

--- a/security.php
+++ b/security.php
@@ -100,9 +100,10 @@ add_action( 'login_form_login', 'wpcom_vip_login_limit_dont_show_login_form' );
 
 function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
 	static $login_limit_error;
-	if ( ( is_wp_error( $user ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $user->get_error_code() ) ) {
+
+	if ( is_wp_error( $user ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $user->get_error_code() ) {
 		// We need to set a persistent error here, as once there is an auth error in a system.multicall, core will no longer trigger any of the rate limit filters for further login attempts in the set.
-			$login_limit_error = $user;
+		$login_limit_error = $user;
 	}
 
 	if ( is_wp_error( $login_limit_error ) ) {

--- a/security.php
+++ b/security.php
@@ -101,6 +101,7 @@ add_action( 'login_form_login', 'wpcom_vip_login_limit_dont_show_login_form' );
 function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
 	static $login_limit_error;
 	if ( ( is_wp_error( $user ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $user->get_error_code() ) || ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $login_limit_error ) {
+		// We need to set a persistent error here, as once there is an auth error in a system.multicall, core will no longer trigger any of the rate limit filters for further login attempts in the set.
 		$login_limit_error = ERROR_CODE_LOGIN_LIMIT_EXCEEDED;
 		return new IXR_Error( 503, $user->get_error_message() );
 	}

--- a/security.php
+++ b/security.php
@@ -107,7 +107,7 @@ function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
 	}
 
 	if ( is_wp_error( $login_limit_error ) ) {
-		return new IXR_Error( 503, $login_limit_error->get_error_message() );
+		return new IXR_Error( 429, $login_limit_error->get_error_message() );
 	}
 
 	return $error;

--- a/security.php
+++ b/security.php
@@ -100,10 +100,13 @@ add_action( 'login_form_login', 'wpcom_vip_login_limit_dont_show_login_form' );
 
 function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
 	static $login_limit_error;
-	if ( ( is_wp_error( $user ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $user->get_error_code() ) || ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $login_limit_error ) {
+	if ( ( is_wp_error( $user ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $user->get_error_code() ) ) {
 		// We need to set a persistent error here, as once there is an auth error in a system.multicall, core will no longer trigger any of the rate limit filters for further login attempts in the set.
-		$login_limit_error = ERROR_CODE_LOGIN_LIMIT_EXCEEDED;
-		return new IXR_Error( 503, $user->get_error_message() );
+			$login_limit_error = $user;
+	}
+
+	if ( ( is_wp_error( $login_limit_error ) && ERROR_CODE_LOGIN_LIMIT_EXCEEDED === $login_limit_error->get_error_code() ) ) {
+		return new IXR_Error( 503, $login_limit_error->get_error_message() );
 	}
 
 	return $error;

--- a/tests/test-security.php
+++ b/tests/test-security.php
@@ -1,8 +1,5 @@
 <?php
 
-include_once( ABSPATH . WPINC . '/class-IXR.php' );
-include_once( ABSPATH . WPINC . '/class-wp-xmlrpc-server.php' );
-
 class VIP_Go_Security_Test extends WP_UnitTestCase {
 	public function test__admin_username_restricted() {
 		$this->factory->user->create( [
@@ -118,41 +115,6 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 		$this->assertEquals( $errors->get_error_code(), 'lost_password_limit_exceeded' );
 
 	}
-
-	public function test__login_system_multicall_rate_limit() {
-		$this->markTestSkipped( 'Not tracking failed attempts against rate limit in test' );
-		add_filter( 'pre_option_enable_xmlrpc', '__return_true' );
-		$myxmlrpcserver = new wp_xmlrpc_server();
-
-		$method = array(
-			'methodName' => 'wp.getUsersBlogs',
-			'params'     => array(
-				0,
-				'admin20',
-				'password',
-			),
-		);
-
-		$method_calls = array();
-
-		$limit_threshold = 50;
-		$last_threshold_index = $limit_threshold - 1;
-
-		for ( $i = 1; $i <= $limit_threshold + 2; $i++ ) {
-			array_push( $method_calls, $method );
-		}
-
-		$myxmlrpcserver->callbacks = $myxmlrpcserver->methods;
-
-		$result = $myxmlrpcserver->multiCall( $method_calls );
-
-		$this->assertEquals( 403, $result[ $last_threshold_index ]['faultCode'] );
-		$this->assertEquals( 429, $result[ $last_threshold_index + 1 ]['faultCode'] );
-		$this->assertNotEmpty( $result[ $last_threshold_index + 1 ]['faultString'] );
-		$this->assertEquals( 429, $result[ $last_threshold_index + 2 ]['faultCode'] );
-		$this->assertNotEmpty( $result[ $last_threshold_index + 2 ]['faultString'] );
-	}
-
 
 	public function setUp() {
 


### PR DESCRIPTION
Fixes issue with incorrect error being returned in the case of multiple calls(system.multicall) in single xmlrpc request after rate limit was hit.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
2. Send a payload to xmlrpc.php with 50+ login calls via system.multicall
```
<?xml version="1.0"?>
<methodCall>
<methodName>system.multicall</methodName>
<params>
  <param>
      <value><array><data>
          <value><struct>
          <member>
            <name>methodName</name>
            <value><string>wp.getUsersBlogs</string></value>
          </member>
          <member>
            <name>params</name><value><array><data>
            <value><array><data>
            <value><string>admin20</string></value>
            <value><string>password</string></value>
            </data></array></value>
            </data></array></value>
          </member>
          </struct></value>
.....repeat value block 50 times...
  </data></array></value>
  </param>
</params>
</methodCall>
```
3.  Verify that after 50 method calls, all subsequent response codes are 503  not 403)
