### PR TITLE
Change set_group_for_user() to check if group is registered first

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -229,12 +229,16 @@ class Vary_Cache {
 
 		$validate_group_result = self::validate_cookie_value( $group );
 		if ( is_wp_error( $validate_group_result ) ) {
-			return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to register group (%s): %s', $group, $validate_group_result->get_error_message() ) );
+			return new WP_Error( 'invalid_vary_group_name', sprintf( 'Failed to set group (%s): %s', $group, $validate_group_result->get_error_message() ) );
 		}
 
 		$validate_value_result = self::validate_cookie_value( $value );
 		if ( is_wp_error( $validate_value_result ) ) {
-			return new WP_Error( 'invalid_vary_group_segment', sprintf( 'Failed to register group segment (%s): %s', $group, $validate_value_result->get_error_message() ) );
+			return new WP_Error( 'invalid_vary_group_segment', sprintf( 'Failed to set group segment (%s): %s', $group, $validate_value_result->get_error_message() ) );
+		}
+
+		if ( ! array_key_exists( $group, self::$groups ) ) {
+			return new WP_Error( 'invalid_vary_group_notregistered', sprintf( 'Failed to set group (%s): Must register the group with register_group( <groupname> ) first. ', $group ) );
 		}
 
 		self::$groups[ $group ] = $value;

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -327,6 +327,9 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__set_group_for_user__valid() {
+
+		Vary_Cache::register_group( 'dev-group' );
+
 		$actual_result = Vary_Cache::set_group_for_user( 'dev-group', 'yep' );
 
 		$this->assertTrue( $actual_result, 'Return value was not true' );
@@ -345,6 +348,18 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		do_action( 'send_headers' );
 
 		$this->assertEquals( 1, did_action( 'vip_vary_cache_did_send_headers' ) );
+	}
+
+	public function test__set_group_for_user_group_not_registered( ) {
+
+		$expected_error_code = 'invalid_vary_group_notregistered';
+
+		$actual_result  = Vary_Cache::set_group_for_user( 'dev-group', 'yes' );
+
+		$this->assertWPError( $actual_result, 'Not WP_Error object' );
+
+		$actual_error_code = $actual_result->get_error_code();
+		$this->assertEquals( $expected_error_code, $actual_error_code, 'Incorrect error code' );
 	}
 
 	/**


### PR DESCRIPTION
## Description

We need to check to make sure that he group has been added via register_groups() before try adding the user to it.

Fixes #1147 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
2. Callng `var_dump(Vary_Cache::set_group_for_user( 'dev-group', 'yay' ) );` should output an error
3. Adding `Vary_Cache:register_group('dev-group');` before that line should output true
