### PR TITLE
Optimize cookie output by removing empty groups

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -335,7 +335,7 @@ class Vary_Cache {
 	 * @throws string If credentials ENV Variables aren't defined.
 	 * @return string encrypted version of string
 	 */
-	public static function encrypt_cookie_value( $value ) {
+	private static function encrypt_cookie_value( $value ) {
 		$client_key = constant( 'VIP_GO_AUTH_COOKIE_KEY' );
 		$client_iv = constant( 'VIP_GO_AUTH_COOKIE_IV' );
 		$cookie_value = random_bytes( 32 ) . '|' . $value . '|' . ( time() + self::$cookie_expiry );

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -429,17 +429,14 @@ class Vary_Cache {
 	 * @return string A string representation of the groups
 	 */
 	private static function stringify_groups() {
-		$groups = array_filter(
-			self::$groups,
-			function( $value ) {
-				return '' !== $value;
+		ksort( self::$groups ); // make sure the string order is the same every time.
+		$flattened = [];
+		foreach ( self::$groups as $key => $value ) {
+			if ( '' === trim( $value ) ) {
+				continue;
 			}
-		);
-		ksort( $groups ); // make sure the string order is the same every time.
-		$flatten = function ( $key, $value ) {
-			return $key . self::VALUE_SEPARATOR . $value;
-		};
-		$flattened = array_map( $flatten, array_keys( $groups ), $groups );
+			$flattened[] = $key . self::VALUE_SEPARATOR . $value;
+		}
 
 		return self::VERSION_PREFIX . implode( self::GROUP_SEPARATOR, $flattened );
 	}

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -442,6 +442,10 @@ class Vary_Cache {
 			$flattened[] = $key . self::VALUE_SEPARATOR . $value;
 		}
 
+		if ( empty( $flattened ) ) {
+			return;
+		}
+
 		return self::VERSION_PREFIX . implode( self::GROUP_SEPARATOR, $flattened );
 	}
 

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -429,6 +429,10 @@ class Vary_Cache {
 	 * @return string A string representation of the groups
 	 */
 	private static function stringify_groups() {
+		if ( empty( self::$groups ) ) {
+			return;
+		}
+
 		ksort( self::$groups ); // make sure the string order is the same every time.
 		$flattened = [];
 		foreach ( self::$groups as $key => $value ) {
@@ -517,11 +521,16 @@ class Vary_Cache {
 	 * @access  private
 	 */
 	private static function set_group_cookie() {
+		$group_string = self::stringify_groups();
+		if ( empty( $group_string ) ) {
+			return;
+		}
+
 		if ( self::is_encryption_enabled() ) {
-			$cookie_value = self::encrypt_cookie_value( self::stringify_groups() );
+			$cookie_value = self::encrypt_cookie_value( $group_string );
 			self::set_cookie( self::COOKIE_AUTH, $cookie_value );
 		} else {
-			self::set_cookie( self::COOKIE_SEGMENT, self::stringify_groups() );
+			self::set_cookie( self::COOKIE_SEGMENT, $group_string );
 		}
 	}
 

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -335,7 +335,7 @@ class Vary_Cache {
 	 * @throws string If credentials ENV Variables aren't defined.
 	 * @return string encrypted version of string
 	 */
-	private static function encrypt_cookie_value( $value ) {
+	public static function encrypt_cookie_value( $value ) {
 		$client_key = constant( 'VIP_GO_AUTH_COOKIE_KEY' );
 		$client_iv = constant( 'VIP_GO_AUTH_COOKIE_IV' );
 		$cookie_value = random_bytes( 32 ) . '|' . $value . '|' . ( time() + self::$cookie_expiry );
@@ -412,6 +412,9 @@ class Vary_Cache {
 		$cookie_value = str_replace( self::VERSION_PREFIX, '', $cookie_value );
 		$groups = explode( self::GROUP_SEPARATOR, $cookie_value );
 		foreach ( $groups as $group ) {
+			if ( empty( $group ) ) {
+				continue;
+			}
 			list( $group_name, $group_value ) = explode( self::VALUE_SEPARATOR, $group );
 			self::$groups[ $group_name ] = $group_value ?? '';
 		}

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -426,11 +426,17 @@ class Vary_Cache {
 	 * @return string A string representation of the groups
 	 */
 	private static function stringify_groups() {
-		ksort( self::$groups ); // make sure the string order is the same every time.
+		$groups = array_filter(
+			self::$groups,
+			function( $value ) {
+				return '' !== $value;
+			}
+		);
+		ksort( $groups ); // make sure the string order is the same every time.
 		$flatten = function ( $key, $value ) {
 			return $key . self::VALUE_SEPARATOR . $value;
 		};
-		$flattened = array_map( $flatten, array_keys( self::$groups ), self::$groups );
+		$flattened = array_map( $flatten, array_keys( $groups ), $groups );
 
 		return self::VERSION_PREFIX . implode( self::GROUP_SEPARATOR, $flattened );
 	}
@@ -597,6 +603,9 @@ class Vary_Cache {
 
 		return true;
 	}
+
+
+
 }
 
 Vary_Cache::load();

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -606,6 +606,13 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				],
 				'vc-v1__dev-group_--_yes'
 			],
+			'values_for_all_empty_groups' => [
+				[
+				],
+				[
+				],
+				'vc-v1__'
+			],
 
 		];
 	}
@@ -613,7 +620,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	/**
 	 * @dataProvider get_test_data__stringify_groups
 	 */
-	public function test__validate_stringify_groups_valid( $groups, $group_values, $expected_result ) {
+	public function test__stringify_groups_valid( $groups, $group_values, $expected_result ) {
 		$get_stringify_groups_method = self::get_vary_cache_method( 'stringify_groups' );
 		Vary_Cache::register_groups( $groups );
 		foreach($group_values as $key => $value) {
@@ -624,6 +631,70 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected_result, $actual_result );
 		Vary_Cache::unload();
+	}
+
+	public function get_test_data__parse_group_cookies() {
+		return [
+			'values_regular_group' => [
+				[],
+				[
+					'vip-go-seg' => 'vc-v1__design-group_--_no---__dev-group_--_yes',
+				],
+				[
+					'design-group' => 'no' ,
+					'dev-group' => 'yes'
+				],
+			],
+			'values_encrypted_group' => [
+				[	'key' => 'abc',
+					'iv' => '1231231231231234',
+				],
+				[
+					'vip-go-auth' => 'VyLXNl8VFvGE4+ZyW1jpbS677cXNgN4owowO0jIOq48LS3ImPe4l2RPUSd3YuD8bLS4UtV4Z6fxFW/E22qvKXaQwPI3fEnZghINwbwaqKhV0jqdovLCVfEIu9SAA4v6I',
+				],
+				[
+					'design-group' => 'no' ,
+					'dev-group' => 'yes'
+				],
+			],
+			'values_regular_nogroup' => [
+				[],
+				[
+					'vip-go-seg' => 'vc-v1__',
+				],
+				[
+				],
+			],
+			'values_encrypted_nogroup' => [
+				[	'key' => 'abc',
+					'iv' => '1231231231231234',
+				],
+				[
+					'vip-go-auth' => 'qSME2LdfVuNvZa0GfeUJ45/uHCu7Auqj3iesSL4CITteGfva/N0wQ5TCIzcyeBImeTf3On2P4f7EtQyviw2ooA==',
+				],
+				[
+				],
+			],
+		];
+
+	}
+
+	/**
+	 * @dataProvider get_test_data__parse_group_cookies
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__parse_group_cookie_valid( $secrets, $initial_cookie, $expected_result )
+	{
+		$_COOKIE = $initial_cookie;
+		$get_parse_group_cookie_method = self::get_vary_cache_method( 'parse_group_cookie' );
+		if ( ! empty( $secrets ) ) {
+			define( 'VIP_GO_AUTH_COOKIE_KEY', $secrets[ 'key' ] );
+			define( 'VIP_GO_AUTH_COOKIE_IV', $secrets[ 'iv' ] );
+			Vary_Cache::enable_encryption();
+		}
+		$get_parse_group_cookie_method->invokeArgs(null, [ ] );
+		$this->assertEquals( $expected_result, Vary_Cache::get_groups() );
 	}
 
 }

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -630,7 +630,6 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		$actual_result = $get_stringify_groups_method->invokeArgs(null, [ ] );
 
 		$this->assertEquals( $expected_result, $actual_result );
-		Vary_Cache::unload();
 	}
 
 	public function get_test_data__parse_group_cookies() {

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -611,7 +611,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				],
 				[
 				],
-				'vc-v1__'
+				null
 			],
 
 		];

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -580,4 +580,50 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( 1, did_action( 'vip_vary_cache_did_send_headers' ) );
 	}
+
+
+
+	public function get_test_data__stringify_groups() {
+		return [
+			'values_for_all_groups' => [
+				[
+					'dev-group',
+					'design-group',
+				],
+				[
+					'dev-group' => 'yes',
+					'design-group' => 'no',
+				],
+				'vc-v1__design-group_--_no---__dev-group_--_yes'
+			],
+			'values_for_only_nonempty_groups' => [
+				[
+					'dev-group',
+					'design-group'
+				],
+				[
+					'dev-group' => 'yes',
+				],
+				'vc-v1__dev-group_--_yes'
+			],
+
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__stringify_groups
+	 */
+	public function test__validate_stringify_groups_valid( $groups, $group_values, $expected_result ) {
+		$get_stringify_groups_method = self::get_vary_cache_method( 'stringify_groups' );
+		Vary_Cache::register_groups( $groups );
+		foreach($group_values as $key => $value) {
+			Vary_Cache::set_group_for_user($key, $value);
+		}
+
+		$actual_result = $get_stringify_groups_method->invokeArgs(null, [ ] );
+
+		$this->assertEquals( $expected_result, $actual_result );
+		Vary_Cache::unload();
+	}
+
 }


### PR DESCRIPTION
## Description

To conserve resources, we probably don't need to embed empty groups in the cookie value. This removes empty groups before we generate the cookie text.

Fixes #1159 
Fixes #1139 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

