### PR TITLE
Fix PHPdoc documentation Generation

### DIFF
--- a/ci/generate-docs.sh
+++ b/ci/generate-docs.sh
@@ -51,7 +51,8 @@ mkdir -p $VIP_PHPDOC_DIR
 cd $VIP_PHPDOC_DIR
 # Using Composer to install PHPDoc is slower than other methods, but installs
 # a more up to date version.
-composer --quiet require phpdocumentor/phpdocumentor
+composer --quiet require jms/serializer:1.7.*
+composer --quiet require phpdocumentor/phpdocumentor:^2.9
 PATH="$PATH:${VIP_PHPDOC_DIR}/vendor/phpdocumentor/phpdocumentor/bin/"
 echo $PATH
 


### PR DESCRIPTION
The Doc build have been failing with the following error:

PHP Fatal error:  Uncaught Doctrine\Common\Annotations\AnnotationException: [Semantical Error] The annotation "JMS\Serializer\Annotation\Type" in property phpDocumentor\Configuration::$title does not exist, or could not be auto-loaded. in /tmp/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php:54

This appears to be from a newer version of jms/serializer that's incompatible:
https://github.com/phpDocumentor/phpDocumentor2/issues/1868

This pins the version of both to get the doc generation running again.

