### PR TITLE
Update wpcom_vip_url_to_postid() to be interchangeable with url_to_postid()

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -250,15 +250,6 @@ add_action( 'transition_post_status', 'wpcom_vip_flush_get_page_by_path_cache', 
  * @return int Post ID, or 0 on failure.
  */
 function wpcom_vip_url_to_postid( $url ) {
-	// Can only run after init, since home_url() has not been filtered to the mapped domain prior to that,
-	// which will cause url_to_postid to fail
-	// @see https://vip.wordpress.com/documentation/vip-development-tips-tricks/home_url-vs-site_url/
-	if ( ! did_action( 'init' ) ) {
-		_doing_it_wrong( 'wpcom_vip_url_to_postid', 'wpcom_vip_url_to_postid must be called after the init action, as home_url() has not yet been filtered', '' );
-
-		return 0;
-	}
-
 	// Sanity check; no URLs not from this site
 	if ( parse_url( $url, PHP_URL_HOST ) !== wpcom_vip_get_home_host() ) {
 		return 0;

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -250,11 +250,6 @@ add_action( 'transition_post_status', 'wpcom_vip_flush_get_page_by_path_cache', 
  * @return int Post ID, or 0 on failure.
  */
 function wpcom_vip_url_to_postid( $url ) {
-	// Sanity check; no URLs not from this site
-	if ( parse_url( $url, PHP_URL_HOST ) !== wpcom_vip_get_home_host() ) {
-		return 0;
-	}
-
 	$cache_key = md5( $url );
 	$post_id = wp_cache_get( $cache_key, 'url_to_postid' );
 


### PR DESCRIPTION
## Description

I found that `wpcom_vip_url_to_postid()` couldn't be directly substituted with `url_to_postid()` when debugging a performance issue last month. The reason was that the sanity check we do doesn't account for when only a path is passed and not a full URL. Core does this same sanity check, so we shouldn't need to: https://github.com/WordPress/WordPress/blob/6fd8080e7ee7599b36d4528f72a8ced612130b8c/wp-includes/rewrite.php#L477-L483

And then I'm 90% sure the first condition is no longer needed either as we just directly use the site/home urls on VIP GO rather than the mapping logic on wpcom.