### PR TITLE
Remove private scope on Vary Cache consts to enable PHPdoc generation

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -5,14 +5,14 @@ namespace Automattic\VIP\Cache;
 use WP_Error;
 
 class Vary_Cache {
-	private const COOKIE_NOCACHE = 'vip-go-cb';
-	private const COOKIE_SEGMENT = 'vip-go-seg';
-	private const COOKIE_AUTH = 'vip-go-auth';
+	const COOKIE_NOCACHE = 'vip-go-cb';
+	const COOKIE_SEGMENT = 'vip-go-seg';
+	const COOKIE_AUTH = 'vip-go-auth';
 
 	// Allowed values in cookie are alphanumerics (A-Za-z0-9) and underscore (_) and hyphen (-).
-	private const GROUP_SEPARATOR = '---__';
-	private const VALUE_SEPARATOR = '_--_';
-	private const VERSION_PREFIX = 'vc-v1__';
+	const GROUP_SEPARATOR = '---__';
+	const VALUE_SEPARATOR = '_--_';
+	const VERSION_PREFIX = 'vc-v1__';
 
 	/**
 	 * Flag to indicate if this an encrypted group request
@@ -195,7 +195,7 @@ class Vary_Cache {
 	 * @since   1.0.0
 	 * @access  public
 	 *
-	 * @param  string $groups A group to vary on.
+	 * @param  string $group A group to vary on.
 	 * @return boolean
 	 */
 	public static function register_group( string $group ) {

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -29,6 +29,7 @@
 		<file>000-vip-init.php</file>
 		<file>lib/proxy/ip-forward.php</file>
 		<file>vip-cache-manager/api.php</file>
+		<file>cache/class-vary-cache.php</file>
 		<directory>vip-helpers</directory>
 	</files>
 </phpdoc>


### PR DESCRIPTION
The latest stable version of PHPDocumentor(2.9.0) doesn't seem to support private consts (that were introduced in PHP7.1)

This changes the Vary Cache constants to public which does result in the docs generating correctly.

I tried adding the `@ignore` annotations to the constants, but this didn't appear to make a difference.
