### PR TITLE
Stream Wrapper: Tweaks to `vip files update-filesizes` script

### DIFF
--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -20,8 +20,14 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--start-index=<start-index>]
+	 * : Which ID to start from
+	 * ---
+	 * default: 0
+	 * ---
+	 *
 	 * [--dry-run=<dry-run>]
-	 * : Wether or not to update to database, or simply inspect it.
+	 * : Whether or not to update to database, or simply inspect it.
 	 * ---
 	 * default: false
 	 * options:
@@ -64,6 +70,12 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 			$this->dry_run = false;
 		}
 
+		$start_index = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'start-index', 0 );
+		if ( 0 > $start_index ) {
+			WP_CLI::error( 'Invalid start index: ' . $start_index );
+			WP_CLI::halt( 1 );
+		}
+
 		$batch_size = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'batch', 1000 );
 		if ( 0 >= $batch_size ) {
 			WP_CLI::error( 'Invalid batch size: ' . $batch_size );
@@ -73,6 +85,7 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 		WP_CLI::line( '' );
 		WP_CLI::line( 'ARGUMENTS' );
 		WP_CLI::line( '* dry run: ' . ( $this->dry_run ? 'yes' : 'no' ) );
+		WP_CLI::line( '* start index: ' . $start_index );
 		WP_CLI::line( '* batch size: ' . $batch_size );
 		WP_CLI::line( '* log file: ' . $log_file_name );
 		WP_CLI::line( '' );
@@ -87,7 +100,6 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 
 		$max_id = $wpdb->get_var( 'SELECT ID FROM ' . $wpdb->posts . ' ORDER BY ID DESC LIMIT 1' );
 
-		$start_index = 0;
 		$end_index = $start_index + $batch_size;
 
 		do {

--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -78,6 +78,8 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 			WP_CLI::halt( 1 );
 		}
 
+		WP_CLI::confirm( sprintf( 'Should we start processing %s attachments?', number_format( $attachment_count ) ), $assoc_args );
+
 		$this->progress = \WP_CLI\Utils\make_progress_bar(
 			'Checking ' . number_format( $attachment_count ) . ' attachments', $attachment_count );
 

--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -37,6 +37,10 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 	 * default: 1000
 	 * ---
 	 *
+	 * [--yes]
+	 * : Skip confirmation step
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *     wp vip files update-filesizes
 	 *

--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -133,6 +133,11 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
+		// If the meta doesn't exist at all, it's worth still storing the filesize
+		if ( empty( $meta ) ) {
+			$meta = [];
+		}
+
 		if ( ! is_array( $meta ) ) {
 			return [ false, 'does not have valid metadata' ];
 		}

--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -48,6 +48,11 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 
 		$offset = 0;
 
+		if ( ! defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) || true !== VIP_FILESYSTEM_USE_STREAM_WRAPPER ) {
+			WP_CLI::error( 'This script only works when the VIP Stream Wrapper is enabled. Please add `define( \'VIP_FILESYSTEM_USE_STREAM_WRAPPER\', true );` to vip-config.php and try again.' );
+			return;
+		}
+
 		WP_CLI::line( 'Updating attachment filesize metadata...' );
 
 		$log_file_name = sprintf( '%svip-files-update-filesizes-%s%s.csv', get_temp_dir(), $this->dry_run ? 'dry-run-' : '', date( 'YmdHi' ) );

--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -69,6 +69,7 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 		WP_CLI::line( 'ARGUMENTS' );
 		WP_CLI::line( '* dry run: ' . ( $this->dry_run ? 'yes' : 'no' ) );
 		WP_CLI::line( '* batch size: ' . $batch_size );
+		WP_CLI::line( '* log file: ' . $log_file_name );
 		WP_CLI::line( '' );
 
 		$attachment_count = array_sum( (array) wp_count_posts( 'attachment' ) );


### PR DESCRIPTION
A couple of optimizations and improvements:

- Create meta if it doesn't exist
- BETWEEN instead of LIMIT (much faster when using INDEX)
- Confirmation step

And a few other small changes.

## Checklist

Please make sure the items below have been covered before requesting a review:

- n/a This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).