### PR TITLE
Add initial Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,18 @@ job-references:
             WP_MULTISITE=1 vendor/bin/phpunit
 
 jobs:
-  php73-build:
+  php73-build-multisite:
     <<: *php_job
+    environment:
+      - WP_MULTISITE=1
+    docker:
+      - image: circleci/php:7.3
+      - image: *mysql_image
+
+  php73-build-singlesite:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE=0
     docker:
       - image: circleci/php:7.3
       - image: *mysql_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ workflows:
 version: 2
 
 job-references:
-  mysql_image: &mysql_image
-    circleci/mysql:5.6
+  db_image: &db_image
+    circleci/mariadb:10.2
 
   setup_environment: &setup_environment
     name: "Setup Environment Variables"
@@ -23,7 +23,7 @@ job-references:
       sudo apt-get update && sudo apt-get install subversion
       sudo -E docker-php-ext-install mysqli
       sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-      sudo apt-get update && sudo apt-get install mysql-client-5.7
+      sudo apt-get update && sudo apt-get install mysql-client
       composer install -n
 
   prepare_repo: &prepare_repo
@@ -56,7 +56,7 @@ jobs:
       - WP_MULTISITE=1
     docker:
       - image: circleci/php:7.3
-      - image: *mysql_image
+      - image: *db_image
 
   php73-build-singlesite:
     <<: *php_job
@@ -64,4 +64,4 @@ jobs:
       - WP_MULTISITE=0
     docker:
       - image: circleci/php:7.3
-      - image: *mysql_image
+      - image: *db_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ job-references:
       sudo -E docker-php-ext-install mysqli
       sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
       sudo apt-get update && sudo apt-get install mysql-client-5.7
+      composer install -n
 
   prepare_repo: &prepare_repo
     name: "Prepare Repo"
@@ -44,8 +45,8 @@ job-references:
           command: |
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION
-            phpunit
-            WP_MULTISITE=1 phpunit
+            vendor/bin/phpunit --version
+            WP_MULTISITE=1 vendor/bin/phpunit
 
 jobs:
   php72-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ job-references:
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION
             vendor/bin/phpunit --version
-            WP_MULTISITE=1 vendor/bin/phpunit
+            vendor/bin/phpunit
 
 jobs:
   php73-build-multisite:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ workflows:
   version: 2
   main:
     jobs:
-      - php72-build
+      - php73-build
 
 version: 2
 
@@ -49,12 +49,6 @@ job-references:
             WP_MULTISITE=1 vendor/bin/phpunit
 
 jobs:
-  php72-build:
-    <<: *php_job
-    docker:
-      - image: circleci/php:7.2
-      - image: *mysql_image
-
   php73-build:
     <<: *php_job
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ workflows:
   version: 2
   main:
     jobs:
-      - php73-build
+      - php73-build-multisite
+      - php73-build-singlesite
 
 version: 2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,6 @@ job-references:
     environment:
       - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
       - WP_CORE_DIR: "/tmp/wordpress/"
-      - WP_VERSION: "latest"
     steps:
       - checkout
       - run: *setup_environment
@@ -53,7 +52,8 @@ jobs:
   php73-build-multisite:
     <<: *php_job
     environment:
-      - WP_MULTISITE=1
+      - WP_MULTISITE: "1"
+      - WP_VERSION: "latest"
     docker:
       - image: circleci/php:7.3
       - image: *db_image
@@ -61,7 +61,8 @@ jobs:
   php73-build-singlesite:
     <<: *php_job
     environment:
-      - WP_MULTISITE=0
+      - WP_MULTISITE: "0"
+      - WP_VERSION: "latest"
     docker:
       - image: circleci/php:7.3
       - image: *db_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+workflows:
+  version: 2
+  main:
+    jobs:
+      - php72-build
+
+version: 2
+
+job-references:
+  mysql_image: &mysql_image
+    circleci/mysql:5.6
+
+  setup_environment: &setup_environment
+    name: "Setup Environment Variables"
+    command: |
+      echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
+      source /home/circleci/.bashrc
+
+  install_dependencies: &install_dependencies
+    name: "Install Dependencies"
+    command: |
+      sudo apt-get update && sudo apt-get install subversion
+      sudo -E docker-php-ext-install mysqli
+      sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
+      sudo apt-get update && sudo apt-get install mysql-client-5.7
+
+  prepare_repo: &prepare_repo
+    name: "Prepare Repo"
+    command: |
+      git submodule update --init --recursive
+
+  php_job: &php_job
+    environment:
+      - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
+      - WP_CORE_DIR: "/tmp/wordpress/"
+      - WP_VERSION: "latest"
+    steps:
+      - checkout
+      - run: *setup_environment
+      - run: *install_dependencies
+      - run: *prepare_repo
+      - run:
+          name: "Run Tests"
+          command: |
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION
+            phpunit
+            WP_MULTISITE=1 phpunit
+
+jobs:
+  php72-build:
+    <<: *php_job
+    docker:
+      - image: circleci/php:7.2
+      - image: *mysql_image
+
+  php73-build:
+    <<: *php_job
+    docker:
+      - image: circleci/php:7.3
+      - image: *mysql_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ job-references:
       - run:
           name: "Run Tests"
           command: |
+            make lint
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION
             vendor/bin/phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,7 @@ git:
   submodules: false
 
 php:
-  - 7.2
   - 7.3
-
-env:
-  matrix:
-    - WP_VERSION=latest WP_MULTISITE=0 DEPLOY_BRANCH=master RUN_PHPCS=1
-    - WP_VERSION=latest WP_MULTISITE=1 DEPLOY_BRANCH=master RUN_PHPCS=0
 
 addons:
   apt:
@@ -23,23 +17,6 @@ before_install:
   - ./ci/prepare.sh
 
 install: true
-
-before_script:
-  - composer install -n
-  - vendor/bin/phpunit --version
-
-script:
-  # Linting and unit tests
-  - make lint
-  - if [[ "$RUN_PHPCS" == "1" ]]; then echo "Skipping make sniff since it's broken right now"; fi
-  - make phpunit
-
-notifications:
-  email: false
-  slack:
-    secure: "DFGhxNw5Ai4/P3Ur55RTgOIowejSzIbH9YFYatULUZfIRdXk8Zuo75n+xyysciqdGD4hV1jVZCecb37LRZtUiKPwsr7tRPsw5e7H7sb0M1FG1eVrupTZS+HwJ3/Dwg8B866JCGVOhniaaW4rDXLYn2n96H+2N60Su37VaYoHQPQfwSZuRp5QSRsHz6gAlIScYG4emOmREhmTw/x6K5GcT0k3Sv18uIWfrO9WTkCaUsVraT0f0LYkPGJNL91E8KYKrcX3/vGEFF8nL/JUyM3KexB/6OCG+0IxGcFlZ0FJAu2mTaEk6Y6S53u3NpoCjZTSPOA+ClHEfV52HrimpAsKBhY9VmuYkdlaJOLeRuxKvBma5VTOQf9zlWxcKeOf6ySWsxYfD8nFlwdIbcqOBTU4QeKQXUAOmmk8E/nbe+NBl02VI0A9n4P+QOMoedJjF9Ds+T98d4POAhzbvVH3igdB++w7/X/86JsJqVUnQXk7LE/qWiYDcPmIdFxKB4gUfQBS4e7KOqsCpN35b4Nrjex12Jk4sPYk9eQLBP1NxCn2A+y4Wm0WHN6MOoRrVC4CXHwz4r+hyVcGFthabG3uH+s7/EyG5nUESbaoYpwJ+5+yvYi/HyC7IcwPY6Cp2CnMfFMm3ROrrGw+MaVQxbkrpFen2UZe5wjkOJY2NmNTjaSQzvg="
-    on_success: change
-    on_failure: change
 
 after_success:
   # Push the aggregated code, including submodules, to the public repo

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ git:
 php:
   - 7.3
 
+branches:
+  only:
+  - master
+
 addons:
   apt:
     packages:
@@ -16,7 +20,9 @@ addons:
 before_install:
   - ./ci/prepare.sh
 
-install: true
+install: echo "Skipping install"
+
+script: echo "Skipping script"
 
 after_success:
   # Push the aggregated code, including submodules, to the public repo

--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -15,8 +15,3 @@ git submodule update --init
 # Now recurse over all the contained submodules,
 # sub-submodules, etc, to do the same
 date; git submodule foreach --recursive 'if [ -w .gitmodules ]; then sed -i -e "s|git@\([^:]*\):|https://\1/|" "$toplevel/$path/.gitmodules"; fi; git submodule update --init "$toplevel/$path";'; date;
-
-# Install unit tests
-# ==================
-
-bash bin/install-wp-tests.sh wordpress_test root '' localhost "${WP_VERSION}"


### PR DESCRIPTION
Based on the WP-CLI scaffold template: https://github.com/wp-cli/scaffold-command/blob/master/templates/plugin-circle.mustache

Fixes #1176

### TODO

- [x] Use the local composer versions of phpunit
- [x] Test both multisite and single site
- [ ] Add "deploy" script (i.e. push to `vip-go-mu-plugins-built`; should probably rename this...)
- [ ] Add generate docs script

### TODO (Bonus)

- [x] Support for testing multiple versions of WP
- [ ] PHPCS