### PR TITLE
Debug Mode: Track stats when enabled/disabled

### DIFF
--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -21,8 +21,8 @@ use function Automattic\VIP\Stats\send_pixel;
 // How long should we enable Debug mode for?
 const COOKIE_TTL = 2 * HOUR_IN_SECONDS;
 
-// Wait till our VIP context is loaded so we can use som internal functions.
-add_action( 'vip_loaded', __NAMESPACE__ . '\init_debug_mode' );
+// Wait till our VIP context is loaded so we can use some internal functions.
+add_action( 'muplugins_loaded', __NAMESPACE__ . '\init_debug_mode' );
 
 function init_debug_mode() {
 	if ( isset( $_GET['a8c-debug'] ) ) {

--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Automattic\VIP\Stats\send_pixel;
+
 /**
  * Logged out Debug Mode for VIP
  *
@@ -63,12 +65,16 @@ function enable_debug_mode() {
 	nocache_headers();
 
 	if ( ! \is_proxied_request() ) {
+		send_pixel( [ 'vip-go-a8c-debug' => 'fail-noproxy' ] );
+
 		wp_die( 'A8C: Please proxy to enable Debug Mode.', 'Proxy Required', [ 'response' => 403 ] );
 	}
 
 	$ttl = time() + COOKIE_TTL;
 	setcookie( 'vip-go-cb', '1', $ttl );
 	setcookie( 'a8c-debug', '1', $ttl );
+
+	send_pixel( [ 'vip-go-a8c-debug' => 'enable' ] );
 
 	redirect_back();
 }
@@ -79,6 +85,8 @@ function disable_debug_mode() {
 	$ttl = time() - COOKIE_TTL;
 	setcookie( 'vip-go-cb', '', $ttl );
 	setcookie( 'a8c-debug', '', $ttl );
+
+	send_pixel( [ 'vip-go-a8c-debug' => 'disable' ] );
 
 	redirect_back();
 }

--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -53,7 +53,7 @@ function redirect_back() {
 		'a8c-debug' => false,
 
 		// Redirect with a cache buster on the URL to avoid browser-based caches.
-		'random' => time(),
+		'_cachebuster' => time(),
 	] );
 
 	// Note: this is called early so we can't use wp_safe_redirect


### PR DESCRIPTION
Related #1164 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

- Pull down PR
- Enable Debug Mode by appending `?a8c-debug=true` - verify it works as expected
- Disable Debug Mode by appending `?a8c-debug=false` - verify it works as expected
- Attempt to enable with proxy disabled - verify it works as expected
- Verify that the appropriate stats have been tracked in MC