### PR TITLE
Add cache-nav-menus submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "gutenberg-ramp"]
 	path = gutenberg-ramp
 	url = https://github.com/Automattic/gutenberg-ramp.git
+[submodule "cache-nav-menus"]
+	path = cache-nav-menus
+	url = https://github.com/Automattic/cache-nav-menus.git


### PR DESCRIPTION
## Description

I'm sure there's a good reason this hasn't been included already but added it to at least evoke the discussion.

Context, I'm looking to use this plugin on a VIP build and was surprised it wasn't including in the mu-plugins.
