### PR TITLE
Make (Local) Core Upgrades Work Again

### DIFF
--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -56,8 +56,11 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 			return $this->direct;
 		}
 
-		/* Translators: 1) file name 2) class name */
-		$error_msg = sprintf( __( 'The `%1$s` file cannot be managed by the `%2$s` class. Writes are only allowed for the `/uploads` and `/tmp` directories and reads can be performed everywhere.' ), $filename, __CLASS__ );
+		$upload_dir = wp_get_upload_dir()['basedir'];
+		$temp_dir = get_temp_dir();
+
+		/* Translators: 1) file name 2) class name 3) tmp dir path 4) uploads dir path */
+		$error_msg = sprintf( __( 'The `%1$s` file cannot be managed by the `%2$s` class. Writes are only allowed for the `%3$s` and `%4$s` directories and reads can be performed everywhere.' ), $filename, __CLASS__, $temp_dir, $upload_dir );
 
 		$this->errors->add( 'unsupported-filepath', $error_msg );
 

--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -42,6 +42,13 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 	 * @return WP_Filesystem_VIP_Uploads|bool|mixed|WP_Filesystem_Direct
 	 */
 	private function get_transport_for_path( $filename, $context = 'read' ) {
+		// If we're not in a VIP environment, allow core upgrades to work.
+		// Note: WP_CLI doesn't set WP_INSTALLING so we fallback to checking for the upgrade lock instead.
+		if ( true !== VIP_GO_ENV &&
+		       ( wp_installing() || get_option( 'core_updater.lock' ) ) ) {
+			return $this->direct;
+		}
+
 		// Uploads paths can just use PHP functions when stream wrapper is enabled.
 		// This is because wp_upload_dir will return a vip:// path.
 		if ( $this->is_uploads_path( $filename ) ) {


### PR DESCRIPTION
Pretty annoying that this this didn't work. If we're outside the VIP environment and in installing mode, just use the direct method for `WP_Filesystem` rather than blocking it.

Previously:

```
$ wp core upgrade
Updating to version 5.1.1 (en_US)...
Downloading update from https://downloads.wordpress.org/release/wordpress-5.1.1-no-content.zip...
Unpacking the update...
Warning: The `/vagrant/www/wordpress-default/public_html/wp-content/upgrade/wp_5c8aa1b7b5437` file cannot be managed by the `Automattic\VIP\Files\WP_Filesystem_VIP` class. Writes are only allowed for the `/uploads` and `/tmp` directories and reads can be performed everywhere. in /vagrant/www/wordpress-default/public_html/wp-content/mu-plugins/files/class-wp-filesystem-vip.php on line 65
Warning: The `/vagrant/www/wordpress-default/public_html/wp-content/upgrade/wp_5c8aa1b7b5437` file cannot be managed by the `Automattic\VIP\Files\WP_Filesystem_VIP` class. Writes are only allowed for the `/uploads` and `/tmp` directories and reads can be performed everywhere. in /vagrant/www/wordpress-default/public_html/wp-content/mu-plugins/files/class-wp-filesystem-vip.php on line 65
Error: Could not create directory.
```

Now:

```
$ wp core upgrade
Updating to version 5.1.1 (en_US)...
Using cached file '/home/vagrant/.wp-cli/cache/core/wordpress-5.1.1-no-content-en_US.zip'...
Unpacking the update...
Cleaning up files...
No files found that need cleaning up.
Success: WordPress updated successfully.
```

Fixes #1054 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- n/a This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Make sure your install is on an older version
1. Run `wp core update`
1. Verify it works.
1. Downgrade back to an old version.
1. Upgrade from wp-admin
1. Verify it works.
1. Make sure other Filesystem interaction works:

```
$ wp shell
$creds = request_filesystem_credentials( site_url() )
WP_Filesystem( $creds )
global $wp_filesystem

# this will not work (will throw a warning and return false)
$wp_filesystem->put_contents( 'file.txt', 'yay' )

# these will work
$wp_filesystem->put_contents( get_temp_dir() . 'file.txt', 'yay' )
$wp_filesystem->get_contents( get_temp_dir() . 'file.txt' )
$wp_filesystem->put_contents( wp_get_upload_dir()['basedir'] . '/file.txt', 'yay' )
$wp_filesystem->get_contents( wp_get_upload_dir()['basedir'] . '/file.txt' )```
