### PR TITLE
Plugin Compat: Add fix for Contact Form 7 attachments

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -1,15 +1,28 @@
 <?php
 /*
-Plugin Name: VIP Go Plugin Fixes
-Description: A collection of fixes for various plugins.
+Plugin Name: VIP Go Plugin Compat
+Description: A collection of compatibility fixes to make sure various plugins run smoothly on VIP Go.
 Author: Automattic
 Version: 1.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-// Make sure the `amp` query var has an explicit value.
-// Avoids issues when filtering the deprecated `query_string` hook.
-// Copy of upstream fix: https://github.com/Automattic/amp-wp/pull/910
+/**
+ * Contact Form 7 (https://en-ca.wordpress.org/plugins/contact-form-7/)
+ * 
+ * The plugin attempts to write to a `wp-content` path which will fail.
+ * These files are transient and only meant to be included as attachment,
+ * so let's just tell CF7 to put them in `/tmp/`.
+ */
+define( 'WPCF7_UPLOADS_TMP_DIR', get_temp_dir() );
+
+/**
+ * AMP for WordPress (https://github.com/ampproject/amp-wp)
+ * Make sure the `amp` query var has an explicit value.
+ * Avoids issues when filtering the deprecated `query_string` hook.
+ *
+ * Copy of upstream fix: https://github.com/Automattic/amp-wp/pull/910
+ */
 function vip_go_amp_force_query_var_value( $query_vars ) {
 	// Don't bother if AMP is not active
 	if ( ! defined( 'AMP_QUERY_VAR' ) ) {


### PR DESCRIPTION
The plugin attempts to write to a `wp-content` path which will fail. These files are transient and only meant to be included as attachment, so let's just tell CF7 to put them in `/tmp/` which will work.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Install and activate Contact Form 7.
1. Add a form with an file field.
1. Something a form with a file and verify it's attached to the outgoing email.
