### PR TITLE
Stream Wrapper: Don’t schedule meta update for non-prod env

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -442,6 +442,16 @@ class VIP_Filesystem {
 	}
 
 	public function schedule_update_job() {
+		// Only schedule meta update job on production
+		if ( 'production' !== VIP_GO_ENV ) {
+			// Remove any existing meta update jobs from non-production
+			if ( wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
+				wp_clear_scheduled_hook( self::CRON_EVENT_NAME );
+			}
+
+			return;
+		}
+
 		if ( get_option( self::OPT_ALL_FILESIZE_PROCESSED ) ) {
 			if ( wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
 				wp_clear_scheduled_hook( self::CRON_EVENT_NAME );

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -471,6 +471,11 @@ class VIP_Filesystem {
 	 * Cron job to update attachment metadata with file size
 	 */
 	public function update_attachment_meta() {
+		if ( 'production' !== VIP_GO_ENV ) {
+			// Don't run on non-production env
+			return;
+		}
+
 		wpcom_vip_irc(
 			'#vip-go-filesize-updates',
 			sprintf( 'Starting %s on %s... $vip-go-streams-debug',


### PR DESCRIPTION
## Description

Only schedule the meta update event on production environments.

Also removes any existing scheduled meta update event from non-production environments.

Fixes #1190 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

