### PR TITLE
Lockout: Fix message display when locked

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -115,11 +115,11 @@ class Lockout {
 	 * @return array
 	 */
 	public function filter_user_has_cap( $user_caps, $caps, $args, $user ) {
-		if ( is_automattician( $user->ID ) ) {
-			return $user_caps;
-		}
-
 		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === VIP_LOCKOUT_STATE ) {
+			if ( is_automattician( $user->ID ) ) {
+				return $user_caps;
+			}
+
 			$subscriber = get_role( 'subscriber' );
 			if ( null !== $subscriber ) {
 				$this->locked_cap = $subscriber->capabilities;

--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -42,22 +42,25 @@ class Lockout {
 		if ( defined( 'VIP_LOCKOUT_STATE' ) ) {
 			$user = wp_get_current_user();
 
-			$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'manage_options' ), VIP_LOCKOUT_STATE, $user );
-			if ( ! $show_notice ) {
-				return;
-			}
-
 			switch ( VIP_LOCKOUT_STATE ) {
 				case 'warning':
-					$this->render_warning_notice();
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'manage_options' ), VIP_LOCKOUT_STATE, $user );
+					if ( $show_notice ) {
+						$this->render_warning_notice();
 
-					$this->user_seen_notice( $user );
+						$this->user_seen_notice( $user );
+					}
+
 					break;
 
 				case 'locked':
-					$this->render_locked_notice();
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'read' ), VIP_LOCKOUT_STATE, $user );
+					if ( $show_notice ) {
+						$this->render_locked_notice();
 
-					$this->user_seen_notice( $user );
+						$this->user_seen_notice( $user );
+					}
+
 					break;
 			}
 		}

--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -145,6 +145,10 @@ class Lockout {
 	 */
 	public function filter_site_admin_option( $pre_option, $option, $network_id, $default ) {
 		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === VIP_LOCKOUT_STATE ) {
+			if ( is_automattician() ) {
+				return $pre_option;
+			}
+
 			return [];
 		}
 


### PR DESCRIPTION
We remove all caps when locked and should show the lockout message to all users with `read` instead. Otherwise the message never gets displayed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Enabled lockout with warning (`define( 'VIP_LOCKOUT_STATE', 'warning' )` and `define( 'VIP_LOCKOUT_MESSAGE', 'oh no!' );`)
1. Verify message is displayed to an administrator user but not any other roles.
1. Switch to locked (`define( 'VIP_LOCKOUT_STATE', 'locked' )`)
1. Verify message is displayed to all users and they can only access Dashboard and Profile.