### PR TITLE
Cast returned max ID as int

### DIFF
--- a/files/class-meta-updater.php
+++ b/files/class-meta-updater.php
@@ -82,7 +82,7 @@ class Meta_Updater {
 
 		global $wpdb;
 
-		$this->max_id = $wpdb->get_var( 'SELECT ID FROM ' . $wpdb->posts . ' ORDER BY ID DESC LIMIT 1' );
+		$this->max_id = (int) $wpdb->get_var( 'SELECT ID FROM ' . $wpdb->posts . ' ORDER BY ID DESC LIMIT 1' );
 
 		return $this->max_id;
 	}


### PR DESCRIPTION
If the site has no posts, we get a null and fatal because the return value is typecast as an int.