### PR TITLE
Move update filesizes job

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -894,16 +894,6 @@ class A8C_Files {
 	}
 
 	public function schedule_update_job() {
-		// Only schedule meta update job on production
-		if ( 'production' !== VIP_GO_ENV ) {
-			// Remove any existing meta update jobs from non-production
-			if ( wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
-				wp_clear_scheduled_hook( self::CRON_EVENT_NAME );
-			}
-
-			return;
-		}
-
 		if ( get_option( self::OPT_ALL_FILESIZE_PROCESSED ) ) {
 			if ( wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
 				wp_clear_scheduled_hook( self::CRON_EVENT_NAME );
@@ -923,11 +913,6 @@ class A8C_Files {
 	 * Cron job to update attachment metadata with file size
 	 */
 	public function update_attachment_meta() {
-		if ( 'production' !== VIP_GO_ENV ) {
-			// Don't run on non-production env
-			return;
-		}
-
 		wpcom_vip_irc(
 			'#vip-go-filesize-updates',
 			sprintf( 'Starting %s on %s... $vip-go-streams-debug',

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -86,11 +86,14 @@ class A8C_Files {
 		// ensure the correct upload URL is used even after switch_to_blog is called
 		add_filter( 'option_upload_url_path', array( $this, 'upload_url_path' ), 10, 2 );
 
-		// add new cron schedule for filesize update
-		add_filter( 'cron_schedules', array( $this, 'filter_cron_schedules' ), 10, 1 );
+		// Conditionally schedule the attachment filesize metaata update job
+		if ( defined( 'VIP_FILESYSTEM_SCHEDULE_FILESIZE_UPDATE' ) && true === VIP_FILESYSTEM_SCHEDULE_FILESIZE_UPDATE ) {
+			// add new cron schedule for filesize update
+			add_filter( 'cron_schedules', array( $this, 'filter_cron_schedules' ), 10, 1 );
 
-		// Schedule meta update job
-		$this->schedule_update_job();
+			// Schedule meta update job
+			$this->schedule_update_job();
+		}
 	}
 
 	/**
@@ -944,6 +947,9 @@ class A8C_Files {
 		}
 
 		$batch_size = 3000;
+		if ( defined( 'VIP_FILESYSTEM_FILESIZE_UPDATE_BATCH_SIZE' ) ) {
+			$batch_size = (int) VIP_FILESYSTEM_FILESIZE_UPDATE_BATCH_SIZE;
+		}
 		$updater = new Meta_Updater( $batch_size );
 
 		$max_id = (int) get_option( self::OPT_MAX_POST_ID );

--- a/files/class-meta-updater.php
+++ b/files/class-meta-updater.php
@@ -202,13 +202,6 @@ class Meta_Updater {
 		}
 
 		return (int) wp_remote_retrieve_header( $response, 'Content-Length' );
-		$file = get_attached_file( $attachment_id );
-
-		if ( ! file_exists( $file ) ) {
-			return 0;
-		}
-
-		return filesize( $file );
 	}
 
 	/**

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -12,29 +12,6 @@ class VIP_Filesystem {
 	const PROTOCOL = 'vip';
 
 	/**
-	 * The name of the scheduled cron event to update attachment metadata
-	 */
-	const CRON_EVENT_NAME = 'vip_update_attachment_filesizes';
-
-	/**
-	 * Option name to mark all attachment filesize update completed
-	 */
-	const OPT_ALL_FILESIZE_PROCESSED = 'vip_all_attachment_filesize_processed_v2';
-
-	/**
-	 * Option name to mark next index for starting the next batch of filesize updates
-	 */
-	const OPT_NEXT_FILESIZE_INDEX = 'vip_next_attachment_filesize_index_v2';
-
-	/**
-	 * Option name for storing Max ID.
-	 *
-	 * We do not need to keep this updated as new attachments will already have file sizes
-	 * included in their meta.
-	 */
-	const OPT_MAX_POST_ID = 'vip_attachment_max_post_id_v2';
-
-	/**
 	 * The unique identifier of this plugin.
 	 *
 	 * @since    1.0.0
@@ -87,11 +64,6 @@ class VIP_Filesystem {
 		 * The class representing the VIP Files stream
 		 */
 		require_once __DIR__ . '/class-vip-filesystem-stream-wrapper.php';
-
-		/**
-		 * The class use to update attachment meta data
-		 */
-		require_once __DIR__ . '/class-meta-updater.php';
 	}
 
 	/**
@@ -106,9 +78,6 @@ class VIP_Filesystem {
 		$this->stream_wrapper = new VIP_Filesystem_Stream_Wrapper( new_api_client(),
 			self::PROTOCOL );
 		$this->stream_wrapper->register();
-
-		// Schedule meta update job
-		$this->schedule_update_job();
 	}
 
 	/**
@@ -124,7 +93,6 @@ class VIP_Filesystem {
 		add_filter( 'wp_delete_file', [ $this, 'filter_delete_file' ], 20, 1 );
 		add_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20, 2 );
 		add_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ], 10, 2 );
-		add_filter( 'cron_schedules', [ $this, 'filter_cron_schedules' ], 10, 1 );
 	}
 
 	/**
@@ -140,7 +108,6 @@ class VIP_Filesystem {
 		remove_filter( 'wp_delete_file', [ $this, 'filter_delete_file' ], 20 );
 		remove_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20 );
 		remove_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ] );
-		remove_filter( 'cron_schedules', [ $this, 'filter_cron_schedules' ], 10 );
 	}
 
 	/**
@@ -417,144 +384,5 @@ class VIP_Filesystem {
 		}
 
 		return $file;
-	}
-
-	/**
-	 * Filter `cron_schedules` output
-	 *
-	 * Add a custom schedule for a 5 minute interval
-	 *
-	 * @param   array   $schedule
-	 *
-	 * @return  mixed
-	 */
-	public function filter_cron_schedules( $schedule ) {
-		if ( isset( $schedule[ 'vip_five_minutes' ] ) ) {
-			return $schedule;
-		}
-
-		// Not actually five minutes; we want it to run faster though to get through everything.
-		$schedule['vip_five_minutes'] = [
-			'interval' => 180,
-			'display' => __( 'Once every 3 minutes, unlike what the slug says. Originally used to be 5 mins.' ),
-		];
-
-		return $schedule;
-	}
-
-	public function schedule_update_job() {
-		// Only schedule meta update job on production
-		if ( 'production' !== VIP_GO_ENV ) {
-			// Remove any existing meta update jobs from non-production
-			if ( wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
-				wp_clear_scheduled_hook( self::CRON_EVENT_NAME );
-			}
-
-			return;
-		}
-
-		if ( get_option( self::OPT_ALL_FILESIZE_PROCESSED ) ) {
-			if ( wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
-				wp_clear_scheduled_hook( self::CRON_EVENT_NAME );
-			}
-
-			return;
-		}
-
-		if (! wp_next_scheduled ( self::CRON_EVENT_NAME )) {
-			wp_schedule_event(time(), 'vip_five_minutes', self::CRON_EVENT_NAME );
-		}
-
-		add_action( self::CRON_EVENT_NAME, [ $this, 'update_attachment_meta' ] );
-	}
-
-	/**
-	 * Cron job to update attachment metadata with file size
-	 */
-	public function update_attachment_meta() {
-		if ( 'production' !== VIP_GO_ENV ) {
-			// Don't run on non-production env
-			return;
-		}
-
-		wpcom_vip_irc(
-			'#vip-go-filesize-updates',
-			sprintf( 'Starting %s on %s... $vip-go-streams-debug',
-				self::CRON_EVENT_NAME,
-				home_url() ),
-			5 );
-
-		if ( get_option( self::OPT_ALL_FILESIZE_PROCESSED ) ) {
-			// already done. Nothing to update
-			wpcom_vip_irc(
-				'#vip-go-filesize-updates',
-				sprintf( 'Already completed updates on %s. Exiting %s... $vip-go-streams-debug',
-					home_url(),
-					self::CRON_EVENT_NAME ),
-				5 );
-			return;
-		}
-
-		$batch_size = 3000;
-		$updater = new Meta_Updater( $batch_size );
-
-		$max_id = (int) get_option( self::OPT_MAX_POST_ID );
-		if ( ! $max_id ) {
-			$max_id = $updater->get_max_id();
-			update_option( self::OPT_MAX_POST_ID, $max_id, false );
-		}
-
-		$num_lookups = 0;
-		$max_lookups = 10;
-
-		$orig_start_index = $start_index = get_option( self::OPT_NEXT_FILESIZE_INDEX, 0 );
-		$end_index = $start_index + $batch_size;
-
-		do {
-			if ( $start_index > $max_id ) {
-				// This means all attachments have been processed so marking as done
-				update_option( self::OPT_ALL_FILESIZE_PROCESSED, 1 );
-
-				wpcom_vip_irc(
-					'#vip-go-filesize-updates',
-					sprintf( 'Passed max ID (%d) on %s. Exiting %s... $vip-go-streams-debug',
-						$max_id,
-						home_url(),
-						self::CRON_EVENT_NAME
-					),
-					5
-				);
-
-				return;
-			}
-
-			$attachments = $updater->get_attachments( $start_index, $end_index );
-
-			// Bump the next index in case the cron job dies before we've processed everything
-			update_option( self::OPT_NEXT_FILESIZE_INDEX, $start_index, false );
-
-			$start_index = $end_index + 1;
-			$end_index = $start_index + $batch_size;
-
-			// Avoid infinite loops
-			$num_lookups++;
-			if ( $num_lookups >= $max_lookups ) {
-				break;
-			}
-		} while ( empty( $attachments ) );
-
-		if ( $attachments ) {
-			$counts = $updater->update_attachments( $attachments );
-		}
-
-		// All done, update next index option
-		wpcom_vip_irc(
-			'#vip-go-filesize-updates',
-			sprintf( 'Batch %d to %d (of %d) completed on %s. Processed %d attachments (%s) $vip-go-streams-debug',
-				$orig_start_index, $start_index, $max_id, home_url(), count( $attachments ), json_encode( $counts ) ),
-			5
-		);
-
-		update_option( self::OPT_NEXT_FILESIZE_INDEX, $start_index, false );
 	}
 }


### PR DESCRIPTION
## Description

Move the scheduled attachment filesize metadata updater into `a8c-files` so that it can run on all sites regardless of wether Stream Wrappers is active or not. This will allow us to run the job before activating the Stream Wrapper for a site and avoid the initial performance hit.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

