### PR TITLE
Production sync of update-filesize changes

### DIFF
--- a/files/class-meta-updater.php
+++ b/files/class-meta-updater.php
@@ -82,7 +82,7 @@ class Meta_Updater {
 
 		global $wpdb;
 
-		$this->max_id = $wpdb->get_var( 'SELECT ID FROM ' . $wpdb->posts . ' ORDER BY ID DESC LIMIT 1' );
+		$this->max_id = (int) $wpdb->get_var( 'SELECT ID FROM ' . $wpdb->posts . ' ORDER BY ID DESC LIMIT 1' );
 
 		return $this->max_id;
 	}
@@ -100,9 +100,18 @@ class Meta_Updater {
 
 		$sql = $wpdb->prepare( 'SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = "attachment" AND ID BETWEEN %d AND %d',
 			$start_index, $end_index );
-		$attachments = $wpdb->get_results( $sql );
+		$attachments = $wpdb->get_col( $sql );
 
-		return $attachments;
+		// Only return attachments without filesize
+		$filtered = [];
+		foreach ( $attachments as $attachment_id ) {
+			$meta = wp_get_attachment_metadata( $attachment_id );
+			if ( is_array( $meta ) && ! isset( $meta['filesize'] ) ) {
+				$filtered[] = $attachment_id;
+			}
+		}
+
+		return $filtered;
 	}
 
 	/**
@@ -111,20 +120,30 @@ class Meta_Updater {
 	 * @param array $attachments
 	 * @param bool $dry_run
 	 */
-	public function update_attachments( array $attachments, bool $dry_run = false ): void {
+	public function update_attachments( array $attachments, bool $dry_run = false ): array {
 		$this->dry_run = $dry_run;
 
-		foreach ( $attachments as $attachment ) {
-			list( $did_update, $result ) = $this->update_attachment_filesize( $attachment->ID );
+		$counts = [];
+
+		foreach ( $attachments as $attachment_id ) {
+			list( $result, $details ) = $this->update_attachment_filesize( $attachment_id );
+
+			if ( ! isset( $counts[ $result ] ) ) {
+				$counts[ $result ] = 0;
+			}
+			$counts[ $result ]++;
 
 			if ( $this->log_file ) {
 				fputcsv( $this->log_file, [
-					$attachment->ID,
-					$did_update ? 'updated' : 'skipped',
+					date( 'c' ),
+					$attachment_id,
 					$result,
+					$details,
 				] );
 			}
 		}
+
+		return $counts;
 	}
 
 	/**
@@ -143,27 +162,27 @@ class Meta_Updater {
 		}
 
 		if ( ! is_array( $meta ) ) {
-			return [ false, 'does not have valid metadata' ];
+			return [ 'skip-invalid-metadata', 'does not have valid metadata' ];
 		}
 
 		if ( isset( $meta['filesize'] ) ) {
-			return [ false, 'already has filesize' ];
+			return [ 'skip-has-filesize', 'already has filesize' ];
 		}
 
 		$filesize = $this->get_filesize_from_file( $attachment_id );
 
 		if ( 0 >= $filesize ) {
-			return [ false, 'failed to get filesize' ];
+			return [ 'fail-get-filesize', 'failed to get filesize' ];
 		}
 
 		$meta['filesize'] = $filesize;
 
 		if ( $this->dry_run ) {
-			return [ false, 'dry-run; would have updated filesize to ' . $filesize ];
+			return [ 'skip-dry-run', 'dry-run; would have updated filesize to ' . $filesize ];
 		}
 
 		wp_update_attachment_metadata( $attachment_id, $meta );
-		return [ true, 'updated filesize to ' . $filesize ];
+		return [ 'updated', 'updated filesize to ' . $filesize ];
 	}
 
 	/**
@@ -174,6 +193,15 @@ class Meta_Updater {
 	 * @return int
 	 */
 	private function get_filesize_from_file( $attachment_id ) {
+		$attachment_url = wp_get_attachment_url( $attachment_id );
+
+		$response = wp_remote_head( $attachment_url );
+		if ( is_wp_error( $response ) ) {
+			trigger_error( sprintf( '%s: failed to HEAD attachment %s because %s', __METHOD__, $attachment_url, $response->get_error_message() ), E_USER_WARNING );
+			return 0;
+		}
+
+		return (int) wp_remote_retrieve_header( $response, 'Content-Length' );
 		$file = get_attached_file( $attachment_id );
 
 		if ( ! file_exists( $file ) ) {

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -19,12 +19,12 @@ class VIP_Filesystem {
 	/**
 	 * Option name to mark all attachment filesize update completed
 	 */
-	const OPT_ALL_FILESIZE_PROCESSED = 'vip_all_attachment_filesize_processed';
+	const OPT_ALL_FILESIZE_PROCESSED = 'vip_all_attachment_filesize_processed_v2';
 
 	/**
 	 * Option name to mark next index for starting the next batch of filesize updates
 	 */
-	const OPT_NEXT_FILESIZE_INDEX = 'vip_next_attachment_filesize_index';
+	const OPT_NEXT_FILESIZE_INDEX = 'vip_next_attachment_filesize_index_v2';
 
 	/**
 	 * Option name for storing Max ID.
@@ -32,7 +32,7 @@ class VIP_Filesystem {
 	 * We do not need to keep this updated as new attachments will already have file sizes
 	 * included in their meta.
 	 */
-	const OPT_MAX_POST_ID = 'vip_attachment_max_post_id';
+	const OPT_MAX_POST_ID = 'vip_attachment_max_post_id_v2';
 
 	/**
 	 * The unique identifier of this plugin.
@@ -433,8 +433,9 @@ class VIP_Filesystem {
 			return $schedule;
 		}
 
+		// Not actually five minutes; we want it to run faster though to get through everything.
 		$schedule['vip_five_minutes'] = [
-			'interval' => 300,
+			'interval' => 180,
 			'display' => __( 'Once every 5 minutes' ),
 		];
 
@@ -494,7 +495,8 @@ class VIP_Filesystem {
 			return;
 		}
 
-		$updater = new Meta_Updater( 1000 );
+		$batch_size = 3000;
+		$updater = new Meta_Updater( $batch_size );
 
 		$max_id = (int) get_option( self::OPT_MAX_POST_ID );
 		if ( ! $max_id ) {
@@ -502,8 +504,11 @@ class VIP_Filesystem {
 			update_option( self::OPT_MAX_POST_ID, $max_id, false );
 		}
 
+		$num_lookups = 0;
+		$max_lookups = 10;
+
 		$orig_start_index = $start_index = get_option( self::OPT_NEXT_FILESIZE_INDEX, 0 );
-		$end_index = $start_index + $updater->get_batch_size();
+		$end_index = $start_index + $batch_size;
 
 		do {
 			if ( $start_index > $max_id ) {
@@ -525,21 +530,31 @@ class VIP_Filesystem {
 
 			$attachments = $updater->get_attachments( $start_index, $end_index );
 
+			// Bump the next index in case the cron job dies before we've processed everything
+			update_option( self::OPT_NEXT_FILESIZE_INDEX, $start_index, false );
+
 			$start_index = $end_index + 1;
-			$end_index = $start_index + $updater->get_batch_size();
+			$end_index = $start_index + $batch_size;
+
+			// Avoid infinite loops
+			$num_lookups++;
+			if ( $num_lookups >= $max_lookups ) {
+				break;
+			}
 		} while ( empty( $attachments ) );
 
 		if ( $attachments ) {
-			$updater->update_attachments( $attachments );
+			$counts = $updater->update_attachments( $attachments );
 		}
 
 		// All done, update next index option
 		wpcom_vip_irc(
 			'#vip-go-filesize-updates',
-			sprintf( 'Batch %d to %d (of %d) completed on %s. Updating options... $vip-go-streams-debug',
-				$orig_start_index, $end_index, $max_id, home_url() ),
+			sprintf( 'Batch %d to %d (of %d) completed on %s. Processed %d attachments (%s) $vip-go-streams-debug',
+				$orig_start_index, $start_index, $max_id, home_url(), count( $attachments ), json_encode( $counts ) ),
 			5
 		);
-		update_option( self::OPT_NEXT_FILESIZE_INDEX, $end_index + 1, false );
+
+		update_option( self::OPT_NEXT_FILESIZE_INDEX, $start_index, false );
 	}
 }

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -436,7 +436,7 @@ class VIP_Filesystem {
 		// Not actually five minutes; we want it to run faster though to get through everything.
 		$schedule['vip_five_minutes'] = [
 			'interval' => 180,
-			'display' => __( 'Once every 5 minutes' ),
+			'display' => __( 'Once every 3 minutes, unlike what the slug says. Originally used to be 5 mins.' ),
 		];
 
 		return $schedule;

--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -107,10 +107,11 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 
 			$attachments = $this->meta_updater->get_attachments( $start_index, $end_index );
 
-			WP_CLI::line( sprintf( '-- found %s attachments', number_format( count( $attachments ) ) ) );
+			WP_CLI::line( sprintf( '-- found %s attachments without a filesize', number_format( count( $attachments ) ) ) );
 
 			if ( $attachments ) {
-				$this->meta_updater->update_attachments( $attachments, $this->dry_run );
+				$counts = $this->meta_updater->update_attachments( $attachments, $this->dry_run );
+				WP_CLI::line( sprintf( '-- results: %s', json_encode( $counts ) ) );
 			}
 
 			// Pause.


### PR DESCRIPTION
- Fix index bug that was causing batches to be skipped
- `get_attachments` only returns attachments without filesize for faster iteration through jobs
- `update_attachments` now returns counts of the various results
- use a HEAD request and header sniffing to get the content size (few requests and faster)
- Speed up the jobs by increasing batch size and frequency
- Add more detail to output