### PR TITLE
Revert "Make feed cache create method static"

### DIFF
--- a/vip-feed-cache/class-vip-go-feed-cache.php
+++ b/vip-feed-cache/class-vip-go-feed-cache.php
@@ -10,7 +10,7 @@ class VIP_Go_Feed_Cache extends SimplePie_Cache {
 	 * @param string $extension 'spi' or 'spc'.
 	 * @return VIP_Go_Feed_Cache_Transient Feed cache handler object that uses transients and normalizes SimplePie Build number.
 	 */
-	public static function create( $location, $filename, $extension ) {
+	public function create( $location, $filename, $extension ) {
 		return new VIP_Go_Feed_Cache_Transient( $location, $filename, $extension );
 	}
 }


### PR DESCRIPTION
Reverts Automattic/vip-go-mu-plugins#1121: `Fatal error: Cannot make non static method SimplePie_Cache::create() static in class VIP_Go_Feed_Cache`