### PR TITLE
Adds missing image sizes to attachment metadata

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -927,11 +927,11 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 		&& false === empty( $data['sizes'] )
 	);
 
-	if ( $sizes_already_exist ) {
-		$available_sizes = array_keys( $_wp_additional_image_sizes );
-		$known_sizes     = array_keys( $data['sizes'] );
-		$missing_sizes   = array_diff( $available_sizes, $known_sizes );
+	$available_sizes = array_keys( $_wp_additional_image_sizes );
+	$known_sizes     = array_keys( $data['sizes'] );
+	$missing_sizes   = array_diff( $available_sizes, $known_sizes );
 
+	if ( $sizes_already_exist ) {
 		if ( empty( $missing_sizes ) ) {
 			return $data;
 		}

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -959,7 +959,7 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 			);
 		}
 
-		if ( ! empty( $new_size ) ) {
+		if ( ! empty( $new_sizes ) ) {
 			$data['sizes'] = array_merge( $data['sizes'], $new_sizes );
 		}
 

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -918,8 +918,6 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 		return $data;
 	}
 
-	global $_wp_additional_image_sizes;
-
 	$sizes_already_exist = (
 		true === is_array( $data )
 		&& true === array_key_exists( 'sizes', $data )
@@ -927,14 +925,14 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 		&& false === empty( $data['sizes'] )
 	);
 
+	global $_wp_additional_image_sizes;
+
 	$available_sizes = array_keys( $_wp_additional_image_sizes );
 	$known_sizes     = array_keys( $data['sizes'] );
 	$missing_sizes   = array_diff( $available_sizes, $known_sizes );
 
-	if ( $sizes_already_exist ) {
-		if ( empty( $missing_sizes ) ) {
-			return $data;
-		}
+	if ( $sizes_already_exist && empty( $missing_sizes )) {
+		return $data;
 	}
 
 	// Missing some critical data we need to determine sizes, so bail


### PR DESCRIPTION
## Description

Due to the way that images are generated dynamically on VIP Go, when new image sizes are added to a site, they do not show up in the attachment metadata.  This will dynamically add missing image sizes to attachment metadata.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Add new image size to site's theme/plugins
1. Visit a media REST API endpoint (ex: `https://example.com/wp-json/wp/v2/media/12345`)
1. Check out PR.
1. Compare before and after of API response for new size.
