### PR TITLE
Cache a local copy of generated image sizes

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -918,6 +918,28 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 		return $data;
 	}
 
+	// Missing some critical data we need to determine sizes, so bail.
+	if ( ! isset( $data['file'] )
+		|| ! isset( $data['width'] )
+		|| ! isset( $data['height'] ) ) {
+		return $data;
+	}
+
+	static $cached_sizes = [];
+
+	// Don't process image sizes that we already processed.
+	if ( isset( $cached_sizes[ $attachment_id ] ) ) {
+		$data['sizes'] = $cached_sizes[ $attachment_id ];
+		return $data;
+	}
+
+	// Skip non-image attachments
+	$mime_type = get_post_mime_type( $attachment_id );
+	$attachment_is_image = preg_match( '!^image/!', $mime_type );
+	if ( 1 !== $attachment_is_image ) {
+		return $data;
+	}
+
 	$sizes_already_exist = (
 		true === is_array( $data )
 		&& true === array_key_exists( 'sizes', $data )
@@ -931,41 +953,31 @@ function a8c_files_maybe_inject_image_sizes( $data, $attachment_id ) {
 	$known_sizes     = array_keys( $data['sizes'] );
 	$missing_sizes   = array_diff( $available_sizes, $known_sizes );
 
-	if ( $sizes_already_exist && empty( $missing_sizes )) {
+	if ( $sizes_already_exist && empty( $missing_sizes ) ) {
 		return $data;
 	}
 
-	// Missing some critical data we need to determine sizes, so bail
-	if ( ! isset( $data['file'] )
-		|| ! isset( $data['width'] )
-		|| ! isset( $data['height'] ) ) {
-		return $data;
+	$new_sizes = array();
+
+	foreach ( $missing_sizes as $size ) {
+		$new_width          = (int) $_wp_additional_image_sizes[ $size ]['width'];
+		$new_height         = (int) $_wp_additional_image_sizes[ $size ]['height'];
+		$new_sizes[ $size ] = array(
+			'file'      => basename( $data['file'] ),
+			'width'     => $new_width,
+			'height'    => $new_height,
+			'mime_type' => $mime_type,
+		);
 	}
 
-	$mime_type           = get_post_mime_type( $attachment_id );
-	$attachment_is_image = preg_match( '!^image/!', $mime_type );
-
-	if ( 1 === $attachment_is_image ) {
-		$new_sizes = array();
-
-		foreach ( $missing_sizes as $size ) {
-			$new_width          = (int) $_wp_additional_image_sizes[ $size ]['width'];
-			$new_height         = (int) $_wp_additional_image_sizes[ $size ]['height'];
-			$new_sizes[ $size ] = array(
-				'file'      => basename( $data['file'] ),
-				'width'     => $new_width,
-				'height'    => $new_height,
-				'mime_type' => $mime_type,
-			);
-		}
-
-		if ( ! empty( $new_sizes ) ) {
-			$data['sizes'] = array_merge( $data['sizes'], $new_sizes );
-		}
-
-		$image_sizes = new Automattic\VIP\Files\ImageSizes( $attachment_id, $data );
-		$data['sizes'] = $image_sizes->generate_sizes_meta();
+	if ( ! empty( $new_sizes ) ) {
+		$data['sizes'] = array_merge( $data['sizes'], $new_sizes );
 	}
+
+	$image_sizes = new Automattic\VIP\Files\ImageSizes( $attachment_id, $data );
+	$data['sizes'] = $image_sizes->generate_sizes_meta();
+
+	$cached_sizes[ $attachment_id ] = $data['sizes'];
 
 	return $data;
 }


### PR DESCRIPTION
wp_get_attachment_metadata can be called a lot on image heavy pages which triggers our image processing code many many time as well.

Once we've processed the sizes we don't really need to do it again so cache in memory and re-use.

Includes a few minor small order optimizations to bail out early if we don't want to process the attachement (e.g. not an image, don't have the necessary data).

## Checklist

Please make sure the items below have been covered before requesting a review:

- n/a This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

TODO