### PR TITLE
Jetpack: Disable CSS for unused modules

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -14,6 +14,9 @@
  */
 require_once( __DIR__ . '/jetpack-mandatory.php' );
 
+// Only load jetpack CSS for active modules
+add_filter( 'jetpack_implode_frontend_css', '__return_false' );
+
 /**
  * Remove certain modules from the list of those that can be activated
  * Blocks access to certain functionality that isn't compatible with the platform.


### PR DESCRIPTION
Jetpack ships a concatenated CSS file that includes CSS for all available modules. Since we concatenate CSS files on VIP Go, we should only include CSS for active modules, which will reduce the transfer size of CSS and eliminate unused styles.