### PR TITLE
Updates files service to allow split URL setup, and go-vip.net domain

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -1002,12 +1002,18 @@ class A8C_Files {
 class A8C_Files_Utils {
 	public static function filter_photon_domain( $photon_url, $image_url ) {
 			$home_url = home_url();
+			$site_url = site_url();
+
 			if ( wp_startswith( $image_url, $home_url ) ) {
 				return $home_url;
 			}
 
+			if ( wp_startswith( $image_url, $site_url ) ) {
+				return $site_url;
+			}
+
 			$image_url_parsed = parse_url( $image_url );
-			if ( wp_endswith( $image_url_parsed['host'], '.go-vip.co' ) ) {
+			if ( wp_endswith( $image_url_parsed['host'], '.go-vip.co' ) || wp_endswith( $image_url_parsed['host'], '.go-vip.net' ) ) {
 				return $image_url_parsed['scheme'] . '://' . $image_url_parsed['host'];
 			}
 

--- a/tests/test-a8c-files-utils.php
+++ b/tests/test-a8c-files-utils.php
@@ -8,9 +8,19 @@ class VIP_Go_A8C_Files_Utils_Test extends WP_UnitTestCase {
 				'http://example.com',
 			],
 
-			'image_on_go-vip_url' => [
+			'image_on_site_url' => [
+				'http://subdomain.example.com/image.jpg',
+				'http://subdomain.example.com',
+			],
+
+			'image_on_go-vip-co_url' => [
 				'http://example.go-vip.co/image.jpg',
 				'http://example.go-vip.co',
+			],
+
+			'image_on_go-vip-net_url' => [
+				'http://example.go-vip.net/image.jpg',
+				'http://example.go-vip.net',
 			],
 
 			'image_on_external_url' => [
@@ -26,6 +36,10 @@ class VIP_Go_A8C_Files_Utils_Test extends WP_UnitTestCase {
 	public function test__filter_photon_domain( $image_url, $expected_photon_url ) {
 		add_filter( 'home_url', function() {
 			return 'http://example.com';
+		} );
+
+		add_filter( 'site_url', function() {
+			return 'http://subdomain.example.com';
 		} );
 
 		$actual_photon_url = A8C_Files_Utils::filter_photon_domain( 'http://i0.wp.com', $image_url );


### PR DESCRIPTION
## Description

The VIP Go files service currently only rewrites the home_url of a site.  If a site has a site_url that's different than the home_url, it will default to a Photon URL instead.  Also, some sites now have .go-vip.net domains as their native domains, and this should allow them to work properly.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Find site with split URL setup
1. Verify all proper URLs are being rewritten.