### PR TITLE
Don't force 2FA for OneLogin or SimplSaml

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -33,7 +33,7 @@ function wpcom_vip_should_force_two_factor() {
 	}
 
 	// Don't force 2FA for SimpleSaml
-	if ( function_exists( '\HumanMade\SimpleSaml\instance()' ) ) {
+	if ( function_exists( '\HumanMade\SimpleSaml\instance' ) && \HumanMade\SimpleSaml\instance() ) {
 		return false;
 	}
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -129,6 +129,11 @@ function wpcom_vip_two_factor_prep_admin_notice() {
 	if ( wpcom_vip_is_two_factor_forced() ) {
 		return;
 	}
+	
+	// Allow site owners to hide the preparatory notice if this doesn't apply to their site
+	if ( apply_filters( 'wpcom_vip_two_factor_prep_hide_admin_notice', false ) ) {
+		return;
+	}
 
 	$timezone = get_option( 'timezone_string' );
 	if ( ! $timezone || $timezone === '' ) {


### PR DESCRIPTION
These popular SSO solutions already provide a way for users to login
via multi-factor authentication, we don't need to add yet another
authentication mechanism to the mix.