### PR TITLE
Add wpcom_vip_enable_two_factor filter

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -68,6 +68,11 @@ function wpcom_vip_enforce_two_factor_plugin() {
 
 add_action( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
 function wpcom_enable_two_factor_plugin() {
+	$enable_two_factor = apply_filters( 'wpcom_vip_enable_two_factor', true );
+	if ( true !== $enable_two_factor ) {
+		return;	
+	}
+
 	wpcom_vip_load_plugin( 'two-factor' );
 	add_action( 'set_current_user', 'wpcom_vip_enforce_two_factor_plugin' );
 }


### PR DESCRIPTION
To allow completely skipping loading the two-factor plugin

## Steps to Test

1. Check out PR.
1. Verify the two-factor plugin loads as expected.
1. Add `add_filter( 'wpcom_vip_enable_two_factor', '__return_false' );`
1. Verify the two-factor plugin is no longer loaded.
