### PR TITLE
Better screen check

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -102,7 +102,7 @@ function wpcom_vip_should_show_notice_on_current_screen() {
 	$screen = get_current_screen();
 
 	// Don't show on the "Edit Post" screen as it interferes with the Block Editor.
-	if ( 'post' === $screen->id ) {
+	if ( $screen->is_block_editor() ) {
 		return false;
 	}
 


### PR DESCRIPTION
Use `is_block_editor()` method to capture all cases where the block editor is active to hide the 2fa notice

## Steps to Test

1. Check out PR.
1. Start with an account without 2fa active.
1. Verify that when the block editor is loaded, the 2fa notice is not displayed.
1. Verify that the notice shows up on other pages.
