### PR TITLE
Added footnote to SMS provider field about country codes

### DIFF
--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -153,7 +153,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 			<label>Phone Number
 				<input name="vip-two-factor-phone" type="tel" placeholder="+14158675309" value="<?php echo esc_attr( $sms );?>" />
 			</label>
-			<p>You must use your country's calling code( e.g +44, +1, +61) otherwise no SMS message will be sent to you.</p>
+			<p><strong>Note:</strong> Please include your country calling code (e.g. +44, +1, +61, etc.) to ensure SMS messages are correctly sent.</p>
 		</div>
 		<?php
 	}

--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -153,6 +153,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 			<label>Phone Number
 				<input name="vip-two-factor-phone" type="tel" placeholder="+14158675309" value="<?php echo esc_attr( $sms );?>" />
 			</label>
+			<p>You must use your country's calling code( e.g +44, +1, +61) otherwise no SMS message will be sent to you.</p>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
This PR simply adds a footnote to the SMS 2FA provider field about the need to use a country code when entering your phone number.

I'm aware it's indicated in the placeholder but it isn't obvious enough. Since the 2FA nag went live yesterday I've had to help multiple users who had locked themselves out of their accounts because they chose SMS 2FA and didn't use a country code, thus never received the SMS messages.
