### PR TITLE
Add pre release version of Cron Control for testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "gutenberg-ramp"]
 	path = gutenberg-ramp
 	url = https://github.com/Automattic/gutenberg-ramp.git
+[submodule "cron-control-next"]
+	path = cron-control-next
+	url = git@github.com:Automattic/Cron-Control.git

--- a/001-cron.php
+++ b/001-cron.php
@@ -138,5 +138,13 @@ if ( ! wpcom_vip_use_core_cron() ) {
 	add_action( 'a8c_cron_control_event_threw_catchable_error', 'wpcom_vip_log_cron_control_event_for_caught_error', 10, 2 );
 	add_action( 'a8c_cron_control_freeing_event_locks_after_uncaught_error', 'wpcom_vip_log_cron_control_event_object' );
 
-	require_once __DIR__ . '/cron-control/cron-control.php';
+	$cron_control_next_version = __DIR__ . '/cron-control-next/cron-control.php';
+
+	if ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION' ) && VIP_CRON_CONTROL_USE_NEXT_VERSION && file_exists( $cron_control_next_version ) ) {
+		// Use latest version for testing
+		require_once $cron_control_latest_version;
+	} else {
+		// Use regular version
+		require_once __DIR__ . '/cron-control/cron-control.php';
+	}
 }

--- a/001-cron.php
+++ b/001-cron.php
@@ -140,7 +140,7 @@ if ( ! wpcom_vip_use_core_cron() ) {
 
 	$cron_control_next_version = __DIR__ . '/cron-control-next/cron-control.php';
 
-	if ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION' ) && VIP_CRON_CONTROL_USE_NEXT_VERSION && file_exists( $cron_control_next_version ) ) {
+	if ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION' ) && true === VIP_CRON_CONTROL_USE_NEXT_VERSION && file_exists( $cron_control_next_version ) ) {
 		// Use latest version for testing
 		require_once $cron_control_next_version;
 	} else {

--- a/001-cron.php
+++ b/001-cron.php
@@ -142,7 +142,7 @@ if ( ! wpcom_vip_use_core_cron() ) {
 
 	if ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION' ) && VIP_CRON_CONTROL_USE_NEXT_VERSION && file_exists( $cron_control_next_version ) ) {
 		// Use latest version for testing
-		require_once $cron_control_latest_version;
+		require_once $cron_control_next_version;
 	} else {
 		// Use regular version
 		require_once __DIR__ . '/cron-control/cron-control.php';


### PR DESCRIPTION
## Description

Adds a new "next" submodule for Cron Control along with the ability to conditionally load this next version via setting the `VIP_CRON_CONTROL_USE_NEXT_VERSION` constant to `true`.

Currently, the "next" version is pinned to https://github.com/Automattic/Cron-Control/pull/178/commits/df1740b005bfc2ce92b35772df2e86fddd962b35 from https://github.com/Automattic/Cron-Control/pull/178

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Update submodules - `git submodule update --init --recursive`
1. `define( 'VIP_CRON_CONTROL_USE_NEXT_VERSION', true );` in `vip-config.php` or similar
1. Try some cron commands, should work normally:
1. `wp --allow-root cron event schedule something`
1. `wp --allow-root cron schedule list`
1. `wp --allow-root cron-control events list`
1. Try above again without the constant defined, to ensure it loads regular Cron Control
