### PR TITLE
Two Factor: Load MS constants

### DIFF
--- a/wpcom-vip-two-factor/is-jetpack-sso.php
+++ b/wpcom-vip-two-factor/is-jetpack-sso.php
@@ -3,6 +3,10 @@
 namespace Automattic\VIP\TwoFactor;
 
 // muplugins_loaded fires before cookie constants are set
+if ( is_multisite() ) {
+	ms_cookie_constants();
+}
+
 wp_cookie_constants();
 
 define( 'VIP_IS_JETPACK_SSO_COOKIE', AUTH_COOKIE . '_vip_jetpack_sso' );


### PR DESCRIPTION
We load the cookie constants early. This ensures we properly define the MS cookie constants.