### PR TITLE
Two Factor: Load on plugins_loaded instead of muplugins_loaded

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -75,7 +75,7 @@ function wpcom_vip_enforce_two_factor_plugin() {
 	}
 }
 
-add_action( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
+add_action( 'plugins_loaded', 'wpcom_enable_two_factor_plugin' );
 function wpcom_enable_two_factor_plugin() {
 	$enable_two_factor = apply_filters( 'wpcom_vip_enable_two_factor', true );
 	if ( true !== $enable_two_factor ) {

--- a/wpcom-vip-two-factor/is-jetpack-sso.php
+++ b/wpcom-vip-two-factor/is-jetpack-sso.php
@@ -2,13 +2,6 @@
 
 namespace Automattic\VIP\TwoFactor;
 
-// muplugins_loaded fires before cookie constants are set
-if ( is_multisite() ) {
-	ms_cookie_constants();
-}
-
-wp_cookie_constants();
-
 define( 'VIP_IS_JETPACK_SSO_COOKIE', AUTH_COOKIE . '_vip_jetpack_sso' );
 define( 'VIP_IS_JETPACK_SSO_2SA_COOKIE', AUTH_COOKIE . '_vip_jetpack_sso_2sa' );
 


### PR DESCRIPTION
## Description

`muplugins_loaded` is very early. So early that the cookie constants
aren't even set yet. In order to remove our hack that loads the cookie
constants early, we should load two-factor a bit later if possible.

**Note:** Needs testing.

## Deploy Note

We'll need to open PRs with any client repos that have manually unhooked
this from `muplugins_loaded`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] Tested on single site
- [ ] Tested on multisite

## Steps to Test

Example:

1. Check out PR
1. Login with SSO
1. Confirm two-factor notice is not visible