### PR TITLE
Only lock out contributors and up

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -54,7 +54,7 @@ class Lockout {
 					break;
 
 				case 'locked':
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'read' ), VIP_LOCKOUT_STATE, $user );
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'edit_posts' ), VIP_LOCKOUT_STATE, $user );
 					if ( $show_notice ) {
 						$this->render_locked_notice();
 


### PR DESCRIPTION
Sites may have external registered users that have a subscriber role (with `read`) who we don't want to display the message to.

## Steps to Test

1. Check out PR.
1. Enable lockout by setting the constants.
1. Login as subscriber and verify you don't see the message.
1. Login as contributor and verify you do see the message.
