### PR TITLE
Remove executing full sync on user authorization to Jetpack

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -133,3 +133,10 @@ function wpcom_vip_disable_jetpack_email_no_recaptcha( $is_enabled ) {
 	return defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' );
 }
 add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recaptcha', PHP_INT_MAX );
+
+// Disable Jetpack sync when user is added to blog.
+if ( defined( 'VIP_GO_APP_ID' ) && ( 1398 === VIP_GO_APP_ID || 1420 === VIP_GO_APP_ID ) ) {
+	add_action( 'init', function() {
+		remove_action( 'jetpack_user_authorized', [ 'Jetpack_Sync_Actions', 'do_initial_sync' ] );
+	} );
+}


### PR DESCRIPTION
## Description

Since Jetpack executes a full sync on user connection, it overrides an ongoing full sync and thus, the ongoing full sync never ends up completing:

https://github.com/Automattic/jetpack/blame/19f9d99879d28bcdc51da94539cb26b0d1b117be/sync/class.jetpack-sync-actions.php#L529

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Unfortunately, this needs to be deployed on production, as it communicates via the Jetpack production code per Enej.