### PR TITLE
Allow JP Sync to run during WP CLI commands

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -106,6 +106,10 @@ function wpcom_vip_disable_jetpack_sync_for_frontend_get_requests( $should_load 
 		return $should_load;
 	}
 
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return $should_load;
+	}
+
 	if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) {
 		$should_load = false;
 	}


### PR DESCRIPTION
## Description

Currently JP Sync is disabled for WP CLI commands. This presents a big problem for the consistency of the data, as changes from CLI commands are not synced normally.

Previously: https://github.com/Automattic/vip-go-mu-plugins/pull/665

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. wp option update blogdescription 'My new description'
1. Check value on wpcom, not updated 😑 
1. Check out PR.
1. wp option update blogdescription 'My new description'
1. Check value on wpcom, now is updated 🎉 
