### PR TITLE
VaultPress 1.9.10

### DIFF
--- a/akismet.php
+++ b/akismet.php
@@ -4,7 +4,7 @@
 Plugin Name: Akismet Anti-Spam
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 4.1.1
+Version: 4.1.2
 Author: Automattic
 Author URI: https://automattic.com/wordpress-plugins/
 License: GPLv2 or later

--- a/akismet/_inc/akismet.css
+++ b/akismet/_inc/akismet.css
@@ -80,8 +80,10 @@ table.comments td.comment p a:after {
     display: inline-block !important;
 }
 .checkforspam-progress {
-	padding-left: 1ex;
 	display: none;
+}
+.checkforspam.checking .checkforspam-progress {
+	padding-left: 1ex;
 }
 .checkforspam.button-disabled .checkforspam-progress {
 	display: inline;
@@ -246,7 +248,6 @@ table.comments td.comment p a:after {
 	font-size: 140px;
 	color: #769F33;
 	font-family: Georgia, "Times New Roman", Times, serif;
-	z-index: 1;
 }
 
 .akismet_activate .aa_button {
@@ -312,7 +313,6 @@ table.comments td.comment p a:after {
 	margin-left: 25px;
 	color: #E5F2B1;
 	font-size: 15px;
-	z-index: 1000;
 }
 
 .akismet_activate .aa_description strong {

--- a/akismet/_inc/akismet.js
+++ b/akismet/_inc/akismet.js
@@ -146,10 +146,15 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
-	$('.checkforspam:not(.button-disabled)').click( function(e) {
+	$( '.checkforspam' ).click( function( e ) {
 		e.preventDefault();
 
-		$('.checkforspam:not(.button-disabled)').addClass('button-disabled');
+		if ( $( this ).hasClass( 'button-disabled' ) ) {
+			window.location.href = $( this ).data( 'success-url' ).replace( '__recheck_count__', 0 ).replace( '__spam_count__', 0 );
+			return;
+		}
+
+		$('.checkforspam').addClass('button-disabled').addClass( 'checking' );
 		$('.checkforspam-spinner').addClass( 'spinner' ).addClass( 'is-active' );
 
 		// Update the label on the "Check for Spam" button to use the active "Checking for Spam" language.

--- a/akismet/akismet.php
+++ b/akismet/akismet.php
@@ -6,7 +6,7 @@
 Plugin Name: Akismet Anti-Spam
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 4.1.1
+Version: 4.1.2
 Author: Automattic
 Author URI: https://automattic.com/wordpress-plugins/
 License: GPLv2 or later
@@ -37,7 +37,7 @@ if ( !function_exists( 'add_action' ) ) {
 	exit;
 }
 
-define( 'AKISMET_VERSION', '4.1.1' );
+define( 'AKISMET_VERSION', '4.1.2' );
 define( 'AKISMET__MINIMUM_WP_VERSION', '4.0' );
 define( 'AKISMET__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'AKISMET_DELETE_LIMIT', 100000 );

--- a/akismet/class.akismet-admin.php
+++ b/akismet/class.akismet-admin.php
@@ -390,9 +390,9 @@ class Akismet_Admin {
 		$comments_count = wp_count_comments();
 		
 		echo '</div>';
-		echo '<div class="alignleft">';
+		echo '<div class="alignleft actions">';
 		echo '<a
-				class="button-secondary checkforspam"
+				class="button-secondary checkforspam' . ( $comments_count->moderated == 0 ? ' button-disabled' : '' ) . '"
 				href="' . esc_url( $link ) . '"
 				data-active-label="' . esc_attr( __( 'Checking for Spam', 'akismet' ) ) . '"
 				data-progress-label-format="' . esc_attr( __( '(%1$s%)', 'akismet' ) ) . '"

--- a/akismet/readme.txt
+++ b/akismet/readme.txt
@@ -2,8 +2,8 @@
 Contributors: matt, ryan, andy, mdawaffe, tellyworth, josephscott, lessbloat, eoigal, cfinke, automattic, jgs, procifer, stephdau
 Tags: akismet, comments, spam, antispam, anti-spam, anti spam, comment moderation, comment spam, contact form spam, spam comments
 Requires at least: 4.0
-Tested up to: 5.0
-Stable tag: 4.1.1
+Tested up to: 5.2
+Stable tag: 4.1.2
 License: GPLv2 or later
 
 Akismet checks your comments and contact form submissions against our global database of spam to protect you and your site from malicious content.
@@ -29,6 +29,15 @@ Upload the Akismet plugin to your blog, Activate it, then enter your [Akismet.co
 1, 2, 3: You're done!
 
 == Changelog ==
+
+= 4.1.2 =
+*Release Date - 14 May 2019*
+
+* Fixed a conflict between the Akismet setup banner and other plugin notices.
+* Reduced the number of API requests made by the plugin when attempting to verify the API key.
+* Include additional data in the pingback pre-check API request to help make the stats more accurate.
+* Fixed a bug that was enabling the "Check for Spam" button when no comments were eligible to be checked.
+* Improved Akismet's AMP compatibility.
 
 = 4.1.1 =
 *Release Date - 31 January 2019*

--- a/akismet/views/get.php
+++ b/akismet/views/get.php
@@ -1,3 +1,9 @@
+<?php
+
+//phpcs:disable VariableAnalysis
+// There are "undefined" variables here because they're defined in the code that includes this file as a template.
+
+?>
 <form name="akismet_activate" action="https://akismet.com/get/" method="POST" target="_blank">
 	<input type="hidden" name="passback_url" value="<?php echo esc_url( Akismet_Admin::get_page_url() ); ?>"/>
 	<input type="hidden" name="blog" value="<?php echo esc_url( get_option( 'home' ) ); ?>"/>

--- a/akismet/wrapper.php
+++ b/akismet/wrapper.php
@@ -206,7 +206,8 @@ function akismet_kill_proxy_check( $option ) {
 	return 0;
 }
 function akismet_pingback_forwarded_for( $r, $url ) {
-	return Akismet::pingback_forwarded_for( $r, $url );
+	// This functionality is now in core.
+	return false;
 }
 function akismet_pre_check_pingback( $method ) {
 	return Akismet::pre_check_pingback( $method );

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: https://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>.
- * Version: 1.9.8
+ * Version: 1.9.10
  * Author: Automattic
  * Author URI: https://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+

--- a/vaultpress/cron-tasks.php
+++ b/vaultpress/cron-tasks.php
@@ -107,8 +107,18 @@ class VP_Site_Scanner {
 		if ( empty( $paths ) || $this->_scan_clean_up( $paths ) )
 			return false;
 
+		if ( ! is_array( $paths ) ) {
+			return false;
+		}
+
 		reset( $paths );
-		list( $type, $current ) = each( $paths );
+
+		$type    = null;
+		$current = false;
+		foreach ( $paths as $type => $current ) {
+			break;
+		}
+
 		if ( !is_object( $current ) || empty( $current->last_dir ) )
 			return $this->_scan_clean_up( $paths, $type );
 

--- a/vaultpress/readme.txt
+++ b/vaultpress/readme.txt
@@ -2,8 +2,8 @@
 Contributors: automattic, apokalyptik, briancolinger, josephscott, shaunandrews, xknown, thingalon, annezazu, rachelsquirrel
 Tags: security, malware, virus, archive, back up, back ups, backup, backups, scanning, restore, wordpress backup, site backup, website backup
 Requires at least: 3.2
-Tested up to: 5.0
-Stable tag: 1.9.8
+Tested up to: 5.1.1
+Stable tag: 1.9.10
 License: GPLv2
 
 VaultPress is a subscription service offering real-time backup, automated security scanning, and support from WordPress experts.
@@ -30,11 +30,11 @@ View our full list of FAQs at [http://help.vaultpress.com/faq/](http://help.vaul
 
 = What’s included in each plan? =
 
-All plans include automated daily backups (unlimited storage space) of your entire site, 1-click restores, stats, priority support, brute force attack protection, uptime monitoring, spam protection, site migration, and an activity log.
+All plans include automated daily backups (unlimited storage space) of your entire site, 1-click restores, stats, priority support, brute force attack protection, uptime monitoring, spam protection, site migration, and an activity log. 
 
 The Personal and Premium plans are limited to a 30-day backup archive while Professional is unlimited.
 
-The Premium and Professional plans also offer automated security scanning against malware and infiltrations with the Professional plan also offering automated threat resolution.
+The Premium and Professional plans also offer automated security scanning against malware and infiltrations with the Professional plan also offering automated threat resolution. 
 
 [Visit our site](https://vaultpress.com/contact/) for more detail and up-to-date information.
 
@@ -47,6 +47,13 @@ A VaultPress subscription is for a single WordPress site. You can purchase addit
 Yes, VaultPress supports Multisite installs. Each site will require its own subscription.
 
 == Changelog ==
+= 1.9.10 - 4 April 2019 =
+* Bugfix: Fix a PHP fatal error caused by passing an object to the current() function.
+
+= 1.9.9 - 28 March 2019 =
+* PHP 7.2.0 compatibility fix.
+* Adding button to delete all VaultPress settings
+
 = 1.9.8 - 7 February 2019 =
 * Limit the size of _vp_ai_ping_% entries when a site gets disconnected from VaultPress.com
 
@@ -110,7 +117,7 @@ Yes, VaultPress supports Multisite installs. Each site will require its own subs
 = 1.7.9 - 24 Feb 2016 =
 * PHP 7 support. Drop support for PHP 4 and versions of WordPress older than 3.2.
 * Silence PHP errors when attempting to change the execution time limit when PHP is running in safe mode.
-* Prevent database update pings from being stored when not connected to a paid VaultPress account.
+* Prevent database update pings from being stored when not connected to a paid VaultPress account. 
 
 = 1.7.8 - 15 Oct 2015 =
 * Security: Hotfix for Akismet < 3.1.5.

--- a/vaultpress/vaultpress.php
+++ b/vaultpress/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href="http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">Need some help?</a>
- * Version: 1.9.8
+ * Version: 1.9.10
  * Author: Automattic
  * Author URI: http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+
@@ -18,7 +18,7 @@ class VaultPress {
 	var $option_name          = 'vaultpress';
 	var $auto_register_option = 'vaultpress_auto_register';
 	var $db_version           = 4;
-	var $plugin_version       = '1.9.8';
+	var $plugin_version       = '1.9.10';
 
 	function __construct() {
 		register_activation_hook( __FILE__, array( $this, 'activate' ) );
@@ -441,6 +441,27 @@ class VaultPress {
 		if ( !current_user_can( 'manage_options' ) )
 			return;
 
+		if ( isset( $_POST['action'] ) && 'delete-vp-settings' == $_POST['action'] ) {
+			check_admin_referer( 'delete_vp_settings' );
+
+			$ai_ping_queue_size = $this->ai_ping_queue_size();
+			if ( ! empty( $ai_ping_queue_size->option_count ) && $ai_ping_queue_size->option_count > 1 ) {
+				$this->ai_ping_queue_delete();
+			}
+
+			delete_option( $this->option_name );
+			delete_option( 'vaultpress_service_ips_external_cidr' );
+			delete_option( '_vp_signatures' );
+			delete_option( '_vp_config_option_name_ignore' );
+			delete_option( '_vp_config_post_meta_name_ignore' );
+			delete_option( '_vp_config_should_ignore_files' );
+			delete_option( '_vp_current_scan' );
+			delete_option( 'vaultpress_auto_register' );
+
+			wp_redirect( admin_url( 'admin.php?page=vaultpress&delete-vp-settings=1' ) );
+			exit();
+		}
+
 		// run code that might be updating the registration key
 		if ( isset( $_POST['action'] ) && 'register' == $_POST['action'] ) {
 			check_admin_referer( 'vaultpress_register' );
@@ -548,7 +569,9 @@ class VaultPress {
 		</div>
 			</div><!-- .card-grid -->
 		</div><!-- #vp_registration -->
-	</div><!-- #vp-head -->
+
+        <?php $this->ui_delete_vp_settings_button(); ?>
+    </div><!-- #vp-head -->
 <?php
 	}
 
@@ -559,6 +582,8 @@ class VaultPress {
 			$response = base64_decode( $this->contact_service( 'plugin_ui' ) );
 			echo $response;
 		?>
+
+		<?php $this->ui_delete_vp_settings_button(); ?>
 	</div>
 <?php
 	}
@@ -598,6 +623,32 @@ class VaultPress {
 			</div>
 		</div>
 <?php
+	}
+
+	function ui_delete_vp_settings_button() {
+		?>
+        <div class="grid" style="margin-top: 10px;">
+            <div class="vp_card half">
+				<?php
+				if ( isset( $_GET['delete-vp-settings'] ) && 1 == (int) $_GET['delete-vp-settings'] ) {
+					?>
+                    <p><?php _e( 'All VaultPress settings have been deleted.', 'vaultpress' ); ?></p>
+					<?php
+				} else {
+					?>
+                    <h2><?php _e( 'Delete VaultPress Settings', 'vaultpress' ); ?></h2>
+                    <p class="vp_card-description"><?php _e( 'Warning: Clicking this button will reset ALL VaultPress options in the database.', 'vaultpress' ); ?></p>
+                    <form method="post" action="">
+                        <button class="vp_button-secondary"><?php _e( 'Delete all VaultPress Settings', 'vaultpress' ); ?></button>
+                        <input type="hidden" name="action" value="delete-vp-settings"/>
+						<?php wp_nonce_field( 'delete_vp_settings' ); ?>
+                    </form>
+					<?php
+				}
+				?>
+            </div>
+        </div><!-- .card-grid -->
+		<?php
 	}
 
 	function get_config( $key ) {
@@ -1031,6 +1082,12 @@ class VaultPress {
 			"SELECT * FROM $wpdb->options WHERE `option_name` LIKE '\_vp\_ai\_ping\_%%' ORDER BY `option_id` $order LIMIT %d",
 			min( 10, max( 1, (int)$num ) )
 		) );
+	}
+
+	function ai_ping_queue_delete() {
+		global $wpdb;
+
+		return $wpdb->query( "DELETE FROM `$wpdb->options` WHERE `option_name` LIKE '\_vp\_ai\_ping%'" );
 	}
 
 	function request_firewall_update( $external_services = false ) {


### PR DESCRIPTION
```
1.9.10 – 4 April 2019

    * Bugfix: Fix a PHP fatal error caused by passing an object to the current() function.

1.9.9 – 28 March 2019

    * PHP 7.2.0 compatibility fix.
    * Adding button to delete all VaultPress settings

```

Note this includes the change made in #907 changing `error` to `warning` @scarstocea any update on the change upstream?
