### PR TITLE
Prevent super admin updates when locked

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -32,6 +32,7 @@ class Lockout {
 
 			add_filter( 'user_has_cap', [ $this, 'filter_user_has_cap' ], PHP_INT_MAX, 4 );
 			add_filter( 'pre_site_option_site_admins', [ $this, 'filter_site_admin_option' ], PHP_INT_MAX, 4 );
+			add_filter( 'pre_update_site_option_site_admins', [ $this, 'filter_prevent_site_admin_option_updates' ], PHP_INT_MAX, 2 );
 		}
 	}
 
@@ -153,6 +154,23 @@ class Lockout {
 		}
 
 		return $pre_option;
+	}
+
+	/**
+	 * Don't allow updates to the site_admins option.
+	 *
+	 * When a site is locked, we filter the site_admins list to limit super powers
+	 * to VIP Support users. However, if (grant|revoke)_super_admin are called, that
+	 * ends up clearing out the list, which is not ideal.
+	 *
+	 * Instead, just block updates to the option if a site is locked.
+	 */
+	public function filter_prevent_site_admin_option_updates( $value, $old_value ) {
+		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === VIP_LOCKOUT_STATE ) {
+			return $old_value;
+		}
+
+		return $value;
 	}
 }
 


### PR DESCRIPTION
Can end up emptying out the entire list of super admin because of how the filter interacts with grant and revoke super admin functions.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Make sure you're testing on a multisite.
1. Check out PR.
1. Add a super admin user.
1. Enable lockout by adding `define( 'VIP_LOCKOUT_STATE', 'locked' ); define( 'VIP_LOCKOUT_MESSAGE', 'Oh no!' );` to `vip-config.php`
1. Add another user and try to grant them super admin via `wp shell`: `grant_super_admin( $user_id )`
1. Verify in the db that the site_admins option still has the original user and not the new user (`SELECT * FROM wp_sitemeta WHERE meta_key = 'site_admins'`).