### PR TITLE
Force all VIP sites to use local domain for Photon

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -119,6 +119,11 @@ class A8C_Files {
 		} else {
 			$this->init_vip_photon_filters();
 		}
+
+		// The VIP File Service has Photon capabilities, but is served from the same domain.
+		// If the Photon module is enabled, force Jetpack to use the files service instead of the default Photon domains (`i*.wp.com`) for internal files.
+		// Externally hosted files continue to use the remote Photon service.
+		add_filter( 'jetpack_photon_domain', [ 'A8C_Files_Utils', 'filter_photon_domain' ], 10, 2 );
 	}
 
 	private function init_jetpack_photon_filters() {
@@ -127,11 +132,6 @@ class A8C_Files {
 			trigger_error( 'Cannot initialize Photon filters as the Jetpack_Photon class is not loaded. Please verify that Jetpack is loaded and active to restore this functionality.', E_USER_WARNING );
 			return;
 		}
-
-		// The files service has Photon capabilities, but is served from the same domain.
-		// Force Jetpack to use the files service instead of the default Photon domains (`i*.wp.com`) for internal files.
-		// Externally hosted files continue to use the remot Photon service.
-		add_filter( 'jetpack_photon_domain', [ 'A8C_Files_Utils', 'filter_photon_domain' ], 10, 2 );
 
 		// If Jetpack dev mode is enabled, jetpack_photon_url is short-circuited.
 		// This results in all images being full size (which is not ideal)


### PR DESCRIPTION
The VIP File Service has Photon capabilities, but is served from the same domain. If the Photon module is enabled, force Jetpack to use the files service instead of the default Photon domains (`i*.wp.com`) for internal files.

Externally hosted files continue to use the remote Photon service.

Previously, this was only enabled if you had the `WPCOM_VIP_USE_JETPACK_PHOTON` constant enabled. This enables it for all since we want this behaviour everywhere. We also don't need to wait until #1012 is deployed.

Fixes #1274 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Enable Photon module (`wp jetpack module enable photon`)
1. Ensure `WPCOM_VIP_USE_JETPACK_PHOTON` constant isn't set.
1. Load a post with a local image and an externally hosted image.
1. Verify that the local image is loaded from the site itself and external image from the `i*.wp.com` domain.

Then, enable the `WPCOM_VIP_USE_JETPACK_PHOTON` constant and verify that the behaviour doesn't change.

Then, retest with the Photon module disabled and verify that all images load from their respective domains.