### PR TITLE
Add phone verification step when configuring SMS two-factor

### DIFF
--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -158,7 +158,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 				Correctly configured for <?php echo esc_attr( $sms ); ?>.
 				<input type="submit" class="button" name="vip-two-factor-phone-delete"
 					   value="<?php esc_attr_e( 'Delete', 'two-factor' ); ?>"/>
-			<?php elseif ( !empty( $hashed_token ) ) : ?>
+			<?php elseif ( ! empty( $hashed_token ) ) : ?>
 				<p>
 					Verification code has been sent to <?php echo esc_attr( $sms ); ?>
 					<input type="submit" class="button" name="vip-two-factor-phone-send-code"

--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -86,7 +86,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 	 */
 	public function generate_and_send_token( $user ) {
 		require_once( WPMU_PLUGIN_DIR . '/lib/sms.php' );
-		$message = 'The WordPress VIP security code you requested is: ' . $this->generate_token( $user->ID );
+		$message = 'The verification code you requested is: ' . $this->generate_token( $user->ID );
 		$sms = get_user_meta( $user->ID, self::PHONE_META_KEY, true );
 			return \Automattic\VIP\SMS\send_sms( $sms, $message );
 		}
@@ -195,7 +195,9 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 			$user = get_userdata( $user_id ) ;
 			if ( $this->validate_authentication( $user ) ) {
 				update_user_meta( $user_id, self::SMS_CONFIGURED_META_KEY, 1 );
-			}
+			} else {
+
+            }
 		}
 
 		if ( isset( $_POST['vip-two-factor-phone-delete'] ) ) {

--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -91,30 +91,30 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 			return \Automattic\VIP\SMS\send_sms( $sms, $code );
 		}
 
-		/**
-		 * Prints the form that prompts the user to authenticate.
-		 *
-		 * @param WP_User $user WP_User object of the logged-in user.
-		 */
-		public function authentication_page( $user ) {
-			if ( ! $user ) {
-				return;
-			}
+    /**
+     * Prints the form that prompts the user to authenticate.
+     *
+     * @param WP_User $user WP_User object of the logged-in user.
+     */
+    public function authentication_page( $user ) {
+        if ( ! $user ) {
+            return;
+        }
 
-			if ( ! isset( $_GET['action'] ) || 'validate_2fa' !== $_GET['action'] ) {
-				$this->generate_and_send_token( $user );
-			}
+        if ( ! isset( $_GET['action'] ) || 'validate_2fa' !== $_GET['action'] ) {
+            $this->generate_and_send_token( $user );
+        }
 
-			// Including template.php for submit_button()
-			require_once( ABSPATH .  '/wp-admin/includes/template.php' );
-			?>
-			<p><?php esc_html_e( 'A verification code has been sent to the phone number associated with your account.', 'two-factor' ); ?></p>
-		<p>
-			<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
-			<input type="tel" name="two-factor-sms-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
-		</p>
-		<?php
-		submit_button( __( 'Log In', 'two-factor' ) );
+        // Including template.php for submit_button()
+        require_once( ABSPATH .  '/wp-admin/includes/template.php' );
+        ?>
+        <p><?php esc_html_e( 'A verification code has been sent to the phone number associated with your account.', 'two-factor' ); ?></p>
+    <p>
+        <label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
+        <input type="tel" name="two-factor-sms-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
+    </p>
+    <?php
+    submit_button( __( 'Log In', 'two-factor' ) );
 	}
 
 	/**
@@ -154,26 +154,33 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 		wp_nonce_field( 'user_two_factor_sms_options', '_nonce_user_two_factor_sms_options', false );
 		?>
 		<div>
-		<?php if( '1' === $sms_configured ) : ?>
-            Correctly configured for <?php echo esc_attr( $sms );?>.
-            <input type="submit" class="button" name="vip-two-factor-phone-delete" value="<?php esc_attr_e( 'Delete', 'two-factor' ); ?>" />
-		<?php elseif( ! empty( $hashed_token ) ) : ?>
-            <p>
-                Verification code has been sent to <?php echo esc_attr( $sms );?>
-                <input type="submit" class="button" name="vip-two-factor-phone-send-code" value="<?php esc_attr_e( 'Resend', 'two-factor' ); ?>" />
-                <input type="submit" class="button" name="vip-two-factor-phone-delete" value="<?php esc_attr_e( 'Delete', 'two-factor' ); ?>" />
-            </p>
-            <label>Verification Code:
-                <input name="two-factor-sms-code" />
-            </label>
-            <input type="submit" class="button" name="vip-two-factor-phone-verify-code" value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>" />
-		<?php else: ?>
-			<label>Phone Number
-				<input name="vip-two-factor-phone" type="tel" placeholder="+14158675309" value="<?php echo esc_attr( $sms );?>" />
-			</label>
-            <input type="submit" class="button" name="vip-two-factor-phone-send-code" value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>" />
-			<p><strong>Note:</strong> Please include your country calling code (e.g. +44, +1, +61, etc.) to ensure SMS messages are correctly sent.</p>
-        <?php endif; ?>
+			<?php if ( '1' === $sms_configured ) : ?>
+				Correctly configured for <?php echo esc_attr( $sms ); ?>.
+				<input type="submit" class="button" name="vip-two-factor-phone-delete"
+					   value="<?php esc_attr_e( 'Delete', 'two-factor' ); ?>"/>
+			<?php elseif ( !empty( $hashed_token ) ) : ?>
+				<p>
+					Verification code has been sent to <?php echo esc_attr( $sms ); ?>
+					<input type="submit" class="button" name="vip-two-factor-phone-send-code"
+						   value="<?php esc_attr_e( 'Resend', 'two-factor' ); ?>"/>
+					<input type="submit" class="button" name="vip-two-factor-phone-delete"
+						   value="<?php esc_attr_e( 'Delete', 'two-factor' ); ?>"/>
+				</p>
+				<label>Verification Code:
+					<input name="two-factor-sms-code"/>
+				</label>
+				<input type="submit" class="button" name="vip-two-factor-phone-verify-code"
+					   value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>"/>
+			<?php else: ?>
+				<label>Phone Number
+					<input name="vip-two-factor-phone" type="tel" placeholder="+14158675309"
+						   value="<?php echo esc_attr( $sms ); ?>"/>
+				</label>
+				<input type="submit" class="button" name="vip-two-factor-phone-send-code"
+					   value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>"/>
+				<p><strong>Note:</strong> Please include your country calling code (e.g. +44, +1, +61, etc.) to ensure
+					SMS messages are correctly sent.</p>
+			<?php endif; ?>
 		</div>
 		<?php
 	}
@@ -188,7 +195,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 			$user = get_userdata( $user_id ) ;
 			if ( $this->validate_authentication( $user ) ) {
 				update_user_meta( $user_id, self::SMS_CONFIGURED_META_KEY, 1 );
-            }
+			}
 		}
 
 		if ( isset( $_POST['vip-two-factor-phone-delete'] ) ) {
@@ -198,7 +205,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 			delete_user_meta( $user_id, self::TOKEN_META_KEY );
 		}
 
-        if ( isset( $_POST['vip-two-factor-phone'] ) ) {
+		if ( isset( $_POST['vip-two-factor-phone'] ) ) {
 			// Remove all characters except digits and +-
 			$sms = filter_var( $_POST[ 'vip-two-factor-phone' ], FILTER_SANITIZE_NUMBER_FLOAT );
 			update_user_meta( $user_id, self::PHONE_META_KEY, $sms );

--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -91,30 +91,30 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 			return \Automattic\VIP\SMS\send_sms( $sms, $code );
 		}
 
-    /**
-     * Prints the form that prompts the user to authenticate.
-     *
-     * @param WP_User $user WP_User object of the logged-in user.
-     */
-    public function authentication_page( $user ) {
-        if ( ! $user ) {
-            return;
-        }
+	/**
+	 * Prints the form that prompts the user to authenticate.
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 */
+	public function authentication_page( $user ) {
+		if ( ! $user ) {
+			return;
+		}
 
-        if ( ! isset( $_GET['action'] ) || 'validate_2fa' !== $_GET['action'] ) {
-            $this->generate_and_send_token( $user );
-        }
+		if ( ! isset( $_GET['action'] ) || 'validate_2fa' !== $_GET['action'] ) {
+			$this->generate_and_send_token( $user );
+		}
 
-        // Including template.php for submit_button()
-        require_once( ABSPATH .  '/wp-admin/includes/template.php' );
-        ?>
-        <p><?php esc_html_e( 'A verification code has been sent to the phone number associated with your account.', 'two-factor' ); ?></p>
-    <p>
-        <label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
-        <input type="tel" name="two-factor-sms-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
-    </p>
-    <?php
-    submit_button( __( 'Log In', 'two-factor' ) );
+		// Including template.php for submit_button()
+		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
+		?>
+		<p><?php esc_html_e( 'A verification code has been sent to the phone number associated with your account.', 'two-factor' ); ?></p>
+	<p>
+		<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
+		<input type="tel" name="two-factor-sms-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
+	</p>
+	<?php
+	submit_button( __( 'Log In', 'two-factor' ) );
 	}
 
 	/**

--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -86,9 +86,9 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 	 */
 	public function generate_and_send_token( $user ) {
 		require_once( WPMU_PLUGIN_DIR . '/lib/sms.php' );
-		$code = $this->generate_token( $user->ID );
+		$message = 'The WordPress VIP security code you requested is: ' . $this->generate_token( $user->ID );
 		$sms = get_user_meta( $user->ID, self::PHONE_META_KEY, true );
-			return \Automattic\VIP\SMS\send_sms( $sms, $code );
+			return \Automattic\VIP\SMS\send_sms( $sms, $message );
 		}
 
 	/**


### PR DESCRIPTION
## Description
Add a confirmation step to the SMS provider to make sure the user is able to receive messages at the phone number they entered

Fixes #535 

## Steps to Test
1. Go into the Edit profile for a user in wp-admin
2. Enter your SMS number and click Submit
3. The verification fields should now be where the phone number fields were.Enter the verification code and click submit"
4. The 'Correctly configured for <phone number>` message should now appear

Delete the number and repeat steps 1-4, this time checking the "enabled" checkbox on each step. It should only persist as 'enabled' once the 'correctly configured' message appears 
