### PR TITLE
Allow VIP_2FA_TIME_GATE to be overwritten by other mu-plugins

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/wpcom-vip-two-factor/set-providers.php';
 // Detect if the current user is logged in via Jetpack SSO
 require_once __DIR__ . '/wpcom-vip-two-factor/is-jetpack-sso.php';
 
-define( 'VIP_2FA_TIME_GATE', strtotime( '2019-07-17 18:00:00' ) );
+defined( 'VIP_2FA_TIME_GATE' ) || define( 'VIP_2FA_TIME_GATE', strtotime( '2019-07-17 18:00:00' ) );
 define( 'VIP_IS_AFTER_2FA_TIME_GATE', time() > VIP_2FA_TIME_GATE );
 
 function wpcom_vip_should_force_two_factor() {


### PR DESCRIPTION
We'll use this to enable 2FA for all newly created sites.