### PR TITLE
Disable current theme validation

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -9,6 +9,16 @@
 
 require_once( __DIR__ . '/001-core/privacy.php' );
 
+/**
+ * Disable current theme validation
+ *
+ * By default, WordPress falls back to a default theme if it can't find
+ * the active theme. This is undesirable because it requires manually
+ * re-activating the correct theme and can lead to data loss in the form
+ * of missing sidebar widgets.
+ */
+add_filter( 'validate_current_theme', '__return_false' );
+
 if ( false !== WPCOM_IS_VIP_ENV ) {
 	add_action( 'muplugins_loaded', 'wpcom_vip_init_core_restrictions' );
 }

--- a/001-core.php
+++ b/001-core.php
@@ -15,7 +15,7 @@ require_once( __DIR__ . '/001-core/privacy.php' );
  * By default, WordPress falls back to a default theme if it can't find
  * the active theme. This is undesirable because it requires manually
  * re-activating the correct theme and can lead to data loss in the form
- * of missing sidebar widgets.
+ * of of deactivated widgets and menu location assignments.
  */
 add_filter( 'validate_current_theme', '__return_false' );
 

--- a/001-core.php
+++ b/001-core.php
@@ -15,7 +15,7 @@ require_once( __DIR__ . '/001-core/privacy.php' );
  * By default, WordPress falls back to a default theme if it can't find
  * the active theme. This is undesirable because it requires manually
  * re-activating the correct theme and can lead to data loss in the form
- * of of deactivated widgets and menu location assignments.
+ * of deactivated widgets and menu location assignments.
  */
 add_filter( 'validate_current_theme', '__return_false' );
 


### PR DESCRIPTION
By default, WordPress falls back to a default theme if it can't find
the active theme. This is undesirable because it requires manually
re-activating the correct theme and can lead to data loss in the form
of missing sidebar widgets.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Checkout PR
1. Activate a non-default theme.
1. Delete the active theme.
1. Navigate to the Appearance > Themes page.
1. Observe the error message, but the theme does not revert to default.

Expected notice with this change:

```
ERROR: The theme directory "twentyfifteen" does not exist.
```

Expected notice without this change:

```
The active theme is broken. Reverting to the default theme.
```
