### PR TITLE
Fixes #1283. Delete cached attachment url to post ID cache when attac…

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -593,6 +593,16 @@ function wpcom_vip_attachment_url_to_postid( $url ) {
 }
 
 /**
+ * Remove cached post ID when attachment post deleted
+ *
+ * @see wpcom_vip_attachment_url_to_postid()
+ */
+add_action( 'delete_attachment', function ( $post_id ) {
+	$url = wp_get_attachment_url( $post_id );
+	wp_cache_delete( 'wpcom_vip_attachment_url_post_id_' . md5( $url ) );
+} );
+
+/**
  * Use this function to cache the comment counting in the wp menu that can be slow on sites with lots of comments
  * use like this:
  *


### PR DESCRIPTION
…hment post deleted.

## Description

Delete cached values related to attachment URLs when attachment posts deleted.

Fixes #1283

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [na] This change has relevant unit tests (if applicable).
- [na] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Create new attachment post `25` with file name `photos-by-beks-1625589-unsplash-1024.jpg`

```
wp> $url = 'http://example.com/wp-content/uploads/2019/06/photos-by-beks-1625589-unsplash-1024.jpg';
=> string(106) "http://example.com/wp-content/uploads/2019/06/photos-by-beks-1625589-unsplash-1024.jpg"

wpcom_vip_attachment_url_to_postid($url);
=> int(25)

wp> wp_cache_get( 'wpcom_vip_attachment_url_post_id_' . md5( $url ) );
=> int(25)

wp post delete 25 --force
Success: Deleted post 25.
```

Upload the same image to create a new attachment post `26`

```
wp> $url = 'http://example.com/wp-content/uploads/2019/06/photos-by-beks-1625589-unsplash-1024.jpg';
=> string(106) "http://example.com/wp-content/uploads/2019/06/photos-by-beks-1625589-unsplash-1024.jpg"

wp> wpcom_vip_attachment_url_to_postid($url);
=> int(25)

wp> attachment_url_to_postid( $url );
=> int(26)
```

Now enable the fix and deleting the attachment post. The cached value should also be deleted.

```
wp post delete 26 --force
Success: Deleted post 26.

wp> $url = 'http://example.com/wp-content/uploads/2019/06/photos-by-beks-1625589-unsplash-1024.jpg';
=> string(106) "http://example.com/wp-content/uploads/2019/06/photos-by-beks-1625589-unsplash-1024.jpg"

wp> wp_cache_get( 'wpcom_vip_attachment_url_post_id_' . md5( $url ) );
=> bool(false)

wp> wpcom_vip_attachment_url_to_postid($url);
=> int(0)
```

