### PR TITLE
Cache Personalization: Tweaks to encrypted segmentation flow

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -362,8 +362,7 @@ class Vary_Cache {
 	private static function encrypt_cookie_value( $value ) {
 		$client_key = constant( 'VIP_GO_AUTH_COOKIE_KEY' );
 		$client_iv = constant( 'VIP_GO_AUTH_COOKIE_IV' );
-		$random = random_int( 0,  PHP_INT_MAX ) . random_int( 0,  PHP_INT_MAX );
-		$cookie_value = $random . '|' . $value . '|' . ( time() + self::$cookie_expiry );
+		$cookie_value = random_int( 0,  PHP_INT_MAX ) . '|' . $value . '|' . ( time() + self::$cookie_expiry );
 		$cipher_cookie = openssl_encrypt( $cookie_value, 'aes-128-cbc', $client_key, 0, $client_iv );
 
 		return $cipher_cookie;

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -540,7 +540,8 @@ class Vary_Cache {
 
 		if ( self::is_encryption_enabled() ) {
 			$cookie_value = self::encrypt_cookie_value( $group_string );
-			self::set_cookie( self::COOKIE_AUTH, $cookie_value );
+			$base_64 = base64_encode( $cookie_value ) ;
+			self::set_cookie( self::COOKIE_AUTH, VIP_GO_APP_ID . '.' . $base_64 );
 		} else {
 			self::set_cookie( self::COOKIE_SEGMENT, $group_string );
 		}

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -576,7 +576,7 @@ class Vary_Cache {
 			if ( self::is_encryption_enabled() ) {
 				header( 'Vary: X-VIP-Go-Auth' );
 			} else {
-				header( 'Vary: X-VIP-Go-Segmentation: '. $group_string );
+				header( 'Vary: X-VIP-Go-Segmentation' );
 			}
 
 			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -591,7 +591,7 @@ class Vary_Cache {
 	 */
 	private static function set_cookie( $name, $value ) {
 		$expiry = time() + self::$cookie_expiry;
-		setcookie( $name, $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
+		setrawcookie( $name, $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
 	}
 
 	/**

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -420,8 +420,8 @@ class Vary_Cache {
 			// If the header auth isn't set (in case of a logged-in user), fall back to decrypting the cookie itself.
 			$auth_cookie = null;
 			// $_COOKIE is automatically urldecoded, so we need to search through the $_SERVER version to get the unencoded one.
-			foreach( explode('; ',$_SERVER[ 'HTTP_COOKIE' ] ) as $rawcookie ) {
-				list( $k, $v ) = explode('=', $rawcookie,2 );
+			foreach( explode( '; ', $_SERVER[ 'HTTP_COOKIE' ] ) as $rawcookie ) {
+				list( $k, $v ) = explode( '=', $rawcookie, 2 );
 				if( self::COOKIE_AUTH === $k ) {
 					$auth_cookie = $v;
 					break;

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -570,9 +570,6 @@ class Vary_Cache {
 		if ( ! empty( self::$groups ) ) {
 			$sent_vary = true;
 
-			$group_string = self::stringify_groups();
-
-
 			if ( self::is_encryption_enabled() ) {
 				header( 'Vary: X-VIP-Go-Auth' );
 			} else {
@@ -595,6 +592,7 @@ class Vary_Cache {
 	 */
 	private static function set_cookie( $name, $value ) {
 		$expiry = time() + self::$cookie_expiry;
+		//need to use setrawcookie() here to prevent PHP from URLEncoding the base-64 terminator (==) on encrypted payloads
 		setrawcookie( $name, $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
 	}
 

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -414,14 +414,14 @@ class Vary_Cache {
 	 * Parses the group/segment cookie into the local groups array of key-values.
 	 */
 	private static function parse_group_cookie() {
-		//use the decrypted value provided from the cache layer
+		// Use the decrypted value provided from the cache layer.
 		if ( self::is_encryption_enabled() && isset( $_SERVER[ self::HEADER_AUTH ] ) &&  ! empty( $_SERVER[ self::HEADER_AUTH ] ) ) {
 			$cookie_value = $_SERVER[ self::HEADER_AUTH ];
 		} elseif ( self::is_encryption_enabled() && ! empty( $_COOKIE[ self::COOKIE_AUTH ] ) ) {
-			// if the header auth isn't set (in case of a logged-in user), fall back to decrypting the cookie itself.
+			// If the header auth isn't set (in case of a logged-in user), fall back to decrypting the cookie itself.
 
 			$auth_cookie = null;
-			//$_COOKIE is automatically urldecoded, so we need to search through the $_SERVER version to get the unencoded one.
+			// $_COOKIE is automatically urldecoded, so we need to search through the $_SERVER version to get the unencoded one.
 			foreach(explode('; ',$_SERVER['HTTP_COOKIE']) as $rawcookie)
 			{
 				list($k,$v) = explode('=',$rawcookie, 2);
@@ -434,7 +434,7 @@ class Vary_Cache {
 			$value = ltrim( $auth_cookie, VIP_GO_APP_ID . '.' ); // remove the site prefix
 			$cookie_value = self::decrypt_cookie_value( $value );
 
-		}elseif ( ! empty( $_COOKIE[ self::COOKIE_SEGMENT ] ) ) {
+		} elseif ( ! empty( $_COOKIE[ self::COOKIE_SEGMENT ] ) ) {
 			$cookie_value = $_COOKIE[ self::COOKIE_SEGMENT ];
 		}
 
@@ -609,7 +609,7 @@ class Vary_Cache {
 	 */
 	private static function set_cookie( $name, $value ) {
 		$expiry = time() + self::$cookie_expiry;
-		//need to use setrawcookie() here to prevent PHP from URLEncoding the base-64 terminator (==) on encrypted payloads
+		// Need to use setrawcookie() here to prevent PHP from URLEncoding the base-64 terminator (==) on encrypted payloads
 		setrawcookie( $name, $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
 	}
 

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -414,18 +414,16 @@ class Vary_Cache {
 	 * Parses the group/segment cookie into the local groups array of key-values.
 	 */
 	private static function parse_group_cookie() {
-		// Use the decrypted value provided from the cache layer.
+		// If the cache layer supplies a decrypted segmentation header, use that instead of decrypting it again.
 		if ( self::is_encryption_enabled() && isset( $_SERVER[ self::HEADER_AUTH ] ) &&  ! empty( $_SERVER[ self::HEADER_AUTH ] ) ) {
 			$cookie_value = $_SERVER[ self::HEADER_AUTH ];
 		} elseif ( self::is_encryption_enabled() && ! empty( $_COOKIE[ self::COOKIE_AUTH ] ) ) {
 			// If the header auth isn't set (in case of a logged-in user), fall back to decrypting the cookie itself.
-
 			$auth_cookie = null;
 			// $_COOKIE is automatically urldecoded, so we need to search through the $_SERVER version to get the unencoded one.
-			foreach(explode('; ',$_SERVER['HTTP_COOKIE']) as $rawcookie)
-			{
-				list($k,$v) = explode('=',$rawcookie, 2);
-				if( self::COOKIE_AUTH === $k) {
+			foreach( explode('; ',$_SERVER[ 'HTTP_COOKIE' ] ) as $rawcookie ) {
+				list( $k, $v ) = explode('=', $rawcookie,2 );
+				if( self::COOKIE_AUTH === $k ) {
 					$auth_cookie = $v;
 					break;
 				}

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -417,7 +417,24 @@ class Vary_Cache {
 		//use the decrypted value provided from the cache layer
 		if ( self::is_encryption_enabled() && isset( $_SERVER[ self::HEADER_AUTH ] ) &&  ! empty( $_SERVER[ self::HEADER_AUTH ] ) ) {
 			$cookie_value = $_SERVER[ self::HEADER_AUTH ];
-		} elseif ( ! empty( $_COOKIE[ self::COOKIE_SEGMENT ] ) ) {
+		} elseif ( self::is_encryption_enabled() && ! empty( $_COOKIE[ self::COOKIE_AUTH ] ) ) {
+			// if the header auth isn't set (in case of a logged-in user), fall back to decrypting the cookie itself.
+
+			$auth_cookie = null;
+			//$_COOKIE is automatically urldecoded, so we need to search through the $_SERVER version to get the unencoded one.
+			foreach(explode('; ',$_SERVER['HTTP_COOKIE']) as $rawcookie)
+			{
+				list($k,$v) = explode('=',$rawcookie, 2);
+				if( self::COOKIE_AUTH === $k) {
+					$auth_cookie = $v;
+					break;
+				}
+			}
+
+			$value = ltrim( $auth_cookie, VIP_GO_APP_ID . '.' ); // remove the site prefix
+			$cookie_value = self::decrypt_cookie_value( $value );
+
+		}elseif ( ! empty( $_COOKIE[ self::COOKIE_SEGMENT ] ) ) {
 			$cookie_value = $_COOKIE[ self::COOKIE_SEGMENT ];
 		}
 

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -361,7 +361,8 @@ class Vary_Cache {
 	private static function encrypt_cookie_value( $value ) {
 		$client_key = constant( 'VIP_GO_AUTH_COOKIE_KEY' );
 		$client_iv = constant( 'VIP_GO_AUTH_COOKIE_IV' );
-		$cookie_value = random_bytes( 32 ) . '|' . $value . '|' . ( time() + self::$cookie_expiry );
+		$random = random_int( 100000,  PHP_INT_MAX );
+		$cookie_value = $random . '|' . $value . '|' . ( time() + self::$cookie_expiry );
 		$cipher_cookie = openssl_encrypt( $cookie_value, 'aes-128-cbc', $client_key, 0, $client_iv );
 
 		return $cipher_cookie;

--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -362,7 +362,7 @@ class Vary_Cache {
 	private static function encrypt_cookie_value( $value ) {
 		$client_key = constant( 'VIP_GO_AUTH_COOKIE_KEY' );
 		$client_iv = constant( 'VIP_GO_AUTH_COOKIE_IV' );
-		$random = random_int( 100000,  PHP_INT_MAX );
+		$random = random_int( 0,  PHP_INT_MAX ) . random_int( 0,  PHP_INT_MAX );
 		$cookie_value = $random . '|' . $value . '|' . ( time() + self::$cookie_expiry );
 		$cipher_cookie = openssl_encrypt( $cookie_value, 'aes-128-cbc', $client_key, 0, $client_iv );
 

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -647,7 +647,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 					'dev-group' => 'yes'
 				],
 			],
-			'values_encrypted_group' => [
+			'values_encrypted_group_header' => [
 				[	'key' => 'abc',
 					'iv' => '1231231231231234',
 				],
@@ -655,6 +655,20 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				],
 				[
 					'HTTP_X_VIP_GO_AUTH' => 'vc-v1__design-group_--_no---__dev-group_--_yes'
+				],
+				[
+					'design-group' => 'no' ,
+					'dev-group' => 'yes'
+				],
+			],
+			'values_encrypted_group_no_header' => [
+				[	'key' => 'abc',
+					'iv' => '1231231231231234',
+				],
+				[
+					'vip-go-auth' => 'VyLXNl8VFvGE4+ZyW1jpbS677cXNgN4owowO0jIOq48LS3ImPe4l2RPUSd3YuD8bLS4UtV4Z6fxFW/E22qvKXaQwPI3fEnZghINwbwaqKhV0jqdovLCVfEIu9SAA4v6I',
+				],
+				[
 				],
 				[
 					'design-group' => 'no' ,

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -15,6 +15,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		parent::setUp();
 
 		$this->original_COOKIE = $_COOKIE;
+		$this->original_SERVER = $_SERVER;
 
 		Vary_Cache::load();
 	}
@@ -23,6 +24,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		Vary_Cache::unload();
 
 		$_COOKIE = $this->original_COOKIE;
+		$_SERVER = $this->original_SERVER;
 
 		parent::tearDown();
 	}
@@ -639,6 +641,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				[
 					'vip-go-seg' => 'vc-v1__design-group_--_no---__dev-group_--_yes',
 				],
+				[],
 				[
 					'design-group' => 'no' ,
 					'dev-group' => 'yes'
@@ -649,7 +652,9 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 					'iv' => '1231231231231234',
 				],
 				[
-					'vip-go-auth' => 'VyLXNl8VFvGE4+ZyW1jpbS677cXNgN4owowO0jIOq48LS3ImPe4l2RPUSd3YuD8bLS4UtV4Z6fxFW/E22qvKXaQwPI3fEnZghINwbwaqKhV0jqdovLCVfEIu9SAA4v6I',
+				],
+				[
+					'HTTP_X_VIP_GO_AUTH' => 'vc-v1__design-group_--_no---__dev-group_--_yes'
 				],
 				[
 					'design-group' => 'no' ,
@@ -661,6 +666,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 				[
 					'vip-go-seg' => 'vc-v1__',
 				],
+				[],
 				[
 				],
 			],
@@ -669,9 +675,13 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 					'iv' => '1231231231231234',
 				],
 				[
-					'vip-go-auth' => 'qSME2LdfVuNvZa0GfeUJ45/uHCu7Auqj3iesSL4CITteGfva/N0wQ5TCIzcyeBImeTf3On2P4f7EtQyviw2ooA==',
 				],
 				[
+					'HTTP_X_VIP_GO_AUTH' => 'vc-v1__design-group_--_yes---__dev-group_--_no'
+				],
+				[
+					'design-group' => 'yes' ,
+					'dev-group' => 'no'
 				],
 			],
 		];
@@ -683,8 +693,9 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test__parse_group_cookie_valid( $secrets, $initial_cookie, $expected_result )
+	public function test__parse_group_cookie_valid( $secrets, $initial_cookie, $headers, $expected_result )
 	{
+		$_SERVER = array_merge( $_SERVER, $headers );
 		$_COOKIE = $initial_cookie;
 		$get_parse_group_cookie_method = self::get_vary_cache_method( 'parse_group_cookie' );
 		if ( ! empty( $secrets ) ) {

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -650,6 +650,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 			'values_encrypted_group_header' => [
 				[	'key' => 'abc',
 					'iv' => '1231231231231234',
+					'siteid' => 123,
 				],
 				[
 				],
@@ -664,11 +665,13 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 			'values_encrypted_group_no_header' => [
 				[	'key' => 'abc',
 					'iv' => '1231231231231234',
+					'siteid' => 123,
 				],
 				[
-					'vip-go-auth' => 'VyLXNl8VFvGE4+ZyW1jpbS677cXNgN4owowO0jIOq48LS3ImPe4l2RPUSd3YuD8bLS4UtV4Z6fxFW/E22qvKXaQwPI3fEnZghINwbwaqKhV0jqdovLCVfEIu9SAA4v6I',
+					'vip-go-auth' => '123.VyLXNl8VFvGE4+ZyW1jpbS677cXNgN4owowO0jIOq48LS3ImPe4l2RPUSd3YuD8bLS4UtV4Z6fxFW/E22qvKXaQwPI3fEnZghINwbwaqKhV0jqdovLCVfEIu9SAA4v6I',
 				],
 				[
+					'HTTP_COOKIE' => 'vip-go-auth=123.VyLXNl8VFvGE4+ZyW1jpbS677cXNgN4owowO0jIOq48LS3ImPe4l2RPUSd3YuD8bLS4UtV4Z6fxFW/E22qvKXaQwPI3fEnZghINwbwaqKhV0jqdovLCVfEIu9SAA4v6I;',
 				],
 				[
 					'design-group' => 'no' ,
@@ -687,6 +690,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 			'values_encrypted_nogroup' => [
 				[	'key' => 'abc',
 					'iv' => '1231231231231234',
+					'siteid' => 123,
 				],
 				[
 				],
@@ -715,6 +719,7 @@ class Vary_Cache_Test extends \WP_UnitTestCase {
 		if ( ! empty( $secrets ) ) {
 			define( 'VIP_GO_AUTH_COOKIE_KEY', $secrets[ 'key' ] );
 			define( 'VIP_GO_AUTH_COOKIE_IV', $secrets[ 'iv' ] );
+			define( 'VIP_GO_APP_ID', $secrets[ 'siteid' ]);
 			Vary_Cache::enable_encryption();
 		}
 		$get_parse_group_cookie_method->invokeArgs(null, [ ] );


### PR DESCRIPTION
## Description
Sets the encrypted cookie in orer for Varnish to properly decrypte and deconstruct on future requests
## Steps to Test

1. Use a segmentation example such as:
https://github.com/Automattic/vip-go-mu-plugins/blob/master/cache/examples/segmentation-beta/beta.php
2. After the register_groups command, add `Vary_Cache::enable_encryption();`
3. Ensure the group logic works as it did in the unencrypted version