### PR TITLE
Allow bulk editing for hierarchical post types

### DIFF
--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -2,8 +2,7 @@
 
 namespace Automattic\VIP\Performance;
 
-// Core defaults to 20, so let's assume that's safe
-const BULK_EDIT_LIMIT = 20;
+const BULK_EDIT_LIMIT = 40;
 
 /**
  * Bulk edits of lots of posts can trigger slow term count queries for each post updated

--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -23,17 +23,20 @@ add_action( 'load-edit.php', __NAMESPACE__ . '\defer_term_counting' );
  * Determine if bulk editing should be blocked
  */
 function bulk_editing_is_limited() {
-	$per_page = get_query_var( 'posts_per_page' );
-
-	// Get total number of entries
+	// Do not hide bulk edit actions if number of total entries is less than 20, core's default.
 	if ( isset( $GLOBALS['wp_query'] ) && is_a( $GLOBALS['wp_query'], 'WP_Query' ) ) {
 		$total_posts = $GLOBALS['wp_query']->found_posts;
+
+		if ( isset( $total_posts ) && BULK_EDIT_LIMIT > $total_posts ) {
+			return false;
+		}
 	}
 
-	// Core defaults to 20 posts per page
-	// Do no hide bulk edit actions if number of total entries is less than 20
-	if ( isset( $total_posts ) && BULK_EDIT_LIMIT > $total_posts ) {
-		return false;
+	$per_page = get_query_var( 'posts_per_page' );
+
+	// Hierarchical post types set `posts_per_page` to -1 during the original query, but they still respect the per_page value in the posts list table.
+	if ( isset( $GLOBALS['wp_list_table'] ) && is_a( $GLOBALS['wp_list_table'], 'WP_Posts_List_Table' ) ) {
+		$per_page = isset( $GLOBALS['wp_list_table']->_pagination_args['per_page'] ) ? $GLOBALS['wp_list_table']->_pagination_args['per_page'] : $per_page;
 	}
 
 	// If requesting all entries, or more than 20, hide bulk actions
@@ -42,7 +45,6 @@ function bulk_editing_is_limited() {
 	}
 
 	return $per_page > BULK_EDIT_LIMIT;
-
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes https://github.com/Automattic/vip-go-mu-plugins/issues/1280

At the moment, pages (and other hierarchical post types) cannot be bulk edited when there are more than 20 total, regardless of how many are set to show per page. This is because WP core sets the `posts_per_page` query arg to -1 here for these post types, [seen here](https://github.com/WordPress/WordPress/blob/c77e771c849a85b63cef1b9457ad1a501a331afa/wp-admin/includes/post.php#L1169-L1176). I assume this is so it can properly list children under their parents.

The `per_page` value/option is still respected though when it comes to how many posts show per pages in the lists table though, [seen here](https://github.com/WordPress/WordPress/blob/cf3fa9f7c8038447303eea1fbd3636c5fece28cd/wp-admin/includes/class-wp-posts-list-table.php#L155). So we should check this before assuming bulk editing needs to be disabled.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Example:

1. On any VIP test site, add at least 21 pages. Note how bulk editing is disabled.
1. Check out this PR and test again. Bulk editing should work when set to 20 or less per page.