### PR TITLE
Vary cache on Origin

### DIFF
--- a/security.php
+++ b/security.php
@@ -178,3 +178,15 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 
 	return false;
 }
+
+/**
+ * On otherwise cacheable requests, we need to ensure we're varying on Origin
+ * so that the cache cannot be poisoned and prevent CORS requests
+ */
+function vip_maybe_vary_http_origin() {
+	if ( 'GET' === $_SERVER['REQUEST_METHOD'] && ! is_user_logged_in() ) {
+		header( 'Vary: Origin', false );
+	}
+}
+
+add_action( 'send_headers', 'vip_maybe_vary_http_origin' );

--- a/security.php
+++ b/security.php
@@ -182,11 +182,16 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 /**
  * On otherwise cacheable requests, we need to ensure we're varying on Origin
  * so that the cache cannot be poisoned and prevent CORS requests
+ *
+ * NOTE - we hook into the `http_origin` filter instead of the `send_headers` action,
+ * because the REST API doesn't call send_headers
  */
-function vip_maybe_vary_http_origin() {
-	if ( 'GET' === $_SERVER['REQUEST_METHOD'] && ! is_user_logged_in() ) {
+function vip_maybe_vary_http_origin( $origin ) {
+	if ( ! headers_sent() && 'GET' === $_SERVER['REQUEST_METHOD'] && ! is_user_logged_in() ) {
 		header( 'Vary: Origin', false );
 	}
+
+	return $origin;
 }
 
-add_action( 'send_headers', 'vip_maybe_vary_http_origin' );
+add_filter( 'http_origin', 'vip_maybe_vary_http_origin' );


### PR DESCRIPTION
## Description

Ensure cache consistency by always varying on Origin header.

Currently this runs on unauthenticated GET requests, which handles most instances where requests are cacheable, but we can also consider just running it on every request for simplicity and completeness.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).