### PR TITLE
Update x-hacker and x-powered-by headers to use wpvip.com 

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -147,8 +147,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 // Add custom header for VIP
 add_filter( 'wp_headers', function( $headers ) {
-	$headers['X-hacker'] = 'If you\'re reading this, you should visit automattic.com/jobs and apply to join the fun, mention this header.';
-	$headers['X-Powered-By'] = 'WordPress.com VIP <https://vip.wordpress.com>';
+	$headers['X-hacker'] = 'If you\'re reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header.';
+	$headers['X-Powered-By'] = 'WordPress.com VIP <https://wpvip.com>';
 
 	// All non-production domains should not be indexed.
 	// This should not apply only to *.vip-go.co


### PR DESCRIPTION
## Description

Currently, A8C headers point to the old wordpress.com/vip URL and the A8C jobs page

This update changes them to the wpvip.com URL and the VIP jobs page.


## Steps to Test

1. Check out PR.
2. Request site homepage
3. Ensure x-hacker and powered by headers now reference wpvip.com