### PR TITLE
Pass wp-content into the file path for the client sunrise file.

### DIFF
--- a/lib/sunrise/sunrise.php
+++ b/lib/sunrise/sunrise.php
@@ -73,7 +73,7 @@ function handle_not_found_error( $error_type ) {
 			$error_doc = sprintf( '%s/mu-plugins/errors/site-maintenance.html', WP_CONTENT_DIR );
 		} else {
 			$status_code = 404;
-			$error_doc = sprintf( '%s/mu-plugins/errors/%s-not-found.html', WP_CONTENT_DIR, $error_type );
+			$error_doc   = sprintf( '%s/mu-plugins/errors/%s-not-found.html', WP_CONTENT_DIR, $error_type );
 		}
 
 		http_response_code( $status_code );
@@ -85,7 +85,7 @@ function handle_not_found_error( $error_type ) {
 /**
  * When provided, load a client's sunrise too
  */
-$client_sunrise = ABSPATH . '/vip-config/client-sunrise.php';
+$client_sunrise = ABSPATH . 'wp-content/vip-config/client-sunrise.php';
 if ( file_exists( $client_sunrise ) ) {
 	require_once $client_sunrise;
 }


### PR DESCRIPTION
## Description

This is a fix for #1298. Passes the correct path into the `sunrise.php` file.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

1. Check out PR.
1. `cp cp mu-plugins/lib/sunrise/sunrise.php sunrise.php`
1. Go to `wp-admin` > `Network` > `Plugins` > Must Use and see if sunrise is included.
1. $$$