### PR TITLE
Don't enforce 2FA by default in local dev

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -16,6 +16,12 @@ defined( 'VIP_2FA_TIME_GATE' ) || define( 'VIP_2FA_TIME_GATE', strtotime( '2019-
 define( 'VIP_IS_AFTER_2FA_TIME_GATE', time() > VIP_2FA_TIME_GATE );
 
 function wpcom_vip_should_force_two_factor() {
+
+	// Don't force 2FA by default in local environments
+	if ( ! WPCOM_IS_VIP_ENV && ! apply_filters( 'wpcom_vip_is_two_factor_local_testing', false ) ) {
+		return false
+	}
+	
 	// The proxy is the second factor for VIP Support users
 	if ( true === A8C_PROXIED_REQUEST ) {
 		return false;

--- a/two-factor.php
+++ b/two-factor.php
@@ -18,7 +18,7 @@ define( 'VIP_IS_AFTER_2FA_TIME_GATE', time() > VIP_2FA_TIME_GATE );
 function wpcom_vip_should_force_two_factor() {
 
 	// Don't force 2FA by default in local environments
-	if ( ! WPCOM_IS_VIP_ENV && ! apply_filters( 'wpcom_vip_is_two_factor_local_testing', false ) ) {
+	if ( ! WPCOM_IS_VIP_ENV && ! apply_filters( 'wpcom_vip_is_two_factor_local_testing', false ) {
 		return false
 	}
 	

--- a/two-factor.php
+++ b/two-factor.php
@@ -18,8 +18,8 @@ define( 'VIP_IS_AFTER_2FA_TIME_GATE', time() > VIP_2FA_TIME_GATE );
 function wpcom_vip_should_force_two_factor() {
 
 	// Don't force 2FA by default in local environments
-	if ( ! WPCOM_IS_VIP_ENV && ! apply_filters( 'wpcom_vip_is_two_factor_local_testing', false ) {
-		return false
+	if ( ! WPCOM_IS_VIP_ENV && ! apply_filters( 'wpcom_vip_is_two_factor_local_testing', false ) ) {
+		return false;
 	}
 	
 	// The proxy is the second factor for VIP Support users


### PR DESCRIPTION
Adds a `wpcom_vip_is_two_factor_local_testing` filter. 2FA enforcement will be disabled by default in local environments, but if you need to test the 2FA functionality, you can easily enable it in local environments with this filter.

We generally try to make the local environment as close as possible to production, but this is an instance where it would just get in the way most of the time.

Some things to consider during review:

1. The idea of conditionally enabling 2FA enforcement in local dev. Generally we try to keep local dev as close as possible to production, but this seems like a good example of where it will be more annoying than helpful most of the time.
2. The approach used here. I don't know of other functionality that you can optionally enable in local dev. How do we feel about this constant + filter approach?