### PR TITLE
2FA: Don't restrict wpcomvip, logins are blocked anyway

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -102,7 +102,12 @@ defined( 'WPCOM_VIP_MACHINE_USER_ROLE' )  or define( 'WPCOM_VIP_MACHINE_USER_ROL
 
 add_action( 'set_current_user', function() {
 	$user = get_user_by( 'login', WPCOM_VIP_MACHINE_USER_LOGIN );
-	define( 'WPCOM_VIP_MACHINE_USER_ID', $user->ID );
+
+	if ( ! user || ! $user->ID ) {
+		define( 'WPCOM_VIP_MACHINE_USER_ID', 0 );
+	} else {
+		define( 'WPCOM_VIP_MACHINE_USER_ID', $user->ID );
+	}
 }, PHP_INT_MIN );
 
 // Support a limited number of additional "Internal Events" in Cron Control.

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -103,10 +103,8 @@ defined( 'WPCOM_VIP_MACHINE_USER_ROLE' )  or define( 'WPCOM_VIP_MACHINE_USER_ROL
 add_action( 'set_current_user', function() {
 	$user = get_user_by( 'login', WPCOM_VIP_MACHINE_USER_LOGIN );
 
-	if ( ! $user || ! $user->ID ) {
-		define( 'WPCOM_VIP_MACHINE_USER_ID', 0 );
-	} else {
-		define( 'WPCOM_VIP_MACHINE_USER_ID', $user->ID );
+	if ( $user && $user->ID ) {
+		defined( 'WPCOM_VIP_MACHINE_USER_ID' ) or define( 'WPCOM_VIP_MACHINE_USER_ID', $user->ID );
 	}
 }, PHP_INT_MIN );
 

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -103,7 +103,7 @@ defined( 'WPCOM_VIP_MACHINE_USER_ROLE' )  or define( 'WPCOM_VIP_MACHINE_USER_ROL
 add_action( 'set_current_user', function() {
 	$user = get_user_by( 'login', WPCOM_VIP_MACHINE_USER_LOGIN );
 	define( 'WPCOM_VIP_MACHINE_USER_ID', $user->ID );
-}, 0 );
+}, PHP_INT_MIN );
 
 // Support a limited number of additional "Internal Events" in Cron Control.
 // These events run regardless of the number of pending events, and they cannot be deleted.

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -100,6 +100,11 @@ defined( 'WPCOM_VIP_MACHINE_USER_NAME' )  or define( 'WPCOM_VIP_MACHINE_USER_NAM
 defined( 'WPCOM_VIP_MACHINE_USER_EMAIL' ) or define( 'WPCOM_VIP_MACHINE_USER_EMAIL', 'donotreply@wordpress.com' );
 defined( 'WPCOM_VIP_MACHINE_USER_ROLE' )  or define( 'WPCOM_VIP_MACHINE_USER_ROLE', 'administrator' );
 
+add_action( 'set_current_user', function() {
+	$user = get_user_by( 'login', WPCOM_VIP_MACHINE_USER_LOGIN );
+	define( 'WPCOM_VIP_MACHINE_USER_ID', $user->ID );
+}, 0 );
+
 // Support a limited number of additional "Internal Events" in Cron Control.
 // These events run regardless of the number of pending events, and they cannot be deleted.
 define( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', array(

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -103,7 +103,7 @@ defined( 'WPCOM_VIP_MACHINE_USER_ROLE' )  or define( 'WPCOM_VIP_MACHINE_USER_ROL
 add_action( 'set_current_user', function() {
 	$user = get_user_by( 'login', WPCOM_VIP_MACHINE_USER_LOGIN );
 
-	if ( ! user || ! $user->ID ) {
+	if ( ! $user || ! $user->ID ) {
 		define( 'WPCOM_VIP_MACHINE_USER_ID', 0 );
 	} else {
 		define( 'WPCOM_VIP_MACHINE_USER_ID', $user->ID );

--- a/two-factor.php
+++ b/two-factor.php
@@ -26,7 +26,7 @@ function wpcom_vip_should_force_two_factor() {
 	if ( true === A8C_PROXIED_REQUEST ) {
 		return false;
 	}
-	
+
 	// The Two Factor plugin wasn't loaded for some reason.
 	if ( ! class_exists( 'Two_Factor_Core' ) ) {
 		return false;

--- a/two-factor.php
+++ b/two-factor.php
@@ -27,17 +27,6 @@ function wpcom_vip_should_force_two_factor() {
 		return false;
 	}
 	
-	static $current_username;
-	if ( ! $current_username ) {
-		$user = wp_get_current_user();
-		$current_username = $user->user_login;
-	}
-	
-	// Don't restrict the wpcomvip user, for which logins are blocked anyway
-	if ( 'wpcomvip' === $current_username ) {
-		return false;
-	}
-
 	// The Two Factor plugin wasn't loaded for some reason.
 	if ( ! class_exists( 'Two_Factor_Core' ) ) {
 		return false;
@@ -109,7 +98,7 @@ function wpcom_enable_two_factor_plugin() {
  * Remove caps for users without two-factor enabled so they are treated as a Contributor.
  */
 function wpcom_vip_two_factor_filter_caps( $caps, $cap, $user_id, $args ) {
-	if ( wpcom_vip_is_two_factor_forced() ) {
+	if ( wpcom_vip_is_two_factor_forced() && $user_id !== WPCOM_VIP_MACHINE_USER_ID ) {
 		// Use a hard-coded list of caps that give just enough access to set up 2FA
 		$subscriber_caps = [
 			'read',

--- a/two-factor.php
+++ b/two-factor.php
@@ -99,7 +99,7 @@ function wpcom_enable_two_factor_plugin() {
  */
 function wpcom_vip_two_factor_filter_caps( $caps, $cap, $user_id, $args ) {
 	// If the machine user is not defined or the current user is not the machine user, don't filter caps.
-	if ( wpcom_vip_is_two_factor_forced() && ! ( defined( 'WPCOM_VIP_MACHINE_USER_ID' ) && $user_id === WPCOM_VIP_MACHINE_USER_ID ) ) {
+	if ( wpcom_vip_is_two_factor_forced() && ( ! defined( 'WPCOM_VIP_MACHINE_USER_ID' ) || $user_id !== WPCOM_VIP_MACHINE_USER_ID ) ) {
 		// Use a hard-coded list of caps that give just enough access to set up 2FA
 		$subscriber_caps = [
 			'read',

--- a/two-factor.php
+++ b/two-factor.php
@@ -35,7 +35,7 @@ function wpcom_vip_should_force_two_factor() {
 	
 	// Don't restrict the wpcomvip user, for which logins are blocked anyway
 	if ( 'wpcomvip' === $current_username ) {
-		return false
+		return false;
 	}
 
 	// The Two Factor plugin wasn't loaded for some reason.

--- a/two-factor.php
+++ b/two-factor.php
@@ -98,7 +98,8 @@ function wpcom_enable_two_factor_plugin() {
  * Remove caps for users without two-factor enabled so they are treated as a Contributor.
  */
 function wpcom_vip_two_factor_filter_caps( $caps, $cap, $user_id, $args ) {
-	if ( wpcom_vip_is_two_factor_forced() && $user_id !== WPCOM_VIP_MACHINE_USER_ID ) {
+	// If the machine user is not defined or the current user is not the machine user, don't filter caps.
+	if ( wpcom_vip_is_two_factor_forced() && ! ( defined( 'WPCOM_VIP_MACHINE_USER_ID' ) && $user_id === WPCOM_VIP_MACHINE_USER_ID ) ) {
 		// Use a hard-coded list of caps that give just enough access to set up 2FA
 		$subscriber_caps = [
 			'read',

--- a/two-factor.php
+++ b/two-factor.php
@@ -26,6 +26,17 @@ function wpcom_vip_should_force_two_factor() {
 	if ( true === A8C_PROXIED_REQUEST ) {
 		return false;
 	}
+	
+	static $current_username;
+	if ( ! $current_username ) {
+		$user = wp_get_current_user();
+		$current_username = $user->user_login;
+	}
+	
+	// Don't restrict the wpcomvip user, for which logins are blocked anyway
+	if ( 'wpcomvip' === $current_username ) {
+		return false
+	}
 
 	// The Two Factor plugin wasn't loaded for some reason.
 	if ( ! class_exists( 'Two_Factor_Core' ) ) {


### PR DESCRIPTION
The wpcomvip user is responsible for the Jetpack connection, among other things. We don't want to restrict access here and logins are blocked anyway.

### Testing

I've manually tested on a sandbox with my support user and just changed the username instances to `wpcomvip`.