### PR TITLE
Improve 2FA enforcement compatibility with Jetpack

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -42,30 +42,8 @@ function wpcom_vip_should_force_two_factor() {
 	}
 
 	// If it's a request attempting to connect a local user to a
-	// WordPress.com user via XML-RPC, allow it through.
-	// This works with the classic core XML-RPC endpoint, but not
-	// Jetpack's alternate endpoint.
-	if (
-		defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST
-	&&
-		isset( $_GET['for'] ) && 'jetpack' === $_GET['for']
-	&&
-		isset( $GLOBALS['wp_xmlrpc_server'], $GLOBALS['wp_xmlrpc_server']->message , $GLOBALS['wp_xmlrpc_server']->message->methodName )
-	&&
-		'jetpack.remoteAuthorize' === $GLOBALS['wp_xmlrpc_server']->message->methodName
-	) {
-		return false;
-	}
-
-	// If it's a request attempting to connect a local user to a
-	// WordPress.com user via REST, allow it through.
-	if (
-		defined( 'REST_REQUEST' ) && REST_REQUEST
-	&&
-		isset( $GLOBALS['wp_rest_server'] )
-	&&
-		wpcom_vip_is_jetpack_authorize_rest_request()
-	) {
+	// WordPress.com user via XML-RPC or REST, allow it through.
+	if ( wpcom_vip_is_jetpack_authorize_request() ) {
 		return false;
 	}
 
@@ -80,6 +58,23 @@ function wpcom_vip_should_force_two_factor() {
 	}
 
 	return true;
+}
+
+function wpcom_vip_is_jetpack_authorize_request() {
+	return (
+		// XML-RPC Jetpack authorize request
+		// This works with the classic core XML-RPC endpoint, but not
+		// Jetpack's alternate endpoint.
+		defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST
+		&& isset( $_GET['for'] ) && 'jetpack' === $_GET['for']
+		&& isset( $GLOBALS['wp_xmlrpc_server'], $GLOBALS['wp_xmlrpc_server']->message , $GLOBALS['wp_xmlrpc_server']->message->methodName )
+		&& 'jetpack.remoteAuthorize' === $GLOBALS['wp_xmlrpc_server']->message->methodName
+	) || (
+		// REST Jetpack authorize request
+		defined( 'REST_REQUEST' ) && REST_REQUEST
+		&& isset( $GLOBALS['wp_rest_server'] )
+		&& wpcom_vip_is_jetpack_authorize_rest_request()
+	);
 }
 
 /**

--- a/two-factor.php
+++ b/two-factor.php
@@ -41,6 +41,22 @@ function wpcom_vip_should_force_two_factor() {
 		return false;
 	}
 
+	// If it's a request attempting to connect a local user to a
+	// WordPress.com user via XML-RPC, allow it through.
+	// This works with the classic core XML-RPC endpoint, but not
+	// Jetpack's alternate endpoint.
+	if (
+		defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST
+	&&
+		isset( $_GET['for'] ) && 'jetpack' === $_GET['for']
+	&&
+		isset( $GLOBALS['wp_xmlrpc_server'], $GLOBALS['wp_xmlrpc_server']->message , $GLOBALS['wp_xmlrpc_server']->message->methodName )
+	&&
+		'jetpack.remoteAuthorize' === $GLOBALS['wp_xmlrpc_server']->message->methodName
+	) {
+		return false;
+	}
+
 	// Don't force 2FA for OneLogin SSO
 	if ( function_exists( 'is_saml_enabled' ) && is_saml_enabled() ) {
 		return false;


### PR DESCRIPTION
## Description

When connecting a local user to a WordPress.com account via Jetpack, WordPress.com and Jetpack make a few requests back and forth to one another to make sure the connection is legitimate.

Let's not require 2FA to be set up during those WordPress.com -> Jetpack requests, since we don't have all the information yet about whether the user really has 2FA set up :)

Note: Currently, WordPress.com tries these requests via XML-RPC first, and REST as a fallback. For VIP Go sites, we only really need the XML-RPC stuff in this PR (the first commit). The REST stuff is more complicated and will probably never be used currently on VIP Go sites since the XML-RPC request should be sufficient (assuming no other bugs in the connection process :)). It's possible WordPress.com will switch the order at some point (REST first and XML-RPC as a fallback), so I included both.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

On a new VIP Go site:
1. Connect the site to WordPress.com via Jetpack.
2. For a different user (not the one that set up the initial site connection in step 1), go to the site's /wp-admin/.
3. You should get redirected to a Calypso login UI via Jetpack's SSO.
4. Click "Approve", and see that the UI loops and/or otherwise doesn't actually complete.
5. Manually go to the site's /wp-admin/. If you are logged in (despite the confusion from step 4), log out.
6. Apply this patch.
7. Go to the site's /wp-admin/.
8. You should get redirected to a Calypso login UI via Jetpack's SSO.
9. Click "Approve", and you should be redirected back to the site's /wp-admin/.