### PR TITLE
Upgrade Jetpack to 7.6

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 7.5.3
+ * Version: 7.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack


### PR DESCRIPTION
## Description

Upgrades VIP Go sites to Jetpack 7.6

https://github.com/Automattic/jetpack/releases/tag/7.6

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Go to `wp-admin` > `Jetpack`
1. Verify version in footer
1. Verify version via `wp plugin list`
1. Test a variety of functionality, looking for new warnings / errors
