### PR TITLE
Upgrade JP to 7.7

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 7.6
+ * Version: 7.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack


### PR DESCRIPTION
## Description

Updates the JP submodule to 7.7

https://jetpack.com/2019/09/03/jetpack-7-7-better-experience-start/

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Jetpack`
1. Ensure correct JP version is reported
1. `wp plugin list`
1. Ensure right JP version is reported
