### PR TITLE
Makes `wpcom_vip_include_active_plugins()` more defensive.

### DIFF
--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -273,8 +273,10 @@ add_action( 'admin_enqueue_scripts', 'wpcom_vip_plugins_ui_admin_enqueue_scripts
 function wpcom_vip_include_active_plugins() {
 	$retired_plugins_option = get_option( 'wpcom_vip_active_plugins', array() );
 
-	foreach ( $retired_plugins_option as $plugin ) {
-		 wpcom_vip_load_plugin( $plugin );
+	if ( is_iterable( $retired_plugins_option ) ) {
+		foreach ( $retired_plugins_option as $plugin ) {
+			 wpcom_vip_load_plugin( $plugin );
+		}
 	}
 }
 add_action( 'plugins_loaded', 'wpcom_vip_include_active_plugins', 5 );


### PR DESCRIPTION
## Description

Adds a check to make sure that the value returned from `get_option()` is iterable and that the `foreach` will not trigger an error. Issue: #1323 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Set the value of the `wpcom_vip_active_plugins` option to a non-iterable value.
1. Visit `my-site.com/wp-admin/setup-config.php`
1. Verify that no error is thrown during the `foreach`.
