### PR TITLE
Strip query string from file path when deleting files

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -292,6 +292,13 @@ class VIP_Filesystem {
 			$file_path = substr( $file_path, strlen( $upload_path['basedir'] ) + 1 );
 		}
 
+		// Strip any query params that snuck through
+		$queryStringStart = strpos( $file_path, '?' );
+
+		if ( false !== $queryStringStart ) {
+			$file_path = substr( $file_path, 0, $queryStringStart );
+		}
+
 		return $file_path;
 	}
 

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -156,12 +156,14 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		return [
 			'dirty path' => [
 				'vip://wp-content/uploads/vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768',
-				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768',
-				'wp-content/uploads/2019/01/foo.jpg?resize=100,100&foo=bar',
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg',
+				'wp-content/uploads/2019/01/foo.jpg?resize=100,100',
+				'wp-content/uploads/2019/01/foo.jpg',
 			],
 			'clean path' => [
 				'vip://wp-content/uploads/2019/01/IMG_4115.jpg',
 				'vip://wp-content/uploads/2019/01/IMG_4115.jpg',
+				'wp-content/uploads/2019/01/foo.jpg',
 				'wp-content/uploads/2019/01/foo.jpg',
 			]
 		];

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -156,11 +156,13 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		return [
 			'dirty path' => [
 				'vip://wp-content/uploads/vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768',
-				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768'
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768',
+				'wp-content/uploads/2019/01/foo.jpg?resize=100,100&foo=bar',
 			],
 			'clean path' => [
-				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768',
-				'vip://wp-content/uploads/2019/01/IMG_4115.jpg?resize=768,768'
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg',
+				'vip://wp-content/uploads/2019/01/IMG_4115.jpg',
+				'wp-content/uploads/2019/01/foo.jpg',
 			]
 		];
 	}


### PR DESCRIPTION
## Description

Before deleting files, strip off any query string params that snuck through.

WIP

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

TBD
