### PR TITLE
Debug Bar: Play nice with other enable filters

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -8,11 +8,11 @@
  Author URI: https://wordpress.org/
  Text Domain: debug-bar
  */
-add_filter( 'debug_bar_enable', function( $enable ) {
-	$enable = is_automattician();
 
-	return $enable;
-}, 99 );
+// If the user is an Automattician (typically a vip_support user), then force-enable Debug Bar.
+add_filter( 'debug_bar_enable', function( $enable ) {
+	return is_automattician() ? true : $enable;
+}, 999 );
 
 // We only need to load the files if it's enabled
 add_action( 'init', function() {

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -11,8 +11,12 @@
 
 // If the user is an Automattician (typically a vip_support user), then force-enable Debug Bar.
 add_filter( 'debug_bar_enable', function( $enable ) {
-	return is_automattician() ? true : $enable;
-}, 999 );
+	if ( is_automattician() ) {
+		return true;
+	}
+
+	return $enable;
+}, PHP_INT_MAX );
 
 // We only need to load the files if it's enabled
 add_action( 'init', function() {


### PR DESCRIPTION
## Description

The existing filter callback to force-enable the Debug Bar for Automatticians was a little too black-and-white. If you are an Automattician, it was enabled, and if you aren't, then it got disabled.

This doesn't work well with filter callbacks that clients might have, that may enable or disable it based on role, capability, or environment.

If they ran at an earlier priority (say, 50), then their conditions get ignored, as the vip-mu-go-plugins code doesn't take any of it into consideration.

If they ran at a later priority, then their conditions would also need to take `is_automattician()` into account, or otherwise Debug Bar gets disabled for VIP Support users; that isn't something that the client code should care about.

The solution is to only force-enable Debug Bar for Automatticians, but NOT force-disable if they are not - instead, let whatever value that might have been set by an earlier callback be maintained.

This doesn't stop a later client callback from trouncing all over the VIP logic, but with this callback being more accommodating, they should no longer need to run their callback at a later priority; I've bumped the priority of our callback to hopefully ensure that we run after any existing client callbacks.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

On a "production" test site, include code like (copy of actual client code):

```php
function mysite_enable_debug_bar_admins() {
	if ( defined( 'VIP_GO_ENV' ) && 'production' !== VIP_GO_ENV && is_super_admin() ) {
		return true;
	}
	return false;
}
add_filter( 'debug_bar_enable', 'mysite_enable_debug_bar_admins', 100 );
```

Note, that as an Automattician, the Debug Bar is not enabled.

Now apply the PR. The `mysite` code will still work, but the Debug Bar will now be enabled for all conditions for Automatticians.
