### PR TITLE
Fix namespacing for remove_action of do_initial_sync

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -145,5 +145,5 @@ add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recapt
 
 // Disable Jetpack sync when user is added to blog.
 add_action( 'init', function() {
-	remove_action( 'jetpack_user_authorized', [ 'Jetpack_Sync_Actions', 'do_initial_sync' ] );
+	remove_action( 'jetpack_user_authorized', [ 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ] );
 } );


### PR DESCRIPTION
## Description

Initial syncs are being triggered again overwriting full syncs. See #1257.  However, Jetpack was re-factored and we need to update it with the correct namespace: https://github.com/Automattic/jetpack/blob/a5a11059d24eb7ee50b25dbdb08f04ead55a0d50/packages/sync/src/Main.php#L32