### PR TITLE
Introduce new wpcom_vip_load_plugin_args filter

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -964,6 +964,7 @@ function _wpcom_vip_load_plugin_sanitizer( $folder ) {
  * @return bool True if the include was successful
  */
 function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_candidate_not_used = null ) {
+	// This filter is used in the WP.com compatibility plugin (https://github.com/Automattic/vip-go-wpcom-compat).
 	$filtered_args = apply_filters( 'wpcom_vip_load_plugin_args', array( 'plugin'  => $plugin, 'folder'  => $folder ), $load_release_candidate_not_used );
 	if ( is_array( $filtered_args ) ) {
 		$plugin = isset( $filtered_args['plugin'] ) ? $filtered_args['plugin'] : $plugin;

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -964,6 +964,12 @@ function _wpcom_vip_load_plugin_sanitizer( $folder ) {
  * @return bool True if the include was successful
  */
 function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_candidate_not_used = null ) {
+	$filtered_args = apply_filters( 'wpcom_vip_load_plugin_args', array( 'plugin'  => $plugin, 'folder'  => $folder ), $load_release_candidate_not_used );
+	if ( is_array( $filtered_args ) ) {
+		$plugin = isset( $filtered_args['plugin'] ) ? $filtered_args['plugin'] : $plugin;
+		$folder = isset( $filtered_args['folder'] ) ? $filtered_args['folder'] : $folder;
+	}
+
 	// Make sure there's a plugin to load
 	if ( empty($plugin) ) {
 		if ( ! WPCOM_IS_VIP_ENV ) {


### PR DESCRIPTION
## Description

Add new filter to `wpcom_vip_load_plugin()`. Allows filtering the $plugin and $folder parameters.

Main purpose is for WPcom -> Go migrations, so we can allow for the previous functionality around versioning as well as resolve the deprecated approach of setting the $folder to `theme`. Secondary purposes could be to give clients some more flexibility around conditionally loading different plugins, versions, or using different locations.

I decided to pass `$load_release_candidate_not_used` as an extra argument to the filter rather than including it in the return. However, I'm pretty impartial to this as it could go either way. Doesn't matter at all as this variable currently is never used, as least right now.

The filter is designed to be as flexible as possible, to avoid getting in the way of any future edits to the function. Future args could easily be added, or even removed.
________


Example usage:

```
function wpcom_compat_load_plugin_args( $args, $version ) {
  if ( ! empty( $args['plugin'] ) && ! empty( $version ) && is_string( $args['plugin'] ) && is_string( $version ) ) {
    $args['plugin'] = "{$args['plugin']}-{$version}/{$args['plugin']}.php";
  }

  if ( ! empty( $args['folder'] ) && in_array( $args['folder'], [ 'theme', 'plugins' ], true ) ) {
    $args['folder'] = false;
  }

  return $args;
}
add_filter( 'wpcom_vip_load_plugin_args','wpcom_compat_load_plugin_args', 10, 2 );
```