### PR TITLE
Do not purge cache if VIP_GO_DISABLE_CACHE_PURGING is enabled

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -291,6 +291,10 @@ class WPCOM_VIP_Cache_Manager {
 		if ( $this->site_cache_purged )
 			return false;
 
+		if ( defined( 'WP_IMPORTING' ) ) {
+			return false;
+		}
+
 		$post = get_post( $post_id );
 		if ( empty( $post ) ||
 		     'revision' === $post->post_type ||

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -290,8 +290,8 @@ class WPCOM_VIP_Cache_Manager {
 	public function queue_post_purge( $post_id ) {
 		if ( $this->site_cache_purged )
 			return false;
-
-		if ( defined( 'WP_IMPORTING' ) ) {
+		// Do not queue anything if an import is running or cache purging is disabled
+		if ( defined( 'WP_IMPORTING' ) || defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) ) {
 			return false;
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -291,7 +291,7 @@ class WPCOM_VIP_Cache_Manager {
 		if ( $this->site_cache_purged )
 			return false;
 		// Do not queue anything if an import is running or cache purging is disabled
-		if ( defined( 'WP_IMPORTING' ) || defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) ) {
+		if ( defined( 'WP_IMPORTING' ) || ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) ) {
 			return false;
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -215,6 +215,11 @@ class WPCOM_VIP_Cache_Manager {
 			return;
 		}
 
+		// Cache purging disabled, bail
+		if ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_FILE_PURGING ) {
+			return;
+		}
+
 		$this->ban_urls = array_unique( $this->ban_urls );
 		$this->purge_urls = array_unique( $this->purge_urls );
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -291,10 +291,6 @@ class WPCOM_VIP_Cache_Manager {
 		if ( $this->site_cache_purged )
 			return false;
 
-		if ( defined( 'WP_IMPORTING' ) ) {
-			return false;
-		}
-
 		$post = get_post( $post_id );
 		if ( empty( $post ) ||
 		     'revision' === $post->post_type ||

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -31,6 +31,12 @@ class WPCOM_VIP_Cache_Manager {
 	}
 
 	public function init() {
+		// Cache purging disabled, bail
+		if (( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) || ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING )) {
+			error_log( 'Cache will not be purged: an import is running, or cache purging is disabled. Check site configuration.' );
+			return;
+		}
+		
 		if ( $this->can_purge_cache() && isset( $_GET['cm_purge_all'] ) && check_admin_referer( 'manual_purge' ) ) {
 			$this->purge_site_cache();
 			add_action( 'admin_notices' , array( $this, 'manual_purge_message' ) );
@@ -215,12 +221,6 @@ class WPCOM_VIP_Cache_Manager {
 			return;
 		}
 
-		// Cache purging disabled, bail
-		if (( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) || ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING )) {
-			error_log( 'Cache will not be purged: an import is running, or cache purging is disabled. Check site configuration.' );
-			return;
-		}
-
 		$this->ban_urls = array_unique( $this->ban_urls );
 		$this->purge_urls = array_unique( $this->purge_urls );
 
@@ -290,8 +290,8 @@ class WPCOM_VIP_Cache_Manager {
 	public function queue_post_purge( $post_id ) {
 		if ( $this->site_cache_purged )
 			return false;
-		// Do not queue anything if an import is running or cache purging is disabled
-		if ( defined( 'WP_IMPORTING' ) || ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) ) {
+
+		if ( defined( 'WP_IMPORTING' ) ) {
 			return false;
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -216,8 +216,8 @@ class WPCOM_VIP_Cache_Manager {
 		}
 
 		// Cache purging disabled, bail
-		if ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) {
-			error_log( 'Cache will not be purged, as purging is disabled for this site. If you think this should not happen, check vip-config.php.' );
+		if (( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) || ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING )) {
+			error_log( 'Cache will not be purged: an import is running, or cache purging is disabled. Check site configuration.' );
 			return;
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -290,7 +290,7 @@ class WPCOM_VIP_Cache_Manager {
 		if ( $this->site_cache_purged )
 			return false;
 
-		if ( ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) ) {
+		if ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) {
 			return false;
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -32,7 +32,7 @@ class WPCOM_VIP_Cache_Manager {
 
 	public function init() {
 		// Cache purging disabled, bail
-		if ( ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) || ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) ) {
+		if ( ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) ) {
 			error_log( 'Cache will not be purged: an import is running, or cache purging is disabled. Check site configuration.' );
 			return;
 		}

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -217,6 +217,7 @@ class WPCOM_VIP_Cache_Manager {
 
 		// Cache purging disabled, bail
 		if ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) {
+			error_log( 'Cache will not be purged, as purging is disabled for this site. If you think this should not happen, check vip-config.php.' );
 			return;
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -216,7 +216,7 @@ class WPCOM_VIP_Cache_Manager {
 		}
 
 		// Cache purging disabled, bail
-		if ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_FILE_PURGING ) {
+		if ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) {
 			return;
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -32,7 +32,7 @@ class WPCOM_VIP_Cache_Manager {
 
 	public function init() {
 		// Cache purging disabled, bail
-		if (( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) || ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING )) {
+		if ( ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) || ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) ) {
 			error_log( 'Cache will not be purged: an import is running, or cache purging is disabled. Check site configuration.' );
 			return;
 		}
@@ -291,7 +291,7 @@ class WPCOM_VIP_Cache_Manager {
 		if ( $this->site_cache_purged )
 			return false;
 
-		if ( defined( 'WP_IMPORTING' ) ) {
+		if ( ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) ) {
 			return false;
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -33,7 +33,7 @@ class WPCOM_VIP_Cache_Manager {
 	public function init() {
 		// Cache purging disabled, bail
 		if ( ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) ) {
-			error_log( 'Cache will not be purged: an import is running, or cache purging is disabled. Check site configuration.' );
+			error_log( 'Cache purging is disabled. Check site configuration.' );
 			return;
 		}
 		

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -33,7 +33,6 @@ class WPCOM_VIP_Cache_Manager {
 	public function init() {
 		// Cache purging disabled, bail
 		if ( ( defined( 'VIP_GO_DISABLE_CACHE_PURGING' ) && true === VIP_GO_DISABLE_CACHE_PURGING ) ) {
-			error_log( 'Cache purging is disabled. Check site configuration.' );
 			return;
 		}
 		


### PR DESCRIPTION
## Description

Adds an option to disable cache purging on content changes.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Apply changes to a platform sandbox host.
1. Sandbox a site (delete and restart if using an existing one)
1. Add the following to `vip-config/vip-config.php`: `define( 'VIP_GO_DISABLE_CACHE_PURGING', true );`
1. Add `error_log( 'Skipping cache purge' );` just before the `return` inside of `init()`, vip-cache-manager/vip-cache-manager.php`
1. Load a page, you should see `[date time] Skipping cache purge` in `/chroot/tmp/php-errors`.
1. Now take away the `define` and reload: you shouldn't see any additional line in `/chroot/tmp/php-errors`