### PR TITLE
Allow SSL verification to be turned off for local dev.

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -492,6 +492,11 @@ function wpcom_vip_file_get_contents( $url, $timeout = 3, $cache_time = 900, $ex
 		'http_api_args' => array(), // See http://codex.wordpress.org/Function_API/wp_remote_get
 	);
 
+	if ( defined( 'WPCOM_VIP_DISABLE_SSL_VERIFY' ) && WPCOM_VIP_DISABLE_SSL_VERIFY ) {
+		// Only allow this to be false on non VIP envs.
+		$extra_args_defaults[ 'sslverify' ] = WPCOM_IS_VIP_ENV;
+	}
+
 	$extra_args = wp_parse_args( $extra_args, $extra_args_defaults );
 
 	$cache_key       = md5( serialize( array_merge( $extra_args, array( 'url' => $url ) ) ) );
@@ -764,7 +769,14 @@ function vip_safe_wp_remote_get( $url, $fallback_value='', $threshold=3, $timeou
 	}
 
 	$start = microtime( true );
-	$response = wp_remote_get( $url, array_merge( $args, array( 'timeout' => $timeout ) ) );
+
+	$extra_args_defaults = array( 'timeout' => $timeout );
+	if ( defined( 'WPCOM_VIP_DISABLE_SSL_VERIFY' ) && WPCOM_VIP_DISABLE_SSL_VERIFY ) {
+		// Only allow this to be false on non VIP envs.
+		$extra_args_defaults[ 'sslverify' ] = WPCOM_IS_VIP_ENV;
+	}
+
+	$response = wp_remote_get( $url, array_merge( $args, $extra_args_defaults ) );
 	$end = microtime( true );
 
 	$elapsed = ( $end - $start ) > $timeout;


### PR DESCRIPTION
## Description

Whilst developing locally it's useful to be able to turn off SSL
verification easily when using a self signed certificate. This change
will allow a constant to be set `WPCOM_VIP_DISABLE_SSL_VERIFY` (name up for debate) which
will disable ssl verify on `vip_safe_wp_remote_get()` calls.

There is some protection to ensure this doesn't ever occur on VIP envs
where ssl verify should always be turned on.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Have a local environment using a self signed certificate
2. Install [WPCOM-Legacy-Redirector](https://github.com/Automattic/WPCOM-Legacy-Redirector)
3. Attempt to add a redirect notice error 'Error: Redirects need to be from URLs that have a 404 status.' even if the URL in question is a 404.
4. Checkout this PR.
5. Add in vip-config.php `define( 'WPCOM_VIP_DISABLE_SSL_VERIFY', true );`
6. Re-attempt the above.

