### PR TITLE
VIP FS: Add append mode support to streamwrapper

### DIFF
--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -717,7 +717,7 @@ class VIP_Filesystem_Stream_Wrapper {
 	*
 	* @return  bool
 	 */
-	private function validate( $path, $mode ) {
+	public function validate( $path, $mode ) {
 		if ( ! in_array( $mode, self::ALLOWED_MODES, true ) ) {
 			trigger_error( "Mode not supported: { $mode }. Use one 'r', 'w', 'a', or 'x'." );
 

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -237,6 +237,11 @@ class VIP_Filesystem_Stream_Wrapper {
 
 		if ( 'r' === $this->mode ) {
 			// No writes in 'read' mode
+			trigger_error(
+				sprintf( 'stream_flush failed for %s with error: No writes allowed in "read" mode #vip-go-streams', $this->path ),
+				E_USER_WARNING
+			);
+
 			return false;
 		}
 

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -235,6 +235,11 @@ class VIP_Filesystem_Stream_Wrapper {
 			return false;
 		}
 
+		if ( 'r' === $this->mode ) {
+			// No writes in 'read' mode
+			return false;
+		}
+
 		try {
 			// Upload to file service
 			$result = $this->client

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -10,6 +10,16 @@ class VIP_Filesystem_Stream_Wrapper {
 	const DEFAULT_PROTOCOL = 'vip';
 
 	/**
+	 * Allowed fopen modes
+	 *
+	 * We are ignoring `b`, `t` and `+` modes as they do not affect how this
+	 * Stream Wrapper works.
+	 * Not supporting `c` and `e` modes as these are rarely used and adds complexity
+	 * to support.
+	 */
+	const ALLOWED_MODES = [ 'r', 'w', 'a', 'x' ];
+
+	/**
 	 * The Stream context. Set by PHP
 	 *
 	 * @since   1.0.0
@@ -708,7 +718,7 @@ class VIP_Filesystem_Stream_Wrapper {
 	* @return  bool
 	 */
 	private function validate( $path, $mode ) {
-		if ( ! in_array( $mode, [ 'r', 'w', 'a', 'x' ], true ) ) {
+		if ( ! in_array( $mode, self::ALLOWED_MODES, true ) ) {
 			trigger_error( "Mode not supported: { $mode }. Use one 'r', 'w', 'a', or 'x'." );
 
 			return false;

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -656,6 +656,7 @@ class VIP_Filesystem_Stream_Wrapper {
 			$this->file = null;
 			$this->path = null;
 			$this->uri  = null;
+			$this->mode = null;
 		}
 
 		return $result;

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -131,7 +131,8 @@ class VIP_Filesystem_Stream_Wrapper {
 	 */
 	public function stream_open( $path, $mode, $options, &$opened_path ) {
 		$path = $this->trim_path( $path );
-		$mode = rtrim( $mode, 'bt' );
+		// Also ignore '+' modes since the handlers are all read+write anyway
+		$mode = rtrim( $mode, 'bt+' );
 
 		if ( ! $this->validate( $path, $mode ) ) {
 			return false;

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -315,6 +315,16 @@ class VIP_Filesystem_Stream_Wrapper {
 	 * @return  int|bool    Number of bytes written or false on error
 	 */
 	public function stream_write( $data ) {
+		if ( 'r' === $this->mode ) {
+			// No writes in 'read' mode
+			trigger_error(
+				sprintf( 'stream_write failed for %s with error: No writes allowed in "read" mode #vip-go-streams', $this->path ),
+				E_USER_WARNING
+			);
+
+			return false;
+		}
+
 		$length = fwrite( $this->file, $data );
 
 		if ( false === $length ) {

--- a/tests/files/test-image-sizes.php
+++ b/tests/files/test-image-sizes.php
@@ -148,6 +148,16 @@ class A8C_Files_ImageSizes_Test extends \WP_UnitTestCase {
 						'height' => '1024',
 						'crop' => false,
 					],
+					'1536x1536' => [
+						'width' => 1536,
+						'height' => 1536,
+						'crop' => false,
+				],
+					'2048x2048' => [
+						'width' => 2048,
+						'height' => 2048,
+						'crop' => false,
+					],
 				],
 			],
 		];
@@ -255,6 +265,18 @@ class A8C_Files_ImageSizes_Test extends \WP_UnitTestCase {
 						'file' => 'image.jpg?resize=1024,576',
 						'width' => 1024,
 						'height' => 576,
+						'mime-type' => 'image/jpeg',
+					],
+					'1536x1536' => [
+						'file' => 'image.jpg?resize=1536,865',
+						'width' => 1536,
+						'height' => 865,
+						'mime-type' => 'image/jpeg',
+					],
+					'2048x2048' => [
+						'file' => 'image.jpg?resize=2048,1153',
+						'width' => 2048,
+						'height' => 1153,
 						'mime-type' => 'image/jpeg',
 					],
 				]
@@ -402,6 +424,28 @@ class A8C_Files_ImageSizes_Test extends \WP_UnitTestCase {
 					'resize' => '1024,576',
 				],
 			],
+			'1536x1536' => [
+				'width' => 1536,
+				'height' => 1536,
+				'calculated_dimensions' => [
+					'width' => 1536,
+					'height' => 865,
+				],
+				'params' => [
+					'resize' => '1536,865',
+				],
+			],
+			'2048x2048' => [
+				'width' => 2048,
+				'height' => 2048,
+				'calculated_dimensions' => [
+					'width' => 2048,
+					'height' => 1153,
+				],
+				'params' => [
+					'resize' => '2048,1153',
+				],
+			]
 		];
 	}
 
@@ -574,7 +618,9 @@ class A8C_Files_ImageSizes_Test extends \WP_UnitTestCase {
 		$expected_srcset =
 			'http://example.org/wp-content/uploads/' . $this->test_image . '?resize=300,169 300w'
 			.', http://example.org/wp-content/uploads/' . $this->test_image . '?resize=768,432 768w'
-			.', http://example.org/wp-content/uploads/' . $this->test_image . '?resize=1024,576 1024w';
+			.', http://example.org/wp-content/uploads/' . $this->test_image . '?resize=1024,576 1024w'
+			.', http://example.org/wp-content/uploads/' . $this->test_image . '?resize=1536,865 1536w'
+			.', http://example.org/wp-content/uploads/' . $this->test_image . '?resize=2048,1153 2048w';
 
 		$this->assertEquals( $expected_srcset, wp_get_attachment_image_srcset( $attachment_id ) );
 


### PR DESCRIPTION
## Description

Add support for append mode file operations into the streamwrapper class.

Currently using `fopen()` with `a` or `a+` mode or `file_put_contents()` with the `FILE_APPEND` flag does not work as expected. This should fix that.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Sandbox a test site
1. `wp shell`
1. Create new file: `file_put_contents( 'vip://wp-content/uploads/append-test.txt', 'new file' );`
1. Append to file: `file_put_contents( 'vip://wp-content/uploads/append-test.txt', ' appended', FILE_APPEND );`
1. Verify file contents is now `new file appended`.
