### PR TITLE
Revert #1257 now that https://github.com/Automattic/jetpack/pull/1354 is live

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -142,8 +142,3 @@ function wpcom_vip_disable_jetpack_email_no_recaptcha( $is_enabled ) {
 	return defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' );
 }
 add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recaptcha', PHP_INT_MAX );
-
-// Disable Jetpack sync when user is added to blog.
-add_action( 'init', function() {
-	remove_action( 'jetpack_user_authorized', [ 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ] );
-} );


### PR DESCRIPTION
## Description

#1257 was done as stopgap for initial syncs being interrupted.  Now that https://github.com/Automattic/jetpack/pull/1354 is in 7.9, we should remove it.

