### PR TITLE
Disable the big image threshold in anticipation of WordPress 5.3 rollout

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -1177,3 +1177,9 @@ if ( defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' ) ) {
 		add_filter( 'wp_get_attachment_metadata', 'a8c_files_maybe_inject_image_sizes', 20, 2 );
 	}, 10, 0 );
 }
+
+/**
+ * WordPress 5.3 adds "big image" processing, for images over 2560px (by default).
+ * This is not needed on VIP Go since we use Photon for dynamic image work.
+ */
+add_filter( 'big_image_size_threshold', '__return_false' );

--- a/misc.php
+++ b/misc.php
@@ -151,3 +151,9 @@ add_filter( 'wp_link_query_args', 'wpcom_vip_wp_link_query_args', 10, 1 );
  * Stop Woocommerce from trying to create files on read-only filesystem
  */
 add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
+
+/**
+ * WordPress 5.3 adds "big image" processing, for images over 2560px (by default).
+ * This is not needed on VIP Go since we use Photon for dynamic image work.
+ */
+add_filter( 'big_image_size_threshold', '__return_false' );

--- a/misc.php
+++ b/misc.php
@@ -151,9 +151,3 @@ add_filter( 'wp_link_query_args', 'wpcom_vip_wp_link_query_args', 10, 1 );
  * Stop Woocommerce from trying to create files on read-only filesystem
  */
 add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
-
-/**
- * WordPress 5.3 adds "big image" processing, for images over 2560px (by default).
- * This is not needed on VIP Go since we use Photon for dynamic image work.
- */
-add_filter( 'big_image_size_threshold', '__return_false' );


### PR DESCRIPTION
WordPress 5.3 comes with a new feature capping the max size of uploaded images. This does not seem to be needed on VIP Go as we are using Photon for media handling.

A possible side-effects of limiting the max size of images are users unable to upload hi-res images to their sites.

This can safely land prior 5.3 rollout.