### PR TITLE
Two Factor: Add wpcom_vip_use_custom_sso filter

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -47,34 +47,32 @@ function wpcom_vip_should_force_two_factor() {
 		return false;
 	}
 
-	// Don't force 2FA for OneLogin SSO
-	if ( function_exists( 'is_saml_enabled' ) && is_saml_enabled() ) {
-		return false;
-	}
-
-	// Don't force 2FA for SimpleSaml
-	if ( function_exists( '\HumanMade\SimpleSaml\instance' ) && \HumanMade\SimpleSaml\instance() ) {
+	// Allow custom SSO solutions
+	if ( wpcom_vip_use_custom_sso() ) {
 		return false;
 	}
 
 	return true;
 }
 
-function wpcom_vip_is_jetpack_authorize_request() {
-	return (
-		// XML-RPC Jetpack authorize request
-		// This works with the classic core XML-RPC endpoint, but not
-		// Jetpack's alternate endpoint.
-		defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST
-		&& isset( $_GET['for'] ) && 'jetpack' === $_GET['for']
-		&& isset( $GLOBALS['wp_xmlrpc_server'], $GLOBALS['wp_xmlrpc_server']->message , $GLOBALS['wp_xmlrpc_server']->message->methodName )
-		&& 'jetpack.remoteAuthorize' === $GLOBALS['wp_xmlrpc_server']->message->methodName
-	) || (
-		// REST Jetpack authorize request
-		defined( 'REST_REQUEST' ) && REST_REQUEST
-		&& isset( $GLOBALS['wp_rest_server'] )
-		&& wpcom_vip_is_jetpack_authorize_rest_request()
-	);
+function wpcom_vip_use_custom_sso() {
+
+	$custom_sso_enabled = apply_filters( 'wpcom_vip_use_custom_sso', null );
+	if( null !== $custom_sso_enabled ) {
+		return $custom_sso_enabled;
+	}
+
+	// Check for OneLogin SSO
+	if ( function_exists( 'is_saml_enabled' ) && is_saml_enabled() ) {
+		return true;
+	}
+
+	// Check for SimpleSaml
+	if ( function_exists( '\HumanMade\SimpleSaml\instance' ) && \HumanMade\SimpleSaml\instance() ) {
+		return true;
+	}
+
+	return false;
 }
 
 /**

--- a/two-factor.php
+++ b/two-factor.php
@@ -75,6 +75,23 @@ function wpcom_vip_use_custom_sso() {
 	return false;
 }
 
+function wpcom_vip_is_jetpack_authorize_request() {
+	return (
+		// XML-RPC Jetpack authorize request
+		// This works with the classic core XML-RPC endpoint, but not
+		// Jetpack's alternate endpoint.
+		defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST
+		&& isset( $_GET['for'] ) && 'jetpack' === $_GET['for']
+		&& isset( $GLOBALS['wp_xmlrpc_server'], $GLOBALS['wp_xmlrpc_server']->message , $GLOBALS['wp_xmlrpc_server']->message->methodName )
+		&& 'jetpack.remoteAuthorize' === $GLOBALS['wp_xmlrpc_server']->message->methodName
+	) || (
+		// REST Jetpack authorize request
+		defined( 'REST_REQUEST' ) && REST_REQUEST
+		&& isset( $GLOBALS['wp_rest_server'] )
+		&& wpcom_vip_is_jetpack_authorize_rest_request()
+	);
+}
+
 /**
  * Setter/Getter to keep track of whether the current request is a REST
  * API request for /jetpack/v4/remote_authorize request that connects a


### PR DESCRIPTION
This will make `wpcom_vip_should_force_two_factor` more flexible by allowing other third party SSO solutions or custom logic to help figure out whether or not 2FA should be forced.

## Description
This PR will allow customization of whether or not 2FA should be forced. 

Two Usage examples:
* Implement a custom SSO Plugin other than OneLogin or SimpleSaml
* Force 2FA for users that aren't using SSO. For example:

```php
add_filter( 'wpcom_vip_use_custom_sso', function( $enabled ) {
	
	// The user `justnorris` isn't using OneLogin, force 2FA for him
	$user = wp_get_current_user();
	if ( isset( $user->user_login ) && 'justnorris' === $user->user_login  ) {
		return false;
	}

	// Check if OneLogin SSO is enabled
	if ( function_exists( 'is_saml_enabled' ) && is_saml_enabled() ) {
		return true;
	}

	return $enabled;

} );
```



## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Apply PR
2. Validate that nothing has changed to the login functionality when SSO is used
3. Use the code snippet from above to force Two-Factor on your user (You'll likely also need to disable proxy/local checks in `wpcom_vip_should_force_two_factor() )
