### PR TITLE
Accept multisite paths with no `site` sub-directory

### DIFF
--- a/files/class-path-utils.php
+++ b/files/class-path-utils.php
@@ -4,13 +4,13 @@ namespace Automattic\VIP\Files;
 
 class Path_Utils {
 	public static function is_subdirectory_multisite_path( $file_path, $uploads_path ) {
-		$pattern = '#^/[_0-9a-zA-Z-]+/' . $uploads_path . '/sites/[0-9]+/#';
+		$pattern = '#^/[_0-9a-zA-Z-]+/' . $uploads_path . '/#';
 
 		return preg_match( $pattern, $file_path );
 	}
 
 	public static function is_sub_subdirectory_multisite_path( $file_path, $uploads_path ) {
-		$pattern = '#^/[_0-9a-zA-Z-]+/[_0-9a-zA-Z-]+/' . $uploads_path . '/sites/[0-9]+/#';
+		$pattern = '#^/[_0-9a-zA-Z-]+/[_0-9a-zA-Z-]+/' . $uploads_path . '/#';
 
 		return preg_match( $pattern, $file_path );
 	}

--- a/tests/files/test-path-utils.php
+++ b/tests/files/test-path-utils.php
@@ -26,12 +26,6 @@ class Path_Utils_Test extends \PHPUnit_Framework_TestCase {
 			'no_wp-content-uploads' => [
 				'/subsite1/sites/1/file.jpg',
 			],
-			'no_sites' => [
-				'/subsite1/wp-content/uploads/1/file.jpg',
-			],
-			'invalid_site-id' => [
-				'/subsite1/wp-content/uploads/sites/xyz/file.jpg',
-			],
 		];
 	}
 
@@ -88,12 +82,6 @@ class Path_Utils_Test extends \PHPUnit_Framework_TestCase {
 			'no_wp-content-uploads' => [
 				'/subsite1/subsite2/sites/1/file.jpg',
 			],
-			'no_sites' => [
-				'/subsite1/subsite2/wp-content/uploads/1/file.jpg',
-			],
-			'invalid_site-id' => [
-				'/subsite1/subsite2/wp-content/uploads/sites/xyz/file.jpg',
-			],
 		];
 	}
 
@@ -136,10 +124,18 @@ class Path_Utils_Test extends \PHPUnit_Framework_TestCase {
 				'/subsite1/wp-content/uploads/sites/2/file.jpg',
 				'/wp-content/uploads/sites/2/file.jpg',
 			],
+			'sub_subdirectory_no_site' => [
+				'/subsite1/subsite2/wp-content/uploads/file.jpg',
+				'/wp-content/uploads/file.jpg',
+			],
+			'subdirectory_no_site' => [
+				'/subsite1/wp-content/uploads/file.jpg',
+				'/wp-content/uploads/file.jpg',
+			],
 			'other' => [
 				'',
 				false,
-			]
+			],
 		];
 	}
 


### PR DESCRIPTION
## Description

`Path_Utils::trim_leading_multisite_directory()` will return `false` for file paths that doesn't include the `/sites/#` sub-directory. This causes problems for multisite sites that are running their default site without the `/sites/#` sub-directory as their files are uploaded to the wrong directory.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).


