### PR TITLE
Skip externals for test repo

### DIFF
--- a/bin/download-wp-tests.sh
+++ b/bin/download-wp-tests.sh
@@ -78,8 +78,8 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR_ACTUAL ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR_ACTUAL
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR_ACTUAL/includes
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR_ACTUAL/data
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR_ACTUAL/includes
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR_ACTUAL/data
 	fi
 
 	cd $WP_TESTS_DIR_ACTUAL


### PR DESCRIPTION
The only external included is the wordpress importer, which we don't really need. It's also currently breaking on CircleCI due to rate limits.

## Steps to Test

Make sure the tests on Circle work :)