### PR TITLE
Jetpack: Disable Jetpack feature hints

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -142,3 +142,16 @@ function wpcom_vip_disable_jetpack_email_no_recaptcha( $is_enabled ) {
 	return defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' );
 }
 add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recaptcha', PHP_INT_MAX );
+
+/**
+ * Remove Jetpack's Feature Hints.
+ *
+ * @see https://jetpack.com/?p=59210
+ *
+ * @param array $tools Array of extra tools to include.
+ */
+function wpcom_vip_remove_jetpack_search_hints( $tools ) {
+    unset( $tools[ array_search( 'plugin-search.php', $tools, true ) ] );
+    return $tools;
+}
+add_filter( 'jetpack_tools_to_include', 'wpcom_vip_remove_jetpack_search_hints' );


### PR DESCRIPTION
Fixes #1333.

## Description

Disables Jetpack feature hint.

## Checklist

Not yet tested - wanted to get this draft PR created for visibility.

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Find where the feature hint is displayed.
1. Check out PR.
1. Reload the page to check if feature hint has been removed.
