### PR TITLE
Increase jp sync queue limits

### DIFF
--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -14,7 +14,7 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 			[
 				'jetpack_sync_settings_max_queue_size',
 				10000000,
-				50000,
+				100000,
 			],
 
 			// Just right

--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -63,7 +63,7 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 			[
 				'jetpack_sync_settings_max_queue_lag',
 				10000000,
-				21600,
+				86400,
 			],
 
 			// Just right

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -20,7 +20,7 @@ define( 'VIP_GO_JETPACK_SYNC_MAX_QUEUE_SIZE_LOWER_LIMIT', 10000 );
  * 
  * The queue is stored in the option table, so if the queue gets _too_ large, site performance suffers
  */
-define( 'VIP_GO_JETPACK_SYNC_MAX_QUEUE_SIZE_UPPER_LIMIT', 50000 );
+define( 'VIP_GO_JETPACK_SYNC_MAX_QUEUE_SIZE_UPPER_LIMIT', 100000 );
 
 /**
  * The lower bound for the incremental sync queue lag - if the oldest item has been sitting unsynced for this long,

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -35,7 +35,7 @@ define( 'VIP_GO_JETPACK_SYNC_MAX_QUEUE_LAG_LOWER_LIMIT', 2 * HOUR_IN_SECONDS );
  * The maximum incremental sync queue lag allowed - just sets a reasonable upper bound on this limit to prevent extremely
  * stale incremental sync queues
  */
-define( 'VIP_GO_JETPACK_SYNC_MAX_QUEUE_LAG_UPPER_LIMIT', 6 * HOUR_IN_SECONDS );
+define( 'VIP_GO_JETPACK_SYNC_MAX_QUEUE_LAG_UPPER_LIMIT', DAY_IN_SECONDS );
 
 /**
  * Add the Connection Pilot. Ensures Jetpack is consistently connected.


### PR DESCRIPTION
## Description

Just increases the JP sync queue limits a bit

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).