### PR TITLE
Improve stream wrapper cache memory efficiency

### DIFF
--- a/files/class-api-cache.php
+++ b/files/class-api-cache.php
@@ -63,7 +63,7 @@ class API_Cache {
 	public function cache_file( $filepath, $data ) {
 		$file_name = basename( $filepath );
 
-		if ( ! isset( $this->files[ $file_name ])) {
+		if ( ! isset( $this->files[ $file_name ] ) ) {
 			// create file with unique filename
 			$tmp_file = tempnam( $this->tmp_dir, 'vip' );
 
@@ -72,6 +72,20 @@ class API_Cache {
 
 		// This will overwrite existing file if any
 		file_put_contents( $this->files[ $file_name ], $data );
+	}
+
+	public function copy_to_cache( $dst, $src ) {
+		$file_name = basename( $dst );
+
+		if ( ! isset( $this->files[ $file_name ] ) ) {
+			// create file with unique filename
+			$tmp_file = tempnam( $this->tmp_dir, 'vip' );
+
+			$this->files[ $file_name ] = $tmp_file;
+		}
+
+		// This will overwrite existing file if any
+		copy( $src, $this->files[ $file_name ] );
 	}
 
 	public function remove_file( $filepath ) {

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -139,7 +139,7 @@ class API_Client {
 
 		// response looks like {"filename":"/wp-content/uploads/path/to/file.ext"}
 		// save to cache
-		$this->cache->cache_file( $response_data->filename, file_get_contents( $local_path ) );
+		$this->cache->copy_to_cache( $response_data->filename, $local_path );
 
 		return $response_data->filename;
 	}

--- a/tests/files/test-vip-filesystem-api-cache.php
+++ b/tests/files/test-vip-filesystem-api-cache.php
@@ -102,6 +102,39 @@ class API_Cache_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected, file_get_contents( $files[ 'test.jpg' ] ) );
 	}
 
+	public function test__copy_to_cache() {
+		$file_path = __DIR__ . '/../fixtures/files/upload.jpg';
+		$prop = self::get_property( $this->cache, 'files' );
+
+		$this->cache->copy_to_cache( 'test.txt', $file_path );
+
+		$files = $prop->getValue( $this->cache );
+
+		$this->assertTrue( isset( $files[ 'test.txt' ] ) );
+	}
+
+	public function test__copy_to_cache__update_cache() {
+		$test_file = tempnam( sys_get_temp_dir(), 'test' );
+
+		file_put_contents( $test_file, 'test data' );
+
+		$prop = self::get_property( $this->cache, 'files' );
+		$prop->setValue( $this->cache, [ 'test.jpg' => $test_file ] );
+
+		$expected = 'updated data';
+
+		$test_file2 = tempnam( sys_get_temp_dir(), 'test' );
+
+		file_put_contents( $test_file2, $expected );
+
+		$this->cache->copy_to_cache( 'test.jpg', $test_file2 );
+
+		$files = $prop->getValue( $this->cache );
+
+		$this->assertTrue( isset( $files[ 'test.jpg' ] ) );
+		$this->assertEquals( $expected, file_get_contents( $files[ 'test.jpg' ] ) );
+	}
+
 	public function test__remove_file() {
 		$test_file = tempnam( sys_get_temp_dir(), 'test' );
 


### PR DESCRIPTION
## Description

The current implementation of caching for the Stream Wrapper have issues with `Out of Memory` errors when uploading large files. This is due to the fact the fact the caching works by creating local, temporary copies of the file which can lead to PHP running out of memory when uploading large files.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

Example:

1. Check out PR.
1. Upload a file that's close to the PHP `upload_max_filesize` limit
1. Ensure file is properly uploaded.
