### PR TITLE
Add conditional to check for non-production domains based on HTTP_HOST to properly set X-Robots-Tag for non-prod domains

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -180,7 +180,7 @@ add_filter( 'wp_headers', function( $headers ) {
 	$headers['X-Powered-By'] = 'WordPress.com VIP <https://wpvip.com>';
 
 	// All non-production domains should not be indexed.
-	if ( 'production' !== VIP_GO_ENV || false !== stristr( $_SERVER[ 'HTTP_HOST' ], '.go-vip.' ) ) {
+	if ( 'production' !== VIP_GO_ENV || false !== strpos( $_SERVER[ 'HTTP_HOST' ], '.go-vip.' ) ) {
 		$headers['X-Robots-Tag'] = 'noindex, nofollow';
 	}
 

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -179,7 +179,7 @@ add_filter( 'wp_headers', function( $headers ) {
 	$headers['X-hacker'] = 'If you\'re reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header.';
 	$headers['X-Powered-By'] = 'WordPress.com VIP <https://wpvip.com>';
 
-	// All non-production domains should not be indexed.
+	// Non-production applications and go-vip.(co|net) domains should not be indexed.
 	if ( 'production' !== VIP_GO_ENV || false !== strpos( $_SERVER[ 'HTTP_HOST' ], '.go-vip.' ) ) {
 		$headers['X-Robots-Tag'] = 'noindex, nofollow';
 	}

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -180,8 +180,7 @@ add_filter( 'wp_headers', function( $headers ) {
 	$headers['X-Powered-By'] = 'WordPress.com VIP <https://wpvip.com>';
 
 	// All non-production domains should not be indexed.
-	// This should not apply only to *.vip-go.co
-	if ( 'production' !== VIP_GO_ENV ) {
+	if ( 'production' !== VIP_GO_ENV || false !== stristr( $_SERVER[ 'HTTP_HOST' ], '.go-vip.' ) ) {
 		$headers['X-Robots-Tag'] = 'noindex, nofollow';
 	}
 


### PR DESCRIPTION
It has been discovered that at least in one case a non-prod domain didn't have a proper robots.txt blocking bots. This commit is intended as a fallback for situations like that.