### PR TITLE
Add back-compat for window.$

### DIFF
--- a/back-compat.php
+++ b/back-compat.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Plugin Name: VIP Back-compat
+ * Description: Adds relevant backwards compatibility code.
+ * Author: Automattic
+ * Version: 1.0
+ * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
+/*
+ * WordPress 5.3 fixes a bug in mediaelement which has been leaking the $ to window.
+ * Some plugins, and VIPs, might not be following the best practices and are using the $ instead of jQuery.
+ * Let's preserve the functionality for them (for now).
+ *
+ * @TODO: this will be removed as soon as we've ensured that plugins and sites have stopped using $ in their code.
+ */
+function wpcom_core_compat_leak_jquery_in_non_compat_mode() {
+	wp_add_inline_script( 'mediaelement-core', 'if ( window.jQuery && ! window.$ ) { console.log( "mediaelement-core: Loading VIP back-compat shim to map window.$ to window.jQuery (see mu-plugins/back-compat.php)." ); window.$ = window.jQuery; }', 'after' );
+}
+add_action( 'admin_enqueue_scripts', 'wpcom_core_compat_leak_jquery_in_non_compat_mode' );


### PR DESCRIPTION
Copies over a patch from WP.com which restores `window.$` which was being leaked by the mediaelement script. WP 5.3 "fixed" that leak but there are many instances of code that still rely on that leaked global.

This will help prevent possible issues until we get all those instances fixed.

props @david-binda 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Add the following snippet to a 5.3 site:

```
add_action( 'admin_print_footer_scripts', function() {
    ?>
    <script>console.log( $.fn.jquery );</script>
    <?php
}, PHP_INT_MAX );
```

2. Load the post edit page (with classic editor). Console should show an error (related to $ being undefined)

3. Apply the patch.

4. Error should go away.