### PR TITLE
VaultPress: Allow local instance

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -17,4 +17,14 @@ if ( ! defined( 'VAULTPRESS_TIMEOUT' ) ) {
 	define( 'VAULTPRESS_TIMEOUT', 10 );
 }
 
-require_once( __DIR__ . '/vaultpress/vaultpress.php' );
+$vaultpress_to_load = WPMU_PLUGIN_DIR . '/vaultpress/vaultpress.php';
+if ( defined( 'WPCOM_VIP_VAULTPRESS_LOCAL' ) && WPCOM_VIP_VAULTPRESS_LOCAL ) {
+	// Set a specific alternative VaultPress
+	$vaultpress_to_test = WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . '/vaultpress/vaultpress.php';
+	// Test that our proposed VaultPress exists, otherwise do not use it
+	if ( file_exists( $vaultpress_to_test ) ) {
+		$vaultpress_to_load = $vaultpress_to_test;
+	}
+}
+
+require_once( $vaultpress_to_load );


### PR DESCRIPTION
## Description

If there is a VaultPress install in the `client-mu-plugins` directory, use that instead of the version in vip-go-mu-plugins.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Add a die statement to `client-mu-plugins/vaultpress/vaultpress.php`
1. Load a WP instance.
1. Apply the PR
1. Reload a WP instance and get the die statement to show this is working.
1. Can add a full VaultPress install to `client-mu-plugins/`, and reload to check the dashboard page is still accessible.
