### PR TITLE
Increase jp sync throughput on cron

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -100,6 +100,15 @@ add_filter( 'option_jetpack_sync_settings_cron_sync_time_limit', function( $valu
 	return 4 * MINUTE_IN_SECONDS;
 }, 9999 );
 
+/**
+ * Reduce the time between sync batches on VIP
+ * 
+ * Default is 10 seconds
+ */
+add_filter( 'option_jetpack_sync_settings_sync_wait_time', function( $value ) {
+	return 1;
+}, 9999 );
+
 // Prevent Jetpack version ping-pong when a sandbox has an old version of stacks
 if ( true === WPCOM_SANDBOXED ) {
 	add_action( 'updating_jetpack_version', function( $new_version, $old_version ) {

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -106,7 +106,6 @@ add_filter( 'option_jetpack_sync_settings_cron_sync_time_limit', function( $valu
  *
  * By default, this is 10 seconds, but VIP can be more aggressive and doesn't need to wait as long (we'll still wait a small amount).
  * 
- * Default is 10 seconds
  */
 add_filter( 'option_jetpack_sync_settings_sync_wait_time', function( $value ) {
 	return 1;

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -91,6 +91,15 @@ add_filter( 'option_jetpack_sync_settings_max_queue_lag', function( $value ) {
 	return $value;
 }, 9999 );
 
+/**
+ * Allow incremental syncing via cron to take longer than the default 30 seconds
+ * 
+ * The default interval for this cronjob is 5 minutes
+ */
+add_filter( 'option_jetpack_sync_settings_cron_sync_time_limit', function( $value ) {
+	return 4 * MINUTE_IN_SECONDS;
+}, 9999 );
+
 // Prevent Jetpack version ping-pong when a sandbox has an old version of stacks
 if ( true === WPCOM_SANDBOXED ) {
 	add_action( 'updating_jetpack_version', function( $new_version, $old_version ) {

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -92,7 +92,9 @@ add_filter( 'option_jetpack_sync_settings_max_queue_lag', function( $value ) {
 }, 9999 );
 
 /**
- * Allow incremental syncing via cron to take longer than the default 30 seconds
+ * Allow incremental syncing via cron to take longer than the default 30 seconds.
+ *
+ * This will allow more items to be processed per cron event, while leaving a small buffer between completion and the start of the next event (the event interval is 5 mins).
  * 
  * The default interval for this cronjob is 5 minutes
  */

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -102,7 +102,9 @@ add_filter( 'option_jetpack_sync_settings_cron_sync_time_limit', function( $valu
 }, 9999 );
 
 /**
- * Reduce the time between sync batches on VIP
+ * Reduce the time between sync batches on VIP for performance gains.
+ *
+ * By default, this is 10 seconds, but VIP can be more aggressive and doesn't need to wait as long (we'll still wait a small amount).
  * 
  * Default is 10 seconds
  */

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -96,7 +96,6 @@ add_filter( 'option_jetpack_sync_settings_max_queue_lag', function( $value ) {
  *
  * This will allow more items to be processed per cron event, while leaving a small buffer between completion and the start of the next event (the event interval is 5 mins).
  * 
- * The default interval for this cronjob is 5 minutes
  */
 add_filter( 'option_jetpack_sync_settings_cron_sync_time_limit', function( $value ) {
 	return 4 * MINUTE_IN_SECONDS;


### PR DESCRIPTION
## Description

Increases the throughput of JP Sync when running via cron by:

* Allowing the cron job to run for 4 minutes (default is 30s)
* Reducing the wait time between batches from 10s to 1s

The cron job for incremental syncing runs every 5 minutes, but by default is only allowed to run for 30s. This is much too short for VIP sites, so this PR increases the limit to 4 minutes, to allow more items to be processed per cron event, while leaving a small buffer between completion and the start of the next event.

The `sync_wait_time` change affects how long cron waits in between batches of content before restarting, in an effort to reduce performance impacts. By default this is 10 seconds, but VIP can be more aggressive and doesn't need to wait as long (we'll still wait a small amount).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp shell`
1. `Automattic\Jetpack\Sync\Settings::get_setting( 'cron_sync_time_limit' );`
1. Should be 240 (4 minutes)
1. `Automattic\Jetpack\Sync\Settings::get_setting( 'sync_wait_time' );`
1. Should be 1
