### PR TITLE
Remove ‘manage’ as a mandatory JP module

### DIFF
--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -17,7 +17,6 @@ class WPCOM_VIP_Jetpack_Mandatory {
 	 * @var array
 	 */
 	protected $mandatory_modules = array(
-		'manage',
 		'stats',
 		'vaultpress',
 	);


### PR DESCRIPTION
## Description

Fixes https://github.com/Automattic/vip-go-mu-plugins/issues/1368

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Make this change on a VIP Go site.
1. Load the backend and frontend a few times and make sure there aren't any new PHP errors.
