### PR TITLE
Disable concat for react and react-dom

### DIFF
--- a/http-concat.php
+++ b/http-concat.php
@@ -23,6 +23,14 @@ if ( true === WPCOM_IS_VIP_ENV ) {
 			if ( 'wp-tinymce-root' === $handle || 'wp-tinymce' === $handle ) {
 				$do_concat = false;
 			}
+			
+			// Don't concat core scripts that use strict mode
+			// We can't blindly concatenate strict and non-strict scripts because
+			// strict mode applies to the whole file and changes functionality
+			// More info: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode
+			if ( 'react' === $handle || 'react-dom' === $handle ) {
+				$do_concat = false;
+			}
 
 			return $do_concat;
 		}, 10, 2 );


### PR DESCRIPTION
## Description

Disables concatenation for the two core javascript files that use strict mode.

Noting that this is not a complete solution as any plugin could also use strict mode. It does fix the cases we've seen so far though. We'll use this to fix the immediate issue and follow up with a more robust solution.

> This syntax [use strict] has a trap that has already bitten a major site: it isn’t possible to blindly concatenate conflicting scripts. Consider concatenating a strict mode script with a non-strict mode script: the entire concatenation looks strict! The inverse is also true: non-strict plus strict looks non-strict.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Go to new post screen and confirm undefined reference errors in the console.
1. Check out this PR.
1. Confirm javascript errors are resolved.

If you're having trouble reproducing the issue, make sure HTTP Concat is enabled in your test environment. You'll also need to be using a plugin that's affected by this. I can help find test cases if necessary.