### PR TITLE
Conditionally enable immediate full sync, based on value of constant

### DIFF
--- a/tests/fixtures/jetpack/class-jetpack-sync-immediately.php
+++ b/tests/fixtures/jetpack/class-jetpack-sync-immediately.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Automattic\Jetpack\Sync\Modules;
+
+if ( ! class_exists( 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately' ) ) {
+	// define stub class
+	class Full_Sync_Immediately {}
+}

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -223,6 +223,10 @@ add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recapt
  * Enable the new Full Sync method on sites with the VIP_JETPACK_FULL_SYNC_IMMEDIATELY constant
  */
 add_filter( 'jetpack_sync_modules', function( $modules ) {
+	if ( ! class_exists( 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately' ) ) {
+		return $modules;
+	}
+
 	if ( defined( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY' ) && true === VIP_JETPACK_FULL_SYNC_IMMEDIATELY ) {
 		foreach ( $modules as $key => $module ) {
 			if ( in_array( $module, [ 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync', 'Jetpack_Sync_Modules_Full_Sync' ], true ) ) {

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -223,13 +223,11 @@ add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recapt
  * Enable the new Full Sync method on sites with the VIP_JETPACK_FULL_SYNC_IMMEDIATELY constant
  */
 add_filter( 'jetpack_sync_modules', function( $modules ) {
-	if ( ! defined( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY' ) || ! VIP_JETPACK_FULL_SYNC_IMMEDIATELY ) {
-		return $modules;
-	}
-
-	foreach ( $modules as $key => $module ) {
-		if ( in_array( $module, [ 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync', 'Jetpack_Sync_Modules_Full_Sync' ], true ) ) {
-			$modules[ $key ] = 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately';
+	if ( defined( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY' ) && true === VIP_JETPACK_FULL_SYNC_IMMEDIATELY ) {
+		foreach ( $modules as $key => $module ) {
+			if ( in_array( $module, [ 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync', 'Jetpack_Sync_Modules_Full_Sync' ], true ) ) {
+				$modules[ $key ] = 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately';
+			}
 		}
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -218,3 +218,20 @@ function wpcom_vip_disable_jetpack_email_no_recaptcha( $is_enabled ) {
 	return defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' );
 }
 add_filter( 'sharing_services_email', 'wpcom_vip_disable_jetpack_email_no_recaptcha', PHP_INT_MAX );
+
+/**
+ * Enable the new Full Sync method on sites with the VIP_JETPACK_FULL_SYNC_IMMEDIATELY constant
+ */
+add_filter( 'jetpack_sync_modules', function( $modules ) {
+	if ( ! defined( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY' ) || ! VIP_JETPACK_FULL_SYNC_IMMEDIATELY ) {
+		return $modules;
+	}
+
+	foreach ( $modules as $key => $module ) {
+		if ( in_array( $module, [ 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync', 'Jetpack_Sync_Modules_Full_Sync' ], true ) ) {
+			$modules[ $key ] = 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately';
+		}
+	}
+
+	return $modules;
+} );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -229,6 +229,7 @@ add_filter( 'jetpack_sync_modules', function( $modules ) {
 
 	if ( defined( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY' ) && true === VIP_JETPACK_FULL_SYNC_IMMEDIATELY ) {
 		foreach ( $modules as $key => $module ) {
+			// Replace Jetpack_Sync_Modules_Full_Sync or Full_Sync with the new module
 			if ( in_array( $module, [ 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync', 'Jetpack_Sync_Modules_Full_Sync' ], true ) ) {
 				$modules[ $key ] = 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately';
 			}


### PR DESCRIPTION
## Description

JP 8.0+ includes a new full sync strategy - immediate.

This adds a filter that enables the new strategy, based on the value of the `VIP_JETPACK_FULL_SYNC_IMMEDIATELY` constant, which will be used to do early testing and a gradual rollout of this feature.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

TBD
