### PR TITLE
Add filter for elasticpress index name

### DIFF
--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -2,7 +2,7 @@
 
 class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	/**
-	 * Test `ep_index_name` filter for ElasticPress + VIP ElasticSearch
+	 * Test `ep_index_name` filter for ElasticPress + VIP Elasticsearch
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -18,7 +18,7 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test `ep_index_name` filter for ElasticPress + VIP ElasticSearch
+	 * Test `ep_index_name` filter for ElasticPress + VIP Elasticsearch
 	 *
 	 * USE_VIP_ELASTICSEARCH not defined
 	 *

--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -1,0 +1,57 @@
+<?php
+
+class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
+	/**
+	 * Test `ep_index_name` filter for ElasticPress + VIP ElasticSearch
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__vip_elasticsearch_filter_ep_index_name() {
+		$mock_indexable = (object) [ 'slug' => 'slug' ];
+
+		define( 'VIP_GO_APP_ID', 123 );
+		define( 'USE_VIP_ELASTICSEARCH', true );
+
+		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
+
+		$this->assertEquals( 'vip-123-slug-1', $index_name );
+	}
+
+	/**
+	 * Test `ep_index_name` filter for ElasticPress + VIP ElasticSearch
+	 *
+	 * USE_VIP_ELASTICSEARCH not defined
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__vip_elasticsearch_filter_ep_index_name__no_constant() {
+		$mock_indexable = (object) [ 'slug' => 'slug' ];
+
+		define( 'VIP_GO_APP_ID', 123 );
+
+		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
+
+		$this->assertEquals( 'index-name', $index_name );
+	}
+
+	/**
+	 * Test `ep_index_name` filter for ElasticPress + VIP ElasticSearch
+	 *
+	 * USE_VIP_ELASTICSEARCH is false
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__vip_elasticsearch_filter_ep_index_name__constant_is_false() {
+		$mock_indexable = (object) [ 'slug' => 'slug' ];
+
+		define( 'VIP_GO_APP_ID', 123 );
+		define( 'USE_VIP_ELASTICSEARCH', false );
+
+		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
+
+		$this->assertEquals( 'index-name', $index_name );
+	}
+}

--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -10,7 +10,7 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	public function test__vip_elasticsearch_filter_ep_index_name() {
 		$mock_indexable = (object) [ 'slug' => 'slug' ];
 
-		define( 'VIP_GO_APP_ID', 123 );
+		define( 'FILES_CLIENT_SITE_ID', 123 );
 		define( 'USE_VIP_ELASTICSEARCH', true );
 
 		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
@@ -29,7 +29,7 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	public function test__vip_elasticsearch_filter_ep_index_name__no_constant() {
 		$mock_indexable = (object) [ 'slug' => 'slug' ];
 
-		define( 'VIP_GO_APP_ID', 123 );
+		define( 'FILES_CLIENT_SITE_ID', 123 );
 
 		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
 
@@ -47,7 +47,7 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	public function test__vip_elasticsearch_filter_ep_index_name__constant_is_false() {
 		$mock_indexable = (object) [ 'slug' => 'slug' ];
 
-		define( 'VIP_GO_APP_ID', 123 );
+		define( 'FILES_CLIENT_SITE_ID', 123 );
 		define( 'USE_VIP_ELASTICSEARCH', false );
 
 		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );

--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -10,7 +10,6 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	public function test__vip_elasticsearch_filter_ep_index_name() {
 		$mock_indexable = (object) [ 'slug' => 'slug' ];
 
-		define( 'FILES_CLIENT_SITE_ID', 123 );
 		define( 'USE_VIP_ELASTICSEARCH', true );
 
 		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
@@ -29,8 +28,6 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	public function test__vip_elasticsearch_filter_ep_index_name__no_constant() {
 		$mock_indexable = (object) [ 'slug' => 'slug' ];
 
-		define( 'FILES_CLIENT_SITE_ID', 123 );
-
 		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
 
 		$this->assertEquals( 'index-name', $index_name );
@@ -47,7 +44,6 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	public function test__vip_elasticsearch_filter_ep_index_name__constant_is_false() {
 		$mock_indexable = (object) [ 'slug' => 'slug' ];
 
-		define( 'FILES_CLIENT_SITE_ID', 123 );
 		define( 'USE_VIP_ELASTICSEARCH', false );
 
 		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );

--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -34,7 +34,7 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test `ep_index_name` filter for ElasticPress + VIP ElasticSearch
+	 * Test `ep_index_name` filter for ElasticPress + VIP Elasticsearch
 	 *
 	 * USE_VIP_ELASTICSEARCH is false
 	 *

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -455,11 +455,11 @@ function wpcom_search_api_wp_to_es_args( $args ) {
 /**
  * Filter ElasticPress index name if using VIP ES infrastructure
  */
-function filter_ep_index_name( $index_name, $blog_id, $indexables ) {
+function vip_elasticsearch_filter_ep_index_name( $index_name, $blog_id, $indexables ) {
 	if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
 		$index_name = sprintf( 'vip-%s-%s-%s', VIP_GO_APP_ID, $indexables->slug, $blog_id );
 	}
 
 	return $index_name;
 }
-add_filter( 'ep_index_name', 'filter_ep_index_name', PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
+add_filter( 'ep_index_name', 'vip_elasticsearch_filter_ep_index_name', PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -457,7 +457,7 @@ function wpcom_search_api_wp_to_es_args( $args ) {
  */
 function filter_ep_index_name( $index_name, $blog_id, $indexables ) {
 	if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
-		$index_name = 'vip-' . VIP_GO_APP_ID . '-' . $indexables->slug . '-' . $blog_id;
+		$index_name = sprintf( 'vip-%s-%s-%s', VIP_GO_APP_ID, $indexables->slug, $blog_id );
 	}
 
 	return $index_name;

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -457,7 +457,7 @@ function wpcom_search_api_wp_to_es_args( $args ) {
  */
 function vip_elasticsearch_filter_ep_index_name( $index_name, $blog_id, $indexables ) {
 	if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
-		$index_name = sprintf( 'vip-%s-%s-%s', VIP_GO_APP_ID, $indexables->slug, $blog_id );
+		$index_name = sprintf( 'vip-%s-%s-%s', FILES_CLIENT_SITE_ID, $indexables->slug, $blog_id );
 	}
 
 	return $index_name;

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -462,4 +462,4 @@ function filter_ep_index_name( $index_name, $blog_id, $indexables ) {
 
 	return $index_name;
 }
-add_filter( 'ep_index_name', 'filter_ep_index_name', PHP_INT_MAX, 3 );
+add_filter( 'ep_index_name', 'filter_ep_index_name', PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -449,7 +449,7 @@ function wpcom_search_api_wp_to_es_args( $args ) {
 		}
 	}
 
-    return $es_query_args;
+	return $es_query_args;
 }
 
 /**
@@ -457,6 +457,7 @@ function wpcom_search_api_wp_to_es_args( $args ) {
  */
 function vip_elasticsearch_filter_ep_index_name( $index_name, $blog_id, $indexables ) {
 	if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
+		// TODO: Use FILES_CLIENT_SITE_ID for now as VIP_GO_ENV_ID is not ready yet. Should replace once it is.
 		$index_name = sprintf( 'vip-%s-%s-%s', FILES_CLIENT_SITE_ID, $indexables->slug, $blog_id );
 	}
 

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -451,3 +451,15 @@ function wpcom_search_api_wp_to_es_args( $args ) {
 
     return $es_query_args;
 }
+
+/**
+ * Filter ElasticPress index name if using VIP ES infrastructure
+ */
+function filter_ep_index_name( $index_name, $blog_id, $indexables ) {
+	if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
+		$index_name = 'vip-' . VIP_GO_APP_ID . '-' . $indexables->slug . '-' . $blog_id;
+	}
+
+	return $index_name;
+}
+add_filter( 'ep_index_name', 'filter_ep_index_name', PHP_INT_MAX, 3 );


### PR DESCRIPTION
## Description

Add a filter to rename ElasticPress indexes into something that would work more consistently in VIP Go.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

TBD
