### PR TITLE
Circle CI: Test on PHP 7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ workflows:
     jobs:
       - php73-build-multisite
       - php73-build-singlesite
+      - php74-build-multisite
+      - php74-build-singlesite
+
 
 version: 2
 
@@ -66,4 +69,22 @@ jobs:
       - WP_VERSION: "latest"
     docker:
       - image: circleci/php:7.3
+      - image: *db_image
+
+  php74-build-multisite:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE: "1"
+      - WP_VERSION: "latest"
+    docker:
+      - image: circleci/php:7.4
+      - image: *db_image
+
+  php74-build-singlesite:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE: "0"
+      - WP_VERSION: "latest"
+    docker:
+      - image: circleci/php:7.4
       - image: *db_image


### PR DESCRIPTION
To prep for eventual PHP 7.4 rollout.

## Steps to Test

Make sure Circle tests run PHP 7.4 and are all 🍏 📗 💚 🥗 