### PR TITLE
Allow local install/updates for plugins/themes/language packs via WP-CLI

### DIFF
--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -42,11 +42,26 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 	 * @return WP_Filesystem_VIP_Uploads|bool|mixed|WP_Filesystem_Direct
 	 */
 	private function get_transport_for_path( $filename, $context = 'read' ) {
-		// If we're not in a VIP environment, allow core upgrades to work.
-		// Note: WP_CLI doesn't set WP_INSTALLING so we fallback to checking for the upgrade lock instead.
-		if ( true !== VIP_GO_ENV &&
-		       ( wp_installing() || get_option( 'core_updater.lock' ) ) ) {
-			return $this->direct;
+		// If we're not in a VIP environment, allow some WP_CLI functionality to work.
+		if ( true !== VIP_GO_ENV ) {
+			// Allow access to the maintenance file used by WP-CLI.
+			if ( $this->is_maintenance_file( $filename ) ) {
+				return $this->direct;
+			}
+
+			// Allow core upgrades.
+			// Note: WP_CLI doesn't set WP_INSTALLING so we fallback to checking for the upgrade lock instead.
+			if ( wp_installing() || get_option( 'core_updater.lock' ) ) {
+				return $this->direct;
+			}
+
+			// Allow plugin, theme, and language installs.
+			if ( $this->is_upgrade_path( $filename )
+				|| $this->is_plugins_path( $filename )
+				|| $this->is_themes_path( $filename )
+				|| $this->is_languages_path( $filename ) ) {
+				return $this->direct;
+			}
 		}
 
 		// Uploads paths can just use PHP functions when stream wrapper is enabled.
@@ -77,6 +92,12 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 		return false;
 	}
 
+	private function is_maintenance_file( $file_path ) {
+		$maintenance_file = ABSPATH . '.maintenance';
+
+		return $file_path === $maintenance_file;
+	}
+
 	private function is_tmp_path( $file_path ) {
 		$tmp_dir = get_temp_dir();
 
@@ -88,6 +109,27 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 		$upload_base = $upload_dir['basedir'];
 
 		return 0 === strpos( $file_path, $upload_base );
+	}
+
+	private function is_wp_content_subfolder_path( $file_path, $subfolder ) {
+		$upgrade_base = sprintf( '%s/%s/', WP_CONTENT_DIR, $subfolder );
+		return 0 === strpos( $file_path, $upgrade_base );
+	}
+
+	private function is_upgrade_path( $file_path ) {
+		return $this->is_wp_content_subfolder_path( $file_path, 'upgrade' );
+	}
+
+	private function is_plugins_path( $file_path ) {
+		return $this->is_wp_content_subfolder_path( $file_path, 'plugins' );
+	}
+
+	private function is_themes_path( $file_path ) {
+		return $this->is_wp_content_subfolder_path( $file_path, 'themes' );
+	}
+
+	private function is_languages_path( $file_path ) {
+		return $this->is_wp_content_subfolder_path( $file_path, 'languages' );
 	}
 
 	/**

--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -230,7 +230,7 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 			return false;
 		}
 
-		$return = $transport->delete( $file );
+		$return = $transport->delete( $file, $recursive, $type );
 		if ( false === $return ) {
 			$this->errors = $transport->errors;
 			return false;

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -98,4 +98,140 @@ class WP_Filesystem_VIP_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected_result, $actual_result );
 	}
+
+	public function get_test_data__is_maintenance_file() {
+		return [
+			'invalid path' => [
+				'/var/log/.maintenance',
+				false,
+			],
+			'valid path' => [
+				ABSPATH . '.maintenance',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__is_maintenance_file
+	 */
+	public function test__is_maintenance_file( $file_path, $expected_result ) {
+		$is_tmp_path_method = self::get_method( 'is_maintenance_file' );
+
+		$actual_result = $is_tmp_path_method->invokeArgs( $this->filesystem, [ $file_path ] );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	public function get_test_data__is_upgrade_path() {
+		return [
+			'invalid path' => [
+				'/wp-includes/js/jquery.js',
+				false,
+			],
+			'invalid other wp-content path' => [
+				WP_CONTENT_DIR . '/uploads/image.jpg',
+				false,
+			],
+			'valid path' => [
+				WP_CONTENT_DIR . '/upgrade/.plugin',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__is_upgrade_path
+	 */
+	public function test__is_upgrade_path( $file_path, $expected_result ) {
+		$is_tmp_path_method = self::get_method( 'is_upgrade_path' );
+
+		$actual_result = $is_tmp_path_method->invokeArgs( $this->filesystem, [ $file_path ] );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	public function get_test_data__is_plugins_path() {
+		return [
+			'invalid path' => [
+				'/wp-includes/js/jquery.js',
+				false,
+			],
+			'invalid other wp-content path' => [
+				WP_CONTENT_DIR . '/uploads/image.jpg',
+				false,
+			],
+			'valid path' => [
+				WP_CONTENT_DIR . '/plugins/vip/vip.php',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__is_plugins_path
+	 */
+	public function test__is_plugins_path( $file_path, $expected_result ) {
+		$is_tmp_path_method = self::get_method( 'is_plugins_path' );
+
+		$actual_result = $is_tmp_path_method->invokeArgs( $this->filesystem, [ $file_path ] );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	public function get_test_data__is_themes_path() {
+		return [
+			'invalid path' => [
+				'',
+				false,
+			],
+			'invalid other wp-content path' => [
+				WP_CONTENT_DIR . '/uploads/image.jpg',
+				false,
+			],
+			'valid path' => [
+				WP_CONTENT_DIR . '/themes/vip/functions.php',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__is_themes_path
+	 */
+	public function test__is_themes_path( $file_path, $expected_result ) {
+		$is_tmp_path_method = self::get_method( 'is_themes_path' );
+
+		$actual_result = $is_tmp_path_method->invokeArgs( $this->filesystem, [ $file_path ] );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	public function get_test_data__is_languages_path() {
+		return [
+			'invalid path' => [
+				'',
+				false,
+			],
+			'invalid other wp-content path' => [
+				WP_CONTENT_DIR . '/uploads/image.jpg',
+				false,
+			],
+			'valid path' => [
+				WP_CONTENT_DIR . '/languages/vip/vip-en.mo',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__is_languages_path
+	 */
+	public function test__is_languages_path( $file_path, $expected_result ) {
+		$is_tmp_path_method = self::get_method( 'is_languages_path' );
+
+		$actual_result = $is_tmp_path_method->invokeArgs( $this->filesystem, [ $file_path ] );
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
 }


### PR DESCRIPTION
Our custom filesystem class currently blocks most paths, which can be frustrating locally when trying to install and update plugins / themes / etc. via WP_CLI. This allows that to work and simplifies a pretty frustrating part of managing a site on VIP.

Fixes #1370

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. `wp plugin install gutenberg` and `wp plugin install gutenberg --force` should both work
1. `wp plugin uninstall gutenberg` should work
1. `wp plugin install gutenberg --version=5.0` and `wp plugin update gutenberg` should work.

If you're feeling up for it, feel free to test out theme and language updates too :)