### PR TITLE
wpcom_vip_maybe_skip_old_slug_redirect(): Improve compatibility with local setups

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -707,18 +707,22 @@ function wpcom_vip_flush_wp_old_slug_redirect_cache( $post_id, $post, $post_befo
 }
 
 /**
- * We're seeing an increase of urls that match this pattern: http://example.com/http://othersite.com/random_text
- * These then cause really slow lookups inside of wp_old_slug_redirect, since wp_old_slug redirect does not match on full urls but rather former slugs it's safe to skip the lookup for these. (Most of the calls are from bad ad providers that generate random urls)
+ * Potentially skip redirect for old slugs.
+ *
+ * We're seeing an increase of URLs that match this pattern: http://example.com/http://othersite.com/random_text.
+ *
+ * These then cause really slow lookups inside of wp_old_slug_redirect. Since wp_old_slug redirect does not match
+ * on full URLs but rather former slugs, it's safe to skip the lookup for these. Most of the calls are from bad ad
+ * providers that generate random URLs.
  */
-function wpcom_vip_maybe_skip_old_slug_redirect(){
-
-	//We look to see if a malformed url (represented by 'http:' ) is right after the starting / in DOCUMENT_URI hence position 1
-	if ( is_404() && ( 1 === strpos( $_SERVER['DOCUMENT_URI'], 'http:' ) || 1 === strpos( $_SERVER['DOCUMENT_URI'], 'https:' ) ) ) {
+function wpcom_vip_maybe_skip_old_slug_redirect() {
+	if ( is_404() && ( 0 === strpos( $_SERVER['REQUEST_URI'], '/http:' ) || 0 === strpos( $_SERVER['REQUEST_URI'], '/https:' ) ) ) {
 		remove_action( 'template_redirect', 'wp_old_slug_redirect' );
 		remove_action( 'template_redirect', 'wpcom_vip_wp_old_slug_redirect', 8 );
 	}
 
 }
+
 function wpcom_vip_enable_maybe_skip_old_slug_redirect() {
 	add_action( 'template_redirect', 'wpcom_vip_maybe_skip_old_slug_redirect', 7 ); //Run this before wpcom_vip_wp_old_slug_redirect so we can also remove our caching helper
 }

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -716,11 +716,18 @@ function wpcom_vip_flush_wp_old_slug_redirect_cache( $post_id, $post, $post_befo
  * providers that generate random URLs.
  */
 function wpcom_vip_maybe_skip_old_slug_redirect() {
-	if ( is_404() && ( 0 === strpos( $_SERVER['REQUEST_URI'], '/http:' ) || 0 === strpos( $_SERVER['REQUEST_URI'], '/https:' ) ) ) {
+	if ( ! is_404() ) {
+		return;
+	}
+
+	if( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+		return;
+	}
+
+	if ( 0 === strpos( $_SERVER['REQUEST_URI'], '/http:' ) || 0 === strpos( $_SERVER['REQUEST_URI'], '/https:' ) ) {
 		remove_action( 'template_redirect', 'wp_old_slug_redirect' );
 		remove_action( 'template_redirect', 'wpcom_vip_wp_old_slug_redirect', 8 );
 	}
-
 }
 
 function wpcom_vip_enable_maybe_skip_old_slug_redirect() {

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -720,7 +720,7 @@ function wpcom_vip_maybe_skip_old_slug_redirect() {
 		return;
 	}
 
-	if( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+	if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description

Add support for local development servers that do not have `$_SERVER['DOCUMENT_URI']` defined.

Fixes #976.

_Needs actual testing._

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Create a setup where `$_SERVER['DOCUMENT_URI']` is undefined.
2. Check that function does what it was still meant to, once PR is applied.