### PR TITLE
VIP Go Elasticsearch: Avoid Invalid foreach

### DIFF
--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -146,20 +146,22 @@ class WPCOM_elasticsearch {
 
 		$posts = array();
 
-		// We have to return something in $posts for regular search templates to work, so build up an array
-		// of simple, un-inflated WP_Post objects that will be inflated by ES_WPCOM_SearchResult_Posts_Iterator in The Loop
-		foreach ( $this->search_result['results']['hits'] as $result ) {
-			// Create an empty WP_Post object that will be inflated later
-			$post = new stdClass();
+		if ( isset( $this->search_result['results'], $this->search_result['results']['hits'] ) && is_array( $this->search_result['results']['hits'] ) ) {
+			// We have to return something in $posts for regular search templates to work, so build up an array
+			// of simple, un-inflated WP_Post objects that will be inflated by ES_WPCOM_SearchResult_Posts_Iterator in The Loop
+			foreach ( $this->search_result['results']['hits'] as $result ) {
+				// Create an empty WP_Post object that will be inflated later
+				$post = new stdClass();
 
-			$post->ID 		= $result['fields']['post_id'];
-			$post->blog_id 	= $result['fields']['blog_id'];
+				$post->ID      = $result['fields']['post_id'];
+				$post->blog_id = $result['fields']['blog_id'];
 
-			// Run through get_post() to add all expected properties (even if they're empty)
-			$post = get_post( $post );
+				// Run through get_post() to add all expected properties (even if they're empty)
+				$post = get_post( $post );
 
-			if ( $post ) {
-				$posts[] = $post;
+				if ( $post ) {
+					$posts[] = $post;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description

Belt and braces to check that `$this->search_result['results']['hits']` is set and an array, before looping over it. Easier to see actual changes with the "No whitespace" view.

Fixes #994.

#994 mentions that this plugin is deprecated and going away, but, a year on, it does still exist :-)

_Needs testing._

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

0. See if we can check if any clients are actively using this.
1. Establish how / when the "Invalid foreach" warning appeared.
2. Apply PR.
3. Check if warning has ceased.
