### PR TITLE
Remove trailing slash from valid upload path

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -40,7 +40,7 @@ class API_Client {
 
 	protected function is_valid_path( $path ) {
 		$path = ltrim( $path, '/\\' );
-		return 0 === strpos( $path, 'wp-content/uploads/' );
+		return 0 === strpos( $path, 'wp-content/uploads' );
 	}
 
 	public function get_api_url( $path ) {


### PR DESCRIPTION
## Description

Some sites may not use the year/month upload scheme, and the current `is_valid_path()` will make all uploads fail with this warnings:

```
PHP Warning:  The specified file path (`wp-content/uploadsfilename.jpg`) does not begin with `/wp-content/uploads/`. #vip-go-streams in /var/www/wp-content/mu-plugins/files/class-vip-filesystem.php on line 211
```

There's also a bug somewhere that's not adding a slash between the upload path and filename, as shown above.  This happens even with a standard upload path (`PHP Warning:  The specified file path ('wp-content/uploads/2019/12filename.jpg') does not begin with '/wp-content/uploads/'. #vip-go-streams in /var/www/wp-content/mu-plugins/files/class-vip-filesystem.php on line 210`) but that's a problem I didn't have a quick solution for.

It very well may be that this second bug is the main cause of the problem since this seems to be passing unit tests: https://github.com/Automattic/vip-go-mu-plugins/blob/e09535fd8b56577479b96033fee9d195f717752a/tests/files/test-api-client.php#L71

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Add `add_filter( 'pre_option_uploads_use_yearmonth_folders', function() {return '0';}, 9999 );` to a site.
1. Upload a media file via the admin.
1. Verify upload is correct.
