### PR TITLE
Add trailing slash to make valid upload path

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -197,7 +197,7 @@ class VIP_Filesystem {
 	 * @return  bool        True if filetype is supported. Else false
 	 */
 	protected function check_filetype_with_backend( $filename ) {
-		$upload_path = $this->get_upload_path();
+		$upload_path = trailingslashit( $this->get_upload_path() );
 
 		$file_path = $upload_path . $filename;
 


### PR DESCRIPTION
## Description

Some sites may not use the year/month upload scheme, and the current `check_filetype_with_backend()` will make all uploads fail with this warning:

```
PHP Warning:  The specified file path (`wp-content/uploadsfilename.jpg`) does not begin with `/wp-content/uploads/`. #vip-go-streams in /var/www/wp-content/mu-plugins/files/class-vip-filesystem.php on line 211
```

Unit tests are already written properly at https://github.com/Automattic/vip-go-mu-plugins/blob/e09535fd8b56577479b96033fee9d195f717752a/tests/files/test-api-client.php#L71 so there shouldn't need to be any changes there :)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Add `add_filter( 'pre_option_uploads_use_yearmonth_folders', function() {return '0';}, 9999 );` to a site.
1. Upload a media file via the admin.
1. Verify upload is correct.
