### PR TITLE
Add conditional around add_filter() to prevent PHP fatal

### DIFF
--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -12,6 +12,9 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 
 		define( 'USE_VIP_ELASTICSEARCH', true );
 
+		// Hack to get around the constant not being defined early enough...there is probably a proper PHPUnit way to do that
+		add_filter( 'ep_index_name', 'vip_elasticsearch_filter_ep_index_name', PHP_INT_MAX, 3 );
+
 		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
 
 		$this->assertEquals( 'vip-123-slug-1', $index_name );

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -464,7 +464,7 @@ function vip_elasticsearch_filter_ep_index_name( $index_name, $blog_id, $indexab
 	return $index_name;
 }
 
-// Only add filter when using VIP Elasticsearch, b/c older versions of ElasticPress only pass 2 args to this which is a PHP warning
+// Only add filter when using VIP Elasticsearch, b/c older versions of ElasticPress only pass 2 args to this which is a PHP fatal
 if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
 	add_filter( 'ep_index_name', 'vip_elasticsearch_filter_ep_index_name', PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
 }

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -463,4 +463,8 @@ function vip_elasticsearch_filter_ep_index_name( $index_name, $blog_id, $indexab
 
 	return $index_name;
 }
-add_filter( 'ep_index_name', 'vip_elasticsearch_filter_ep_index_name', PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
+
+// Only add filter when using VIP Elasticsearch, b/c older versions of ElasticPress only pass 2 args to this which is a PHP warning
+if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
+	add_filter( 'ep_index_name', 'vip_elasticsearch_filter_ep_index_name', PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
+}


### PR DESCRIPTION
## Description

Older versions of ElasticPress only pass 2 args to the `ep_index_name` filter which triggers a PHP fatal, so to avoid that, only add the filter when the constant is defined

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

Example:

1. Check out PR.
1. Install ElasticPresss 2.1
1. Ensure no "too few arguments" fatals are thrown
