### PR TITLE
Add default EP_SYNC_CHUNK_LIMIT constant for bulk syncing

### DIFF
--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -83,4 +83,18 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( EP_SYNC_CHUNK_LIMIT, 500 );
 	}
+
+	/**
+	 * Test that the default bulk index chunk size limit is not defined if we're not using VIP Elasticsearch
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__vip_elasticsearch_bulk_chunk_size_not_defined_when_not_using_vip_elasticsearch() {
+		define( 'USE_VIP_ELASTICSEARCH', false );
+
+		vip_elasticsearch_setup_constants();
+
+		$this->assertEquals( defined( 'EP_SYNC_CHUNK_LIMIT' ), false );
+	}
 }

--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -53,4 +53,34 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( 'index-name', $index_name );
 	}
+
+	/**
+	 * Test that we set a default bulk index chunk size limit
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__vip_elasticsearch_bulk_chunk_size_default() {
+		define( 'USE_VIP_ELASTICSEARCH', true );
+
+		vip_elasticsearch_setup_constants();
+
+		$this->assertEquals( EP_SYNC_CHUNK_LIMIT, 250 );
+	}
+
+	/**
+	 * Test that the default bulk index chunk size limit is not applied if constant is already defined
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__vip_elasticsearch_bulk_chunk_size_already_defined() {
+		define( 'USE_VIP_ELASTICSEARCH', true );
+
+		define( 'EP_SYNC_CHUNK_LIMIT', 500 );
+
+		vip_elasticsearch_setup_constants();
+
+		$this->assertEquals( EP_SYNC_CHUNK_LIMIT, 500 );
+	}
 }

--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -93,8 +93,6 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	public function test__vip_elasticsearch_bulk_chunk_size_not_defined_when_not_using_vip_elasticsearch() {
 		define( 'USE_VIP_ELASTICSEARCH', false );
 
-		vip_elasticsearch_setup_constants();
-
 		$this->assertEquals( defined( 'EP_SYNC_CHUNK_LIMIT' ), false );
 	}
 }

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -464,7 +464,19 @@ function vip_elasticsearch_filter_ep_index_name( $index_name, $blog_id, $indexab
 	return $index_name;
 }
 
+/**
+ * Setup constants required by the VIP Elasticsearch service
+ */
+function vip_elasticsearch_setup_constants() {
+	// Ensure we limit bulk indexing chunk size to a reasonable number (no limit by default)
+	if ( ! defined( 'EP_SYNC_CHUNK_LIMIT' ) ) {
+		define( 'EP_SYNC_CHUNK_LIMIT', 250 );
+	}
+}
+
 // Only add filter when using VIP Elasticsearch, b/c older versions of ElasticPress only pass 2 args to this which is a PHP fatal
 if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
+	vip_elasticsearch_setup_constants();
+
 	add_filter( 'ep_index_name', 'vip_elasticsearch_filter_ep_index_name', PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
 }


### PR DESCRIPTION
## Description

Adds a default `EP_SYNC_CHUNK_LIMIT` value for ElasticPress bulk syncing, when using VIP Elasticsearch.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. `define( 'USE_VIP_ELASTICSEARCH', true );` in site code
1. `echo EP_SYNC_CHUNK_LIMIT` - should be 250 (default)
1. `define( 'EP_SYNC_CHUNK_LIMIT', 500 );` - should not cause any problems
