### PR TITLE
Conditionally add blog_id to index name

### DIFF
--- a/tests/vip-helpers/test-vip-elasticsearch.php
+++ b/tests/vip-helpers/test-vip-elasticsearch.php
@@ -21,6 +21,27 @@ class VIP_ElasticSearch_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test `ep_index_name` filter for ElasticPress + VIP Elasticsearch for global indexes
+	 * 
+	 * On "global" indexes, such as users, no blog id will be present
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__vip_elasticsearch_filter_ep_index_name_global_index() {
+		$mock_indexable = (object) [ 'slug' => 'users' ];
+
+		define( 'USE_VIP_ELASTICSEARCH', true );
+
+		// Hack to get around the constant not being defined early enough...there is probably a proper PHPUnit way to do that
+		add_filter( 'ep_index_name', 'vip_elasticsearch_filter_ep_index_name', PHP_INT_MAX, 3 );
+
+		$index_name = apply_filters( 'ep_index_name', 'index-name', null, $mock_indexable );
+
+		$this->assertEquals( 'vip-123-users', $index_name );
+	}
+
+	/**
 	 * Test `ep_index_name` filter for ElasticPress + VIP Elasticsearch
 	 *
 	 * USE_VIP_ELASTICSEARCH not defined

--- a/vip-helpers/vip-elasticsearch.php
+++ b/vip-helpers/vip-elasticsearch.php
@@ -458,7 +458,12 @@ function wpcom_search_api_wp_to_es_args( $args ) {
 function vip_elasticsearch_filter_ep_index_name( $index_name, $blog_id, $indexables ) {
 	if ( defined( 'USE_VIP_ELASTICSEARCH' ) && true === USE_VIP_ELASTICSEARCH ) {
 		// TODO: Use FILES_CLIENT_SITE_ID for now as VIP_GO_ENV_ID is not ready yet. Should replace once it is.
-		$index_name = sprintf( 'vip-%s-%s-%s', FILES_CLIENT_SITE_ID, $indexables->slug, $blog_id );
+		$index_name = sprintf( 'vip-%s-%s', FILES_CLIENT_SITE_ID, $indexables->slug );
+
+		// $blog_id won't be present on global indexes (such as users)
+		if ( $blog_id ) {
+			$index_name .= sprintf( '-%s', $blog_id );
+		}
 	}
 
 	return $index_name;


### PR DESCRIPTION
## Description

Global type Elasticsearch indexes won't have a blog id for ElasticPress index names, so we need to handle that condition to avoid names like `vip-1-users-` (with a trailing dash).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR
1. Do a bulk index of users
1. Check ES indexes, should now have one without the trailing hyphen