### PR TITLE
Update/move es helpers to plugin

### DIFF
--- a/shared-plugins/vip-elasticsearch/src/adapters/class-elasticpress.php
+++ b/shared-plugins/vip-elasticsearch/src/adapters/class-elasticpress.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Automattic\SharedPlugins\VIPElasticsearch\Adapters;
+
+class ElasticPress implements Adapter {
+	public function setup() {
+		$this->setup_constants();
+		$this->setup_filters();
+	}
+
+	public function setup_constants() {
+		if ( ! defined( 'EP_SYNC_CHUNK_LIMIT' ) ) {
+			define( 'EP_SYNC_CHUNK_LIMIT', 250 );
+		}
+	}
+
+	public function setup_filters() {
+		add_filter( 'ep_index_name', [ $this, 'filter__es_index_name' ], PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
+	}
+
+	public function filter__es_index_name( $index_name, $blog_id, $indexables ) {
+		// TODO: Use FILES_CLIENT_SITE_ID for now as VIP_GO_ENV_ID is not ready yet. Should replace once it is.
+		$index_name = sprintf( 'vip-%s-%s', FILES_CLIENT_SITE_ID, $indexables->slug );
+
+		// $blog_id won't be present on global indexes (such as users)
+		if ( $blog_id ) {
+			$index_name .= sprintf( '-%s', $blog_id );
+		}
+
+		return $index_name;
+	}
+}

--- a/shared-plugins/vip-elasticsearch/src/adapters/interface-adapter.php
+++ b/shared-plugins/vip-elasticsearch/src/adapters/interface-adapter.php
@@ -1,0 +1,8 @@
+<?php
+
+
+namespace Automattic\SharedPlugins\VIPElasticsearch\Adapters;
+
+interface Adapter {
+	public function setup();
+}

--- a/shared-plugins/vip-elasticsearch/src/class-vip-elasticsearch.php
+++ b/shared-plugins/vip-elasticsearch/src/class-vip-elasticsearch.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Automattic\SharedPlugins;
+
+class VIPElasticsearch {
+	static private $_instance = null;
+
+	protected $adapter = null;
+
+	public static function instance() {
+		if ( self::$_instance instanceof \Automattic\SharedPlugins\VIPElasticsearch ) {
+			self::$_instance = new \Automattic\SharedPlugins\VIPElasticsearch();
+		}
+
+		return self::$_instance;
+	}
+
+	public function init() {
+		add_action( 'plugins_loaded', [ $this, 'setup_adapter' ] );
+	}
+
+	public function setup_adapter() {
+		$this->adapter = $this->find_adapter();
+
+		if ( ! $this->adapter ) {
+			// TODO Add an admin warning or _doing_it_wrong() call
+			return;
+		}
+
+		$this->adapter->setup();
+	}
+
+	public function find_adapter() {
+		// Is ElasticPress loaded?
+		if ( did_action( 'elasticpress_loaded' ) ) {
+			require_once( __DIR__ . '/adapters/class-elasticpress.php' );
+
+			return new \Automattic\SharedPlugins\VIPElasticsearch\Adapters\ElasticPress();
+		}
+
+		return null;
+	}
+}

--- a/shared-plugins/vip-elasticsearch/vip-elasticsearch.php
+++ b/shared-plugins/vip-elasticsearch/vip-elasticsearch.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+Plugin Name: VIP Elasticsearch
+Description: Elasticsearch, the VIP way
+Author:      Automattic
+Author URI:  http://automattic.com/
+
+**************************************************************************
+
+Copyright (C) 2019-2020 Automattic
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 or greater,
+as published by the Free Software Foundation.
+
+You may NOT assume that you can use any other version of the GPL.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+The license for this software can likely be found here:
+http://www.gnu.org/licenses/gpl-2.0.html
+
+**************************************************************************/
+
+\Automattic\SharedPlugins\VIPElasticsearch::instance()->init();

--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -1,11 +1,11 @@
 <?php /*
 
-This plugins is still in beta. Want to try it? Contact us. :)
+This plugin has been replaced by Jetpack Search and will be removed in the future, please do not use it.
 
 **************************************************************************
 
-Plugin Name: VIP Go Search Add-On
-Description: Super-charged search powered by Jetpack and Elasticsearch. Please contact us before using this plugin.
+Plugin Name: VIP Go Search Add-On (Deprecated)
+Description: This plugin has been replaced by Jetpack Search
 Author:      Automattic
 Author URI:  http://automattic.com/
 

--- a/tests/shared-plugins/test-vip-elasticsearch.php
+++ b/tests/shared-plugins/test-vip-elasticsearch.php
@@ -1,0 +1,5 @@
+<?php
+
+class VIP_SharedPlugins_VIPElasticsearch_Test extends \WP_UnitTestCase {
+	// TODO 
+}

--- a/tests/shared-plugins/vip-elasticsearch/src/adapters/class-elasticpress.php
+++ b/tests/shared-plugins/vip-elasticsearch/src/adapters/class-elasticpress.php
@@ -1,0 +1,7 @@
+<?php
+
+class VIP_SharedPlugins_VIPElasticSearch_Adapters_ElasticPress_Test extends \WP_UnitTestCase {
+	// TODO constants
+	// TODO filters
+	// TODO setup() (calls both setups)
+}

--- a/tests/shared-plugins/vip-elasticsearch/src/class-vip-elasticsearch.php
+++ b/tests/shared-plugins/vip-elasticsearch/src/class-vip-elasticsearch.php
@@ -1,0 +1,5 @@
+<?php
+
+class VIP_SharedPlugins_VIPElasticSearch_Test extends \WP_UnitTestCase {
+	// TODO find_adapter()
+}


### PR DESCRIPTION
## Description

Moves existing ElasticPress <--> VIP Elasticsearch code into a proper plugin, instead of putting it behind a constant. Also makes it more extensible in the future via implementing it as an instance of an Adapter interface.

IN PROGRESS

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

TBD