### PR TITLE
add support for parsing and supplying the blog_url in the WXR parser

### DIFF
--- a/wordpress-importer/parsers.php
+++ b/wordpress-importer/parsers.php
@@ -91,6 +91,9 @@ class WXR_Parser_SimpleXML {
 		$base_url = $xml->xpath('/rss/channel/wp:base_site_url');
 		$base_url = (string) trim( $base_url[0] );
 
+		$blog_url = $xml->xpath('/rss/channel/wp:base_blog_url');
+		$blog_url = (string) trim( $blog_url[0] );
+
 		$namespaces = $xml->getDocNamespaces();
 		if ( ! isset( $namespaces['wp'] ) )
 			$namespaces['wp'] = 'http://wordpress.org/export/1.1/';
@@ -259,6 +262,7 @@ class WXR_Parser_SimpleXML {
 			'tags' => $tags,
 			'terms' => $terms,
 			'base_url' => $base_url,
+			'blog_url' => $blog_url,
 			'version' => $wxr_version
 		);
 	}
@@ -312,6 +316,7 @@ class WXR_Parser_XML {
 			'tags' => $this->tag,
 			'terms' => $this->term,
 			'base_url' => $this->base_url,
+			'blog_url' => $this->blog_url,
 			'version' => $this->wxr_version
 		);
 	}
@@ -403,6 +408,9 @@ class WXR_Parser_XML {
 			case 'wp:base_site_url':
 				$this->base_url = $this->cdata;
 				break;
+			case 'wp:base_blog_url':
+				$this->blog_url = $this->cdata;
+				break;
 			case 'wp:wxr_version':
 				$this->wxr_version = $this->cdata;
 				break;
@@ -431,6 +439,7 @@ class WXR_Parser_Regex {
 	var $tags = array();
 	var $terms = array();
 	var $base_url = '';
+	var $blog_url = '';
 
 	function __construct() {
 		$this->has_gzip = is_callable( 'gzopen' );
@@ -459,6 +468,12 @@ class WXR_Parser_Regex {
 				if ( false !== strpos( $importline, '<wp:base_site_url>' ) ) {
 					preg_match( '|<wp:base_site_url>(.*?)</wp:base_site_url>|is', $importline, $url );
 					$this->base_url = $url[1];
+					continue;
+				}
+
+				if ( false !== strpos( $importline, '<wp:base_blog_url>' ) ) {
+					preg_match( '|<wp:base_blog_url>(.*?)</wp:base_blog_url>|is', $importline, $url );
+					$this->blog_url = $url[1];
 					continue;
 				}
 
@@ -508,6 +523,7 @@ class WXR_Parser_Regex {
 			'tags' => $this->tags,
 			'terms' => $this->terms,
 			'base_url' => $this->base_url,
+			'blog_url' => $this->blog_url,
 			'version' => $wxr_version
 		);
 	}

--- a/wordpress-importer/wordpress-importer.php
+++ b/wordpress-importer/wordpress-importer.php
@@ -48,6 +48,7 @@ class WP_Import extends WP_Importer {
 	var $categories = array();
 	var $tags = array();
 	var $base_url = '';
+	var $blog_url = '';
 
 	// mappings from old information to new
 	var $processed_authors = array();
@@ -151,6 +152,7 @@ class WP_Import extends WP_Importer {
 		$this->categories = $import_data['categories'];
 		$this->tags = $import_data['tags'];
 		$this->base_url = esc_url( $import_data['base_url'] );
+		$this->blog_url = esc_url( $import_data['blog_url'] );
 
 		wp_defer_term_counting( true );
 		wp_defer_comment_counting( true );
@@ -391,7 +393,7 @@ class WP_Import extends WP_Importer {
 	 * Doesn't create a new category if its slug already exists
 	 */
 	function process_categories() {
-		$this->categories = apply_filters( 'wp_import_categories', $this->categories );
+		$this->categories = apply_filters( 'wp_import_categories', $this->categories, $this->blog_url );
 
 		if ( empty( $this->categories ) )
 			return;


### PR DESCRIPTION
## Description

Gets the blog_url property from WXR files and passes it along to the output data. Also supplies the blog_url to the category filter so it is possible to act on categories conditionally based on the URL of the source site. The base URL property for WXRs generated on WP.com is not sufficient for this purpose since it is always just "wordpress.com".

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
2. Write a filter elsewhere in your codebase that hooks to `wp_import_categories`.
3. Use the `blog_url` parameter somehow in the hooked function.
