### PR TITLE
Fix privacy archive generation

### DIFF
--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -188,7 +188,10 @@ function generate_personal_data_export_file( $request_id ) {
 
 		// Create the folder path
 		$local_archive_dirname = dirname( $local_archive_pathname );
-		wp_mkdir_p( $local_archive_dirname );
+		$local_archive_dir_created = wp_mkdir_p( $local_archive_dirname );
+		if ( is_wp_error( $local_archive_dir_created ) ) {
+			wp_send_json_error( $local_archive_dir_created->get_error_message() );
+		}
 	}
 
 	// Note: core deletes the file if it exists, but we can just overwrite it when we upload.


### PR DESCRIPTION
ZipArchive and PclZip don't support stream paths. To make our privacy export workaround work, we're now forcing the archive to be generated locally (in the tmp dir) and then uploaded after.

This also generates the HTML file locally as well, which was previously being generated on the Files Service and then attempted to be downloaded when archiving.

Most of that file and workaround is a bit of a hack so this should be considered a short-term fix.

Fixes #1399 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Go to wp-admin > Tools > Privacy
1. Generate a request
1. Attempt to download the file for the request (it should work)

Alternatively, programatically:

```
wp shell
Automattic\VIP\Core\Privacy\generate_personal_data_export_file( <id-of-request> )
```

That should return a `null` not an error.