### PR TITLE
Use forked version of ElasticPress

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,4 +45,4 @@
 	url = git@github.com:Automattic/Cron-Control.git
 [submodule "elasticsearch/elasticpress"]
 	path = elasticsearch/elasticpress
-	url = git@github.com/Automattic/ElasticPress.git
+	url = git@github.com:Automattic/ElasticPress.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -45,4 +45,4 @@
 	url = git@github.com:Automattic/Cron-Control.git
 [submodule "elasticsearch/elasticpress"]
 	path = elasticsearch/elasticpress
-	url = https://github.com/10up/ElasticPress.git
+	url = git@github.com/Automattic/ElasticPress.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -45,4 +45,4 @@
 	url = git@github.com:Automattic/Cron-Control.git
 [submodule "elasticsearch/elasticpress"]
 	path = elasticsearch/elasticpress
-	url = git@github.com:Automattic/ElasticPress.git
+	url = https://github.com/Automattic/ElasticPress.git


### PR DESCRIPTION
## Description

We are now going to use our own forked version of ElasticPress, because we need to make some VIP-only customization.

## Checklist

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. cd into `elasticsearch`
1. `git submodule sync`
1. `git remote -v` and verify the remote is now pointing to `Automattic/ElasticPress` rather than `10up/ElasticPress`