### PR TITLE
Fix subsite upload path for privacy exports

### DIFF
--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -240,8 +240,9 @@ function _upload_archive_file( $archive_path ) {
 	// Hard-coded and full of assumptions for now.
 	// TODO: need a cleaner approach for this. Can probably borrow `WP_Filesystem_VIP_Uploads::sanitize_uploads_path()`.
 	$archive_file = basename( $archive_path );
-	$exports_folder = basename( wp_privacy_exports_dir() );
-	$upload_path = sprintf( '/wp-content/uploads/%s/%s', $exports_folder, $archive_file );
+	$exports_url = wp_privacy_exports_url();
+	$wp_content_strpos = strpos( $exports_url, '/wp-content/uploads/' );
+	$upload_path = trailingslashit( substr( $exports_url, $wp_content_strpos ) ) . $archive_file;
 
 	$api_client = \Automattic\VIP\Files\new_api_client();
 	$upload_result = $api_client->upload_file( $archive_path, $upload_path );


### PR DESCRIPTION
When generating an export in a subsite (on a multisite install), the export was always uploaded to the root, rather than the `/sites/%d` path.

This fixes the path of the upload.

This is a quick fix until we can remove most of the workaround hacks in this file.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test
From a multisite main site:

1. Generate a export request (Tools > Export Privacy Data)
1. Click "download export file"
1. Verify the zip file downloads and has the correct export.

Then:

1. Goto a subsite, and repeat steps above.

Verify again with stream wrapper disabled. Both should work.