### PR TITLE
Enable new JP full sync approach for all non-prod sites

### DIFF
--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -124,24 +124,7 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 
 	function get_jetpack_sync_modules_data() {
 		return [
-			'not-enabled' => [
-				false, // sync immediately constant
-				// modules input
-				[
-					'sync' => 'Jetpack_Sync_Modules_Full_Sync',
-					'also-sync' => 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
-					'not-sync' => 'Not_Sync_Class',
-				],
-				// modules output
-				[
-					'sync' => 'Jetpack_Sync_Modules_Full_Sync',
-					'also-sync' => 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
-					'not-sync' => 'Not_Sync_Class',
-				],
-			],
-
 			'enabled-no-matching-modules' => [
-				true,
 				[
 					'sync' => 'Other_Sync_Class',
 				],
@@ -151,7 +134,6 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 			],
 
 			'enabled-with-matching-modules' => [
-				true,
 				[
 					'sync' => 'Jetpack_Sync_Modules_Full_Sync',
 					'also-sync' => 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
@@ -167,37 +149,12 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When the class is not defined, modules are not modified.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test__jetpack_sync_modules__without_class() {
-		$modules = [
-			'sync' => 'Jetpack_Sync_Modules_Full_Sync',
-			'also-sync' => 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
-			'not-sync' => 'Not_Sync_Class',
-		];
-		$expected_modules = [
-			'sync' => 'Jetpack_Sync_Modules_Full_Sync',
-			'also-sync' => 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
-			'not-sync' => 'Not_Sync_Class',
-		];
-
-		$actual_modules = apply_filters( 'jetpack_sync_modules', $modules );
-
-		$this->assertEquals( $expected_modules, $actual_modules );
-	}
-
-	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 * @dataProvider get_jetpack_sync_modules_data
 	 */
-	public function test__jetpack_sync_modules__class_exists( $full_sync_enabled, $modules, $expected_modules ) {
+	public function test__jetpack_sync_modules__class_exists( $modules, $expected_modules ) {
 		require_once( __DIR__ . '/fixtures/jetpack/class-jetpack-sync-immediately.php' );
-
-		define( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY', $full_sync_enabled );
 
 		$actual_modules = apply_filters( 'jetpack_sync_modules', $modules );
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -38,6 +38,15 @@ define( 'VIP_GO_JETPACK_SYNC_MAX_QUEUE_LAG_LOWER_LIMIT', 2 * HOUR_IN_SECONDS );
 define( 'VIP_GO_JETPACK_SYNC_MAX_QUEUE_LAG_UPPER_LIMIT', DAY_IN_SECONDS );
 
 /**
+ * Enable the the new Jetpack full sync method (queue-less) on non-production sites for testing
+ * 
+ * Can be removed (along with later code that uses the constant) after Jetpack 8.2 is deployed
+ */
+if ( ! defined( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY' ) && 'production' !== VIP_GO_ENV ) {
+	define( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY', true );
+}
+
+/**
  * Add the Connection Pilot. Ensures Jetpack is consistently connected.
  */
 require_once( __DIR__ . '/connection-pilot/class-jetpack-connection-pilot.php' );


### PR DESCRIPTION
## Description

Enables queue-less full sync across all non-production sites for beta testing prior to JP 8.2

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Example:

1. Check out PR.
1. On non-prod site, ensure the `VIP_JETPACK_FULL_SYNC_IMMEDIATELY` const is always set to `true`
1. On prod site, ensure the constant is not set
1. Define the constant in vip-config.php and ensure there are no conflicts
