### PR TITLE
Send error logs from vip_safe_wp_remote_request() to main logs

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,7 @@ define( 'VIP_GO_MUPLUGINS_TESTS__DIR__', __DIR__ );
 // Ideally we'd have a way to mock these
 define( 'FILES_CLIENT_SITE_ID', 123 );
 define( 'WPCOM_VIP_MAIL_TRACKING_KEY', 'key' );
+define( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING', true );
 
 function _manually_load_plugin() {
 	require_once( __DIR__ . '/../000-vip-init.php' );

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -742,8 +742,9 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	$cache_key = 'disable_remote_request_' . md5( parse_url( $url, PHP_URL_HOST ) . '_' . $parsed_args[ 'method' ] );
 
 	// valid url
-	if ( empty( $url ) || !parse_url( $url ) )
+	if ( empty( $url ) || !parse_url( $url ) ) {
 		return ( $fallback_value ) ? $fallback_value : new WP_Error('invalid_url', $url );
+	}
 
 	// Ensure positive values
 	$timeout   = abs( $timeout );
@@ -761,8 +762,9 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 
 	// check if the timeout was hit and obey the option and return the fallback value
 	if ( false !== $option && time() - $option['time'] < $retry ) {
-		if ( $option['hits'] >= $threshold )
+		if ( $option['hits'] >= $threshold ) {
 			return ( $fallback_value ) ? $fallback_value : new WP_Error('remote_request_disabled', 'Remote requests disabled: ' . maybe_serialize( $option ) );
+		}
 	}
 
 	$start = microtime( true );
@@ -771,18 +773,20 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 
 	$elapsed = ( $end - $start ) > $timeout;
 	if ( true === $elapsed ) {
-		if ( false !== $option && $option['hits'] < $threshold )
+		if ( false !== $option && $option['hits'] < $threshold ) {
 			wp_cache_set( $cache_key, array( 'time' => floor( $end ), 'hits' => $option['hits']+1 ), $cache_group, $retry );
-		else if ( false !== $option && $option['hits'] == $threshold )
+		} else if ( false !== $option && $option['hits'] == $threshold ) {
 			wp_cache_set( $cache_key, array( 'time' => floor( $end ), 'hits' => $threshold ), $cache_group, $retry );
-		else
+		} else {
 			wp_cache_set( $cache_key, array( 'time' => floor( $end ), 'hits' => 1 ), $cache_group, $retry );
+		}
 	}
 	else {
-		if ( false !== $option && $option['hits'] > 0 && time() - $option['time'] < $retry )
+		if ( false !== $option && $option['hits'] > 0 && time() - $option['time'] < $retry ) {
 			wp_cache_set( $cache_key, array( 'time' => $option['time'], 'hits' => $option['hits']-1 ), $cache_group, $retry );
-		else
+		} else {
 			wp_cache_delete( $cache_key, $cache_group);
+		}
 	}
 
 	if ( is_wp_error( $response ) ) {

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -763,6 +763,8 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	// check if the timeout was hit and obey the option and return the fallback value
 	if ( false !== $option && time() - $option['time'] < $retry ) {
 		if ( $option['hits'] >= $threshold ) {
+			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} has been throttled after {$option['hits']} attempts. Not reattempting until after $retry seconds", E_USER_NOTICE );
+
 			return ( $fallback_value ) ? $fallback_value : new WP_Error('remote_request_disabled', 'Remote requests disabled: ' . maybe_serialize( $option ) );
 		}
 	}

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -764,7 +764,7 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	if ( false !== $option && time() - $option['time'] < $retry ) {
 		if ( $option['hits'] >= $threshold ) {
 			if ( ! defined( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING' ) || ! WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING ) {
-				trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} has been throttled after {$option['hits']} attempts. Not reattempting until after $retry seconds", E_USER_WARNING);
+				trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} has been throttled after {$option['hits']} attempts. Not reattempting until after $retry seconds", E_USER_WARNING );
 			}
 
 			return ( $fallback_value ) ? $fallback_value : new WP_Error('remote_request_disabled', 'Remote requests disabled: ' . maybe_serialize( $option ) );

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -792,7 +792,6 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	}
 
 	if ( is_wp_error( $response ) ) {
-		// Log errors for internal WP.com debugging
 		if ( ! defined( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING' ) || ! WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING ) {
 			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} and a timeout of $timeout failed. Result: " . maybe_serialize( $response ), E_USER_WARNING );
 		}

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -792,7 +792,7 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	if ( is_wp_error( $response ) ) {
 		// Log errors for internal WP.com debugging
 		if ( ! defined( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING' ) || ! WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING ) {
-			error_log( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with a timeout of $timeout failed. Result: " . maybe_serialize( $response ) );
+			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with a timeout of $timeout failed. Result: " . maybe_serialize( $response ), E_USER_NOTICE );
 		}
 		do_action( 'wpcom_vip_remote_request_error', $url, $response );
 

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -794,7 +794,7 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	if ( is_wp_error( $response ) ) {
 		// Log errors for internal WP.com debugging
 		if ( ! defined( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING' ) || ! WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING ) {
-			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with a timeout of $timeout failed. Result: " . maybe_serialize( $response ), E_USER_NOTICE );
+			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} and a timeout of $timeout failed. Result: " . maybe_serialize( $response ), E_USER_NOTICE );
 		}
 		do_action( 'wpcom_vip_remote_request_error', $url, $response );
 

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -763,7 +763,7 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	// check if the timeout was hit and obey the option and return the fallback value
 	if ( false !== $option && time() - $option['time'] < $retry ) {
 		if ( $option['hits'] >= $threshold ) {
-			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} has been throttled after {$option['hits']} attempts. Not reattempting until after $retry seconds", E_USER_NOTICE );
+			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} has been throttled after {$option['hits']} attempts. Not reattempting until after $retry seconds", E_USER_WARNING);
 
 			return ( $fallback_value ) ? $fallback_value : new WP_Error('remote_request_disabled', 'Remote requests disabled: ' . maybe_serialize( $option ) );
 		}
@@ -794,7 +794,7 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	if ( is_wp_error( $response ) ) {
 		// Log errors for internal WP.com debugging
 		if ( ! defined( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING' ) || ! WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING ) {
-			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} and a timeout of $timeout failed. Result: " . maybe_serialize( $response ), E_USER_NOTICE );
+			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} and a timeout of $timeout failed. Result: " . maybe_serialize( $response ), E_USER_WARNING );
 		}
 		do_action( 'wpcom_vip_remote_request_error', $url, $response );
 

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -763,7 +763,9 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	// check if the timeout was hit and obey the option and return the fallback value
 	if ( false !== $option && time() - $option['time'] < $retry ) {
 		if ( $option['hits'] >= $threshold ) {
-			trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} has been throttled after {$option['hits']} attempts. Not reattempting until after $retry seconds", E_USER_WARNING);
+			if ( ! defined( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING' ) || ! WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING ) {
+				trigger_error( "vip_safe_wp_remote_request: Blog ID {$blog_id}: Requesting $url with method {$parsed_args[ 'method' ]} has been throttled after {$option['hits']} attempts. Not reattempting until after $retry seconds", E_USER_WARNING);
+			}
 
 			return ( $fallback_value ) ? $fallback_value : new WP_Error('remote_request_disabled', 'Remote requests disabled: ' . maybe_serialize( $option ) );
 		}


### PR DESCRIPTION
## Description

Previously, `vip_safe_wp_remote_get()` called `error_log()`, which doesn't properly format the messages for sending to VIP's error log service. This changes that call to a `trigger_error()` (notice level), and adds another logging call that records when requests have been throttled.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Add this to a test site, and ensure the right errors are logged (3 for timeouts, 2 for throttle):
```
for( $i = 0; $i < 5; $i++ ) {
	vip_safe_wp_remote_get( 'http://slowwly.robertomurray.co.uk/delay/2000/url/http://www.google.co.uk' );
}
```
