### PR TITLE
Only ping #vip-deploy-on-call for alloptions issues affecting production

### DIFF
--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -115,7 +115,9 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 		// Send to IRC, if we have a host configured
 		if ( defined( 'ALERT_SERVICE_ADDRESS' ) && ALERT_SERVICE_ADDRESS ) {
 			wpcom_vip_irc( '#nagios-vip', $to_irc, $irc_alert_level, 'a8c-alloptions' );
-			wpcom_vip_irc( '#vip-deploy-on-call', $to_irc , $irc_alert_level, 'a8c-alloptions' );
+			if ( 'production' === $environment ) {
+				wpcom_vip_irc( '#vip-deploy-on-call', $to_irc , $irc_alert_level, 'a8c-alloptions' );
+			}
 		}
 
 		$email_recipient = defined( 'VIP_ALLOPTIONS_NOTIFY_EMAIL' ) ? VIP_ALLOPTIONS_NOTIFY_EMAIL : false;


### PR DESCRIPTION
On the Automattic-side, a ping in #vip-deploy-on-call is fairly disruptive to developers. Only things impacting production environments should land there.

This adds that restriction, while maintaining alerts in #nagios-vip.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Quick:

1. Verify no syntax errors
1. Make sure strings and vars are spelled properly

Super-sure:

1. Pick a test site
1. `update_option( 'large-option-test', implode( ' ', range( 0, 149999 ) ) );` should create an option big enough to create a warning (give or take other options)
1. In some environments, IRC may be blocked. Can modify the `wpcom_vip_irc()` lines to use `error_log()` for testing
1. Note the `VIP_GO_ENV` value for your test site and test the conditional
