### PR TITLE
Define the EP_HOST and ES_SHIELD constants automatically

### DIFF
--- a/elasticsearch/class-elasticsearch.php
+++ b/elasticsearch/class-elasticsearch.php
@@ -32,6 +32,16 @@ class Elasticsearch {
 		if ( ! defined( 'EP_SYNC_CHUNK_LIMIT' ) ) {
 			define( 'EP_SYNC_CHUNK_LIMIT', 250 );
 		}
+
+		if ( ! defined( 'EP_HOST' ) && defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) && is_array( VIP_ELASTICSEARCH_ENDPOINTS ) ) {
+			$host = VIP_ELASTICSEARCH_ENDPOINTS[ 0 ];
+
+			define( 'EP_HOST', $host );
+		}
+
+		if ( ! defined( 'ES_SHIELD' ) && ( defined( 'VIP_ELASTICSEARCH_USERNAME' ) && defined( 'VIP_ELASTICSEARCH_PASSWORD' ) ) ) {
+			define( 'ES_SHIELD', sprintf( '%s:%s', VIP_ELASTICSEARCH_USERNAME, VIP_ELASTICSEARCH_PASSWORD ) );
+		}
 	}
 
 	protected function setup_hooks() {

--- a/elasticsearch/class-elasticsearch.php
+++ b/elasticsearch/class-elasticsearch.php
@@ -10,9 +10,9 @@ class Elasticsearch {
 	 * Initialize the VIP Elasticsearch plugin
 	 */
 	public function init() {
-		$this->load_dependencies();
 		$this->setup_constants();
 		$this->setup_hooks();
+		$this->load_dependencies();
 		$this->load_commands();
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,7 @@ define( 'VIP_GO_MUPLUGINS_TESTS__DIR__', __DIR__ );
 // Ideally we'd have a way to mock these
 define( 'FILES_CLIENT_SITE_ID', 123 );
 define( 'WPCOM_VIP_MAIL_TRACKING_KEY', 'key' );
+define( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING', true );
 
 function _manually_load_plugin() {
 	require_once( __DIR__ . '/../000-vip-init.php' );

--- a/tests/elasticsearch/test-class-elasticsearch.php
+++ b/tests/elasticsearch/test-class-elasticsearch.php
@@ -87,6 +87,49 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the ES config constants are set automatically when not already defined and VIP-provided configs are present
+	 */
+	public function test__vip_elasticsearch_connection_constants() {
+		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
+			'https://es-endpoint1',
+			'https://es-endpoint2',
+		) );
+
+		define( 'VIP_ELASTICSEARCH_USERNAME', 'foo' );
+		define( 'VIP_ELASTICSEARCH_PASSWORD', 'bar' );
+
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$this->assertEquals( EP_HOST, 'https://es-endpoint1' );
+		$this->assertEquals( ES_SHIELD, 'foo:bar' );
+	}
+
+	/**
+	 * Test that the ES config constants are _not_ set automatically when already defined and VIP-provided configs are present
+	 * 
+	 */
+	public function test__vip_elasticsearch_connection_constants_with_overrides() {
+		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
+			'https://es-endpoint1',
+			'https://es-endpoint2',
+		) );
+
+		define( 'VIP_ELASTICSEARCH_USERNAME', 'foo' );
+		define( 'VIP_ELASTICSEARCH_PASSWORD', 'bar' );
+
+		// Client over-rides - don't fatal
+		define( 'EP_HOST', 'https://somethingelse' );
+		define( 'ES_SHIELD', 'bar:baz' );
+
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$this->assertEquals( EP_HOST, 'https://somethingelse' );
+		$this->assertEquals( ES_SHIELD, 'bar:baz' );
+	}
+
+	/**
 	 * Test that we are sending HTTP requests through the VIP helper functions
 	 */
 	public function test__vip_elasticsearch_has_http_layer_filters() {


### PR DESCRIPTION
## Description

For VIP Elasticsearch, define the requisite ElasticPress constants automatically when they have been defined by the system in wp-config.php

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Define `VIP_ELASTICSEARCH_ENDPOINTS` to an array of hostnames
1. Define `VIP_ELASTICSEARCH_USERNAME` and `VIP_ELASTICSEARCH_PASSWORD`
1. Check that `EP_HOST` and `ES_SHIELD` are correctly populated with those values
