### PR TITLE
VaultPress: skip some files

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -11,10 +11,27 @@
  * Domain Path: /languages/
  */
 
+define( 'VIP_VAULTPRESS_SKIP_FILES', [
+	// The following EP files are large and complex and consistently trigger 100% CPU usage on scan.
+	'/elasticpress/dist/js/ordering-script.min.js',
+	'/elasticpress/dist/js/related-posts-block-script.min.js',
+	'/elasticpress/dist/js/stats-script.min.js',
+] );
+
 // VaultPress uses a default timeout of 60s, which can be bad in the rare cases where its API is slow to respond.
 // Drop it down to something a bit more reasonable.
 if ( ! defined( 'VAULTPRESS_TIMEOUT' ) ) {
 	define( 'VAULTPRESS_TIMEOUT', 10 );
 }
+
+add_filter( 'pre_scan_file', function( $should_skip_file, $file, $real_file, $file_content ) {
+	foreach ( VIP_VAULTPRESS_SKIP_FILES as $vp_skip_file ) {
+		if ( wp_endswith( $file, $vp_skip_file ) ) {
+			return true;
+		}
+	}
+
+	return $should_skip_file;
+}, 10, 4 );
 
 require_once( __DIR__ . '/vaultpress/vaultpress.php' );


### PR DESCRIPTION
There are a few large and complex JS files that lead to consistently high CPU usage on scan. Ignore them for now until we get things fixed on the VP side.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Non-skipped file:

- `wp shell`
- `$GLOBALS['vp_signatures'] = get_option( '_vp_signatures' );`
- `vp_scan_file( WPMU_PLUGIN_DIR . '/vip-plugins/js/plugins-ui.js' )`
- Should return an empty array

Skipped file:

- `vp_scan_file( WPMU_PLUGIN_DIR . 'elasticsearch/elasticpress/dist/js/ordering-script.min.js' )`
- Should return true