### PR TITLE
Setup constants / hooks _before_ loading dependencies

### DIFF
--- a/elasticsearch/class-elasticsearch.php
+++ b/elasticsearch/class-elasticsearch.php
@@ -10,9 +10,9 @@ class Elasticsearch {
 	 * Initialize the VIP Elasticsearch plugin
 	 */
 	public function init() {
-		$this->load_dependencies();
 		$this->setup_constants();
 		$this->setup_hooks();
+		$this->load_dependencies();
 		$this->load_commands();
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,7 @@ define( 'VIP_GO_MUPLUGINS_TESTS__DIR__', __DIR__ );
 // Ideally we'd have a way to mock these
 define( 'FILES_CLIENT_SITE_ID', 123 );
 define( 'WPCOM_VIP_MAIL_TRACKING_KEY', 'key' );
+define( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING', true );
 
 function _manually_load_plugin() {
 	require_once( __DIR__ . '/../000-vip-init.php' );


### PR DESCRIPTION
## Description

Previously our hooks/constants were defined _after_ the plugin code was loaded, which meant that early-running code (such as on-require) could run before config constants and filters were registered, leading to inconsistent behavior.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Setup ES configs (`EP_HOST` and `ES_SHIELD` if applicable)
1. Test ES functionality to ensure it's normal
