### PR TITLE
$enable => true

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -34,7 +34,7 @@ add_filter( 'two_factor_user_api_login_enable', function( $enable ) {
 
 	// Do not allow API requests for users with 2fa enabled.
 	return false;
-}, 1 );
+}, 1 ); // Allow overrides at later priorities
 
 function wpcom_vip_should_force_two_factor() {
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -23,7 +23,7 @@ add_filter( 'two_factor_user_api_login_enable', function( $enable ) {
 			'vip-go-2fa-api-allowed' => sprintf( '%d-%s', FILES_CLIENT_SITE_ID, sanitize_key( $_SERVER['HTTP_USER_AGENT'] ) ),
 		] );
 
-		return $enable;
+		return true;
 	}
 
 	// Track stats around how frequently we're hitting this


### PR DESCRIPTION
Continued from #1424 

We need to actually allow the requests for now rather than passing back the default which is `false`.