### PR TITLE
Temporarily disable ssl verification on requests to VIP ES server

### DIFF
--- a/elasticsearch/class-elasticsearch.php
+++ b/elasticsearch/class-elasticsearch.php
@@ -77,6 +77,10 @@ class Elasticsearch {
 	public function filter__ep_do_intercept_request( $request, $query, $args, $failures ) {
 		$fallback_error = new \WP_Error( 'vip-elasticsearch-upstream-request-failed', 'There was an error connecting to the upstream Elasticsearch server' );
 
+		// TEMP - currently ES server is using a self signed cert during the testing phase...that'll be changed in the near
+		// future, at which time we can remove this
+		$args['sslverify'] = false;
+	
 		$request = vip_safe_wp_remote_request( $query['url'], $fallback_error, 3, 1, 20, $args );
 	
 		return $request;


### PR DESCRIPTION
## Description

ES server is using a self-signed cert during testing phase, will be replaced with real cert in near future then this can be removed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Try query operation - should succeed
1. Try indexing operation - should succeed
