### PR TITLE
Make Jetpack_Start_CLI_Command::maybe_create_user not die silently on error

### DIFF
--- a/jetpack-start/wp-cli-api.php
+++ b/jetpack-start/wp-cli-api.php
@@ -197,9 +197,10 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 
 	private function maybe_create_user() {
 		$user = get_user_by( 'login', WPCOM_VIP_MACHINE_USER_LOGIN );
+
 		if ( ! $user ) {
 			$cmd = sprintf(
-				'user create --url=%s --role=%s --display_name=%s --porcelain %s %s',
+				'user create --url=%s --role=%s --display_name=%s --porcelain %s %s --skip-plugins --skip-themes',
 				escapeshellarg( get_site_url() ),
 				escapeshellarg( WPCOM_VIP_MACHINE_USER_ROLE ),
 				escapeshellarg( WPCOM_VIP_MACHINE_USER_NAME ),
@@ -207,9 +208,16 @@ class Jetpack_Start_CLI_Command extends WP_CLI_Command {
 				escapeshellarg( WPCOM_VIP_MACHINE_USER_EMAIL )
 			);
 
-			$user_id = WP_CLI::runcommand( $cmd, [
-				'return' => true,
+			$user_create_cmd_result = WP_CLI::runcommand( $cmd, [
+				'return'     => 'all',
+				'exit_error' => false,
 			] );
+
+			$user_id = $user_create_cmd_result->stdout;
+
+			if ( $user_create_cmd_result->stderr && ! $user_id ) {
+				return new WP_Error( 'maybe_create_user-failed', 'Failed to create new user. Reason: ' . $user_create_cmd_result->stderr );
+			}
 
 			$user = get_userdata( $user_id );
 			if ( ! $user ) {


### PR DESCRIPTION
## Description

Currently the method silently dies in case case WP_CLI::runcommand for `wp user create` errors out. This behavior is opaque and confusing.

To change that this commit updates WP_CLI::runcommand with 
```
[ 
  'return' => 'all', 
  'exit_error' => false
]
```

This changes behavior for the runcommand - it doesn't die and instead of returning STDOUT only it returns an object:

```
class stdClass#1609 (3) {
  public $stdout =>
  string(0) ""
  public $stderr =>
  string(40) "Error: Role doesn't exist: administrator"
  public $return_code =>
  int(1)
}
```

If `$stderr` is not empty and `$stdout` is, we return a new `WP_Error` with the value of `$stderr`

This should be sufficient for the purpose of surfacing the error.

To further minimize the chance of the child command erroring pass `--skip-themes` and `--skip-plugins`

### Current behavior:

```
wp jetpack-start connect --skip-themes --skip-plugins
Connecting Jetpack!
- Verifying VIP machine user exists (or creating one, if not)

# dies 
```

### The new behavior

```
Connecting Jetpack!
- Verifying VIP machine user exists (or creating one, if not)
Warning: Failed to create new user. Reason: Error: Role doesn't exist: administrator
Warning: Attempt completed. Please resolve the issues noted above and try again.
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Sandbox a site.
2. Delete the `administrator` role
3. Run `wp jetpack-start connect`
4. Observe and verify the error.
5. Delete the machine user and run `wp role reset administrator` 
6. Run step 3 again.
7. Verify the user was created and Jetpack was connected.
