### PR TITLE
Enforce the jetpack_active_plan option

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -164,7 +164,9 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
  * which can then break features like Jetpack Search.
  */
 add_filter( 'pre_option_jetpack_active_plan', function( $pre_option, $option, $default ) {
-	if ( true === WPCOM_IS_VIP_ENV && defined( 'VIP_JETPACK_DEFAULT_PLAN' ) ) {
+	if ( true === WPCOM_IS_VIP_ENV
+		&& defined( 'VIP_JETPACK_DEFAULT_PLAN' )
+		&& Jetpack::is_active() ) {
 		return VIP_JETPACK_DEFAULT_PLAN;
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -46,6 +46,89 @@ if ( ! defined( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY' ) && 'production' !== VIP_GO
 	define( 'VIP_JETPACK_FULL_SYNC_IMMEDIATELY', true );
 }
 
+// Default plan object for all VIP sites.
+define( 'VIP_JETPACK_DEFAULT_PLAN', array(
+	'product_id' => 'vip',
+	'product_slug' => 'vip',
+	'product_name_short' => 'VIP',
+	'product_variation' => 'vip',
+	'supports' => array (
+		'videopress',
+		'akismet',
+		'vaultpress',
+		'seo-tools',
+		'google-analytics',
+		'wordads',
+		'search',
+	),
+	'features' => array (
+		'active' => array (
+			'premium-themes',
+			'akismet',
+			'vaultpress-backups',
+			'vaultpress-backup-archive',
+			'vaultpress-storage-space',
+			'vaultpress-automated-restores',
+			'vaultpress-security-scanning',
+			'polldaddy',
+			'simple-payments',
+			'support',
+			'wordads-jetpack',
+		),
+		'available' => array (
+			'akismet' => array (
+				'jetpack_free',
+				'jetpack_premium',
+				'jetpack_personal',
+				'jetpack_premium_monthly',
+				'jetpack_business_monthly',
+				'jetpack_personal_monthly',
+			),
+			'vaultpress-backups' => array (
+				'jetpack_premium',
+				'jetpack_premium_monthly',
+				'jetpack_business_monthly',
+			),
+			'vaultpress-backup-archive' => array (
+				'jetpack_premium',
+				'jetpack_premium_monthly',
+				'jetpack_business_monthly',
+			),
+			'vaultpress-storage-space' => array (
+				'jetpack_premium',
+				'jetpack_premium_monthly',
+				'jetpack_business_monthly',
+			),
+			'vaultpress-automated-restores' => array (
+				'jetpack_premium',
+				'jetpack_premium_monthly',
+				'jetpack_business_monthly',
+			),
+			'simple-payments' => array (
+				'jetpack_premium',
+				'jetpack_premium_monthly',
+				'jetpack_business_monthly',
+			),
+			'support' => array (
+				'jetpack_premium',
+				'jetpack_personal',
+				'jetpack_premium_monthly',
+				'jetpack_business_monthly',
+				'jetpack_personal_monthly',
+			),
+			'premium-themes' => array (
+				'jetpack_business_monthly',
+			),
+			'vaultpress-security-scanning' => array (
+				'jetpack_business_monthly',
+			),
+			'polldaddy' => array (
+				'jetpack_business_monthly',
+			),
+		),
+	),
+) );
+
 /**
  * Add the Connection Pilot. Ensures Jetpack is consistently connected.
  */
@@ -71,6 +154,22 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 
 	return $modules;
 }, 999 );
+
+/**
+ * Prevent the jetpack_active_plan from ever being overridden.
+ *
+ * All sites on VIP Go should always have have a valid VIP plan.
+ *
+ * This will prevent issues from the plan option being corrupted,
+ * which can then break features like Jetpack Search.
+ */
+add_filter( 'pre_option_jetpack_active_plan', function( $pre_option, $option, $default ) {
+	if ( true === WPCOM_IS_VIP_ENV && defined( 'VIP_JETPACK_DEFAULT_PLAN' ) ) {
+		return VIP_JETPACK_DEFAULT_PLAN;
+	}
+
+	return $pre_option;
+}, 10, 3 );
 
 /**
  * Lock down the jetpack_sync_settings_max_queue_size to an allowed range


### PR DESCRIPTION
To a default that we expect for VIP. This will avoid issues with the option getting corrupted and breaking Jetpack features like Search.

props @mikeyarce and @brettshumaker for the initial batch of work on this.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. `get_option( 'jetpack_active_plan' )` should return the correct object.
1. Jetpack functionality like Search and Dashboard should continue to work.
