### PR TITLE
chore: add note about turning xdebug on in vvv prior to running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ composer install
 vagrant@vvv:/wp-content/mu-plugins$ vendor/bin/phpunit
 ```
 
+Tests failing with `Error: Call to undefined function xdebug_get_headers()` or similar? xdebug needs to be turned on in VVV before running tests: 
+```bash
+vagrant@vvv:/wp-content/mu-plugins$ xdebug_on
+```
+
 #### Travis
 
 PHP Linting and PHPUnit tests are also run by Travis as part of PRs and merges. See the `script` section of [`.travis.yml`](https://github.com/Automattic/vip-go-mu-plugins/blob/master/.travis.yml).


### PR DESCRIPTION
## Description

Added text stating that xdebug must be enabled in VVV prior to running tests if you get an error stating that an xdebug function is undefined.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [X] This change has relevant unit tests (if applicable).
- [X] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Attempt to run tests as outlined in the README without xdebug enabled on VVV. 

You should get an error of `Error: Call to undefined function Automattic\VIP\Cache\xdebug_get_headers()` or similar.

Turn xdebug on in VVV and then try to run tests again. All tests should pass successfully.