### PR TITLE
chore: fix listed install-wp-tests.sh usage by swapping db_name for d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ vagrant@vvv:~$cd /path/to/wp-content/mu-plugins
 4. Setup the WordPress tests:
 
 ```bash
-vagrant@vvv:
-vagrant@vvv:/wp-content/mu-plugins$ ./bin/install-wp-tests.sh %empty_DB_name% %db_user% %db_name%
+vagrant@vvv:/wp-content/mu-plugins$ ./bin/install-wp-tests.sh %empty_DB_name% %db_user% %db_user_password%
 ```
 
 Note: you need to replace the `%placeholder%` strings above with the appropriate values. Use a separate test database for this as the contents will get trashed during testing.


### PR DESCRIPTION
## Description

Swap out %db_name% placeholder for %db_user_password% placeholder since the field is for the users password and not for a database name.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [X] This change has relevant unit tests (if applicable).
- [X] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Run(on fresh VVV with mu-plugins installed):

```bash
vagrant@vvv:/wp-content/mu-plugins$ ./bin/install-wp-tests.sh mu-plugins-one-test root wordpress-one
```

Receive:

```
...
mysqladmin: connect to server at 'localhost' failed
error: 'Access denied for user 'root'@'localhost' (using password: YES)'
```

Run:

```bash
vagrant@vvv:/wp-content/mu-plugins$ ./bin/install-wp-tests.sh mu-plugins-one-test root root
```

Receive no error.