### PR TITLE
Add missing 'use' statement for WP_Error class namespace

### DIFF
--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -7,7 +7,7 @@ use \ElasticPress\Indexables as Indexables;
 
 use \WP_Query as WP_Query;
 use \WP_User_Query as WP_User_Query;
-
+use \WP_Error as WP_Error;
 
 class Health {
 	/**


### PR DESCRIPTION
## Description

```
Fatal error: Uncaught Error: Class 'Automattic\VIP\Elasticsearch\WP_Error' not found in wp-content/mu-plugins/elasticsearch/includes/classes/class-health.php:52
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Change the `EP_HOST` constant to an invalid host, to fail the connection
1. Run `wp vip-es health validate-counts`
1. Should be no fatal error when the request fails
