### PR TITLE
Get accurate total count from Elasticsearch

### DIFF
--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -39,6 +39,10 @@ class Health {
 		try {
 			$query = self::query_objects( $query_args, $indexable->slug );
 			$formatted_args = $indexable->format_args( $query->query_vars, $query );
+
+			// Get exact total count since Elasticsearch default stops at 10,000.
+			$formatted_args['track_total_hits'] = true;
+
 			$es_result = $indexable->query_es( $formatted_args, $query->query_vars );
 		} catch ( \Exception $e ) {
 			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-go-elasticsearch', $e->get_error_message() ) );


### PR DESCRIPTION
By default, it stops at 10,000. We can ask for an exact number by setting the `track_total_hits` arg.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#track-total-hits-10000-default

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

- On a test site with indexed documents more than 10K, run `wp vip-es health validate-posts-count`
- Verify that diff doesn't error.