### PR TITLE
ES Health: Cleanup diff output

### DIFF
--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -44,7 +44,6 @@ class Health {
 			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-go-elasticsearch', $e->get_error_message() ) );
 		}
 
-		$diff = '';
 		// There is not other useful information out of query_es(): it just returns false in case of failure
 		if ( ! $es_result ) {
 			$es_total = 'N/A';
@@ -55,8 +54,9 @@ class Health {
 		// Verify actual results
 		$es_total = (int) $es_result[ 'found_documents' ][ 'value' ];
 
+		$diff = 0;
 		if ( $db_total !== $es_total ) {
-			$diff = sprintf( ', diff: %d', $es_total - $db_total );
+			$diff = $es_total - $db_total;
 		}
 
 		return [
@@ -64,7 +64,7 @@ class Health {
 			'type' => ( array_key_exists( 'post_type', $query_args ) ? $query_args[ 'post_type' ] : 'N/A' ),
 			'db_total' => $db_total,
 			'es_total' => $es_total,
-			'diff' => $diff
+			'diff' => $diff,
 		];
 	}
 


### PR DESCRIPTION
The `diff` returned by the health class should be an int and the calling class should decide what to do with it.

Right now, we're sending a string which makes the value less useful and makes the output somewhat awkward: `(DB: 5789, ES: 0, Diff: , diff: -5789)`

With this change, we're much cleaner: `(DB: 5789, ES: 0, Diff: -5789)`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

- Run `wp vip-es health validate-posts-count`
- Verify that the diff output looks clean.