### PR TITLE
IRC/Slack alert when cron control cron option is uncacheable

### DIFF
--- a/001-cron.php
+++ b/001-cron.php
@@ -118,7 +118,7 @@ function wpcom_vip_cron_control_event_object_to_string( $event ) {
  */
 function wpcom_vip_log_cron_control_uncacheable_cron_option( $option_size, $buckets, $option_flat_count ) {
 	$message = sprintf( 'Cron Control Cron Option Uncacheable Alert - home: %s | option size: %d | buckets: %d | option flat count: %d', home_url( '/' ), $option_size, $buckets, $option_flat_count );
-	wpcom_vip_irc( 'vipv2-alerts', $message, 2, '', 5 );
+	wpcom_vip_irc( 'vipv2-alerts', $message, 2, 'cache-control-uncacheable-cron-option', 900 );
 }
 
 /**

--- a/001-cron.php
+++ b/001-cron.php
@@ -112,6 +112,18 @@ function wpcom_vip_cron_control_event_object_to_string( $event ) {
 }
 
 /**
+ * Callback for 'a8c_cron_control_uncacheable_cron_option' action. Send an alert to IRC and Slack in case of cron option being too big.
+ *
+ * @param $event object
+ */
+function wpcom_vip_log_cron_control_uncacheable_cron_option( $option_size, $buckets, $option_flat_count ) {
+	$message = sprintf( 'Cron Control Cron Option Uncacheable Alert - home: %s | option size: %d | buckets: %d | option flat count: %d', home_url( '/' ), $option_size, $buckets, $option_flat_count );
+	if( ! wpcom_vip_irc( 'vipv2-alerts', $message, 2 ) ) {
+		error_log( "IRC message failed. " . $message);
+	}
+}
+
+/**
  * Should Cron Control load
  */
 if ( ! wpcom_vip_use_core_cron() ) {
@@ -137,7 +149,8 @@ if ( ! wpcom_vip_use_core_cron() ) {
 	 */
 	add_action( 'a8c_cron_control_event_threw_catchable_error', 'wpcom_vip_log_cron_control_event_for_caught_error', 10, 2 );
 	add_action( 'a8c_cron_control_freeing_event_locks_after_uncaught_error', 'wpcom_vip_log_cron_control_event_object' );
-
+	add_action( 'a8c_cron_control_uncacheable_cron_option', 'wpcom_vip_log_cron_control_uncacheable_cron_option', 10, 3 );
+	
 	$cron_control_next_version = __DIR__ . '/cron-control-next/cron-control.php';
 
 	if ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION' ) && true === VIP_CRON_CONTROL_USE_NEXT_VERSION && file_exists( $cron_control_next_version ) ) {

--- a/001-cron.php
+++ b/001-cron.php
@@ -118,9 +118,7 @@ function wpcom_vip_cron_control_event_object_to_string( $event ) {
  */
 function wpcom_vip_log_cron_control_uncacheable_cron_option( $option_size, $buckets, $option_flat_count ) {
 	$message = sprintf( 'Cron Control Cron Option Uncacheable Alert - home: %s | option size: %d | buckets: %d | option flat count: %d', home_url( '/' ), $option_size, $buckets, $option_flat_count );
-	if( ! wpcom_vip_irc( 'vipv2-alerts', $message, 2 ) ) {
-		error_log( "IRC message failed. " . $message);
-	}
+	wpcom_vip_irc( 'vipv2-alerts', $message, 2 );
 }
 
 /**

--- a/001-cron.php
+++ b/001-cron.php
@@ -118,7 +118,7 @@ function wpcom_vip_cron_control_event_object_to_string( $event ) {
  */
 function wpcom_vip_log_cron_control_uncacheable_cron_option( $option_size, $buckets, $option_flat_count ) {
 	$message = sprintf( 'Cron Control Cron Option Uncacheable Alert - home: %s | option size: %d | buckets: %d | option flat count: %d', home_url( '/' ), $option_size, $buckets, $option_flat_count );
-	wpcom_vip_irc( 'vipv2-alerts', $message, 2 );
+	wpcom_vip_irc( 'vipv2-alerts', $message, 2, '', 5 );
 }
 
 /**


### PR DESCRIPTION
## Description

[PLAT-888]

Added IRC/Slack alert for uncacheable cron options in cron-control. 

Still have to test this properly on a Vip Go sandbox and explore mu-plugins a bit more since it still feels a bit rough to me.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [X] This change has relevant unit tests (if applicable).
- [X] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Checkout the PR and either: 
- run a  `do_action` on `a8c_cron_control_uncacheable_cron_option`; or
- make the cron option too big(overload the `a8c_cron_control_jobs` database table) or lower the `MAX_CACHE_BUCKET` value.

[PLAT-888]: https://vipjira.atlassian.net/browse/PLAT-888