### PR TITLE
Start health check only on production env

### DIFF
--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -63,9 +63,16 @@ class Elasticsearch {
 	}
 
 	protected function setup_healthchecks() {
-		// Only start healthcheck job on production env
-		if ( 'production' === VIP_GO_ENV ) {
+		/**
+		 * Filter wether to enable VIP search healthcheck
+		 *
+		 * @param		bool	$enable		True to enable the healthcheck cron job
+		 */
+		$enable = apply_filters( 'enable_vip_search_healthchecks', 'production' === VIP_GO_ENV );
+		if ( $enable ) {
 			$healhcheck = new HealthJob();
+
+			// Hook into init action to ensure cron-control has already been loaded
 			add_action( 'init', [ $healhcheck, 'init' ] );
 		}
 	}

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -63,8 +63,11 @@ class Elasticsearch {
 	}
 
 	protected function setup_healthchecks() {
-		$healhcheck = new HealthJob();
-		add_action( 'init', [ $healhcheck, 'init' ] );
+		// Only start healthcheck job on production env
+		if ( 'production' === VIP_GO_ENV ) {
+			$healhcheck = new HealthJob();
+			add_action( 'init', [ $healhcheck, 'init' ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description

Limit the Elasticsearch health check cron job to only run on `production` sites.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

Example:

1. Check out PR.
1. Sandbox a production site
1. `wp cron-control events list`
1. Ensure the `vip_search_healthcheck` job is scheduled
