### PR TITLE
Shared plugins: Add defensive code to fix Warning

### DIFF
--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -273,6 +273,10 @@ add_action( 'admin_enqueue_scripts', 'wpcom_vip_plugins_ui_admin_enqueue_scripts
 function wpcom_vip_include_active_plugins() {
 	$retired_plugins_option = get_option( 'wpcom_vip_active_plugins', array() );
 
+	if ( ! is_array( $retired_plugins_option ) ) {
+		return;
+	}
+
 	foreach ( $retired_plugins_option as $plugin ) {
 		 wpcom_vip_load_plugin( $plugin );
 	}


### PR DESCRIPTION
## Description

Ensures that if a value stored in `wpcom_vip_active_plugins` is not an array, that the subsequent `foreach` does not run. Without it, "Invalid argument supplied for foreach" PHP Warnings are generated (currently ~3700 per day on VIP Go).

Fix could optionally also include a ` || empty( retired_plugins_option )` in the conditional as well, though the `foreach` should not through a warning for an empty array. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `wp option set wpcom_vip_active_plugins notanarray`
1. Load site and check logs for "Invalid argument supplied for foreach" PHP Warnings.
1. Apply PR
1. Load site again, and check for no new PHP Warnings.
