### PR TITLE
Increase ep_bulk_items_per_page and EP_SYNC_CHUNK_LIMIT to 500

### DIFF
--- a/elasticsearch/elasticpress/includes/classes/Indexable.php
+++ b/elasticsearch/elasticpress/includes/classes/Indexable.php
@@ -70,7 +70,7 @@ abstract class Indexable {
 		 * @return  {int} New number of items
 		 * @since  3.0
 		 */
-		return apply_filters( 'ep_bulk_items_per_page', 350, $this );
+		return apply_filters( 'ep_bulk_items_per_page', 500, $this );
 	}
 
 	/**

--- a/elasticsearch/elasticpress/includes/classes/Indexable.php
+++ b/elasticsearch/elasticpress/includes/classes/Indexable.php
@@ -70,7 +70,7 @@ abstract class Indexable {
 		 * @return  {int} New number of items
 		 * @since  3.0
 		 */
-		return apply_filters( 'ep_bulk_items_per_page', 500, $this );
+		return apply_filters( 'ep_bulk_items_per_page', 350, $this );
 	}
 
 	/**

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -51,7 +51,7 @@ class Elasticsearch {
 		add_filter( 'ep_index_name', [ $this, 'filter__ep_index_name' ], PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
 
 		// Override default per page value set in elasticsearch/elasticpress/includes/classes/Indexable.php
-		add_filter( 'ep_bulk_items_per_page', function() { return 500; } );
+		add_filter( 'ep_bulk_items_per_page', [ $this, 'filter__ep_bulk_items_per_page' ], PHP_INT_MAX, 0 );
 
 		// Network layer replacement to use VIP helpers (that handle slow/down upstream server)
 		add_filter( 'ep_intercept_remote_request', '__return_true', 9999 );
@@ -83,6 +83,13 @@ class Elasticsearch {
 		}
 
 		return $index_name;
+	}
+
+	/**
+	 * Filter to set ep_bulk_items_per_page to 500
+	 */
+	public function filter__ep_bulk_items_per_page() {
+		return 500;
 	}
 
 	public function filter__ep_do_intercept_request( $request, $query, $args, $failures ) {

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -33,7 +33,7 @@ class Elasticsearch {
 	protected function setup_constants() {
 		// Ensure we limit bulk indexing chunk size to a reasonable number (no limit by default)
 		if ( ! defined( 'EP_SYNC_CHUNK_LIMIT' ) ) {
-			define( 'EP_SYNC_CHUNK_LIMIT', 250 );
+			define( 'EP_SYNC_CHUNK_LIMIT', 500 );
 		}
 
 		if ( ! defined( 'EP_HOST' ) && defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) && is_array( VIP_ELASTICSEARCH_ENDPOINTS ) ) {

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -50,6 +50,9 @@ class Elasticsearch {
 	protected function setup_hooks() {
 		add_filter( 'ep_index_name', [ $this, 'filter__ep_index_name' ], PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
 
+		// Override default per page value set in elasticsearch/elasticpress/includes/classes/Indexable.php
+		add_filter( 'ep_bulk_items_per_page', function() { return 500; } );
+
 		// Network layer replacement to use VIP helpers (that handle slow/down upstream server)
 		add_filter( 'ep_intercept_remote_request', '__return_true', 9999 );
 		add_filter( 'ep_do_intercept_request', [ $this, 'filter__ep_do_intercept_request' ], 9999, 4 );

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -51,7 +51,7 @@ class Elasticsearch {
 		add_filter( 'ep_index_name', [ $this, 'filter__ep_index_name' ], PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
 
 		// Override default per page value set in elasticsearch/elasticpress/includes/classes/Indexable.php
-		add_filter( 'ep_bulk_items_per_page', [ $this, 'filter__ep_bulk_items_per_page' ], PHP_INT_MAX, 0 );
+		add_filter( 'ep_bulk_items_per_page', [ $this, 'filter__ep_bulk_items_per_page' ], PHP_INT_MAX );
 
 		// Network layer replacement to use VIP helpers (that handle slow/down upstream server)
 		add_filter( 'ep_intercept_remote_request', '__return_true', 9999 );

--- a/tests/elasticsearch/test-class-elasticsearch.php
+++ b/tests/elasticsearch/test-class-elasticsearch.php
@@ -64,7 +64,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
 		$es->init();
 
-		$this->assertEquals( EP_SYNC_CHUNK_LIMIT, 250 );
+		$this->assertEquals( EP_SYNC_CHUNK_LIMIT, 500 );
 	}
 
 	/**


### PR DESCRIPTION
## Description

PLAT-885

Increase ep_bulk_items_per_page and EP_SYNC_CHUNK_LIMIT to 500

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

TBD