### PR TITLE
Deactivate jetpack widgets when VIP search is enabled

### DIFF
--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -110,7 +110,17 @@ class Elasticsearch {
 		return array_values( $filtered );
 	}
 
-	public function filter__jetpack_widgets_to_include( $widget_include ) {
-		return [];
+	public function filter__jetpack_widgets_to_include( $widgets ) {
+		if ( ! is_array( $widgets ) ) {
+			return $widgets;
+		}
+
+		foreach( $widgets as $index => $file ) {
+			if( wp_endswith( $file, '/jetpack/modules/widgets/search.php' ) ) {
+				unset( $widgets[ $index ] );
+			}
+		}
+
+		return $widgets;
 	}
 }

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -116,6 +116,8 @@ class Elasticsearch {
 		}
 
 		foreach( $widgets as $index => $file ) {
+			// If the Search widget is included and it's active on a site, it will automatically re-enable the Search module,
+			// even though we filtered it to off earlier, so we need to prevent it from loading
 			if( wp_endswith( $file, '/jetpack/modules/widgets/search.php' ) ) {
 				unset( $widgets[ $index ] );
 			}

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -123,6 +123,9 @@ class Elasticsearch {
 			}
 		}
 
+		// Flatten the array back down now that may have removed values from the middle (to keep indexes correct)
+		$widgets = array_values( $widgets );
+
 		return $widgets;
 	}
 }

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -54,6 +54,9 @@ class Elasticsearch {
 		add_filter( 'ep_intercept_remote_request', '__return_true', 9999 );
 		add_filter( 'ep_do_intercept_request', [ $this, 'filter__ep_do_intercept_request' ], 9999, 4 );
 		add_filter( 'jetpack_active_modules', [ $this, 'filter__jetpack_active_modules' ], 9999 );
+
+		//Filter jetpack widgets
+		add_filter( 'jetpack_widgets_to_include', [ $this, 'filter__jetpack_widgets_to_include' ], 10, 1 );
 	}
 
 	protected function load_commands() {
@@ -105,5 +108,9 @@ class Elasticsearch {
 
 		// array_filter() preserves keys, so to get a clean / flat array we must pass it through array_values()
 		return array_values( $filtered );
+	}
+
+	public function filter__jetpack_widgets_to_include( $widget_include ) {
+		return [];
 	}
 }

--- a/tests/elasticsearch/test-class-elasticsearch.php
+++ b/tests/elasticsearch/test-class-elasticsearch.php
@@ -233,4 +233,59 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	public function vip_elasticsearch_filter__jetpack_widgets_to_include_data() {
+		return array(
+			array(
+				// Input
+				array(
+					'/path/to/jetpack/modules/widgets/file.php',
+					'/path/to/jetpack/modules/widgets/other.php',
+				),
+
+				// Expected
+				array(
+					'/path/to/jetpack/modules/widgets/file.php',
+					'/path/to/jetpack/modules/widgets/other.php',
+				),
+			),
+
+			array(
+				// Input
+				array(
+					'/path/to/jetpack/modules/widgets/file.php',
+					'/path/to/jetpack/modules/widgets/search.php',
+					'/path/to/jetpack/modules/widgets/other.php',
+				),
+
+				// Expected
+				array(
+					'/path/to/jetpack/modules/widgets/file.php',
+					'/path/to/jetpack/modules/widgets/other.php',
+				),
+			),
+
+			array(
+				// Input
+				12345, // non-array
+
+				// Expected
+				12345,
+			),
+		);
+	}
+
+	/**
+	 * Test that the widgets filter works as expected
+	 * 
+	 * @dataProvider vip_elasticsearch_filter__jetpack_widgets_to_include_data
+	 */
+	public function test__vip_elasticsearch_filter__jetpack_widgets_to_include( $input, $expected ) {
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$result = $es->filter__jetpack_widgets_to_include( $input );
+
+		$this->assertEquals( $expected, $result );
+	}
 }


### PR DESCRIPTION
## Description

Deactivate all the automatically registered Jetpack widgets when VIP Search is enabled as the widgets will force the site to keep using Jetpack search.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Pull down PR
1. Enable JP Search + a widget on a test site
1. Set `USE_VIP_ELASTICSEARCH` to true in wp-config.php
1. Run a query on the frontend - JP Search should not enable itself (check Debug Bar for any Elasticsearch queries from JP)
