### PR TITLE
Fix fatal error in validate-health command

### DIFF
--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -90,7 +90,7 @@ class HealthJob {
 	 */
 	protected function process_results( $result ) {
 		// If there's an error, alert
-		if( array_key_exists( 'error', $results ) ) {
+		if( array_key_exists( 'error', $result ) ) {
 			wpcom_vip_irc(
 				'#vip-go-es-alerts',
 				sprintf( 'Error while validating index for %s: %s',

--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -51,7 +51,6 @@ class Health {
 		// There is not other useful information out of query_es(): it just returns false in case of failure
 		if ( ! $es_result ) {
 			$es_total = 'N/A';
-			$msg = 'error while querying ElasticSearch.';
 			return new WP_Error( 'es_query_error', 'failure querying ES. Hint: verify arguments format. #vip-go-elasticsearch' );
 		}
 

--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -79,6 +79,15 @@ class Health {
 	 */
 	public static function validate_index_users_count() {
 		$users = Indexables::factory()->get( 'user' );
+		// Indexables::factory()->get() returns boolean|array
+		// False is returned in case of error
+		if ( ! $users ) {
+			$result = [
+				'entity' => 'user',
+				'type' => 'N/A',
+				'error' => 'Error retrieving users indexables from Elasticsearch',
+			];
+		}
 
 		$query_args = [
 			'order' => 'asc',

--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -82,11 +82,7 @@ class Health {
 		// Indexables::factory()->get() returns boolean|array
 		// False is returned in case of error
 		if ( ! $users ) {
-			$result = [
-				'entity' => 'user',
-				'type' => 'N/A',
-				'error' => 'Error retrieving users documents from Elasticsearch',
-			];
+			return new WP_Error( 'es_users_query_error', 'failure retrieving user documents from ES #vip-go-elasticsearch' );
 		}
 
 		$query_args = [
@@ -95,11 +91,7 @@ class Health {
 
 		$result = self::validate_index_entity_count( $query_args, $users );
 		if ( is_wp_error( $result ) ) {
-			$result = [
-				'entity' => $users->slug,
-				'type' => 'N/A',
-				'error' => $result->get_error_message()
-			];
+			return new WP_Error( 'es_users_query_error', sprintf( 'failure retrieving users from ES: %s #vip-go-elasticsearch', $result->get_error_message() ) );
 		}
 		return array( $result );
 	}
@@ -116,11 +108,7 @@ class Health {
 		// Indexables::factory()->get() returns boolean|array
 		// False is returned in case of error
 		if ( ! $posts ) {
-			$result = [
-				'entity' => 'post',
-				'type' => 'N/A',
-				'error' => 'Error retrieving posts documents from Elasticsearch',
-			];
+			return new WP_Error( 'es_users_query_error', 'failure retrieving post documents from ES #vip-go-elasticsearch' );
 		}
 
 		$post_types = $posts->get_indexable_post_types();
@@ -138,6 +126,7 @@ class Health {
 			$result = self::validate_index_entity_count( $query_args, $posts );
 
 			// In case of error skip to the next post type
+			// Not returning an error, otherwise there is no visibility on other post types
 			if ( is_wp_error( $result ) ) {
 				$result = [
 					'entity' => $posts->slug,

--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -85,7 +85,7 @@ class Health {
 			$result = [
 				'entity' => 'user',
 				'type' => 'N/A',
-				'error' => 'Error retrieving users indexables from Elasticsearch',
+				'error' => 'Error retrieving users documents from Elasticsearch',
 			];
 		}
 
@@ -112,6 +112,16 @@ class Health {
 	public static function validate_index_posts_count() {
 		// Get indexable objects
 		$posts = Indexables::factory()->get( 'post' );
+
+		// Indexables::factory()->get() returns boolean|array
+		// False is returned in case of error
+		if ( ! $posts ) {
+			$result = [
+				'entity' => 'post',
+				'type' => 'N/A',
+				'error' => 'Error retrieving posts documents from Elasticsearch',
+			];
+		}
 
 		$post_types = $posts->get_indexable_post_types();
 

--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -48,10 +48,11 @@ class Health {
 			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-go-elasticsearch', $e->get_error_message() ) );
 		}
 
-		// There is not other useful information out of query_es(): it just returns false in case of failure
+		// There is not other useful information out of query_es(): it just returns false in case of failure.
+		// This may be due to different causes, e.g. index not existing or incorrect connection parameters.
 		if ( ! $es_result ) {
 			$es_total = 'N/A';
-			return new WP_Error( 'es_query_error', 'failure querying ES. Hint: verify arguments format. #vip-go-elasticsearch' );
+			return new WP_Error( 'es_query_error', 'failure querying ES. #vip-go-elasticsearch' );
 		}
 
 		// Verify actual results

--- a/elasticsearch/includes/classes/commands/class-healthcommand.php
+++ b/elasticsearch/includes/classes/commands/class-healthcommand.php
@@ -80,7 +80,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		foreach( $results as $result ) {
 			// If it's an error, print out a warning and go to the next iteration
 			if ( array_key_exists( 'error', $result ) ) {
-				WP_CLI::warning( 'Error while validating count:' . $result->get_error_message() );
+				WP_CLI::warning( 'Error while validating count:' . $result[ 'error' ]);
 				continue;
 			}
 

--- a/elasticsearch/includes/classes/commands/class-healthcommand.php
+++ b/elasticsearch/includes/classes/commands/class-healthcommand.php
@@ -52,6 +52,10 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		WP_CLI::line( sprintf( "Validating users count\n" ) );
 
 		$users_results = \Automattic\VIP\Elasticsearch\Health::validate_index_users_count();
+		if ( is_wp_error( $users_results ) ) {
+			WP_CLI::warning( $users_results->get_error_message() );
+			return;
+		}
 		$this->render_results( $users_results );
 	}
 

--- a/elasticsearch/includes/classes/commands/class-healthcommand.php
+++ b/elasticsearch/includes/classes/commands/class-healthcommand.php
@@ -80,7 +80,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		foreach( $results as $result ) {
 			// If it's an error, print out a warning and go to the next iteration
 			if ( array_key_exists( 'error', $result ) ) {
-				WP_CLI::warning( 'Error while validating count:' . $result[ 'error' ]);
+				WP_CLI::warning( 'Error while validating count: ' . $result[ 'error' ]);
 				continue;
 			}
 


### PR DESCRIPTION
## Description

Fixes [PLAT-911].
Also adds a missing check on the result of `Indexables::factory()->get()` that may return `boolean|Array`.
In case of failure, that function returns `false` so we must take that into account.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Delete ES indexes on test site: `dcwp elasticpress delete-index`.
1. Run the validation command: `dcwp vip-es health validate-counts`.
1. Verify that no stacktrace gets printed out.


[PLAT-911]: https://vipjira.atlassian.net/browse/PLAT-911