### PR TITLE
Add debug-bar-elasticpress submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,4 +46,6 @@
 [submodule "elasticsearch/elasticpress"]
 	path = elasticsearch/elasticpress
 	url = https://github.com/Automattic/ElasticPress.git
-	branch = develop
+[submodule "elasticsearch/debug-bar-elasticpress"]
+	path = elasticsearch/debug-bar-elasticpress
+	url = https://github.com/10up/debug-bar-elasticpress.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -46,6 +46,7 @@
 [submodule "elasticsearch/elasticpress"]
 	path = elasticsearch/elasticpress
 	url = https://github.com/Automattic/ElasticPress.git
+	branch = develop
 [submodule "elasticsearch/debug-bar-elasticpress"]
 	path = elasticsearch/debug-bar-elasticpress
 	url = https://github.com/10up/debug-bar-elasticpress.git

--- a/elasticsearch/elasticsearch.php
+++ b/elasticsearch/elasticsearch.php
@@ -20,4 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/includes/classes/class-elasticsearch.php';
 
+// Load ElasticPress
+require_once __DIR__ . '/elasticpress/elasticpress.php';
+// Load ElasticPress Debug Bar
+require_once __DIR__ . '/debug-bar-elasticpress/debug-bar-elasticpress.php';
+
+
 do_action( 'vip_search_loaded' );

--- a/elasticsearch/elasticsearch.php
+++ b/elasticsearch/elasticsearch.php
@@ -20,10 +20,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/includes/classes/class-elasticsearch.php';
 
-// Load ElasticPress
-require_once __DIR__ . '/elasticpress/elasticpress.php';
-// Load ElasticPress Debug Bar
-require_once __DIR__ . '/debug-bar-elasticpress/debug-bar-elasticpress.php';
-
-
 do_action( 'vip_search_loaded' );

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -23,10 +23,6 @@ class Elasticsearch {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 		}
-		// Load ElasticPress
-		require_once __DIR__ . '/../../elasticpress/elasticpress.php';
-		// Load ElasticPress Debug Bar
-		require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
 
 		// Load health check cron job
 		require_once __DIR__ . '/class-health-job.php';

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -88,7 +88,7 @@ class Elasticsearch {
 
 	public function action__plugins_loaded() {
 		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
-		// NOTE - must hook in here b/c the functions required for checking if debug bar is enabled aren't loaded earlier
+		// NOTE - must hook in here b/c the wp_get_current_user function required for checking if debug bar is enabled isn't loaded earlier
 		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
 			// Load ElasticPress Debug Bar
 			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -24,6 +24,15 @@ class Elasticsearch {
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 		}
 
+		// Load ElasticPress
+		require_once __DIR__ . '/elasticpress/elasticpress.php';
+
+		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
+		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
+			// Load ElasticPress Debug Bar
+			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
+		}
+
 		// Load health check cron job
 		require_once __DIR__ . '/class-health-job.php';
 	}

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -25,6 +25,8 @@ class Elasticsearch {
 		}
 		// Load ElasticPress
 		require_once __DIR__ . '/../../elasticpress/elasticpress.php';
+		// Load ElasticPress Debug Bar
+		require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
 
 		// Load health check cron job
 		require_once __DIR__ . '/class-health-job.php';

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -25,12 +25,8 @@ class Elasticsearch {
 		}
 		// Load ElasticPress
 		require_once __DIR__ . '/../../elasticpress/elasticpress.php';
-
-		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
-		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
-			// Load ElasticPress Debug Bar
-			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
-		}
+		// Load ElasticPress Debug Bar
+		require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
 
 		// Load health check cron job
 		require_once __DIR__ . '/class-health-job.php';

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -27,12 +27,6 @@ class Elasticsearch {
 		// Load ElasticPress
 		require_once __DIR__ . '/../../elasticpress/elasticpress.php';
 
-		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
-		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
-			// Load ElasticPress Debug Bar
-			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
-		}
-
 		// Load health check cron job
 		require_once __DIR__ . '/class-health-job.php';
 	}
@@ -55,6 +49,8 @@ class Elasticsearch {
 	}
 
 	protected function setup_hooks() {
+		add_action( 'plugins_loaded', [ $this, 'action__plugins_loaded' ] );
+
 		add_filter( 'ep_index_name', [ $this, 'filter__ep_index_name' ], PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
 
 		// Override default per page value set in elasticsearch/elasticpress/includes/classes/Indexable.php
@@ -87,6 +83,15 @@ class Elasticsearch {
 
 			// Hook into init action to ensure cron-control has already been loaded
 			add_action( 'init', [ $healhcheck, 'init' ] );
+		}
+	}
+
+	public function action__plugins_loaded() {
+		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
+		// NOTE - must hook in here b/c the functions required for checking if debug bar is enabled aren't loaded earlier
+		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
+			// Load ElasticPress Debug Bar
+			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
 		}
 	}
 

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -25,7 +25,7 @@ class Elasticsearch {
 		}
 
 		// Load ElasticPress
-		require_once __DIR__ . '/elasticpress/elasticpress.php';
+		require_once __DIR__ . '/../../elasticpress/elasticpress.php';
 
 		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
 		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -25,8 +25,12 @@ class Elasticsearch {
 		}
 		// Load ElasticPress
 		require_once __DIR__ . '/../../elasticpress/elasticpress.php';
-		// Load ElasticPress Debug Bar
-		require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
+
+		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
+		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
+			// Load ElasticPress Debug Bar
+			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
+		}
 
 		// Load health check cron job
 		require_once __DIR__ . '/class-health-job.php';

--- a/tests/elasticsearch/test-class-elasticsearch.php
+++ b/tests/elasticsearch/test-class-elasticsearch.php
@@ -130,6 +130,94 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that we load the ElasticPress Debug Bar plugin when Debug Bar is showing
+	 */
+	public function test__vip_elasticsearch_loads_ep_debug_bar_when_debug_bar_showing() {
+		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
+		remove_all_filters( 'debug_bar_enable' );
+
+		// Debug bar enabled
+		add_filter( 'debug_bar_enable', '__return_true', PHP_INT_MAX );
+
+		// Be sure we don't already have the class loaded (or our test does nothing)
+		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );
+
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$es->action__plugins_loaded();
+
+		// Class should now exist
+		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ) );
+	}
+
+	/**
+	 * Test that we load the ElasticPress Debug Bar plugin when Debug Bar is disabled, but Query Monitor is showing
+	 */
+	public function test__vip_elasticsearch_loads_ep_debug_bar_when_debug_bar_disabled_but_qm_enabled() {
+		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
+		remove_all_filters( 'debug_bar_enable' );
+
+		// Debug bar enabled
+		add_filter( 'debug_bar_enable', '__return_false', PHP_INT_MAX );
+		add_filter( 'wpcom_vip_qm_enable', '__return_true', PHP_INT_MAX );
+
+		// Be sure we don't already have the class loaded (or our test does nothing)
+		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );
+
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$es->action__plugins_loaded();
+
+		// Class should now exist
+		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ) );
+	}
+
+	/**
+	 * Test that we load the ElasticPress Debug Bar plugin when both Debug Bar Query Monitor are showing
+	 */
+	public function test__vip_elasticsearch_loads_ep_debug_bar_when_debug_bar_and_qm_enabled() {
+		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
+		remove_all_filters( 'debug_bar_enable' );
+
+		// Debug bar enabled
+		add_filter( 'debug_bar_enable', '__return_true', PHP_INT_MAX );
+		add_filter( 'wpcom_vip_qm_enable', '__return_true', PHP_INT_MAX );
+
+		// Be sure we don't already have the class loaded (or our test does nothing)
+		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );
+
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$es->action__plugins_loaded();
+
+		// Class should now exist
+		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ) );
+	}
+
+	/**
+	 * Test that we don't load the ElasticPress Debug Bar plugin when neither Debug Bar or Query Monitor are showing
+	 */
+	public function test__vip_elasticsearch_does_not_load_ep_debug_bar_when_debug_bar_and_qm_disabled() {
+		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
+		remove_all_filters( 'debug_bar_enable' );
+
+		// Debug bar enabled
+		add_filter( 'debug_bar_enable', '__return_false', PHP_INT_MAX );
+		add_filter( 'wpcom_vip_qm_enable', '__return_false', PHP_INT_MAX );
+
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$es->action__plugins_loaded();
+
+		// Class should not exist
+		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );
+	}
+
+	/**
 	 * Test that we are sending HTTP requests through the VIP helper functions
 	 */
 	public function test__vip_elasticsearch_has_http_layer_filters() {

--- a/tests/elasticsearch/test-class-elasticsearch.php
+++ b/tests/elasticsearch/test-class-elasticsearch.php
@@ -158,8 +158,9 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
 		remove_all_filters( 'debug_bar_enable' );
 
-		// Debug bar enabled
+		// Debug bar disabled
 		add_filter( 'debug_bar_enable', '__return_false', PHP_INT_MAX );
+		// But QM enabled
 		add_filter( 'wpcom_vip_qm_enable', '__return_true', PHP_INT_MAX );
 
 		// Be sure we don't already have the class loaded (or our test does nothing)
@@ -183,6 +184,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 
 		// Debug bar enabled
 		add_filter( 'debug_bar_enable', '__return_true', PHP_INT_MAX );
+		// And QM enabled
 		add_filter( 'wpcom_vip_qm_enable', '__return_true', PHP_INT_MAX );
 
 		// Be sure we don't already have the class loaded (or our test does nothing)
@@ -204,8 +206,9 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
 		remove_all_filters( 'debug_bar_enable' );
 
-		// Debug bar enabled
+		// Debug bar disabled
 		add_filter( 'debug_bar_enable', '__return_false', PHP_INT_MAX );
+		// And QM disabled
 		add_filter( 'wpcom_vip_qm_enable', '__return_false', PHP_INT_MAX );
 
 		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();


### PR DESCRIPTION
## Description

Fixes [PLAT-924].

Adds the debug bar plugin for ElasticPress and loads it if ES is enabled and EP is loaded.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Clone the PR on a sandbox host.
Sandbox a site and activate VIP Search; verify that the Debug bar contains an "Elastic Press" item.
Query monitor should not contain anything related to EP, instead.

[PLAT-924]: https://vipjira.atlassian.net/browse/PLAT-924