### PR TITLE
Fix typo in variable name

### DIFF
--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -86,11 +86,11 @@ class HealthJob {
 	 * Process the health check result
 	 *
 	 * @access	protected
-	 * @param		array		$result		Array of results from Health index validation
+	 * @param	array		$result		Array of results from Health index validation
 	 */
 	protected function process_results( $result ) {
 		// If there's an error, alert
-		if( array_key_exists( 'error', $results ) ) {
+		if( array_key_exists( 'error', $result ) ) {
 			wpcom_vip_irc(
 				'#vip-go-es-alerts',
 				sprintf( 'Error while validating index for %s: %s',


### PR DESCRIPTION
## Description

Found by looking at PHP logs:

```
phpfpm_1         | NOTICE: PHP message: PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /var/www/html/wp-content/mu-plugins/elasticsearch/includes/classes/class-health-job.php on line 93
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Look at your PHP (or phpfpm if you are using 10updocker) logs, they should be clean, no warnings.
