### PR TITLE
Remove ElasticPress dashboard

### DIFF
--- a/elasticsearch/includes/classes/class-dashboard.php
+++ b/elasticsearch/includes/classes/class-dashboard.php
@@ -1,5 +1,19 @@
 <?php
 
-add_action( 'admin_init', function() {
-	remove_menu_page( 'elasticpress' );
-} );
+namespace Automattic\VIP\Elasticsearch;
+
+class Dashboard {
+
+	function __construct() {
+		add_action( 'admin_init', array( __CLASS__, 'admin_init' ) );
+	}
+
+	/**
+	 * Disable the Elasticpress dashboard
+	 */
+	function admin_init() {
+		remove_menu_page( 'elasticpress' );
+	}
+}
+
+new Dashboard;

--- a/elasticsearch/includes/classes/class-dashboard.php
+++ b/elasticsearch/includes/classes/class-dashboard.php
@@ -11,7 +11,7 @@ class Dashboard {
 	/**
 	 * Disable the Elasticpress dashboard
 	 */
-	function admin_init() {
+	static function admin_init() {
 		if ( ! is_automattician() ) {
 			remove_menu_page( 'elasticpress' );
 		}

--- a/elasticsearch/includes/classes/class-dashboard.php
+++ b/elasticsearch/includes/classes/class-dashboard.php
@@ -1,0 +1,5 @@
+<?php
+
+add_action( 'admin_init', function() {
+	remove_menu_page( 'elasticpress' );
+} );

--- a/elasticsearch/includes/classes/class-dashboard.php
+++ b/elasticsearch/includes/classes/class-dashboard.php
@@ -12,7 +12,9 @@ class Dashboard {
 	 * Disable the Elasticpress dashboard
 	 */
 	function admin_init() {
-		remove_menu_page( 'elasticpress' );
+		if ( ! is_automattician() ) {
+			remove_menu_page( 'elasticpress' );
+		}
 	}
 }
 

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -28,6 +28,9 @@ class Elasticsearch {
 
 		// Load health check cron job
 		require_once __DIR__ . '/class-health-job.php';
+
+		// Load our custom dashboard
+		require_once __DIR__ . '/class-dashboard.php';
 	}
 
 	protected function setup_constants() {


### PR DESCRIPTION
We don't need most of the EP dashboard. We'll provide a custom
dashboard for things like health info and we don't want it to
be possible to trigger an index operation from the dashboard.

Note: This only hides the dashboard so far. We'll also want to
explicitly block indexing from the dashboard.