### PR TITLE
Switch Elasticsearch auto-loader to require_once

### DIFF
--- a/elasticsearch/elasticsearch.php
+++ b/elasticsearch/elasticsearch.php
@@ -17,33 +17,7 @@ namespace Automattic\VIP\Elasticsearch;
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-/**
-* PSR-4-ish autoloading
-*
-* @since 1.0
-*/
-spl_autoload_register( function( $class ) {
-	// project-specific namespace prefix.
-	$prefix = 'Automattic\\VIP\\Elasticsearch\\';
 
-	// base directory for the namespace prefix.
-	$base_dir = __DIR__ . '/includes/classes/';
-
-	// does the class use the namespace prefix?
-	$len = strlen( $prefix );
-
-	if ( strncmp( $prefix, $class, $len ) !== 0 ) {
-		return;
-	}
-
-	$relative_class = strtolower( substr( $class, $len ) );
-
-	$file = $base_dir . 'class-' . str_replace( '\\', '/', $relative_class ) . '.php';
-
-	// if the file exists, require it.
-	if ( file_exists( $file ) ) {
-		require_once $file;
-	}
-} );
+require_once __DIR__ . '/includes/classes/class-elasticsearch.php';
 
 do_action( 'vip_search_loaded' );


### PR DESCRIPTION
Since we're only requiring one file here, an auto-loader seems a bit
overkill. Having the explicit `require_once` line leaves no doubt
about what code is running and where.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. `define( 'USE_VIP_ELASTICSEARCH', true );`
1. Go to `wp-admin`
1. Verify ElasticPress menu shows on the left