### PR TITLE
Add EP_DASHBOARD_SYNC constant

### DIFF
--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -45,6 +45,12 @@ class Elasticsearch {
 		if ( ! defined( 'ES_SHIELD' ) && ( defined( 'VIP_ELASTICSEARCH_USERNAME' ) && defined( 'VIP_ELASTICSEARCH_PASSWORD' ) ) ) {
 			define( 'ES_SHIELD', sprintf( '%s:%s', VIP_ELASTICSEARCH_USERNAME, VIP_ELASTICSEARCH_PASSWORD ) );
 		}
+
+		// Do not allow sync via Dashboard (WP-CLI is preferred for indexing).
+		// The Dashboard is hidden anyway but just in case.
+		if ( ! defined( 'EP_DASHBOARD_SYNC' ) ) {
+			define( 'EP_DASHBOARD_SYNC', false );
+		}
 	}
 
 	protected function setup_hooks() {


### PR DESCRIPTION
Do not allow sync via Dashboard (WP-CLI is preferred for indexing). The Dashboard is hidden anyway but just in case.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. On a site with VIP Search enabled, `wp shell`.
1. `constant( 'EP_DASHBOARD_SYNC' )` should be false.
