### PR TITLE
Fix missing require for es health class and typo

### DIFF
--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -5,6 +5,8 @@ namespace Automattic\VIP\Elasticsearch;
 use \WP_CLI;
 
 class Elasticsearch {
+	public $healthcheck;
+
 	/**
 	 * Initialize the VIP Elasticsearch plugin
 	 */
@@ -88,11 +90,12 @@ class Elasticsearch {
 		 * @param		bool	$enable		True to enable the healthcheck cron job
 		 */
 		$enable = apply_filters( 'enable_vip_search_healthchecks', 'production' === VIP_GO_ENV );
+	
 		if ( $enable ) {
-			$healhcheck = new HealthJob();
+			$this->healthcheck = new HealthJob();
 
 			// Hook into init action to ensure cron-control has already been loaded
-			add_action( 'init', [ $healhcheck, 'init' ] );
+			add_action( 'init', [ $this->healthcheck, 'init' ] );
 		}
 	}
 

--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -116,7 +116,7 @@ class HealthJob {
 			}
 
 			// Only alert if inconsistencies found
-			if ( $result[ 'diff' ] ) {
+			if ( isset( $result[ 'diff' ] ) ) {
 				wpcom_vip_irc(
 					'#vip-go-es-alerts',
 					sprintf( 'Index inconsistencies found for %s: (entity: %s, type: %s, DB count: %s, ES count: %s, Diff: %s)',

--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -4,6 +4,8 @@ namespace Automattic\VIP\Elasticsearch;
 
 use Automattic\VIP\Elasticsearch\Health as Health;
 
+require_once __DIR__ . '/class-health.php';
+
 class HealthJob {
 
 	/**

--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -91,12 +91,12 @@ class HealthJob {
 	 */
 	protected function process_results( $results ) {
 		// If the whole thing failed, error
-		if( is_wp_error( $result ) ) {
+		if( is_wp_error( $results ) ) {
 			wpcom_vip_irc(
 				'#vip-go-es-alerts',
 				sprintf( 'Error while validating index for %s: %s',
 				home_url(),
-				$result->get_error_message() ),
+				$results->get_error_message() ),
 				2
 			);
 

--- a/elasticsearch/includes/classes/commands/class-healthcommand.php
+++ b/elasticsearch/includes/classes/commands/class-healthcommand.php
@@ -5,6 +5,8 @@ namespace Automattic\VIP\Elasticsearch\Commands;
 use \WP_CLI;
 use \WP_CLI\Utils;
 
+require_once __DIR__ . '/../class-health.php';
+
 /**
  * Commands to view and manage the health of VIP Go Elasticsearch indexes
  *

--- a/tests/elasticsearch/includes/classes/commands/test-class-healthcommand.php
+++ b/tests/elasticsearch/includes/classes/commands/test-class-healthcommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Automattic\VIP\Elasticsearch\Commands;
+
+
+class HealthCommand_Test extends \WP_UnitTestCase {
+	public function setUp() {
+		define( 'WP_CLI', true );
+
+		// require_once __DIR__ . '/../../../../../vip-helpers/vip-wp-cli.php';
+		// require_once __DIR__ . '/../../../../../elasticsearch/elasticsearch.php';
+		// require_once __DIR__ . '/../../../../../elasticsearch/includes/classes/commands/class-healthcommand.php';
+	}
+
+	public function test__vip_search_healthcommand_validate_users_count() {
+		// We have to test under the assumption that the main class has been loaded and initialized,
+		// as it does various setup tasks like including dependencies
+		/*$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$command = new \Automattic\VIP\Elasticsearch\HealthCommand();
+
+		$command->validate_users_count();*/
+
+		$this->markTestIncomplete(
+			'Our test suite is not setup to include the WP CLI plugin at this time'
+		);
+	}
+}

--- a/tests/elasticsearch/includes/classes/commands/test-class-healthcommand.php
+++ b/tests/elasticsearch/includes/classes/commands/test-class-healthcommand.php
@@ -2,10 +2,9 @@
 
 namespace Automattic\VIP\Elasticsearch\Commands;
 
-
 class HealthCommand_Test extends \WP_UnitTestCase {
 	public function setUp() {
-		define( 'WP_CLI', true );
+		// define( 'WP_CLI', true );
 
 		// require_once __DIR__ . '/../../../../../vip-helpers/vip-wp-cli.php';
 		// require_once __DIR__ . '/../../../../../elasticsearch/elasticsearch.php';

--- a/tests/elasticsearch/includes/classes/test-class-healthjob.php
+++ b/tests/elasticsearch/includes/classes/test-class-healthjob.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Automattic\VIP\Elasticsearch;
+
+class HealthJob_Test extends \WP_UnitTestCase {
+	public function setUp() {
+		require_once __DIR__ . '/../../../../elasticsearch/elasticsearch.php';
+		require_once __DIR__ . '/../../../../elasticsearch/includes/classes/class-health-job.php';
+	}
+
+	public function test__vip_search_healthjob_check_health() {
+		// We have to test under the assumption that the main class has been loaded and initialized,
+		// as it does various setup tasks like including dependencies
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$job = new \Automattic\VIP\Elasticsearch\HealthJob();
+
+		$job->check_health();
+	}
+}

--- a/tests/elasticsearch/test-class-elasticsearch.php
+++ b/tests/elasticsearch/test-class-elasticsearch.php
@@ -379,4 +379,33 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	/**
+	 * Test that instantiating the HealthJob works as expected (files are properly included, init is hooked)
+	 */
+	public function test__vip_elasticsearch_setup_healthchecks_with_enabled() {
+		// Need to filter to enable the HealthJob
+		add_filter( 'enable_vip_search_healthchecks', '__return_true' );
+
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		// Should not have fataled (class was included)
+
+		// Should have registered the init action to setup the health check
+		$this->assertEquals( true, has_action( 'init', [ $es->healthcheck, 'init' ] ) );
+	}
+
+	/**
+	 * Test that instantiating the HealthJob does not happen when not in production
+	 */
+	public function test__vip_elasticsearch_setup_healthchecks_disabled_in_non_production_env() {
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		// Should not have fataled (class was included)
+
+		// Should not have instantiated and registered the init action to setup the health check
+		$this->assertEquals( false, isset( $es->healthcheck ) );
+	}
 }


### PR DESCRIPTION
## Description

We're missing some requires now that we removed the autoloader, and I missed updating a variable name in one spot.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. `wp vip-es health validate-counts`
1. `wp shell`
1. `do_action( 'vip_search_healthcheck' );`
