### PR TITLE
Only alert when diff is not 0

### DIFF
--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -116,7 +116,7 @@ class HealthJob {
 			}
 
 			// Only alert if inconsistencies found
-			if ( isset( $result[ 'diff' ] ) ) {
+			if ( isset( $result[ 'diff' ] ) && 0 !== $result[ 'diff' ] ) {
 				wpcom_vip_irc(
 					'#vip-go-es-alerts',
 					sprintf( 'Index inconsistencies found for %s: (entity: %s, type: %s, DB count: %s, ES count: %s, Diff: %s)',

--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -89,7 +89,7 @@ class HealthJob {
 	 * @access	protected
 	 * @param	array		$result		Array of results from Health index validation
 	 */
-	protected function process_results( $results ) {
+	public function process_results( $results ) {
 		// If the whole thing failed, error
 		if( is_wp_error( $results ) ) {
 			$message = sprintf( 'Error while validating index for %s: %s', home_url(), $results->get_error_message() );

--- a/tests/elasticsearch/includes/classes/test-class-healthjob.php
+++ b/tests/elasticsearch/includes/classes/test-class-healthjob.php
@@ -18,4 +18,112 @@ class HealthJob_Test extends \WP_UnitTestCase {
 
 		$job->check_health();
 	}
+
+	/**
+	 * Test that we correctly handle the results of health checks when inconsistencies are found
+	 */
+	public function test__vip_search_healthjob_process_results_with_inconsistencies() {
+		$results = array(
+			array(
+				'entity' => 'post',
+				'type' => 'post',
+				'db_total' => 1000,
+				'es_total' => 900,
+				'diff' => -100,
+			),
+			array(
+				'entity' => 'post',
+				'type' => 'custom_type',
+				'db_total' => 100,
+				'es_total' => 200,
+				'diff' => 100,
+			),
+			array(
+				'entity' => 'users',
+				'type' => 'N/A',
+				'db_total' => 100,
+				'es_total' => 100,
+				'diff' => 0,
+			),
+			array(
+				'error' => 'Foo Error',
+			),
+		);
+
+		// We have to test under the assumption that the main class has been loaded and initialized,
+		// as it does various setup tasks like including dependencies
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$stub = $this->getMockBuilder( \Automattic\VIP\Elasticsearch\HealthJob::class )
+			->setMethods( [ 'send_alert' ] )
+			->getMock();
+
+		$stub->expects( $this->exactly( 3 ) )
+			->method( 'send_alert' )
+			->withConsecutive(
+				array(
+					'#vip-go-es-alerts',
+					sprintf(
+						'Index inconsistencies found for %s: (entity: %s, type: %s, DB count: %s, ES count: %s, Diff: %s)',
+						home_url(),
+						$results[ 0 ][ 'entity' ],
+						$results[ 0 ][ 'type' ],
+						$results[ 0 ][ 'db_total' ],
+						$results[ 0 ][ 'es_total' ],
+						$results[ 0 ][ 'diff' ]
+					),
+					2
+				),
+				array(
+					'#vip-go-es-alerts',
+					sprintf(
+						'Index inconsistencies found for %s: (entity: %s, type: %s, DB count: %s, ES count: %s, Diff: %s)',
+						home_url(),
+						$results[ 1 ][ 'entity' ],
+						$results[ 1 ][ 'type' ],
+						$results[ 1 ][ 'db_total' ],
+						$results[ 1 ][ 'es_total' ],
+						$results[ 1 ][ 'diff' ]
+					),
+					2
+				),
+				// NOTE - we've skipped the 3rd result here b/c it has a diff of 0 and shouldn't alert
+				array(
+					'#vip-go-es-alerts',
+					'Error while validating index for http://example.org: Foo Error',
+					2
+				)
+			)
+			->will( $this->returnValue( true ) );
+
+		$stub->process_results( $results );
+	}
+
+	/**
+	 * Test that we correctly handle the results of health checks when a check fails completely
+	 */
+	public function test__vip_search_healthjob_process_results_with_wp_error() {
+		$results = new \WP_Error( 'foo', 'Bar' );
+
+		// We have to test under the assumption that the main class has been loaded and initialized,
+		// as it does various setup tasks like including dependencies
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$stub = $this->getMockBuilder( \Automattic\VIP\Elasticsearch\HealthJob::class )
+			->setMethods( [ 'send_alert' ] )
+			->getMock();
+
+		$stub->expects( $this->once() )
+			->method( 'send_alert' )
+			->with(
+				'#vip-go-es-alerts',
+				sprintf( 'Error while validating index for %s: %s', home_url(), 'Bar' ),
+				2
+			)
+			->will( $this->returnValue( true ) );
+
+		$stub->process_results( $results );
+	}
 }


### PR DESCRIPTION
## Description

The new isset() to prevent undefined index warnings caused the reporting to run for all results, instead of just those where a diff was detected.

This PR adds tests to `Health::process_results()` to prevent future regressions.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. `wp shell`
1. `do_action( 'vip_search_healthcheck' )`
