### PR TITLE
Manually setup EP Debug Bar logging due to plugins_loaded already firing

### DIFF
--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -108,6 +108,11 @@ class Elasticsearch {
 		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
 			// Load ElasticPress Debug Bar
 			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
+
+			// And ensure the logging has been setup (since it also hooks on plugins_loaded)
+			if ( function_exists( 'ep_setup_query_log' ) ) {
+				ep_setup_query_log();
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

This code runs on plugins_loaded, but the EP debug bar also hooks into plugins_loaded, so we need to explicitly call the setup function ourselves to ensure it registers itself.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run some search queries
1. Ensure queries show up in EP Debug Bar
