### PR TITLE
Term change integration for Search

### DIFF
--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -136,6 +136,8 @@ class Elasticsearch {
 	}
 
 	public function action__edited_term( $term_id, $tt_id, $taxonomy ) {
+		global $wpdb;
+
 		// Find ID of all attached posts (query lifted from wp_delete_term())
 		$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $tt_id ) );
 

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -143,6 +143,9 @@ class Elasticsearch {
 
 		// Bulk index them all
 		\ElasticPress\Indexables::factory()->get( 'post' )->bulk_index( $object_ids );
+		if ( ! count( $object_ids ) ) {
+			return false;
+		}
 	}
 
 	public function action__set_object_terms( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -128,13 +128,14 @@ class Elasticsearch {
 		// Find ID of all attached posts (query lifted from wp_delete_term())
 		$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $tt_id ) );
 
-		// Queue::queue_objects_for_indexing( $object_ids, 'post' );
+		// Bulk index them all
+		\ElasticPress\Indexables::factory()->get( 'post' )->bulk_index( $object_ids );
 	}
 
 	public function action__set_object_terms( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
 		// TODO only run if the taxonomy is one that is indexed...use the ep_sync_taxonomies filter
 
-		// Queue::queue_object_for_indexing( $object_id, 'post' );
+		\ElasticPress\Indexables::factory()->get( 'post' )->index( $object_id );
 	}
 
 	/**

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -80,12 +80,12 @@ class Elasticsearch {
 		add_filter( 'ep_skip_user_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5 );
 
 		// Term changes
-		add_action( 'edited_term', array( __CLASS__, 'action__edited_term' ), 10, 3 );
+		add_action( 'edited_term', array( $this, 'action__edited_term' ), 10, 3 );
 
 		// We hook into individual posts' set_object_terms action instead of delete_term because the latter could fail
 		// part way through (out of memory, timeout) and leave some posts with update terms, others without, and us with an 
 		// inconsistent index. So we handle the individual post change instead as it is definitive and independent
-		add_action( 'set_object_terms', array( __CLASS__, 'action__set_object_terms' ), 10, 6 );
+		add_action( 'set_object_terms', array( $this, 'action__set_object_terms' ), 10, 6 );
 	}
 
 	protected function load_commands() {

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -78,6 +78,15 @@ class Elasticsearch {
 		// Disable query integration by default
 		add_filter( 'ep_skip_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5 );
 		add_filter( 'ep_skip_user_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5 );
+
+		// Term changes
+		add_action( 'edited_term', array( __CLASS__, 'action__edited_term' ), 10, 3 );
+
+		// If we hook into pre_delete_term, we could query the objects and schedule a cron job that can diff
+		// those and what's in the term at runtime, to detect if the deletion failed half way. b/c it loops over all
+		// objects and updates their terms. introduces a race condition though. but need to still stay in sync when
+		// it fails half way through...before delete_term fires
+		add_action( 'delete_term', array( __CLASS__, 'action__delete_term' ), 10, 4 );
 	}
 
 	protected function load_commands() {
@@ -114,6 +123,18 @@ class Elasticsearch {
 				ep_setup_query_log();
 			}
 		}
+	}
+
+	public function action__edited_term( $term_id, $tt_id, $taxonomy ) {
+		// Find ID of all attached posts (query lifted from wp_delete_term())
+		$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $tt_id ) );
+
+		// Queue::queue_objects_for_indexing( $object_ids, 'post' );
+	}
+
+	public function action__delete_term( $term, $tt_id, $taxonomy, $deleted_term, $object_ids ) {
+		// After a term is deleted, we need to re-index all the posts that were attached (from $object_ids)
+		// Queue::queue_objects_for_indexing( $object_ids, 'post' );
 	}
 
 	/**

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -110,6 +110,17 @@ class Elasticsearch {
 		}
 	}
 
+	/**
+	 * Abstract the retrieval of ElasticPress Indexable instances for easier mocking in tests
+	 * 
+	 * @see \ElasticPress\Indexables::get()
+	 * @param string $type The type of indexable to retrieve
+	 * @return \ElasticPress\Indexable Indexable instance, or false if not found
+	 */
+	public function get_indexable( $type ) {
+		return \ElasticPress\Indexables::factory()->get( $type );
+	}
+
 	public function action__plugins_loaded() {
 		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
 		// NOTE - must hook in here b/c the wp_get_current_user function required for checking if debug bar is enabled isn't loaded earlier


### PR DESCRIPTION
## Description

IN PROGRESS

Hooks into WP term changes and schedules all associated posts to be re-indexed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

TBD