### PR TITLE
Enabled Stream Wrappers on AMS

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -68,9 +68,7 @@ class A8C_Files {
 
 		// Conditionally load either the new Stream Wrapper implementation or old school a8c-files.
 		// The old school implementation will be phased out soon.
-		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER
-			// NOTE: Temporarily disable Stream Wrapper loading for sites on AMS as it's not ready for use there
-			&& 'ams-files.vipv2.net' !== FILE_SERVICE_ENDPOINT ) {
+		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER ) {
 			$this->init_vip_filesystem();
 		} else {
 			$this->init_legacy_filesystem();


### PR DESCRIPTION
This will be bundled with an internal change to incrementally release stream wrappers to all envs.

There are lots of other unused functions now in this file that can likely be removed, but we'll want to throw a deprecated notice to them first just to be safe.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Try to upload a file to the media library.
1. Verify it works.
