### PR TITLE
Only validate user counts in Search healthcheck if Users feature is enabled

### DIFF
--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -97,9 +97,11 @@ class HealthJob {
 			return;
 		}
 
-		$user_results = Health::validate_index_users_count();
+		if ( \ElasticPress\Features::factory()->get_registered_feature( 'users' )->is_active() ) {
+			$user_results = Health::validate_index_users_count();
 
-		$this->process_results( $user_results );
+			$this->process_results( $user_results );
+		}
 
 		$post_results = Health::validate_index_posts_count();
 

--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -97,7 +97,9 @@ class HealthJob {
 			return;
 		}
 
-		if ( \ElasticPress\Features::factory()->get_registered_feature( 'users' )->is_active() ) {
+		$users_feature = \ElasticPress\Features::factory()->get_registered_feature( 'users' );
+
+		if ( $users_feature instanceof \ElasticPress\Feature && $users_feature->is_active() ) {
 			$user_results = Health::validate_index_users_count();
 
 			$this->process_results( $user_results );

--- a/tests/elasticsearch/includes/classes/test-class-healthjob.php
+++ b/tests/elasticsearch/includes/classes/test-class-healthjob.php
@@ -19,6 +19,33 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		$job->check_health();
 	}
 
+	public function test__vip_search_healthjob_check_health_with_inactive_features() {
+		add_filter( 'enable_vip_search_healthchecks', '__return_true' );
+
+		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es->init();
+
+		$users_mock = $this->getMockBuilder( \ElasticPress\Feature\Users\Users::class )
+			->setMethods( [ 'is_active' ] )
+			->getMock();
+
+		$users_mock->method( 'is_active' )->will( $this->returnValue( false ) );
+
+		// Mock the users feature
+		\ElasticPress\Features::factory()->registered_features[ 'users' ] = $users_mock;
+
+		// Mock the health job
+		$job = $this->getMockBuilder( \Automattic\VIP\Elasticsearch\HealthJob::class )
+			->setMethods( [ 'process_results' ] )
+			->getMock();
+
+		// Only expect it to process 1 set of results (for regular posts)
+		$job->expects( $this->exactly( 1 ) )
+			->method( 'process_results' );
+
+		$job->check_health();
+	}
+
 	/**
 	 * Test that we correctly handle the results of health checks when inconsistencies are found
 	 */

--- a/tests/elasticsearch/includes/classes/test-class-healthjob.php
+++ b/tests/elasticsearch/includes/classes/test-class-healthjob.php
@@ -26,17 +26,17 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		$es->init();
 
 		$users_mock = $this->getMockBuilder( \ElasticPress\Feature\Users\Users::class )
-			->setMethods( [ 'is_active' ] )
+			->setMethods( array( 'is_active' ) )
 			->getMock();
 
 		$users_mock->method( 'is_active' )->will( $this->returnValue( false ) );
 
 		// Mock the users feature
-		\ElasticPress\Features::factory()->registered_features[ 'users' ] = $users_mock;
+		\ElasticPress\Features::factory()->registered_features['users'] = $users_mock;
 
 		// Mock the health job
 		$job = $this->getMockBuilder( \Automattic\VIP\Elasticsearch\HealthJob::class )
-			->setMethods( [ 'process_results' ] )
+			->setMethods( array( 'process_results' ) )
 			->getMock();
 
 		// Only expect it to process 1 set of results (for regular posts)


### PR DESCRIPTION
## Description

If the Users feature is not enabled, the check will always fail.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR
1. Ensure healthchecks are enabled - `add_filter( 'enable_vip_search_healthchecks', '__return_true' );`
1. `wp elasticpress deactivate-feature users`
1. `wp shell`
1. `$job = new \Automattic\VIP\Elasticsearch\HealthJob()`
1. `$job->check_health()`
1. Ensure it doesn't try to run the user healthcheck - may need to add manual debug code (var_dump(), etc)
1. Enable the feature with `wp elasticpress activate-feature users`
1. Repeat above, ensure the users check runs
