### PR TITLE
Replace Elasticsearch references with VIP Search

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -179,8 +179,8 @@ if ( ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) || // legac
 	defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === VIP_ENABLE_VIP_SEARCH ) {
 	require_once( __DIR__ . '/elasticsearch/elasticsearch.php' );
 
-	$es_plugin = new \Automattic\VIP\Elasticsearch\Elasticsearch();
-	$es_plugin->init();
+	$search_plugin = new \Automattic\VIP\Search\Search();
+	$search_plugin->init();
 }
 
 // Add custom header for VIP

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -175,7 +175,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 // Load elasticsearch helpers
-if ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) {
+if ( ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) || // legacy constant name
+	defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === VIP_ENABLE_VIP_SEARCH ) {
 	require_once( __DIR__ . '/elasticsearch/elasticsearch.php' );
 
 	$es_plugin = new \Automattic\VIP\Elasticsearch\Elasticsearch();

--- a/elasticsearch/elasticsearch.php
+++ b/elasticsearch/elasticsearch.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Plugin Name: Elasticsearch
+ * Plugin Name: VIP Search
  * Description: Power your site search and other queries with Elasticsearch
  * Version:     0.1.0
  * Author:      Automattic VIP
  * Author URI:  https://wpvip.com
  * License:     GPLv2 or later
- * Text Domain: elasticsearch
+ * Text Domain: vip-search
  * Domain Path: /lang/
  *
- * @package  elasticsearch
+ * @package Automattic\VIP\Search
  */
 
 namespace Automattic\VIP\Elasticsearch;

--- a/elasticsearch/elasticsearch.php
+++ b/elasticsearch/elasticsearch.php
@@ -12,7 +12,7 @@
  * @package Automattic\VIP\Search
  */
 
-namespace Automattic\VIP\Elasticsearch;
+namespace Automattic\VIP\Search;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.

--- a/elasticsearch/includes/classes/class-dashboard.php
+++ b/elasticsearch/includes/classes/class-dashboard.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\VIP\Elasticsearch;
+namespace Automattic\VIP\Search;
 
 class Dashboard {
 

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -215,11 +215,11 @@ class Search {
 		}
 
 		// Legacy constant name
-		$query_integration_enabled = defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION;
+		$query_integration_enabled_legacy = defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION;
 
 		$query_integration_enabled = defined( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION;
 
 		// The filter is checking if we should _skip_ query integration
-		return ! $query_integration_enabled;
+		return ! ( $query_integration_enabled || $query_integration_enabled_legacy );
 	}
 }

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -194,8 +194,8 @@ class Search {
 	 * Separate plugin enabled and querying the index
 	 *
 	 * The index can be tested at any time by setting an `es` query argument.
-	 * When we're ready to use the index in production, the `vip_enable_elasticsearch`
-	 * option will be set to `true`, which will enable querying for everyone.
+	 * When the index is ready to serve requests in production, the `VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION`
+	 * constant should be set to `true`, which will enable query integration for all requests
 	 */
 	static function ep_skip_query_integration( $skip ) {
 		if ( isset( $_GET[ 'es' ] ) ) {

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -130,7 +130,7 @@ class Elasticsearch {
 	}
 
 	public function filter__ep_do_intercept_request( $request, $query, $args, $failures ) {
-		$fallback_error = new \WP_Error( 'vip-elasticsearch-upstream-request-failed', 'There was an error connecting to the upstream Elasticsearch server' );
+		$fallback_error = new \WP_Error( 'vip-search-upstream-request-failed', 'There was an error connecting to the upstream search server' );
 
 		$timeout = $this->get_http_timeout_for_query( $query );
 

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -214,7 +214,11 @@ class Elasticsearch {
 			return true;
 		}
 
+		// Legacy constant name
 		$query_integration_enabled = defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION;
+
+		$query_integration_enabled = defined( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION;
+
 		// The filter is checking if we should _skip_ query integration
 		return ! $query_integration_enabled;
 	}

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -8,7 +8,7 @@ class Elasticsearch {
 	public $healthcheck;
 
 	/**
-	 * Initialize the VIP Elasticsearch plugin
+	 * Initialize the VIP Search plugin
 	 */
 	public function init() {
 		$this->setup_constants();
@@ -64,7 +64,7 @@ class Elasticsearch {
 
 		add_filter( 'ep_index_name', [ $this, 'filter__ep_index_name' ], PHP_INT_MAX, 3 ); // We want to enforce the naming, so run this really late.
 
-		// Override default per page value set in elasticsearch/elasticpress/includes/classes/Indexable.php
+		// Override default per page value set in elasticpress/includes/classes/Indexable.php
 		add_filter( 'ep_bulk_items_per_page', [ $this, 'filter__ep_bulk_items_per_page' ], PHP_INT_MAX );
 
 		// Network layer replacement to use VIP helpers (that handle slow/down upstream server)

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Automattic\VIP\Elasticsearch;
+namespace Automattic\VIP\Search;
 
 use \WP_CLI;
 
-class Elasticsearch {
+class Search {
 	public $healthcheck;
 
 	/**

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -82,7 +82,7 @@ class Elasticsearch {
 
 	protected function load_commands() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::add_command( 'vip-es health', __NAMESPACE__ . '\Commands\HealthCommand' );
+			WP_CLI::add_command( 'vip-search health', __NAMESPACE__ . '\Commands\HealthCommand' );
 		}
 	}
 

--- a/elasticsearch/includes/classes/class-elasticsearch.php
+++ b/elasticsearch/includes/classes/class-elasticsearch.php
@@ -214,7 +214,8 @@ class Elasticsearch {
 			return true;
 		}
 
-		return ! ( defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' )
-			&& true === VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION );
+		$query_integration_enabled = defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION;
+		// The filter is checking if we should _skip_ query integration
+		return ! $query_integration_enabled;
 	}
 }

--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Automattic\VIP\Elasticsearch;
+namespace Automattic\VIP\Search;
 
-use Automattic\VIP\Elasticsearch\Health as Health;
+use Automattic\VIP\Search\Health as Health;
 
 require_once __DIR__ . '/class-health.php';
 

--- a/elasticsearch/includes/classes/class-health-job.php
+++ b/elasticsearch/includes/classes/class-health-job.php
@@ -87,7 +87,7 @@ class HealthJob {
 	}
 
 	/**
-	 * Check ElasticSearch index health
+	 * Check index health
 	 */
 	public function check_health() {
 		// Check if job has been disabled

--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -32,7 +32,7 @@ class Health {
 
 			$db_total = (int) $result[ 'total_objects' ];
 		} catch ( \Exception $e ) {
-			return new WP_Error( 'db_query_error', sprintf( 'failure querying the DB: %s #vip-go-elasticsearch', $e->get_error_message() ) );
+			return new WP_Error( 'db_query_error', sprintf( 'failure querying the DB: %s #vip-search', $e->get_error_message() ) );
 		}
 
 		// Get total count in ES index
@@ -45,14 +45,14 @@ class Health {
 
 			$es_result = $indexable->query_es( $formatted_args, $query->query_vars );
 		} catch ( \Exception $e ) {
-			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-go-elasticsearch', $e->get_error_message() ) );
+			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-search', $e->get_error_message() ) );
 		}
 
 		// There is not other useful information out of query_es(): it just returns false in case of failure.
 		// This may be due to different causes, e.g. index not existing or incorrect connection parameters.
 		if ( ! $es_result ) {
 			$es_total = 'N/A';
-			return new WP_Error( 'es_query_error', 'failure querying ES. #vip-go-elasticsearch' );
+			return new WP_Error( 'es_query_error', 'failure querying ES. #vip-search' );
 		}
 
 		// Verify actual results
@@ -82,7 +82,7 @@ class Health {
 		// Indexables::factory()->get() returns boolean|array
 		// False is returned in case of error
 		if ( ! $users ) {
-			return new WP_Error( 'es_users_query_error', 'failure retrieving user documents from ES #vip-go-elasticsearch' );
+			return new WP_Error( 'es_users_query_error', 'failure retrieving user documents from ES #vip-search' );
 		}
 
 		$query_args = [
@@ -91,7 +91,7 @@ class Health {
 
 		$result = self::validate_index_entity_count( $query_args, $users );
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'es_users_query_error', sprintf( 'failure retrieving users from ES: %s #vip-go-elasticsearch', $result->get_error_message() ) );
+			return new WP_Error( 'es_users_query_error', sprintf( 'failure retrieving users from ES: %s #vip-search', $result->get_error_message() ) );
 		}
 		return array( $result );
 	}
@@ -108,7 +108,7 @@ class Health {
 		// Indexables::factory()->get() returns boolean|array
 		// False is returned in case of error
 		if ( ! $posts ) {
-			return new WP_Error( 'es_users_query_error', 'failure retrieving post documents from ES #vip-go-elasticsearch' );
+			return new WP_Error( 'es_users_query_error', 'failure retrieving post documents from ES #vip-search' );
 		}
 
 		$post_types = $posts->get_indexable_post_types();

--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -11,7 +11,7 @@ use \WP_Error as WP_Error;
 
 class Health {
 	/**
-	 * Verify the difference in number for a given entity between the DB and ElasticSearch.
+	 * Verify the difference in number for a given entity between the DB and the index.
 	 * Entities can be either posts or users.
 	 *
 	 * @since   1.0.0

--- a/elasticsearch/includes/classes/class-health.php
+++ b/elasticsearch/includes/classes/class-health.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\VIP\Elasticsearch;
+namespace Automattic\VIP\Search;
 
 use \ElasticPress\Indexable as Indexable;
 use \ElasticPress\Indexables as Indexables;

--- a/elasticsearch/includes/classes/commands/class-healthcommand.php
+++ b/elasticsearch/includes/classes/commands/class-healthcommand.php
@@ -8,7 +8,7 @@ use \WP_CLI\Utils;
 require_once __DIR__ . '/../class-health.php';
 
 /**
- * Commands to view and manage the health of VIP Go Elasticsearch indexes
+ * Commands to view and manage the health of VIP Search indexes
  *
  * @package Automattic\VIP\Elasticsearch
  */

--- a/elasticsearch/includes/classes/commands/class-healthcommand.php
+++ b/elasticsearch/includes/classes/commands/class-healthcommand.php
@@ -29,7 +29,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 *
 	 *
 	 * ## EXAMPLES
-	 *     wp vip-es health validate-counts
+	 *     wp vip-search health validate-counts
 	 *
 	 * @subcommand validate-counts
 	 */

--- a/elasticsearch/includes/classes/commands/class-healthcommand.php
+++ b/elasticsearch/includes/classes/commands/class-healthcommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\VIP\Elasticsearch\Commands;
+namespace Automattic\VIP\Search\Commands;
 
 use \WP_CLI;
 use \WP_CLI\Utils;
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../class-health.php';
 /**
  * Commands to view and manage the health of VIP Search indexes
  *
- * @package Automattic\VIP\Elasticsearch
+ * @package Automattic\VIP\Search
  */
 class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
@@ -53,7 +53,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	public function validate_users_count( $args, $assoc_args ) {
 		WP_CLI::line( sprintf( "Validating users count\n" ) );
 
-		$users_results = \Automattic\VIP\Elasticsearch\Health::validate_index_users_count();
+		$users_results = \Automattic\VIP\Search\Health::validate_index_users_count();
 		if ( is_wp_error( $users_results ) ) {
 			WP_CLI::warning( $users_results->get_error_message() );
 			return;
@@ -73,7 +73,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	public function validate_posts_count( $args, $assoc_args ) {
 		WP_CLI::line( "Validating posts count\n" );
 
-		$posts_results = \Automattic\VIP\Elasticsearch\Health::validate_index_posts_count();
+		$posts_results = \Automattic\VIP\Search\Health::validate_index_posts_count();
 		$this->render_results( $posts_results );
 	}
 

--- a/tests/elasticsearch/includes/classes/commands/test-class-healthcommand.php
+++ b/tests/elasticsearch/includes/classes/commands/test-class-healthcommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\VIP\Elasticsearch\Commands;
+namespace Automattic\VIP\Search\Commands;
 
 class HealthCommand_Test extends \WP_UnitTestCase {
 	public function setUp() {
@@ -14,10 +14,10 @@ class HealthCommand_Test extends \WP_UnitTestCase {
 	public function test__vip_search_healthcommand_validate_users_count() {
 		// We have to test under the assumption that the main class has been loaded and initialized,
 		// as it does various setup tasks like including dependencies
-		/*$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		/*$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$command = new \Automattic\VIP\Elasticsearch\HealthCommand();
+		$command = new \Automattic\VIP\Search\HealthCommand();
 
 		$command->validate_users_count();*/
 

--- a/tests/elasticsearch/includes/classes/test-class-healthjob.php
+++ b/tests/elasticsearch/includes/classes/test-class-healthjob.php
@@ -14,7 +14,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$job = new \Automattic\VIP\SearchHealthJob();
+		$job = new \Automattic\VIP\Search\HealthJob();
 
 		$job->check_health();
 	}
@@ -35,7 +35,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		\ElasticPress\Features::factory()->registered_features['users'] = $users_mock;
 
 		// Mock the health job
-		$job = $this->getMockBuilder( \Automattic\VIP\SearchHealthJob::class )
+		$job = $this->getMockBuilder( \Automattic\VIP\Search\HealthJob::class )
 			->setMethods( array( 'process_results' ) )
 			->getMock();
 
@@ -82,7 +82,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$stub = $this->getMockBuilder( \Automattic\VIP\SearchHealthJob::class )
+		$stub = $this->getMockBuilder( \Automattic\VIP\Search\HealthJob::class )
 			->setMethods( [ 'send_alert' ] )
 			->getMock();
 
@@ -138,7 +138,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$stub = $this->getMockBuilder( \Automattic\VIP\SearchHealthJob::class )
+		$stub = $this->getMockBuilder( \Automattic\VIP\Search\HealthJob::class )
 			->setMethods( [ 'send_alert' ] )
 			->getMock();
 

--- a/tests/elasticsearch/includes/classes/test-class-healthjob.php
+++ b/tests/elasticsearch/includes/classes/test-class-healthjob.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\VIP\Elasticsearch;
+namespace Automattic\VIP\Search;
 
 class HealthJob_Test extends \WP_UnitTestCase {
 	public function setUp() {
@@ -11,10 +11,10 @@ class HealthJob_Test extends \WP_UnitTestCase {
 	public function test__vip_search_healthjob_check_health() {
 		// We have to test under the assumption that the main class has been loaded and initialized,
 		// as it does various setup tasks like including dependencies
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$job = new \Automattic\VIP\Elasticsearch\HealthJob();
+		$job = new \Automattic\VIP\SearchHealthJob();
 
 		$job->check_health();
 	}
@@ -22,7 +22,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 	public function test__vip_search_healthjob_check_health_with_inactive_features() {
 		add_filter( 'enable_vip_search_healthchecks', '__return_true' );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$users_mock = $this->getMockBuilder( \ElasticPress\Feature\Users\Users::class )
@@ -35,7 +35,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		\ElasticPress\Features::factory()->registered_features['users'] = $users_mock;
 
 		// Mock the health job
-		$job = $this->getMockBuilder( \Automattic\VIP\Elasticsearch\HealthJob::class )
+		$job = $this->getMockBuilder( \Automattic\VIP\SearchHealthJob::class )
 			->setMethods( array( 'process_results' ) )
 			->getMock();
 
@@ -79,10 +79,10 @@ class HealthJob_Test extends \WP_UnitTestCase {
 
 		// We have to test under the assumption that the main class has been loaded and initialized,
 		// as it does various setup tasks like including dependencies
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$stub = $this->getMockBuilder( \Automattic\VIP\Elasticsearch\HealthJob::class )
+		$stub = $this->getMockBuilder( \Automattic\VIP\SearchHealthJob::class )
 			->setMethods( [ 'send_alert' ] )
 			->getMock();
 
@@ -135,10 +135,10 @@ class HealthJob_Test extends \WP_UnitTestCase {
 
 		// We have to test under the assumption that the main class has been loaded and initialized,
 		// as it does various setup tasks like including dependencies
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$stub = $this->getMockBuilder( \Automattic\VIP\Elasticsearch\HealthJob::class )
+		$stub = $this->getMockBuilder( \Automattic\VIP\SearchHealthJob::class )
 			->setMethods( [ 'send_alert' ] )
 			->getMock();
 

--- a/tests/elasticsearch/test-class-elasticsearch.php
+++ b/tests/elasticsearch/test-class-elasticsearch.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Automattic\VIP\Elasticsearch;
+namespace Automattic\VIP\Search;
 
-class Elasticsearch_Test extends \WP_UnitTestCase {
+class Search_Test extends \WP_UnitTestCase {
 	/**
 	 * Make tests run in separate processes since we're testing state
 	 * related to plugin init, including various constants.
@@ -15,10 +15,10 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test `ep_index_name` filter for ElasticPress + VIP Elasticsearch
+	 * Test `ep_index_name` filter for ElasticPress + VIP Search
 	 */
-	public function test__vip_elasticsearch_filter_ep_index_name() {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_filter_ep_index_name() {
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$mock_indexable = (object) [ 'slug' => 'slug' ];
@@ -29,12 +29,12 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test `ep_index_name` filter for ElasticPress + VIP Elasticsearch for global indexes
+	 * Test `ep_index_name` filter for ElasticPress + VIP Search for global indexes
 	 *
 	 * On "global" indexes, such as users, no blog id will be present
 	 */
-	public function test__vip_elasticsearch_filter_ep_index_name_global_index() {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_filter_ep_index_name_global_index() {
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$mock_indexable = (object) [ 'slug' => 'users' ];
@@ -45,11 +45,11 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test `ep_index_name` filter for ElasticPress + VIP Elasticsearch
+	 * Test `ep_index_name` filter for ElasticPress + VIP Search
 	 *
 	 * USE_VIP_ELASTICSEARCH not defined (Elasticseach class doesn't load)
 	 */
-	public function test__vip_elasticsearch_filter_ep_index_name__no_constant() {
+	public function test__vip_search_filter_ep_index_name__no_constant() {
 		$mock_indexable = (object) [ 'slug' => 'slug' ];
 
 		$index_name = apply_filters( 'ep_index_name', 'index-name', 1, $mock_indexable );
@@ -60,8 +60,8 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that we set a default bulk index chunk size limit
 	 */
-	public function test__vip_elasticsearch_bulk_chunk_size_default() {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_bulk_chunk_size_default() {
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$this->assertEquals( EP_SYNC_CHUNK_LIMIT, 500 );
@@ -70,26 +70,26 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that the default bulk index chunk size limit is not applied if constant is already defined
 	 */
-	public function test__vip_elasticsearch_bulk_chunk_size_already_defined() {
+	public function test__vip_search_bulk_chunk_size_already_defined() {
 		define( 'EP_SYNC_CHUNK_LIMIT', 500 );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$this->assertEquals( EP_SYNC_CHUNK_LIMIT, 500 );
 	}
 
 	/**
-	 * Test that the default bulk index chunk size limit is not defined if we're not using VIP Elasticsearch
+	 * Test that the default bulk index chunk size limit is not defined if we're not using VIP Search
 	 */
-	public function test__vip_elasticsearch_bulk_chunk_size_not_defined_when_not_using_vip_elasticsearch() {
+	public function test__vip_search_bulk_chunk_size_not_defined_when_not_using_vip_search() {
 		$this->assertEquals( defined( 'EP_SYNC_CHUNK_LIMIT' ), false );
 	}
 
 	/**
 	 * Test that the ES config constants are set automatically when not already defined and VIP-provided configs are present
 	 */
-	public function test__vip_elasticsearch_connection_constants() {
+	public function test__vip_search_connection_constants() {
 		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
 			'https://es-endpoint1',
 			'https://es-endpoint2',
@@ -98,7 +98,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		define( 'VIP_ELASTICSEARCH_USERNAME', 'foo' );
 		define( 'VIP_ELASTICSEARCH_PASSWORD', 'bar' );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$this->assertEquals( EP_HOST, 'https://es-endpoint1' );
@@ -109,7 +109,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	 * Test that the ES config constants are _not_ set automatically when already defined and VIP-provided configs are present
 	 * 
 	 */
-	public function test__vip_elasticsearch_connection_constants_with_overrides() {
+	public function test__vip_search_connection_constants_with_overrides() {
 		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
 			'https://es-endpoint1',
 			'https://es-endpoint2',
@@ -122,7 +122,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		define( 'EP_HOST', 'https://somethingelse' );
 		define( 'ES_SHIELD', 'bar:baz' );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$this->assertEquals( EP_HOST, 'https://somethingelse' );
@@ -132,7 +132,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that we load the ElasticPress Debug Bar plugin when Debug Bar is showing
 	 */
-	public function test__vip_elasticsearch_loads_ep_debug_bar_when_debug_bar_showing() {
+	public function test__vip_search_loads_ep_debug_bar_when_debug_bar_showing() {
 		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
 		remove_all_filters( 'debug_bar_enable' );
 
@@ -142,7 +142,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		// Be sure we don't already have the class loaded (or our test does nothing)
 		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$es->action__plugins_loaded();
@@ -154,7 +154,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that we load the ElasticPress Debug Bar plugin when Debug Bar is disabled, but Query Monitor is showing
 	 */
-	public function test__vip_elasticsearch_loads_ep_debug_bar_when_debug_bar_disabled_but_qm_enabled() {
+	public function test__vip_search_loads_ep_debug_bar_when_debug_bar_disabled_but_qm_enabled() {
 		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
 		remove_all_filters( 'debug_bar_enable' );
 
@@ -166,7 +166,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		// Be sure we don't already have the class loaded (or our test does nothing)
 		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$es->action__plugins_loaded();
@@ -178,7 +178,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that we load the ElasticPress Debug Bar plugin when both Debug Bar Query Monitor are showing
 	 */
-	public function test__vip_elasticsearch_loads_ep_debug_bar_when_debug_bar_and_qm_enabled() {
+	public function test__vip_search_loads_ep_debug_bar_when_debug_bar_and_qm_enabled() {
 		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
 		remove_all_filters( 'debug_bar_enable' );
 
@@ -190,7 +190,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		// Be sure we don't already have the class loaded (or our test does nothing)
 		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$es->action__plugins_loaded();
@@ -202,7 +202,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that we don't load the ElasticPress Debug Bar plugin when neither Debug Bar or Query Monitor are showing
 	 */
-	public function test__vip_elasticsearch_does_not_load_ep_debug_bar_when_debug_bar_and_qm_disabled() {
+	public function test__vip_search_does_not_load_ep_debug_bar_when_debug_bar_and_qm_disabled() {
 		// Remove previous filters that would affect test (b/c it also uses PHP_INT_MAX priority)
 		remove_all_filters( 'debug_bar_enable' );
 
@@ -211,7 +211,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		// And QM disabled
 		add_filter( 'wpcom_vip_qm_enable', '__return_false', PHP_INT_MAX );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$es->action__plugins_loaded();
@@ -223,15 +223,15 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that we are sending HTTP requests through the VIP helper functions
 	 */
-	public function test__vip_elasticsearch_has_http_layer_filters() {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_has_http_layer_filters() {
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$this->assertEquals( true, has_filter( 'ep_intercept_remote_request', '__return_true' ) );
 		$this->assertEquals( true, has_filter( 'ep_do_intercept_request', [ $es, 'filter__ep_do_intercept_request' ] ) );
 	}
 
-	public function vip_elasticsearch_get_http_timeout_for_query_data() {
+	public function vip_search_get_http_timeout_for_query_data() {
 		return array(
 			// Regular search
 			array(
@@ -275,10 +275,10 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that we correctly calculate the HTTP request timeout value for ES requests
 	 * 
-	 * @dataProvider vip_elasticsearch_get_http_timeout_for_query_data()
+	 * @dataProvider vip_search_get_http_timeout_for_query_data()
 	 */
-	public function test__vip_elasticsearch_get_http_timeout_for_query( $query, $expected_timeout ) {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_get_http_timeout_for_query( $query, $expected_timeout ) {
+		$es = new \Automattic\VIP\Search\Search();
 
 		$timeout = $es->get_http_timeout_for_query( $query );
 
@@ -288,14 +288,14 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that we are setting up the filter to auto-disable JP Search
 	 */
-	public function test__vip_elasticsearch_has_jp_search_module_filter() {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_has_jp_search_module_filter() {
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$this->assertEquals( true, has_filter( 'jetpack_active_modules', [ $es, 'filter__jetpack_active_modules' ] ) );
 	}
 
-	public function vip_elasticsearch_filter__jetpack_active_modules() {
+	public function vip_search_filter__jetpack_active_modules() {
 		return array(
 			// No modules, no change
 			array(
@@ -368,10 +368,10 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that our active modules filter works as expected
 	 * 
-	 * @dataProvider vip_elasticsearch_filter__jetpack_active_modules
+	 * @dataProvider vip_search_filter__jetpack_active_modules
 	 */
-	public function test__vip_elasticsearch_filter__jetpack_active_modules( $input, $expected ) {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_filter__jetpack_active_modules( $input, $expected ) {
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$result = $es->filter__jetpack_active_modules( $input );
@@ -379,7 +379,7 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected, $result );
 	}
 
-	public function vip_elasticsearch_filter__jetpack_widgets_to_include_data() {
+	public function vip_search_filter__jetpack_widgets_to_include_data() {
 		return array(
 			array(
 				// Input
@@ -423,10 +423,10 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that the widgets filter works as expected
 	 * 
-	 * @dataProvider vip_elasticsearch_filter__jetpack_widgets_to_include_data
+	 * @dataProvider vip_search_filter__jetpack_widgets_to_include_data
 	 */
-	public function test__vip_elasticsearch_filter__jetpack_widgets_to_include( $input, $expected ) {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_filter__jetpack_widgets_to_include( $input, $expected ) {
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		$result = $es->filter__jetpack_widgets_to_include( $input );
@@ -437,11 +437,11 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that instantiating the HealthJob works as expected (files are properly included, init is hooked)
 	 */
-	public function test__vip_elasticsearch_setup_healthchecks_with_enabled() {
+	public function test__vip_search_setup_healthchecks_with_enabled() {
 		// Need to filter to enable the HealthJob
 		add_filter( 'enable_vip_search_healthchecks', '__return_true' );
 
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		// Should not have fataled (class was included)
@@ -453,8 +453,8 @@ class Elasticsearch_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that instantiating the HealthJob does not happen when not in production
 	 */
-	public function test__vip_elasticsearch_setup_healthchecks_disabled_in_non_production_env() {
-		$es = new \Automattic\VIP\Elasticsearch\Elasticsearch();
+	public function test__vip_search_setup_healthchecks_disabled_in_non_production_env() {
+		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
 		// Should not have fataled (class was included)


### PR DESCRIPTION
## Description

Rename references to "Elasticsearch" with "VIP Search"

NOTE - this doesn't rename any files / directories, just references in code / comments / tests. Files will be renamed in a separate PR.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Example:

1. Check out PR.
1. Try a command - `wp vip-search health validate-counts`
1. Try some searches - `?s=test` - ensure searching works normally
