### PR TITLE
Disable document indexing feature

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -78,6 +78,9 @@ class Search {
 		// Disable query integration by default
 		add_filter( 'ep_skip_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5 );
 		add_filter( 'ep_skip_user_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5 );
+
+		// Disable certain EP Features
+		add_filter( 'ep_feature_active', array( $this, 'filter__ep_feature_active' ), PHP_INT_MAX, 3 );
 	}
 
 	protected function load_commands() {
@@ -156,6 +159,18 @@ class Search {
 		}
 
 		return $timeout;
+	}
+
+	public function filter__ep_feature_active( $active, $feature_settings, $feature ) {
+		$disabled_features = array(
+			'documents',
+		);
+
+		if ( in_array( $feature->slug, $disabled_features, true ) ) {
+			return false;
+		}
+
+		return $active;
 	}
 
 	public function filter__jetpack_active_modules( $modules ) {

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -57,6 +57,32 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 'index-name', $index_name );
 	}
 
+	public function vip_search_enforces_disabled_features_data() {
+		return array(
+			array( 'documents' ),
+		);
+	}
+
+	/**
+	 * Test that given an EP Feature slug, that feature is always disabled
+	 * 
+	 * @dataProvider vip_search_enforces_disabled_features_data
+	 */
+	public function test__vip_search_enforces_disabled_features( $slug ) {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		// Activate the feature
+		\ElasticPress\Features::factory()->activate_feature( $slug );
+
+		// And attempt to force-enable it via filter
+		add_filter( 'ep_feature_active', '__return_true' );
+
+		$active = \ElasticPress\Features::factory()->get_registered_feature( $slug )->is_active();
+
+		$this->assertFalse( $active );
+	}
+
 	/**
 	 * Test that we set a default bulk index chunk size limit
 	 */


### PR DESCRIPTION
## Description

Disable document indexing. Not currently supported.

NOTE - this is branched off #1481 to prevent merge conflicts, so that will need to be merged first.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Attempt to enable document indexing via EP UI
1. Ensure feature stays disabled
1. Attempt to enable document indexing via CLI - `wp elasticpress activate-feature documents`
1. Ensure feature stays disabled
