### PR TITLE
Add header to indicate when search results come from Elasticsearch

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -87,7 +87,7 @@ class Search {
 		// Round-robin retry hosts if connection to a host fails
 		add_filter( 'ep_pre_request_host', array( $this, 'filter__ep_pre_request_host' ), PHP_INT_MAX, 4 );
 		
-		add_filter( 'ep_valid_response', array( $this, 'filter__ep_valid_response' ), 10 );
+		add_filter( 'ep_valid_response', array( $this, 'filter__ep_valid_response' ), 10, 4 );
 	}
 
 	protected function load_commands() {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -86,6 +86,8 @@ class Search {
 
 		// Round-robin retry hosts if connection to a host fails
 		add_filter( 'ep_pre_request_host', array( $this, 'filter__ep_pre_request_host' ), PHP_INT_MAX, 4 );
+		
+		add_filter( 'ep_valid_response', [ $this, 'filter__ep_valid_response' ], 10 );
 	}
 
 	protected function load_commands() {
@@ -276,5 +278,14 @@ class Search {
 		}
 
 		return $hosts[ array_rand( $hosts ) ];
+	}
+
+	public function filter__ep_valid_response( $response, $query, $query_args, $query_object ) {
+		if ( ! headers_sent() ) {
+			/**
+			 * Manually set a header to indicate the search results are from elasticSearch
+			 */
+			header( 'X-ElasticPress-Search-Valid-Response: true' );
+		}
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -87,7 +87,7 @@ class Search {
 		// Round-robin retry hosts if connection to a host fails
 		add_filter( 'ep_pre_request_host', array( $this, 'filter__ep_pre_request_host' ), PHP_INT_MAX, 4 );
 		
-		add_filter( 'ep_valid_response', [ $this, 'filter__ep_valid_response' ], 10 );
+		add_filter( 'ep_valid_response', array( $this, 'filter__ep_valid_response' ), 10 );
 	}
 
 	protected function load_commands() {
@@ -287,5 +287,6 @@ class Search {
 			 */
 			header( 'X-ElasticPress-Search-Valid-Response: true' );
 		}
+		return $response;
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -286,7 +286,7 @@ class Search {
 			/**
 			 * Manually set a header to indicate the search results are from elasticSearch
 			 */
-			if ( isset( $_GET[ 'ep_debug' ] ) ) {
+			if ( isset( $_GET['ep_debug'] ) ) {
 				header( 'X-ElasticPress-Search-Valid-Response: true' );
 			}
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -286,7 +286,9 @@ class Search {
 			/**
 			 * Manually set a header to indicate the search results are from elasticSearch
 			 */
-			header( 'X-ElasticPress-Search-Valid-Response: true' );
+			if ( isset( $_GET[ 'ep_debug' ] ) ) {
+				header( 'X-ElasticPress-Search-Valid-Response: true' );
+			}
 		}
 		return $response;
 	}

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -565,7 +565,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		apply_filters( 'ep_valid_response', [], [], [], [], null );
+		apply_filters( 'ep_valid_response', array(), array(), array(), array(), null );
 		
 		do_action( 'send_headers' );
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -564,11 +564,15 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
-
+		
+		$_GET['ep_debug'] = true;
+		
 		apply_filters( 'ep_valid_response', array(), array(), array(), array(), null );
 		
 		do_action( 'send_headers' );
 
+		unset( $_GET['ep_debug'] );
+		
 		$this->assertContains( 'X-ElasticPress-Search-Valid-Response: true', xdebug_get_headers() );
 	}
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -555,4 +555,21 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$this->assertContains( $es->get_random_host( $hosts ), $hosts );
 	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__send_vary_headers__sent_for_group() {
+
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		apply_filters( 'ep_valid_response', [], [], [], [], null );
+		
+		do_action( 'send_headers' );
+
+		$this->assertContains( 'X-ElasticPress-Search-Valid-Response: true', xdebug_get_headers() );
+	}
+
 }


### PR DESCRIPTION
## Description
This adds a custom HTTP header to indicate when the search results came from Elasticsearch.  This is necessary in cases where we want to ensure the search didn't fall back to using the wpdb query.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR on a site with ElasticPress enabled
1. Enter a search term and click "Search"
1. Verify that the custom header was sent in the HTTP response for the results request. 
