### PR TITLE
Add retries and random load balancing for EP_HOST

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -241,6 +241,11 @@ class Search {
 		return ! ( $query_integration_enabled || $query_integration_enabled_legacy );
 	}
 
+	/**
+	 * Filter for ep_pre_request_host
+	 *
+	 * Return the next host in our enpoint list if it's defined. Otherwise, return the last host.
+	 */
 	static function filter__ep_pre_request_host( $host, $failures, $path, $args ) {
 		if( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) { 
 			return $host;
@@ -249,6 +254,9 @@ class Search {
 		return self::round_robin_hosts( $host, VIP_ELASTICSEARCH_ENDPOINTS );
 	}
 
+	/**
+	 * Return the next host in the list based on the current host
+	 */
 	static function round_robin_hosts( $host, $hostList ) {
 		$cur_index = array_search( $host, $hostList );
 		$max_index = count( $hostList ) - 1;

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -43,7 +43,7 @@ class Search {
 		}
 
 		if ( ! defined( 'EP_HOST' ) && defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) && is_array( VIP_ELASTICSEARCH_ENDPOINTS ) ) {
-			$host = VIP_ELASTICSEARCH_ENDPOINTS[ 0 ];
+			$host = self::load_balance_endpoints( VIP_ELASTICSEARCH_ENDPOINTS );
 
 			define( 'EP_HOST', $host );
 		}
@@ -236,5 +236,18 @@ class Search {
 
 		// The filter is checking if we should _skip_ query integration
 		return ! ( $query_integration_enabled || $query_integration_enabled_legacy );
+	}
+
+	/*
+	 * Given a list of endpoints, randomly select one for load balancing purposes.
+	 */
+	static function load_balance_endpoints( $endpoints ) {
+		if( ! is_array( $endpoints ) ) {
+			return $endpoints;
+		}
+
+		return $endpoints[  
+			rand( 0, count( $endpoints ) - 1 ) 
+		];
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -268,7 +268,7 @@ class Search {
 		return $hostList[ $cur_index + 1 ];
 	} 
 
-	/*
+	/**
 	 * Given a list of endpoints, randomly select one for load balancing purposes.
 	 */
 	static function load_balance_endpoints( $endpoints ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -246,8 +246,8 @@ class Search {
 	 *
 	 * Return the next host in our enpoint list if it's defined. Otherwise, return the last host.
 	 */
-	static function filter__ep_pre_request_host( $host, $failures, $path, $args ) {
-		if( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) { 
+	public static function filter__ep_pre_request_host( $host, $failures, $path, $args ) {
+		if ( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) { 
 			return $host;
 		}
 
@@ -257,27 +257,25 @@ class Search {
 	/**
 	 * Return the next host in the list based on the current host
 	 */
-	static function round_robin_hosts( $host, $hostList ) {
-		$cur_index = array_search( $host, $hostList );
-		$max_index = count( $hostList ) - 1;
+	public static function round_robin_hosts( $host, $host_list ) {
+		$cur_index = array_search( $host, $host_list );
+		$max_index = count( $host_list ) - 1;
 
-		if ( $cur_index === $max_index or is_null( $cur_index ) ) {
-			return $hostList[ 0 ];
+		if ( $cur_index === $max_index || is_null( $cur_index ) ) {
+			return $host_list[0];
 		}
 
-		return $hostList[ $cur_index + 1 ];
+		return $host_list[ $cur_index + 1 ];
 	} 
 
 	/**
 	 * Given a list of endpoints, randomly select one for load balancing purposes.
 	 */
-	static function load_balance_endpoints( $endpoints ) {
-		if( ! is_array( $endpoints ) ) {
+	public static function load_balance_endpoints( $endpoints ) {
+		if ( ! is_array( $endpoints ) ) {
 			return $endpoints;
 		}
 
-		return $endpoints[  
-			rand( 0, count( $endpoints ) - 1 ) 
-		];
+		return $endpoints[ rand( 0, count( $endpoints ) - 1 ) ];
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -43,7 +43,7 @@ class Search {
 		}
 
 		if ( ! defined( 'EP_HOST' ) && defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) && is_array( VIP_ELASTICSEARCH_ENDPOINTS ) ) {
-			$host = self::load_balance_endpoints( VIP_ELASTICSEARCH_ENDPOINTS );
+			$host = $this->get_random_host( VIP_ELASTICSEARCH_ENDPOINTS );
 
 			define( 'EP_HOST', $host );
 		}
@@ -246,36 +246,36 @@ class Search {
 	 *
 	 * Return the next host in our enpoint list if it's defined. Otherwise, return the last host.
 	 */
-	public static function filter__ep_pre_request_host( $host, $failures, $path, $args ) {
+	public function filter__ep_pre_request_host( $host, $failures, $path, $args ) {
 		if ( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) { 
 			return $host;
 		}
 
-		return self::round_robin_hosts( $host, VIP_ELASTICSEARCH_ENDPOINTS );
+		return $this->get_next_host( $host, VIP_ELASTICSEARCH_ENDPOINTS );
 	}
 
 	/**
 	 * Return the next host in the list based on the current host
 	 */
-	public static function round_robin_hosts( $host, $host_list ) {
-		$cur_index = array_search( $host, $host_list );
-		$max_index = count( $host_list ) - 1;
+	public function get_next_host( $host, $hosts ) {
+		$cur_index = array_search( $host, $hosts );
+		$max_index = count( $hosts ) - 1;
 
 		if ( $cur_index === $max_index || is_null( $cur_index ) ) {
-			return $host_list[0];
+			return $hosts[0];
 		}
 
-		return $host_list[ $cur_index + 1 ];
+		return $hosts[ $cur_index + 1 ];
 	} 
 
 	/**
-	 * Given a list of endpoints, randomly select one for load balancing purposes.
+	 * Given a list of hosts, randomly select one for load balancing purposes.
 	 */
-	public static function load_balance_endpoints( $endpoints ) {
-		if ( ! is_array( $endpoints ) ) {
-			return $endpoints;
+	public function get_random_host( $hosts ) {
+		if ( ! is_array( $hosts ) ) {
+			return $hosts;
 		}
 
-		return $endpoints[ rand( 0, count( $endpoints ) - 1 ) ];
+		return $hosts[ array_rand( $hosts ) ];
 	}
 }

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -530,13 +530,13 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 'test0', $es->get_next_host( $hosts, 0 ), 'get_next_host() didn\'t use the same host with 0 total failures and 4 hosts with a starting index of 0' );
 		$this->assertEquals( 'test1', $es->get_next_host( $hosts, 1 ), 'get_next_host() didn\'t get the correct host with 1 total failures and 4 hosts with a starting index of 0' );
 		$this->assertEquals( 'test0', $es->get_next_host( $hosts, 3 ), 'get_next_host() didn\'t restart at the beginning of the list upon reaching the end with 4 total failures and 4 hosts with a starting index of 1' );
-		$this->assertEquals( 'test1', $es->get_next_host( $hosts, 17 ), 'get_next_host() didn\'t match expected result with 21 total failures and 4 hosts. and a starting index of 1' );
+		$this->assertEquals( 'test1', $es->get_next_host( $hosts, 17 ), 'get_next_host() didn\'t match expected result with 21 total failures and 4 hosts. and a starting index of 0' );
 
 		array_push( $hosts, 'test4', 'test5', 'test6' ); // Add some array values
 
-		$this->assertEquals( 'test5', $es->get_next_host( $hosts, 4 ), 'get_next_host() didn\'t get the same host with 21 total failures and 7 hosts with starting index of 1.' );
-		$this->assertEquals( 'test6', $es->get_next_host( $hosts, 1 ), 'get_next_host() didn\'t get the next host with 22 total failure and 7 hosts with starting index of 5' );
-		$this->assertEquals( 'test3', $es->get_next_host( $hosts, 4 ), 'get_next_host() didn\'t get the correct host with 26 total failures and 7 hosts with a starting index of 7' );
+		$this->assertEquals( 'test5', $es->get_next_host( $hosts, 4 ), 'get_next_host() didn\'t get the same host with 25 total failures and 7 hosts with starting index of 1.' );
+		$this->assertEquals( 'test6', $es->get_next_host( $hosts, 1 ), 'get_next_host() didn\'t get the next host with 26 total failure and 7 hosts with starting index of 5' );
+		$this->assertEquals( 'test3', $es->get_next_host( $hosts, 4 ), 'get_next_host() didn\'t get the correct host with 30 total failures and 7 hosts with a starting index of 6' );
 	}
 
 	/*

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -127,7 +127,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$this->assertEquals( true, 'https://es-endpoint1' === EP_HOST || 'https://es-endpoint2' === EP_HOST );
+		$this->assertContains( EP_HOST, VIP_ELASTICSEARCH_ENDPOINTS );
 		$this->assertEquals( ES_SHIELD, 'foo:bar' );
 	}
 
@@ -497,7 +497,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es->init();
 
 		// If VIP_ELASTICSEARCH_ENDPOINTS is not defined, just hand the last host back
-		$this->assertEquals( 'test', $es::filter__ep_pre_request_host( 'test', 0, '', array() ) );
+		$this->assertEquals( 'test', $es->filter__ep_pre_request_host( 'test', 0, '', array() ) );
 
 		define( 
 			'VIP_ELASTICSEARCH_ENDPOINTS', 
@@ -509,13 +509,13 @@ class Search_Test extends \WP_UnitTestCase {
 			) 
 		);
 
-		$this->assertEquals( true, in_array( $es::filter__ep_pre_request_host( 'endpoint1', 0, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS ) );
+		$this->assertContains( $es->filter__ep_pre_request_host( 'endpoint1', 0, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS );
 	}
 
 	/*
 	 * Test for making sure the round robin function returns the next array value
 	 */
-	public function test__vip_search_round_robin_hosts() {
+	public function test__vip_search_get_next_host() {
 		$es = new \Automattic\VIP\Search\Search();
 		$hosts = array(
 			'test0',
@@ -523,22 +523,22 @@ class Search_Test extends \WP_UnitTestCase {
 			'test2', 
 			'test3',
 		);
-		$this->assertEquals( 'test1', $es::round_robin_hosts( 'test0', $hosts ) );
-		$this->assertEquals( 'test0', $es::round_robin_hosts( 'test3', $hosts ) );
+		$this->assertEquals( 'test1', $es->get_next_host( 'test0', $hosts ) );
+		$this->assertEquals( 'test0', $es->get_next_host( 'test3', $hosts ) );
 	}
 
 	/*
 	 * Test for making sure the load balance functionality works
 	 */
-	public function test__vip_search_load_balance_endpoints() {
-		$endpoints = array(
-			'endpoint1',
-			'endpoint2',
-			'endpoint3',
-			'endpoint4',
+	public function test__vip_search_get_random_host() {
+		$hosts = array(
+			'test0',
+			'test1',
+			'test2', 
+			'test3',
 		);
 		$es = new \Automattic\VIP\Search\Search();
 
-		$this->assertEquals( true, in_array( $es::load_balance_endpoints( $endpoints ), $endpoints ) );
+		$this->assertContains( $es->get_random_host( $hosts ), $hosts );
 	}
 }

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -506,10 +506,13 @@ class Search_Test extends \WP_UnitTestCase {
 				'endpoint2',
 				'endpoint3',
 				'endpoint4',
+				'endpoint5',
+				'endpoint6',
 			) 
 		);
 
-		$this->assertContains( $es->filter__ep_pre_request_host( 'endpoint1', 0, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS, 'filter__ep_pre_request_host() didn\'t return a value that exists in VIP_ELASTICSEARCH_ENDPOINTS' );
+		$this->assertContains( $es->filter__ep_pre_request_host( 'endpoint1', 0, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS, 'filter__ep_pre_request_host() didn\'t return a value that exists in VIP_ELASTICSEARCH_ENDPOINTS with 0 total failures' );
+		$this->assertContains( $es->filter__ep_pre_request_host( 'endpoint1', 107, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS, 'filter__ep_pre_request_host() didn\'t return a value that exists in VIP_ELASTICSEARCH_ENDPOINTS with 107 failures' );
 	}
 
 	/*
@@ -523,8 +526,17 @@ class Search_Test extends \WP_UnitTestCase {
 			'test2', 
 			'test3',
 		);
-		$this->assertEquals( 'test1', $es->get_next_host( 'test0', $hosts ), 'get_next_host() didn\'t get the next host in the list' );
-		$this->assertEquals( 'test0', $es->get_next_host( 'test3', $hosts ), 'get_next_host() didn\'t restart at the beginning of the list upon reaching the end' );
+
+		$this->assertEquals( 'test0', $es->get_next_host( $hosts, 0 ), 'get_next_host() didn\'t use the same host with 0 total failures and 4 hosts with a starting index of 0' );
+		$this->assertEquals( 'test1', $es->get_next_host( $hosts, 1 ), 'get_next_host() didn\'t get the correct host with 1 total failures and 4 hosts with a starting index of 0' );
+		$this->assertEquals( 'test0', $es->get_next_host( $hosts, 3 ), 'get_next_host() didn\'t restart at the beginning of the list upon reaching the end with 4 total failures and 4 hosts with a starting index of 1' );
+		$this->assertEquals( 'test1', $es->get_next_host( $hosts, 17 ), 'get_next_host() didn\'t match expected result with 21 total failures and 4 hosts. and a starting index of 1' );
+
+		array_push( $hosts, 'test4', 'test5', 'test6' ); // Add some array values
+
+		$this->assertEquals( 'test5', $es->get_next_host( $hosts, 4 ), 'get_next_host() didn\'t get the same host with 21 total failures and 7 hosts with starting index of 1.' );
+		$this->assertEquals( 'test6', $es->get_next_host( $hosts, 1 ), 'get_next_host() didn\'t get the next host with 22 total failure and 7 hosts with starting index of 5' );
+		$this->assertEquals( 'test3', $es->get_next_host( $hosts, 4 ), 'get_next_host() didn\'t get the correct host with 26 total failures and 7 hosts with a starting index of 7' );
 	}
 
 	/*

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -127,7 +127,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$this->assertEquals( true, 'https://es-endpoint1' === EP_HOST or 'https://es-endpoint2' === EP_HOST );
+		$this->assertEquals( true, 'https://es-endpoint1' === EP_HOST || 'https://es-endpoint2' === EP_HOST );
 		$this->assertEquals( ES_SHIELD, 'foo:bar' );
 	}
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -488,4 +488,16 @@ class Search_Test extends \WP_UnitTestCase {
 		// Should not have instantiated and registered the init action to setup the health check
 		$this->assertEquals( false, $es->healthcheck->is_enabled() );
 	}
+
+	public function test__load_balance_endpoints() {
+		$endpoints = [
+			'endpoint1',
+			'endpoint2',
+			'endpoint3',
+			'endpoint4',
+		];
+		$es = new \Automattic\VIP\Search\Search();
+
+		$this->assertEquals( true, in_array( $es::load_balance_endpoints( $endpoints ), $endpoints ) );
+	}
 }

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -509,7 +509,10 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( true, in_array( $es::filter__ep_pre_request_host( 'endpoint1', 0, '', [] ), VIP_ELASTICSEARCH_ENDPOINTS ) );
 	}
 
-	public function test__round_robin_hosts() {
+	/*
+	 * Test for making sure the round robin function returns the next array value
+	 */
+	public function test__vip_search_round_robin_hosts() {
 		$es = new \Automattic\VIP\Search\Search();
 		$hosts = [
 			'test0',
@@ -521,7 +524,10 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 'test0', $es::round_robin_hosts( 'test3', $hosts ) );
 	}
 
-	public function test__load_balance_endpoints() {
+	/*
+	 * Test for making sure the load balance functionality works
+	 */
+	public function test__vip_search_load_balance_endpoints() {
 		$endpoints = [
 			'endpoint1',
 			'endpoint2',

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -497,7 +497,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es->init();
 
 		// If VIP_ELASTICSEARCH_ENDPOINTS is not defined, just hand the last host back
-		$this->assertEquals( 'test', $es->filter__ep_pre_request_host( 'test', 0, '', array() ) );
+		$this->assertEquals( 'test', $es->filter__ep_pre_request_host( 'test', 0, '', array() ), 'filter__ep_pre_request_host() did\'t just hand the last host back when VIP_ELASTICSEARCH_ENDPOINTS was undefined' );
 
 		define( 
 			'VIP_ELASTICSEARCH_ENDPOINTS', 
@@ -509,7 +509,7 @@ class Search_Test extends \WP_UnitTestCase {
 			) 
 		);
 
-		$this->assertContains( $es->filter__ep_pre_request_host( 'endpoint1', 0, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS );
+		$this->assertContains( $es->filter__ep_pre_request_host( 'endpoint1', 0, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS, 'filter__ep_pre_request_host() didn\'t return a value that exists in VIP_ELASTICSEARCH_ENDPOINTS' );
 	}
 
 	/*
@@ -523,8 +523,8 @@ class Search_Test extends \WP_UnitTestCase {
 			'test2', 
 			'test3',
 		);
-		$this->assertEquals( 'test1', $es->get_next_host( 'test0', $hosts ) );
-		$this->assertEquals( 'test0', $es->get_next_host( 'test3', $hosts ) );
+		$this->assertEquals( 'test1', $es->get_next_host( 'test0', $hosts ), 'get_next_host() didn\'t get the next host in the list' );
+		$this->assertEquals( 'test0', $es->get_next_host( 'test3', $hosts ), 'get_next_host() didn\'t restart at the beginning of the list upon reaching the end' );
 	}
 
 	/*

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -489,6 +489,18 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( false, $es->healthcheck->is_enabled() );
 	}
 
+	public function test__round_robin_hosts() {
+		$es = new \Automattic\VIP\Search\Search();
+		$hosts = [
+			'test0',
+			'test1',
+			'test2', 
+			'test3',
+		];
+		$this->assertEquals( 'test1', $es::round_robin_hosts( 'test0', $hosts ) );
+		$this->assertEquals( 'test0', $es::round_robin_hosts( 'test3', $hosts ) );
+	}
+
 	public function test__load_balance_endpoints() {
 		$endpoints = [
 			'endpoint1',

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -489,6 +489,26 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( false, $es->healthcheck->is_enabled() );
 	}
 
+	/**
+	 * Test that checks both single and multi-host retries
+	 */
+	public function test__vip_search_filter__ep_pre_request_host() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		// If VIP_ELASTICSEARCH_ENDPOINTS is not defined, just hand the last host back
+		$this->assertEquals( 'test', $es::filter__ep_pre_request_host( 'test', 0, '', [] ) );
+
+		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
+			'endpoint1',
+			'endpoint2',
+			'endpoint3',
+			'endpoint4',
+		) );
+
+		$this->assertEquals( true, in_array( $es::filter__ep_pre_request_host( 'endpoint1', 0, '', [] ), VIP_ELASTICSEARCH_ENDPOINTS ) );
+	}
+
 	public function test__round_robin_hosts() {
 		$es = new \Automattic\VIP\Search\Search();
 		$hosts = [

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -497,16 +497,19 @@ class Search_Test extends \WP_UnitTestCase {
 		$es->init();
 
 		// If VIP_ELASTICSEARCH_ENDPOINTS is not defined, just hand the last host back
-		$this->assertEquals( 'test', $es::filter__ep_pre_request_host( 'test', 0, '', [] ) );
+		$this->assertEquals( 'test', $es::filter__ep_pre_request_host( 'test', 0, '', array() ) );
 
-		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
-			'endpoint1',
-			'endpoint2',
-			'endpoint3',
-			'endpoint4',
-		) );
+		define( 
+			'VIP_ELASTICSEARCH_ENDPOINTS', 
+			array(
+				'endpoint1',
+				'endpoint2',
+				'endpoint3',
+				'endpoint4',
+			) 
+		);
 
-		$this->assertEquals( true, in_array( $es::filter__ep_pre_request_host( 'endpoint1', 0, '', [] ), VIP_ELASTICSEARCH_ENDPOINTS ) );
+		$this->assertEquals( true, in_array( $es::filter__ep_pre_request_host( 'endpoint1', 0, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS ) );
 	}
 
 	/*
@@ -514,12 +517,12 @@ class Search_Test extends \WP_UnitTestCase {
 	 */
 	public function test__vip_search_round_robin_hosts() {
 		$es = new \Automattic\VIP\Search\Search();
-		$hosts = [
+		$hosts = array(
 			'test0',
 			'test1',
 			'test2', 
 			'test3',
-		];
+		);
 		$this->assertEquals( 'test1', $es::round_robin_hosts( 'test0', $hosts ) );
 		$this->assertEquals( 'test0', $es::round_robin_hosts( 'test3', $hosts ) );
 	}
@@ -528,12 +531,12 @@ class Search_Test extends \WP_UnitTestCase {
 	 * Test for making sure the load balance functionality works
 	 */
 	public function test__vip_search_load_balance_endpoints() {
-		$endpoints = [
+		$endpoints = array(
 			'endpoint1',
 			'endpoint2',
 			'endpoint3',
 			'endpoint4',
-		];
+		);
 		$es = new \Automattic\VIP\Search\Search();
 
 		$this->assertEquals( true, in_array( $es::load_balance_endpoints( $endpoints ), $endpoints ) );

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -127,7 +127,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$this->assertEquals( EP_HOST, 'https://es-endpoint1' );
+		$this->assertEquals( true, 'https://es-endpoint1' === EP_HOST or 'https://es-endpoint2' === EP_HOST );
 		$this->assertEquals( ES_SHIELD, 'foo:bar' );
 	}
 


### PR DESCRIPTION
## Description
[PLAT-863]

Added a filter for `ep_pre_request_host` to round-robin retry our endpoints.

Added a random load balance implementation for setting EP_HOST from our endpoints.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
2. `./bin/phpunit-docker.sh tests/search/test-class-search.php`

[PLAT-863]: https://vipjira.atlassian.net/browse/PLAT-863