### PR TITLE
Add php linting to pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ job-references:
           name: "Run Tests"
           command: |
             if [[ "$RUN_EXTRA" == "1" ]]; then
-              make lint
+              npm run phplint
               npm run phpcs:changed:remote
             fi
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR

--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "npm run phplint && npm run phpcs:changed:local"
+    "pre-push": "npm run phplint && npm run phpcs:changed:local"
   }
 }

--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "npm run phpcs:changed:local"
+    "pre-commit": "npm run phplint && npm run phpcs:changed:local"
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,4 @@
-.PHONY: lint phpunit phpdoc phpcs phpcbf clean
-
-test: lint phpunit phpcs
-
-sniff: phpcs
-
-lint:
-	find . -name \*.php -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -d display_errors=stderr -l > /dev/null
-
-phpunit:
-	vendor/bin/phpunit
+.PHONY: phpdoc
 
 phpdoc:
 	phpdoc run --no-interaction
-
-phpcs:
-	test -f /tmp/phpcs || curl -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar -o /tmp/phpcs && chmod +x /tmp/phpcs
-	test -d /tmp/wpcs || git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /tmp/wpcs
-	/tmp/phpcs --config-set installed_paths /tmp/wpcs
-	/tmp/phpcs -p . --severity=6 --standard=phpcs.xml --extensions=php --runtime-set ignore_warnings_on_exit true
-
-phpcbf:
-	test -f /tmp/phpcs || curl -L https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar -o /tmp/phpcs && chmod +x /tmp/phpcs
-	test -f /tmp/phpcbf || curl -L https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar -o /tmp/phpcbf && chmod +x /tmp/phpcbf
-	test -d /tmp/wpcs || git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /tmp/wpcs
-	/tmp/phpcs --config-set installed_paths /tmp/wpcs
-	/tmp/phpcbf -p . --standard=phpcs.xml --extensions=php
-
-clean:
-	rm -rf /tmp/phpcs
-	rm -rf /tmp/phpcbf
-	rm -rf /tmp/wpcs

--- a/bin/php-lint.sh
+++ b/bin/php-lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find . -name \*.php -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -d display_errors=stderr -l > /dev/null

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "mu-plugins used on the VIP Go platform",
   "scripts": {
+    "phplint": "bin/php-lint.sh",
     "phpcs": "vendor/bin/phpcs",
     "phpcs:changed:remote": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet",
     "phpcs:changed:local": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet -d index"


### PR DESCRIPTION
Builds on #1486.

Drops most of the stuff from Makefile since that wasn't really being used and centralizes into npm scripts so we have fewer entry points. And adds to husyrc so we can run linting on pre-commit.

```
$ git ci
husky > pre-commit (node v10.15.2)

> @automattic/vip-go-mu-plugins@1.0.0 phplint /Users/mjangda/Sites/vipgo/mu-plugins-docker/mu-plugins
> bin/php-lint.sh


> @automattic/vip-go-mu-plugins@1.0.0 phpcs:changed:local /Users/mjangda/Sites/vipgo/mu-plugins-docker/mu-plugins
> vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet -d index

[update/husky-lint-pre-commit 26b063ca] Update readme for php lint changes
 1 file changed, 5 insertions(+), 1 deletion(-)
```

## Checklist

n/a

## Steps to Test

1. `npm install`
1. Edit a file and add a PHP error.
1. `git add -u` and `git commit`

This should fail.