### PR TITLE
Update ElasticPress submodule to master

### DIFF
--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -72,6 +72,8 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
+		do_action( 'plugins_loaded' );
+
 		// Activate the feature
 		\ElasticPress\Features::factory()->activate_feature( $slug );
 


### PR DESCRIPTION
## Description

Updates our EP submodule to `master` on `Automattic/ElasticPress`.

Brings in EP 3.4 plus term re-indexing, the failed request hook, and a fix for the post status array

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Try some searches `?s=test`
1. Try CLI commands: `wp elasticpress index`, `wp vip-search health validate-counts`
