### PR TITLE
Search: Hide Authorization header in EP Debug Bar request log

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -106,7 +106,7 @@ class Search {
 		// NOTE - must hook in here b/c the wp_get_current_user function required for checking if debug bar is enabled isn't loaded earlier
 		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
 			// Load query log override function to remove Authorization header from requests
-			require_once( __DIR__ . '/../functions/ep-get-query-log.php' );
+			require_once __DIR__ . '/../functions/ep-get-query-log.php';
 			// Load ElasticPress Debug Bar
 			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -100,6 +100,8 @@ class Search {
 		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
 		// NOTE - must hook in here b/c the wp_get_current_user function required for checking if debug bar is enabled isn't loaded earlier
 		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
+			// Load query log override function to remove Authorization header from requests
+			require_once( __DIR__ . '/../functions/ep-get-query-log.php' );
 			// Load ElasticPress Debug Bar
 			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
 

--- a/search/includes/functions/ep-get-query-log.php
+++ b/search/includes/functions/ep-get-query-log.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '../../../elasticpress/elasticpress.php';
+
+// Override query log to remove Authorization header.
+function ep_get_query_log() {
+	$queries = \ElasticPress\Elasticsearch::factory()->get_query_log();
+	foreach ( $queries as $index => $query ) {
+		unset( $queries[ $index ]['args']['headers']['Authorization'] );
+	}
+
+	return $queries;
+}


### PR DESCRIPTION
[PLAT-975]

## Description

Added and required 'ep_get_query_log' function to override queries and filter out the Authorization header so it's not shown in the ElasticPress debug bar/QM panel.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Make sure you constants are set locally for Search(including relevant Search-specific username and password constants).
2. Do a search locally. Check the headers of the action in the EP debug bar. You should see an `Authorization` header.
3. Pull down PR.
4. Do a search locally(again). Check the headers of the action in the EP debug bar. You shouldn't see the `Authorization` header anymore.

[PLAT-975]: https://vipjira.atlassian.net/browse/PLAT-975