### PR TITLE
Fix health check failure notifications related to index counts

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -56,7 +56,7 @@ class Health {
 		}
 
 		// Verify actual results
-		$es_total = $es_result[ 'found_documents' ];
+		$es_total = $es_result['found_documents'];
 
 		$diff = 0;
 		if ( $db_total !== $es_total ) {

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -56,7 +56,7 @@ class Health {
 		}
 
 		// Verify actual results
-		$es_total = (int) $es_result[ 'found_documents' ][ 'value' ];
+		$es_total = $es_result[ 'found_documents' ];
 
 		$diff = 0;
 		if ( $db_total !== $es_total ) {


### PR DESCRIPTION
## Description

Indexable::query_es result was changed slightly. So 'found_documents' is now the result count and not 'found_documents'['value']. This caused our health checks to fail.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).(Will make a separate PR with more thorough tests since this should go out right away).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `wp vip-search health validate-counts` # it will fail.
2. Pull down PR.
3. `wp vip-search health validate-counts` # It will succeed.
