### PR TITLE
Alerts: Send option uncacheable alerts to the critical channel

### DIFF
--- a/001-cron.php
+++ b/001-cron.php
@@ -118,7 +118,7 @@ function wpcom_vip_cron_control_event_object_to_string( $event ) {
  */
 function wpcom_vip_log_cron_control_uncacheable_cron_option( $option_size, $buckets, $option_flat_count ) {
 	$message = sprintf( 'Cron Control Cron Option Uncacheable Alert - home: %s | option size: %d | buckets: %d | option flat count: %d', home_url( '/' ), $option_size, $buckets, $option_flat_count );
-	wpcom_vip_irc( 'vipv2-alerts', $message, 2, 'cache-control-uncacheable-cron-option', 900 );
+	wpcom_vip_irc( 'vip-go-criticals', $message, 2, 'cache-control-uncacheable-cron-option', 900 );
 }
 
 /**


### PR DESCRIPTION
## Description

PLAT-943

As is conventional, send alerts for "option uncacheable" messages to the `#vip-go-criticals` channel.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (not applicable).
- [x] This change has relevant documentation additions / updates (not applicable).

## Steps to Test

1. Check out the branch in this PR
1. Make sure the `wpcom_vip_log_cron_control_uncacheable_cron_option` function exists & is callable without syntax errors