### PR TITLE
Add usage of ep_post_get_taxonomies

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -86,6 +86,9 @@ class Search {
 
 		// Round-robin retry hosts if connection to a host fails
 		add_filter( 'ep_pre_request_host', array( $this, 'filter__ep_pre_request_host' ), PHP_INT_MAX, 4 );
+
+		// Remove post_status from taxonomy list if it exists
+		add_filter( 'ep_post_get_taxonomies', array( $this, 'filter__ep_post_get_taxonomies' ), PHP_INT_MAX );
 	}
 
 	protected function load_commands() {
@@ -256,6 +259,24 @@ class Search {
 		}
 
 		return $this->get_next_host( VIP_ELASTICSEARCH_ENDPOINTS, $failures );
+	}
+
+	/**
+	 * Filter for ep_post_get_taxonomies
+	 *
+	 * Return the list of taxonomies without post_status
+	 */
+	public function filter__ep_post_get_taxonomies( $taxonomies ) {
+		if ( ! in_array( 'post_status', $taxonomies ) ) {
+			return $taxonomies;
+		}
+
+		return array_filter( 
+			$taxonomies, 
+			function( $taxonomy ) {
+				return 'post_status' !== $taxonomy;
+			} 
+		);
 	}
 
 	/**

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -517,6 +517,21 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertContains( $es->filter__ep_pre_request_host( 'endpoint1', 107, '', array() ), VIP_ELASTICSEARCH_ENDPOINTS, 'filter__ep_pre_request_host() didn\'t return a value that exists in VIP_ELASTICSEARCH_ENDPOINTS with 107 failures' );
 	}
 
+	public function test__vip_search_filter__ep_post_get_taxonomies() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$taxonomies = array( 'test', 'cat', 'kitten' );
+
+		$this->assertEquals( $taxonomies, $es->filter__ep_post_get_taxonomies( $taxonomies ), 'filter__ep_post_get_taxonomies should just pass the taxonomies through if it doesn\'t contain post_status' );
+
+		$taxonomies[] = 'post_status';
+		$taxonomies[] = 'post_status';
+		$taxonomies[] = 'post_status';
+
+		$this->assertNotContains( 'post_status', $es->filter__ep_post_get_taxonomies( $taxonomies ), 'filter__ep_post_get_taxonomies should never contain post_status' );
+	}
+
 	/*
 	 * Test for making sure the round robin function returns the next array value
 	 */


### PR DESCRIPTION
## Description

Depends upon https://github.com/Automattic/ElasticPress/pull/13

Filter the taxonomy list so the problematic post_status taxonomy can be
removed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Run an index health check on a wpvip.com sandbox. It will fail.
2. Apply https://github.com/Automattic/ElasticPress/pull/13 to ElasticPress on your sandbox
3. Pull down this PR and apply it to your sandbox.
4. Run an index health check on your wpvip.com sandbox again. The post counts will now successfully be validated.
