### PR TITLE
Removed gutenburg alert

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1116,27 +1116,6 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 			}
 		}
 	}
-
-	// For WordPress 5.0+, any environments that want to use the Gutenberg plugin need to define a specific constant.
-	// Without the constant in place, we skip loading the plugin and fallback to the core block editor.
-	// This will also facilitate the upgrade path where core disables the Gutenberg plugin as part of the upgrade.
-	if ( 'gutenberg' === $plugin ) {
-		$db_version = absint( get_option( 'db_version' ) );
-		$is_50_plus = $db_version >= 43764;
-
-		$should_load_gutenberg = true;
-		if ( ! defined( 'GUTENBERG_USE_PLUGIN' ) ) {
-			$should_load_gutenberg = false;
-		} elseif ( true !== GUTENBERG_USE_PLUGIN ) {
-			$should_load_gutenberg = false;
-		}
-
-		if ( $is_50_plus && ! $should_load_gutenberg ) {
-			trigger_error( 'wpcom_vip_load_plugin: Skipped loading Gutenberg plugin. Please add `define( \'GUTENBERG_USE_PLUGIN\', true );` if you would like to use the plugin over the Core Block Editor. For details, see https://vip.wordpress.com/documentation/vip-go/loading-gutenberg/', E_USER_WARNING );
-
-			return;
-		}
-	}
 	
 	if ( $includepath && file_exists( $includepath ) ) {
 		wpcom_vip_add_loaded_plugin( "{$plugin_type}/{$plugin}/{$file}" );


### PR DESCRIPTION
## Description

Removed alert for if you're not using Gutenburg. It was logging quite a bit to certain sites and is no longer needed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).