### PR TITLE
Temporarily force disable user indexing

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -171,6 +171,7 @@ class Search {
 	public function filter__ep_feature_active( $active, $feature_settings, $feature ) {
 		$disabled_features = array(
 			'documents',
+			'users',
 		);
 
 		if ( in_array( $feature->slug, $disabled_features, true ) ) {


### PR DESCRIPTION
## Description

Temporarily disable user indexing feature.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Enable user feature.
2. Run a health check. It should run.
2. Pull down PR.
3. Run a health check, user check should cause `Warning: failure retrieving user documents from ES #vip-search`