### PR TITLE
More validation checks for ep_pre_request_host

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -256,6 +256,14 @@ class Search {
 			return $host;
 		}
 
+		if ( ! is_array( VIP_ELASTICSEARCH_ENDPOINTS ) ) {
+			return $host;
+		}
+
+		if ( 0 === count( VIP_ELASTICSEARCH_ENDPOINTS ) ) {
+			return $host;
+		}
+
 		return $this->get_next_host( VIP_ELASTICSEARCH_ENDPOINTS, $failures );
 	}
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -518,6 +518,30 @@ class Search_Test extends \WP_UnitTestCase {
 	}
 
 	/*
+	 * Test for making sure filter__ep_pre_request_host handles empty endpoint lists
+	 */
+	public function test__vip_search_filter__ep_pre_request_host_empty_endpoint() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+		
+		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array() );
+
+		$this->assertEquals( 'test', $es->filter__ep_pre_request_host( 'test', 0, '', array() ) );
+	}
+
+	/*
+	 * Test for making sure filter__ep_pre_request_host handles endpoint lists that aren't arrays
+	 */
+	public function test__vip_search_filter__ep_pre_request_host_endpoint_not_array() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+		
+		define( 'VIP_ELASTICSEARCH_ENDPOINTS', 'Random string' );
+	
+		$this->assertEquals( 'test', $es->filter__ep_pre_request_host( 'test', 0, '', array() ) );
+	}
+
+	/*
 	 * Test for making sure the round robin function returns the next array value
 	 */
 	public function test__vip_search_get_next_host() {


### PR DESCRIPTION
## Description

Needed more validation checks for empty array and non-arrays so that
those values don't get handed into the get_next_host function.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Define `VIP_ELASTICSEARCH_ENDPOINTS` as empty array.
2. Trigger an `ep_pre_request_host` action. You should get an error.
3. Pull down PR.
4. Trigger an `ep_pre_request_host` action. You shouldn't get an error.