### PR TITLE
Add the missing WP_EP_DEBUG constant

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -116,11 +116,6 @@ class Search {
 			require_once __DIR__ . '/../functions/ep-get-query-log.php';
 			// Load ElasticPress Debug Bar
 			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
-
-			// And ensure the logging has been setup (since it also hooks on plugins_loaded)
-			if ( function_exists( 'ep_setup_query_log' ) ) {
-				ep_setup_query_log();
-			}
 		}
 	}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -107,6 +107,11 @@ class Search {
 		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
 		// NOTE - must hook in here b/c the wp_get_current_user function required for checking if debug bar is enabled isn't loaded earlier
 		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
+			// Must be set to true to enable saving of queries in \ElasticPress\Elasticsearch
+			if ( ! defined( 'WP_EP_DEBUG' ) ) {
+				define( 'WP_EP_DEBUG', true );
+			}
+
 			// Load query log override function to remove Authorization header from requests
 			require_once __DIR__ . '/../functions/ep-get-query-log.php';
 			// Load ElasticPress Debug Bar

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -170,6 +170,9 @@ class Search_Test extends \WP_UnitTestCase {
 		// Be sure we don't already have the class loaded (or our test does nothing)
 		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ), 'EP Debug Bar plugin already loaded, therefore this test is not asserting that the plugin is loaded' );
 
+		// Be sure the constant isn't already defined (or our test does not assert that it was defined at runtime)
+		$this->assertEquals( false, defined( 'WP_EP_DEBUG' ), 'WP_EP_DEBUG constant already defined, therefore this test is not asserting that the constant is set at runtime' );
+
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
@@ -177,6 +180,9 @@ class Search_Test extends \WP_UnitTestCase {
 
 		// Class should now exist
 		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ), 'EP Debug Bar was not found' );
+
+		// And the debug constant should have been set (required for saving queries)
+		$this->assertEquals( true, constant( 'WP_EP_DEBUG' ), 'Incorrect value for WP_EP_DEBUG constant' );
 	}
 
 	/**

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -168,7 +168,7 @@ class Search_Test extends \WP_UnitTestCase {
 		add_filter( 'debug_bar_enable', '__return_true', PHP_INT_MAX );
 
 		// Be sure we don't already have the class loaded (or our test does nothing)
-		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );
+		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ), 'EP Debug Bar plugin already loaded, therefore this test is not asserting that the plugin is loaded' );
 
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
@@ -176,7 +176,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es->action__plugins_loaded();
 
 		// Class should now exist
-		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ) );
+		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ), 'EP Debug Bar was not found' );
 	}
 
 	/**


### PR DESCRIPTION
## Description

\ElasticPress\Elasticsearch only records queries if WP_DEBUG or WP_EP_DEBUG are true - we're not setting those in prod (WP_DEBUG is set on sandboxes) so the debug bar panel is showing no queries.

See https://github.com/Automattic/ElasticPress/blob/941b5c69e1b0622babe3c54852e03a1a91b70d33/includes/classes/Elasticsearch.php#L1299

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Ensure `WP_DEBUG` is `false`
1. Ensure the `debug_bar_enable` filter returns true (may need to add a filter locally)
1. (For local testing, may also need to comment out this line, which works in local dev but not in production, otherwise it'll set the WP_EP_DEBUG constant instead of our code doing it. https://github.com/Automattic/ElasticPress/blob/0b08b6dc2e074322853c40e2558efefe57f686a8/elasticpress.php#L264)
1. Verify that the ElasticPress debug bar shows queries
