### PR TITLE
Allow queries during indexing

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -88,6 +88,9 @@ class Search {
 		add_filter( 'ep_pre_request_host', array( $this, 'filter__ep_pre_request_host' ), PHP_INT_MAX, 4 );
 		
 		add_filter( 'ep_valid_response', array( $this, 'filter__ep_valid_response' ), 10, 4 );
+
+		// Allow querying while a bulk index is running
+		add_filter( 'ep_enable_query_integration_during_indexing', '__return_true' );
 	}
 
 	protected function load_commands() {

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -541,6 +541,18 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 'test', $es->filter__ep_pre_request_host( 'test', 0, '', array() ) );
 	}
 
+	/**
+	 * Ensure that we're allowing querying during bulk re-index, via the ep_enable_query_integration_during_indexing filter
+	 */
+	public function test__vip_search_filter__ep_enable_query_integration_during_indexing() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$allowed = apply_filters( 'ep_enable_query_integration_during_indexing', false );
+
+		$this->assertTrue( $allowed );
+	}
+
 	/*
 	 * Test for making sure the round robin function returns the next array value
 	 */


### PR DESCRIPTION
## Description

The index isn't dropped or anything, docs are just re-indexed in-place, so it's safe to allow queries against the index while a bulk index is being performed.

NOTE - the filter doesn't yet exist, but will as of https://github.com/Automattic/ElasticPress/pull/15 (safe to deploy without it though)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. First have to be sure you're running the new filter from https://github.com/Automattic/ElasticPress/pull/15
1. Then start a bulk index with `wp elasticpress index`
1. While the index is running, perform some searches (`?s=test`)
1. EP Debug Bar should report queries were performed while the indexing was occurring