### PR TITLE
Added yaml config for search testing

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -62,6 +62,7 @@ yarn.lock
 /cron-control-next/bin/
 /cron-control-next/runner/
 /cron-control-next/tests/
+/search/data/
 /search/elasticpress/bin/
 /search/elasticpress/config/
 /search/elasticpress/docs/

--- a/.deployignore
+++ b/.deployignore
@@ -62,7 +62,6 @@ yarn.lock
 /cron-control-next/bin/
 /cron-control-next/runner/
 /cron-control-next/tests/
-/search/data/
 /search/elasticpress/bin/
 /search/elasticpress/config/
 /search/elasticpress/docs/

--- a/tests/search/data/test_fixtures.yml
+++ b/tests/search/data/test_fixtures.yml
@@ -1,0 +1,90 @@
+#
+# ATTACHMENTS
+#
+Hellonico\Fixtures\Entity\Attachment:
+  image{1..100}:
+    file: <image(<uploadDir()>, 1200, 1200)>
+
+#
+# USERS
+#
+Hellonico\Fixtures\Entity\User:
+  user{1..300}:
+    user_login (unique): <username()>
+    user_pass: 123456
+    user_email: <safeEmail()>
+    user_url: <url()>
+    user_registered: <dateTimeThisDecade()>
+    first_name: <firstName()>
+    last_name: <lastName()>
+    description: <sentence()>
+    role: <randomElement(['subscriber', 'editor', 'publisher', 'reader', 'writer', 'other'])>
+    meta:
+      phone_number: <phoneNumber()>
+      address: <streetAddress()>
+      zip: <postcode()>
+      city: <city()>
+
+#
+# TERMS
+#
+Hellonico\Fixtures\Entity\Term:
+  term_default (template):
+    name (unique): <words(10, true)>
+    description: <sentence()>
+  category{1..2000} (extends term_default):
+    parent: '50%? <termId(childless=1)>'
+    taxonomy: 'category'
+  tag{1..5000} (extends term_default):
+    taxonomy: post_tag
+  places{1..200} (extends term_default):
+    taxonomy: place
+       
+#
+# POSTS
+#
+Hellonico\Fixtures\Entity\Post:
+  post_default (template):
+    post_title (unique): <words(20, true)>
+    post_date: <dateTimeThisDecade()>
+    post_content: <paragraphs(10, true)>
+    post_excerpt: <paragraphs(1, true)>
+    post_author: '@user*->ID'
+    meta:
+      _thumbnail_id: '@image*->ID'
+      extra_field: <paragraphs(1, true)>
+      string_field: <sentence()>
+      int_field: <randomNumber()>
+      date_field: <dateTimeThisCentury()>
+      float_field: <latitude()>
+
+  post{1..1000000} (extends post_default):
+    post_category: '3x @category*->term_id'
+    tax_input:
+      post_tag: '5x @tag*->term_id'
+
+  page{1..5000} (extends post_default):
+    post_type: page
+
+  product{1..10000} (extends post_default):
+    post_type: product
+    
+#
+# COMMENTS
+#
+Hellonico\Fixtures\Entity\Comment:
+  comment{1..2000000}:
+    comment_post_ID: '@post*->ID'
+    user_id: '@user*->ID'
+    comment_date: <dateTimeBetween( '@post*->post_date' )>
+    comment_author: '@user*->user_login'
+    comment_author_email: '@user*->user_email'
+    comment_author_url: '@user*->user_url'
+    comment_content: <paragraphs(2, true)>
+    comment_agent: <userAgent()>
+    comment_author_IP: <ipv4()>
+    comment_approved: 1
+    comment_karma: <numberBetween(1, 100)>
+    comment_meta:
+      some_key: <sentence()>
+      another_key: <sentence()>

--- a/tests/search/data/test_fixtures.yml
+++ b/tests/search/data/test_fixtures.yml
@@ -1,15 +1,18 @@
+# Ran with: 
+# ~$ for i in {1..200}; do wp fixtures load --file=/path/to/test_fixtures.yml; done &> fake_loop_boogaloo.txt &
+# ~$ disown %<JOB ID>
+
 #
 # ATTACHMENTS
 #
 Hellonico\Fixtures\Entity\Attachment:
-  image{1..100}:
-    file: <image(<uploadDir()>, 1200, 1200)>
-
+  image{1..3}:
+    file: <image(<uploadDir()>, 100, 100)>
 #
 # USERS
 #
 Hellonico\Fixtures\Entity\User:
-  user{1..300}:
+  user{1..5}:
     user_login (unique): <username()>
     user_pass: 123456
     user_email: <safeEmail()>
@@ -18,13 +21,12 @@ Hellonico\Fixtures\Entity\User:
     first_name: <firstName()>
     last_name: <lastName()>
     description: <sentence()>
-    role: <randomElement(['subscriber', 'editor', 'publisher', 'reader', 'writer', 'other'])>
+    role: <randomElement(['subscriber', 'editor', 'publisher', 'reader', 'writer', 'author', 'other'])>
     meta:
       phone_number: <phoneNumber()>
       address: <streetAddress()>
       zip: <postcode()>
       city: <city()>
-
 #
 # TERMS
 #
@@ -32,14 +34,13 @@ Hellonico\Fixtures\Entity\Term:
   term_default (template):
     name (unique): <words(10, true)>
     description: <sentence()>
-  category{1..2000} (extends term_default):
+  category{1..20} (extends term_default):
     parent: '50%? <termId(childless=1)>'
     taxonomy: 'category'
-  tag{1..5000} (extends term_default):
+  tag{1..50} (extends term_default):
     taxonomy: post_tag
-  places{1..200} (extends term_default):
+  places{1..5} (extends term_default):
     taxonomy: place
-       
 #
 # POSTS
 #
@@ -57,34 +58,11 @@ Hellonico\Fixtures\Entity\Post:
       int_field: <randomNumber()>
       date_field: <dateTimeThisCentury()>
       float_field: <latitude()>
-
-  post{1..1000000} (extends post_default):
+  post{1..5000} (extends post_default):
     post_category: '3x @category*->term_id'
     tax_input:
       post_tag: '5x @tag*->term_id'
-
-  page{1..5000} (extends post_default):
+  page{1..25} (extends post_default):
     post_type: page
-
-  product{1..10000} (extends post_default):
+  product{1..50} (extends post_default):
     post_type: product
-    
-#
-# COMMENTS
-#
-Hellonico\Fixtures\Entity\Comment:
-  comment{1..2000000}:
-    comment_post_ID: '@post*->ID'
-    user_id: '@user*->ID'
-    comment_date: <dateTimeBetween( '@post*->post_date' )>
-    comment_author: '@user*->user_login'
-    comment_author_email: '@user*->user_email'
-    comment_author_url: '@user*->user_url'
-    comment_content: <paragraphs(2, true)>
-    comment_agent: <userAgent()>
-    comment_author_IP: <ipv4()>
-    comment_approved: 1
-    comment_karma: <numberBetween(1, 100)>
-    comment_meta:
-      some_key: <sentence()>
-      another_key: <sentence()>


### PR DESCRIPTION
## Description

Added yaml config for search testing.

This yaml can be run with [nlemoine/wp-cli-fixtures](https://github.com/nlemoine/wp-cli-fixtures) to generate fake data for testing purposes.  

Presently being run.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).