### PR TITLE
Add 2fa email debug

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -223,3 +223,10 @@ function wpcom_vip_two_factor_admin_notice() {
 	</div>
 	<?php
 }
+
+add_action( 'login_init', function() {
+	// Add some debugging to track down failed 2fa emails
+	add_action( 'wp_mail_failed', function( $error ) {
+		trigger_error( sprintf( 'wp_mail_failed: %s', $error->get_error_message() ), E_USER_WARNING );
+	} );
+} );

--- a/two-factor.php
+++ b/two-factor.php
@@ -227,6 +227,6 @@ function wpcom_vip_two_factor_admin_notice() {
 add_action( 'login_init', function() {
 	// Add some debugging to track down failed 2fa emails
 	add_action( 'wp_mail_failed', function( $error ) {
-		trigger_error( sprintf( 'wp_mail_failed: %s', $error->get_error_message() ), E_USER_WARNING );
+		trigger_error( sprintf( 'wp_mail_failed: %s', esc_html( $error->get_error_message() ) ), E_USER_WARNING );
 	} );
 } );


### PR DESCRIPTION
To track down if/when email fails on the login page. This will log a user warning that we can search and filter. It applies to more than just 2fa (e.g. password reset requests as well) but maybe we'll catch other
bugs that way too :)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

TODO