### PR TITLE
Add constant to use core cron

### DIFF
--- a/001-cron.php
+++ b/001-cron.php
@@ -16,6 +16,11 @@
  * @return bool
  */
 function wpcom_vip_use_core_cron() {
+	
+	if ( defined('WPCOM_VIP_USE_CORE_CRON') && WPCOM_VIP_USE_CORE_CRON ) {
+		return true;
+	}
+
 	// Do not load outside of VIP environments, unless explicitly requested
 	if ( false === WPCOM_IS_VIP_ENV && ( ! defined( 'WPCOM_VIP_LOAD_CRON_CONTROL_LOCALLY' ) || ! WPCOM_VIP_LOAD_CRON_CONTROL_LOCALLY ) ) {
 		return true;

--- a/001-cron.php
+++ b/001-cron.php
@@ -17,7 +17,9 @@
  */
 function wpcom_vip_use_core_cron() {
 
-	if ( defined( 'WPCOM_VIP_USE_CORE_CRON' ) && WPCOM_VIP_USE_CORE_CRON ) {
+	// For some applications, Cron Control is not a good fit. Allow those apps to use core cron instead. 
+	// Note: please check with the VIP team before using this constant as it's not always guaranteed to work.
+	if ( defined( 'VIP_USE_CORE_CRON' ) && true === VIP_USE_CORE_CRON ) {
 		return true;
 	}
 

--- a/001-cron.php
+++ b/001-cron.php
@@ -16,8 +16,8 @@
  * @return bool
  */
 function wpcom_vip_use_core_cron() {
-	
-	if ( defined('WPCOM_VIP_USE_CORE_CRON') && WPCOM_VIP_USE_CORE_CRON ) {
+
+	if ( defined( 'WPCOM_VIP_USE_CORE_CRON' ) && WPCOM_VIP_USE_CORE_CRON ) {
 		return true;
 	}
 
@@ -153,7 +153,7 @@ if ( ! wpcom_vip_use_core_cron() ) {
 	add_action( 'a8c_cron_control_event_threw_catchable_error', 'wpcom_vip_log_cron_control_event_for_caught_error', 10, 2 );
 	add_action( 'a8c_cron_control_freeing_event_locks_after_uncaught_error', 'wpcom_vip_log_cron_control_event_object' );
 	add_action( 'a8c_cron_control_uncacheable_cron_option', 'wpcom_vip_log_cron_control_uncacheable_cron_option', 10, 3 );
-	
+
 	$cron_control_next_version = __DIR__ . '/cron-control-next/cron-control.php';
 
 	if ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION' ) && true === VIP_CRON_CONTROL_USE_NEXT_VERSION && file_exists( $cron_control_next_version ) ) {


### PR DESCRIPTION
## Description

Add constant to use core cron, instead of cron-control.

May be useful for huge multi sites that run only a few smaller jobs.

Bailing as early as possible. Using a constant instead of filters due to how early this file is.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Put some xdebug break points in cron-control/cron-control.php plugin
1. load site, notice cron-control.php loads
1. add `define( 'WPCOM_VIP_USE_CORE_CRON', true );` to vip-config
1. reload site, notice cron-control.php doesn't load
1. check the cron queue, note upcoming or due events
1. wait a few minutes, refresh site a few times (reminder to bust the cache)
1. check cron queue again, that jobs moved from core cron working