### PR TITLE
PHPCS: Add minimum_supported_wp_version of 5.3

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -56,9 +56,13 @@
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
 	<config name="testVersion" value="7.3-"/>
 
-	<!-- Rules: Check WordPress Coding Standards -->
-	<rule ref="WordPress-Core" />
-	<rule ref="WordPress-Extra" />
+	<!-- Rules: WordPress Coding Standards - see
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+	<!-- WordPress-Extra includes WordPress-Core -->
+	<rule ref="WordPress-Extra"/>
+	<!-- For help in understanding these custom sniff properties:
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
+	<config name="minimum_supported_wp_version" value="5.3"/>
 
 	<!-- Rules: Check VIP Coding Standards - see
 		https://github.com/Automattic/VIP-Coding-Standards/ -->


### PR DESCRIPTION
## Description

The `minimum_supported_wp_version` property [is used](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters) for checking deprecated functions, classes and function parameters, and alternative functions.

By default, the value of the `minimum_supported_wp_version` property is set to three versions before the currently released WP version (disregarding patch releases). [Currently `5.0`](https://github.com/WordPress/WordPress-Coding-Standards/blob/2f927b0ba2bfcbffaa8f3251c086e109302d6622/WordPress/Sniff.php#L85).

There are no new violations if this is set to 5.3, but it will mark deprecations as Errors when used in the future.

Aside: Also removes the `WordPress-Core` rule, since it is [already included](https://github.com/WordPress/WordPress-Coding-Standards/blob/2f927b0ba2bfcbffaa8f3251c086e109302d6622/WordPress-Extra/ruleset.xml#L6) as part of `WordPress-Extra`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

There are two tests.

The first is to show how the custom property works.

1. Open any file like `000-vip-init.php`, and add a `new WP_User_Search();` (deprecated in WP 3.1.0) at the bottom.
2. Run `phpcs 000-vip-init.php` and note that an _Error_ of `The WP_User_Search class has been deprecated since WordPress version 3.1.0. Use WP_User_Query instead.` is given.
3. Change the code to `new Services_JSON();` (deprecated in WP 5.3) run PHPCS again and you'll get a _Warning_ of `The Services_JSON class has been deprecated since WordPress version 5.3.0. Use The PHP native JSON extension instead.`
4. Apply the patch and run PHPCS again and the result will be the same, since the supported version is _the same_ as the version at which the class was deprecated).
5. Change the patched value from `5.3` to `5.4` and run PHPCS again and the _Warning_ will now be an _Error_ (since our supported version is _later_ than the version at which the class was deprecated).

The second is to prove that there are no existing uses of deprecations:

1. Run `phpcs --report=summary` and note the total number of violations.
2. Apply the patch and run `phpcs --report=summary` and note total number of violations does not change.

