### PR TITLE
Don't nerf $wp_object_cache->stats in stop_the_insanity()

### DIFF
--- a/vip-helpers/vip-wp-cli.php
+++ b/vip-helpers/vip-wp-cli.php
@@ -14,7 +14,6 @@ class WPCOM_VIP_CLI_Command extends WP_CLI_Command {
 			return;
 
 		$wp_object_cache->group_ops = array();
-		$wp_object_cache->stats = array();
 		$wp_object_cache->memcache_debug = array();
 		$wp_object_cache->cache = array();
 


### PR DESCRIPTION
When we nerf the stats object, it causes errors because the object cache dropin assumes the array exists in a certain format. The value of deleting this object is limited because there are only a handful of integers. It won't actually reclaim that much memory.