### PR TITLE
Check type is numeric first

### DIFF
--- a/lib/wpcom-error-handler/wpcom-error-handler.php
+++ b/lib/wpcom-error-handler/wpcom-error-handler.php
@@ -82,7 +82,7 @@ function wpcom_get_error_backtrace( $last_error_file, $last_error_type, $for_irc
  * When we run at shutdown we must not die as then the pretty printing of the Error doesn't happen which is lame sauce.
  */
 function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file, $line ) {
-	if ( ! is_numeric( $type ) || ! ( $type & ini_get( 'error_reporting' ) ) ) {
+	if ( ! is_numeric( $type ) || ! ( $type & error_reporting() ) ) {
 		return true;
 	}
 

--- a/lib/wpcom-error-handler/wpcom-error-handler.php
+++ b/lib/wpcom-error-handler/wpcom-error-handler.php
@@ -83,7 +83,7 @@ function wpcom_get_error_backtrace( $last_error_file, $last_error_type, $for_irc
  */
 function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file, $line ) {
 	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
-	if ( ! is_numeric( $type ) || ! ( $type & error_reporting() ) ) { 
+	if ( ! is_int( $type ) || ! ( $type & error_reporting() ) ) { 
 		return true;
 	}
 

--- a/lib/wpcom-error-handler/wpcom-error-handler.php
+++ b/lib/wpcom-error-handler/wpcom-error-handler.php
@@ -82,7 +82,8 @@ function wpcom_get_error_backtrace( $last_error_file, $last_error_type, $for_irc
  * When we run at shutdown we must not die as then the pretty printing of the Error doesn't happen which is lame sauce.
  */
 function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file, $line ) {
-	if ( ! is_numeric( $type ) || ! ( $type & error_reporting() ) ) {
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+	if ( ! is_numeric( $type ) || ! ( $type & error_reporting() ) ) { 
 		return true;
 	}
 

--- a/lib/wpcom-error-handler/wpcom-error-handler.php
+++ b/lib/wpcom-error-handler/wpcom-error-handler.php
@@ -82,7 +82,7 @@ function wpcom_get_error_backtrace( $last_error_file, $last_error_type, $for_irc
  * When we run at shutdown we must not die as then the pretty printing of the Error doesn't happen which is lame sauce.
  */
 function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file, $line ) {
-	if ( ! ( $type & ini_get( 'error_reporting' ) ) ) {
+	if ( ! is_numeric( $type ) || ! ( $type & ini_get( 'error_reporting' ) ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
## Description

Checks error type is a numeric value first before checking if the error type is in `error_reporting`.
This is to prevent the error:
`PHP Warning: A non-numeric value encountered in /chroot/var/www/wp-content/mu-plugins/lib/wpcom-error-handler/wpcom-error-handler.php on line 85`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

TBD