### PR TITLE
Fix SMS codes with leading zeros

### DIFF
--- a/tests/wpcom-vip-two-factor/sms-provider.php
+++ b/tests/wpcom-vip-two-factor/sms-provider.php
@@ -7,15 +7,20 @@ class Two_Factor_SMS_Test extends WP_UnitTestCase {
 	}
 
 	public function test__two_factor_sms_formatting() {
+		$token = 123456;
+		$expected = '123456 is your Test Blog verification code.' . "\n\n" . '@example.org #123456';
+
 		$two_factor = Two_Factor_SMS::get_instance();
+		$actual   = $two_factor->format_sms_message( $token );
 
-		$token      = 123456;
-		$site_title = 'Test Blog'; // used set values for test site
-		$home_url   = 'example.org'; // used set values for test site
+		$this->assertEquals( $expected, $actual );
+	}
 
-		$format = '%1$d is your %2$s verification code.' . "\n\n" . '@%3$s #%1$d';
+	public function test__two_factor_sms_formatting__code_with_leading_zero() {
+		$token = 0123456;
+		$expected = '0123456 is your Test Blog verification code.' . "\n\n" . '@example.org #0123456';
 
-		$expected = sprintf( $format, $token, $site_title, $home_url );
+		$two_factor = Two_Factor_SMS::get_instance();
 		$actual   = $two_factor->format_sms_message( $token );
 
 		$this->assertEquals( $expected, $actual );

--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -89,7 +89,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 		$parse = parse_url( home_url() );
 		$home_url_without_protocol = $parse['host'] . $parse['path'];
 
-		$format = '%1$d is your %2$s verification code.' . "\n\n" . '@%3$s #%1$d';
+		$format = '%1$s is your %2$s verification code.' . "\n\n" . '@%3$s #%1$s';
 
 		$message = sprintf( $format, $verification_code, $site_title, $home_url_without_protocol );
 		return $message;


### PR DESCRIPTION
We're formatting the SMS code as a number, but it's really a string that just happens to be made up of numbers. If it starts with 0, we don't want the leading 0 to be truncated.

```
php > var_dump( sprintf( '%d', '08' ) );
string(1) "8"
```

```
php > var_dump( sprintf( '%s', '08' ) );
string(2) "08"
```