### PR TITLE
Add facet query filters to search

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -91,6 +91,13 @@ class Search {
 
 		// Allow querying while a bulk index is running
 		add_filter( 'ep_enable_query_integration_during_indexing', '__return_true' );
+
+		// Set facet taxonomies size. Shouldn't currently be used, but it makes sense to have it set to a sensible
+		// default just in case it ends up in use so that the application doesn't error
+		add_filter( 'ep_facet_taxonomies_size', array( $this, 'filter__ep_facet_taxonomies_size' ), PHP_INT_MAX );
+
+		// Disable facet queries
+		add_filter( 'ep_facet_include_taxonomies', '__return_empty_array' );
 	}
 
 	protected function load_commands() {
@@ -302,5 +309,12 @@ class Search {
 			}
 		}
 		return $response;
+	}
+
+	/*
+	 * Given the current facet taxonomies size and a taxonomy, determine the facet taxonomy size
+	 */
+	public function filter__ep_facet_taxonomies_size( $size, $taxonomy ) {
+		return 5;
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -94,7 +94,7 @@ class Search {
 
 		// Set facet taxonomies size. Shouldn't currently be used, but it makes sense to have it set to a sensible
 		// default just in case it ends up in use so that the application doesn't error
-		add_filter( 'ep_facet_taxonomies_size', array( $this, 'filter__ep_facet_taxonomies_size' ), PHP_INT_MAX );
+		add_filter( 'ep_facet_taxonomies_size', array( $this, 'filter__ep_facet_taxonomies_size' ) );
 
 		// Disable facet queries
 		add_filter( 'ep_facet_include_taxonomies', '__return_empty_array' );

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -618,4 +618,10 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertContains( 'X-ElasticPress-Search-Valid-Response: true', xdebug_get_headers() );
 	}
 
+	public function test__vip_search_filter__ep_facet_taxonomies_size() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$this->assertEquals( 5, $es->filter__ep_facet_taxonomies_size( 10000, 'category' ) );
+	}
 }


### PR DESCRIPTION
## Description

Disable facet queries in VIP Search but still set the default facet taxonomies size just in case it gets enabled at some point so it doesn't error out.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Do a search with VIP Search enabled.
2. Check the Query body in QM/debug bar, there will be multiple size attributes.
3. Check out PR.
4. Do a search.
5. There should now only be one size attribute. 