### PR TITLE
Remove/php modules site health

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -46,6 +46,11 @@ function vip_filter_unnecessary_php_modules_for_site_health_tests( $modules ) {
 		unset( $modules['exif'] );
 	}
 
+	// Remove 'imagick' PHP module.
+	if ( isset( $modules['imagick'] ) ) {
+		unset( $modules['imagick'] );
+	}
+
 	return $modules;
 }
 

--- a/001-core.php
+++ b/001-core.php
@@ -40,6 +40,13 @@ function wpcom_vip_disable_core_update_cap( $caps, $cap ) {
 	return $caps;
 }
 
+/**
+ * Filter PHP modules in the Site Health (AKA site status) tool page
+ *
+ * By default, WordPress runs php_extension tests on the Site Health tool
+ * page in wp-admin. This filters out all irrelevant or unnecessary PHP modules
+	* within the test.
+ */
 function vip_filter_unnecessary_php_modules_for_site_health_tests( $modules ) {
 	// Remove 'exif' PHP module.
 	if ( isset( $modules['exif'] ) ) {

--- a/001-core.php
+++ b/001-core.php
@@ -39,3 +39,14 @@ function wpcom_vip_disable_core_update_cap( $caps, $cap ) {
 	}
 	return $caps;
 }
+
+function vip_filter_unnecessary_php_modules_for_site_health_tests( $modules ) {
+	// Remove 'exif' PHP module.
+	if ( isset( $modules['exif'] ) ) {
+		unset( $modules['exif'] );
+	}
+
+	return $modules;
+}
+
+add_filter( 'site_status_test_php_modules', 'vip_filter_unnecessary_php_modules_for_site_health_tests' );

--- a/001-core.php
+++ b/001-core.php
@@ -63,7 +63,7 @@ add_filter( 'site_status_tests', 'vip_disable_unnecessary_site_health_tests' );
  *
  * By default, WordPress runs php_extension tests on the Site Health tool
  * page in wp-admin. This filters out all irrelevant or unnecessary PHP modules
-	* within the test.
+ * within the test.
  */
 function vip_filter_unnecessary_php_modules_for_site_health_tests( $modules ) {
 	// Remove 'exif' PHP module.


### PR DESCRIPTION
## Description

The Site Health tool page shows a "missing" error/issue for PHP modules that aren't relevant to VIP:
<img width="878" alt="php modules" src="https://user-images.githubusercontent.com/29221840/77617801-3cd5b180-6ef2-11ea-8382-f546d6069b67.png">

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to wp-admin > Tools > Site Health
1. Verify `One or more recommended modules are missing` issue is no longer present:
<img width="888" alt="Screen Shot 2020-03-25 at 11 19 22 PM" src="https://user-images.githubusercontent.com/29221840/77617916-858d6a80-6ef2-11ea-9d7a-b001bea529ea.png">
