### PR TITLE
Allow enabling search query integration via an option

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -218,8 +218,16 @@ class Search {
 
 		$query_integration_enabled = defined( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION;
 
-		// The filter is checking if we should _skip_ query integration
-		return ! ( $query_integration_enabled || $query_integration_enabled_legacy );
+		$enabled_by_constant = ( $query_integration_enabled || $query_integration_enabled_legacy );
+
+		$option_value = get_option( 'vip_enable_vip_search_query_integration' );
+
+		$enabled_by_option = in_array( $option_value, array( true, 'true', 'yes', 1, '1' ), true );
+
+		// The filter is checking if we should _skip_ query integration...so if it's _not_ enabled
+		$skipped = ! ( $enabled_by_constant || $enabled_by_option );
+	
+		return $skipped;
 	}
 
 	/**


### PR DESCRIPTION
## Description

Adds a new option, `vip_enable_vip_search_query_integration`, that if set to a truthy value (`true`, `1`, or `yes`), will enable search integration, even if the `VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION` constant is not set.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Disable integration (ensure constant is not set)
1. Run a query - ensure VIP Search didn't run
1. Set the option `wp option set vip_enable_vip_search_query_integration true`
1. Re-run a search - VIP Search should kick in
1. Disable the option - `wp option set vip_enable_vip_search_query_integration false`
1. VIP Search should not run
1. Enable the constant
1. VIP Search should run
