### PR TITLE
Add StatsD library

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -149,6 +149,7 @@ if ( WPCOM_SANDBOXED ) {
 
 // Logging
 require_once( __DIR__ . '/logstash/logstash.php' );
+require_once( __DIR__ . '/lib/statsd/class-statsd.php' );
 
 // Debugging Tools
 require_once( __DIR__ . '/000-debug/0-load.php' );

--- a/lib/statsd/class-statsd.php
+++ b/lib/statsd/class-statsd.php
@@ -103,14 +103,14 @@ class StatsD {
 
 		// If we don't have server info defined, abort and warn
 		if ( ! defined( 'VIP_STATSD_HOST' ) || ! VIP_STATSD_HOST ) {
-			if ( true === WPCOM_IS_VIP_ENV  ) {
+			if ( true === WPCOM_IS_VIP_ENV ) {
 				trigger_error( 'VIP_STATSD_HOST not set, no data sent to statsd', \E_USER_WARNING );
-			}	
+			}
 			return;
 		} 
 		
 		if ( ! defined( 'VIP_STATSD_PORT' ) || ! VIP_STATSD_PORT ) {
-			if ( true === WPCOM_IS_VIP_ENV  ) {
+			if ( true === WPCOM_IS_VIP_ENV ) {
 				trigger_error( 'VIP_STATSD_PORT not set, no data sent to statsd', \E_USER_WARNING );
 			}
 			return;

--- a/lib/statsd/class-statsd.php
+++ b/lib/statsd/class-statsd.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Automattic\VIP;
+
+/**
+ * Sends statistics to the stats daemon over UDP
+ *
+ * Internal use only!
+ */
+
+class StatsD {
+	/**
+	 * Sets one or more timing values
+	 *
+	 * @param string|array $stats The metric(s) to set.
+	 * @param float $time The elapsed time (ms) to log
+	 **/
+	public static function timing( $stats, $time ) {
+		StatsD::updateStats( $stats, $time, 1, 'ms' );
+	}
+
+	/**
+	 * Sets one or more gauges to a value
+	 *
+	 * @param string|array $stats The metric(s) to set.
+	 * @param float $value The value for the stats.
+	 **/
+	public static function gauge( $stats, $value ) {
+		StatsD::updateStats( $stats, $value, 1, 'g' );
+	}
+
+	/**
+	 * A "Set" is a count of unique events.
+	 * This data type acts like a counter, but supports counting
+	 * of unique occurences of values between flushes. The backend
+	 * receives the number of unique events that happened since
+	 * the last flush.
+	 *
+	 * The reference use case involved tracking the number of active
+	 * and logged in users by sending the current userId of a user
+	 * with each request with a key of "uniques" (or similar).
+	 *
+	 * @param string|array $stats The metric(s) to set.
+	 * @param float $value The value for the stats.
+	 **/
+	public static function set( $stats, $value ) {
+		StatsD::updateStats( $stats, $value, 1, 's' );
+	}
+
+	/**
+	 * Increments one or more stats counters
+	 *
+	 * @param string|array $stats The metric(s) to increment.
+	 * @param float|1 $sampleRate the rate (0-1) for sampling.
+	 * @return boolean
+	 **/
+	public static function increment( $stats, $sampleRate = 1 ) {
+		StatsD::updateStats( $stats, 1, $sampleRate, 'c' );
+	}
+
+	/**
+	 * Decrements one or more stats counters.
+	 *
+	 * @param string|array $stats The metric(s) to decrement.
+	 * @param float|1 $sampleRate the rate (0-1) for sampling.
+	 * @return boolean
+	 **/
+	public static function decrement( $stats, $sampleRate = 1 ) {
+		StatsD::updateStats( $stats, -1, $sampleRate, 'c' );
+	}
+
+	/**
+	 * Updates one or more stats.
+	 *
+	 * @param string|array $stats The metric(s) to update. Should be either a string or array of metrics.
+	 * @param int|1 $delta The amount to increment/decrement each metric by.
+	 * @param float|1 $sampleRate the rate (0-1) for sampling.
+	 * @param string|c $metric The metric type ("c" for count, "ms" for timing, "g" for gauge, "s" for set)
+	 * @return boolean
+	 **/
+	public static function updateStats( $stats, $delta = 1, $sampleRate = 1, $metric = 'c' ) {
+		if ( ! is_array( $stats ) ) {
+			$stats = array( $stats ); 
+		}
+
+		$data = array();
+
+		foreach( $stats as $stat ) {
+			$data[ $stat ] = "$delta|$metric";
+		}
+
+		StatsD::send( $data, $sampleRate );
+	}
+
+	/*
+	 * Send the metrics over UDP
+	 **/
+	public static function send( $data, $sampleRate = 1 ) {
+		// Disables StatsD logging for test environments
+		if ( defined( 'VIP_DISABLE_STATSD' ) && VIP_DISABLE_STATSD ) {
+			return;
+		}
+
+		// If we don't have server info defined, abort
+		if ( ! defined( 'VIP_STATSD_HOST' ) || ! VIP_STATSD_HOST || ! defined( 'VIP_STATSD_PORT' ) || ! VIP_STATSD_PORT ) {
+			return;
+		}
+
+		// sampling
+		$sampledData = array();
+
+		if ( $sampleRate < 1 ) {
+			foreach ( $data as $stat => $value ) {
+				if ( ( mt_rand() / mt_getrandmax() ) <= $sampleRate ) {
+					$sampledData[ $stat ] = "$value|@$sampleRate";
+				}
+			}
+		} else {
+			$sampledData = $data;
+		}
+
+		if ( empty( $sampledData ) ) {
+			return;
+		}
+
+		// Wrap this in a try/catch - failures in any of this should be silently ignored
+		try {
+			$host = VIP_STATSD_HOST;
+			$port = VIP_STATDS_PORT;
+
+			$fp = fsockopen( "udp://$host", $port, $errno, $errstr );
+
+			if ( ! $fp ) {
+				return;
+			}
+
+			foreach ( $sampledData as $stat => $value ) {
+				fwrite( $fp, "$stat:$value" );
+			}
+
+			fclose( $fp );
+		} catch (Exception $e) {
+
+		}
+	}
+}

--- a/lib/statsd/class-statsd.php
+++ b/lib/statsd/class-statsd.php
@@ -126,7 +126,7 @@ class StatsD {
 		// Wrap this in a try/catch - failures in any of this should be silently ignored
 		try {
 			$host = VIP_STATSD_HOST;
-			$port = VIP_STATDS_PORT;
+			$port = VIP_STATSD_PORT;
 
 			$fp = fsockopen( "udp://$host", $port, $errno, $errstr );
 

--- a/lib/statsd/class-statsd.php
+++ b/lib/statsd/class-statsd.php
@@ -154,11 +154,11 @@ class StatsD {
 			}
 
 			if ( false === fclose( $fp ) ) {
-				throw new \Exception( "fclose: failed to close open file pointer" );
+				throw new \Exception( 'fclose: failed to close open file pointer' );
 			}
 		} catch ( \Exception $e ) {
 			$escaped_url = addslashes( $url );
-			trigger_error( "Statsd::send exception('$escaped_url'): {$e->getMessage()}", \E_USER_WARNING );
+			trigger_error( "Statsd::send exception('$escaped_url'): {$e->getMessage()}", \E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 }

--- a/lib/statsd/class-statsd.php
+++ b/lib/statsd/class-statsd.php
@@ -103,12 +103,16 @@ class StatsD {
 
 		// If we don't have server info defined, abort and warn
 		if ( ! defined( 'VIP_STATSD_HOST' ) || ! VIP_STATSD_HOST ) {
-			trigger_error( 'VIP_STATSD_HOST not set, no data sent to statsd', E_USER_WARNING );
+			if ( true === WPCOM_IS_VIP_ENV  ) {
+				trigger_error( 'VIP_STATSD_HOST not set, no data sent to statsd', \E_USER_WARNING );
+			}	
 			return;
 		} 
 		
 		if ( ! defined( 'VIP_STATSD_PORT' ) || ! VIP_STATSD_PORT ) {
-			trigger_error( 'VIP_STATSD_PORT not set, no data sent to statsd', E_USER_WARNING );
+			if ( true === WPCOM_IS_VIP_ENV  ) {
+				trigger_error( 'VIP_STATSD_PORT not set, no data sent to statsd', \E_USER_WARNING );
+			}
 			return;
 		}
 
@@ -154,7 +158,7 @@ class StatsD {
 			}
 		} catch ( \Exception $e ) {
 			$escaped_url = addslashes( $url );
-			trigger_error( "Statsd::send exception('$escaped_url'): {$e->getMessage()}", E_USER_WARNING );
+			trigger_error( "Statsd::send exception('$escaped_url'): {$e->getMessage()}", \E_USER_WARNING );
 		}
 	}
 }


### PR DESCRIPTION
## Description

Add StatsD library

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Run StatsD locally - it's very easy:
1. Clone https://github.com/statsd/statsd
1. Edit `exampleConfig.js` in that directory to this:

```
{
 port: 8125
, backends: [ "./backends/console" ]
}
```

1. Run StatsD - `node stats.js exampleConfig.js`
1. Check out PR
1. Define the host/port constants somewhere:

```
define( 'VIP_STATSD_HOST', 'host.docker.internal' );
define( 'VIP_STATSD_PORT', 8125 );
```

1. Anywhere in the code path, just track a stat:

```

$statsD = new Automattic\VIP\StatsD();

$statsD->increment( 'my-custom-stat' );
```

1. Watch the StatsD console and see the stat being recorded