### PR TITLE
Add track_total hits as true to formatted args

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -94,6 +94,9 @@ class Search {
 
 		// Disable facet queries
 		add_filter( 'ep_facet_include_taxonomies', '__return_empty_array' );
+
+		// Enable track_total_hits for all queries for proper result sets if track_total_hits isn't already set
+		add_filter( 'ep_post_formatted_args', array( $this, 'filter__ep_post_formatted_args' ), 10, 3 );
 	}
 
 	protected function load_commands() {
@@ -321,5 +324,18 @@ class Search {
 
 		// Flatten the array back down now that may have removed values from the middle (to keep indexes correct)
 		return array_values( $widgets );
+	}
+
+	/*
+	 * Filter for formatted_args in post queries
+	 */ // phpcs:ignore WordPress.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed
+	public function filter__ep_post_formatted_args( $formatted_args, $query_vars, $query ) {
+		// Check if track_total_hits is set
+		// Don't override it if it is
+		if ( ! array_key_exists( 'track_total_hits', $formatted_args ) ) {
+			$formatted_args['track_total_hits'] = true;
+		}
+
+		return $formatted_args;
 	}
 }

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -614,4 +614,19 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	/**
+	 * Test that the track_total_hits arg exists
+	 */
+	public function test__vip_filter__ep_post_formatted_args() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$result = $es->filter__ep_post_formatted_args( array(), '', '' );
+
+		$this->assertTrue( array_key_exists( 'track_total_hits', $result ), 'track_total_hits doesn\'t exist in fortmatted args' );
+		if ( array_key_exists( 'track_total_hits', $result ) ) {
+			$this->assertTrue( $result['track_total_hits'], 'track_total_hits isn\'t set to true' );
+		}
+	}
 }


### PR DESCRIPTION
## Description
Add track_total hits as true to formatted args.

Only when the value isn't already set.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Do a search with VIP Search enabled. The query body won't have 'track_total_hits' set.
2. Checkout the PR.
3. Do a search with VIP Search enabled. The query body will have 'track_total_hits' set to true.
