### PR TITLE
Remove fuzziness from EP search queries

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -98,8 +98,8 @@ class Search {
 		// Enable track_total_hits for all queries for proper result sets if track_total_hits isn't already set
 		add_filter( 'ep_post_formatted_args', array( $this, 'filter__ep_post_formatted_args' ), 10, 3 );
 
-		// Disable query fuzziness
-		add_filter( 'ep_fuzziness_arg', '__return_zero', PHP_INT_MAX );
+		// Disable query fuzziness by default
+		add_filter( 'ep_fuzziness_arg', '__return_zero', 0 );
 	}
 
 	protected function load_commands() {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -97,6 +97,9 @@ class Search {
 
 		// Enable track_total_hits for all queries for proper result sets if track_total_hits isn't already set
 		add_filter( 'ep_post_formatted_args', array( $this, 'filter__ep_post_formatted_args' ), 10, 3 );
+
+		// Disable query fuzziness
+		add_filter( 'ep_fuzziness_arg', '__return_zero', PHP_INT_MAX );
 	}
 
 	protected function load_commands() {


### PR DESCRIPTION
## Description

Fuzziness is enabled by default for queries. This results in some pretty unexpected search results since something like 'March' would match 'arch' and anything else within a Levenshtein distance of 1. Not great for search relevancy or performance.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Perform a search with VIP Search and query monitory/debug bar enabled.
2. Note that fuzziness is 1 in places.
3. Apply PR.
4. Perform another search.
5. Fuzziness is 0 across the board.