### PR TITLE
First pass at simple plugin upgrade script

### DIFF
--- a/bin/upgrade-plugin.sh
+++ b/bin/upgrade-plugin.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -o errexit   # exit on error
+
+if [ $# -lt 1 ]; then
+	echo "usage: $0 <plugin>"
+	exit 1
+fi
+
+PLUGIN_SLUG=$1
+
+update_wporg_plugin() {
+	URL=https://downloads.wordpress.org/plugin/${PLUGIN_SLUG}.zip
+
+	echo "Removing current dir: ${PLUGIN_SLUG}"
+	rm -rf ${PLUGIN_SLUG}
+
+	echo "Downloading latest release: ${URL}"
+	wget $URL
+
+	echo "Unzipping"
+	unzip ${PLUGIN_SLUG}.zip
+	rm ${PLUGIN_SLUG}.zip
+
+	echo 
+	echo "- Don't forget to update $PLUGIN_SLUG.php with the version number."
+}
+
+case $PLUGIN_SLUG in
+	vaultpress | akismet)
+		update_wporg_plugin
+		;;
+	
+	*)
+		echo "Unknown plugin; skipping"
+		;;
+esac


### PR DESCRIPTION
Currently supports just VaultPress and Akismet but makes it easier to go through and update to the latest but automating a few of the steps.

Could be improved further in additional PRs by:

- Updating the version number in the mu-plugins plugin file
- Adding support for other plugins including those in subdirs and using submodules (e.g. Jetpack)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- n/a This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

- `./bin/upgrade-plugin.sh` should show usage
- `./bin/upgrade-plugin.sh akismet` should update akismet locally
- `./bin/upgrade-plugin.sh other` should fail 