### PR TITLE
Added a quick win for search relevancy

### DIFF
--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -782,4 +782,34 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $prefix );
 	}
+
+	/**
+	 * Test formatted args structure checks
+	 */
+	public function test__vip_search_filter__ep_formatted_args() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$this->assertEquals( array( 'wrong' ), $es->filter__ep_formatted_args( array( 'wrong' ), '' ), 'didn\'t just return formatted args when the structure of formatted args didn\'t match what was expected' );
+
+		$formatted_args = array(
+			'query' => array(
+				'bool' => array(
+					'should' => array(
+						array(
+							'multi_match' => array(
+								'operator' => 'Random string',
+							),
+						),
+						'Random string',
+					),
+				),
+			),
+		);
+
+		$result = $es->filter__ep_formatted_args( $formatted_args, '' );
+
+		$this->assertTrue( array_key_exists( 'must', $result['query']['bool'] ), 'didn\'t replace should with must' );
+		$this->assertEquals( $result['query']['bool']['must'][0]['multi_match']['operator'], 'AND', 'didn\'t set the remainder of the query correctly' );
+	}
 }


### PR DESCRIPTION
## Description

Added a quick win for search relevancy

Only applied when the query structure is in an expected format

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `./bin/phpunit-docker.sh tests/search/test-class-search.php`


1. Run a VIP Search without this PR that doesn't changed formatted args structure.
2. Record the query body from ElasticPress tab of Query Monitor/Debug Bar.
3. Apply this PR.
4. Run the same search.
5. Record the query body from ElasticPress tab of Query Monitor/Debug Bar.
6. Compare the query bodies. There should be one 'should' replaced with a 'must' and a new 'AND'. 
