### PR TITLE
Added new defaults for date relevancy

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -106,6 +106,20 @@ class Search {
 
 		// Replace base 'should' with 'must' in Elasticsearch query if formatted args structure matches what's expected
 		add_filter( 'ep_formatted_args', array( $this, 'filter__ep_formatted_args' ), 0, 2 );
+
+		// Date relevancy defaults. Taken from Jetpack Search.
+		// Set to 'gauss'
+		add_filter( 'epwr_decay_function', array( $this, 'filter__epwr_decay_function' ), 0, 3 );
+		// Set to '360d'	
+		add_filter( 'epwr_scale', array( $this, 'filter__epwr_scale' ), 0, 3 );
+		// Set to .9 
+		add_filter( 'epwr_decay', array( $this, 'filter__epwr_decay' ), 0, 3 );
+		// Set to '0d'
+		add_filter( 'epwr_offset', array( $this, 'filter__epwr_offset' ), 0, 3 );
+		// Set to 'multiply'	
+		add_filter( 'epwr_score_mode', array( $this, 'filter__epwr_score_mode' ), 0, 3 );
+		// Set to 'multiply'
+		add_filter( 'epwr_boost_mode', array( $this, 'filter__epwr_boost_mode' ), 0, 3 );
 	}
 
 	protected function load_commands() {
@@ -536,5 +550,47 @@ class Search {
 		unset( $formatted_args['query']['bool']['should'] );
 
 		return $formatted_args;
+	}
+
+	/*
+	 * Filter for setting decay function for date relevancy in ElasticPress
+	 */
+	public function filter__epwr_decay_function( $decay_function, $formatted_args, $args ) {
+		return 'gauss';
+	}
+
+	/*
+	 * Filter for setting scale for date relevancy in ElasticPress
+	 */
+	public function filter__epwr_scale( $scale, $formatted_args, $args ) {
+		return '360d';
+	}
+	
+	/*
+	 * Filter for setting decay for date relevancy in ElasticPress
+	 */
+	public function filter__epwr_decay( $decay, $formatted_args, $args ) {
+		return .9;
+	}
+
+	/*
+	 * Filter for setting offset for date relevancy in ElasticPress
+	 */
+	public function filter__epwr_offset( $offset, $formatted_args, $args ) {
+		return '0d';
+	}
+
+	/*
+	 * Filter for setting score mode for date relevancy in ElasticPress
+	 */
+	public function filter__epwr_score_mode( $score_mode, $formatted_args, $args ) {
+		return 'multiply';
+	}
+
+	/*
+	 * Filter for setting boost mode for date relevancy in ElasticPress
+	 */
+	public function filter__epwr_boost_mode( $boost_mode, $formatted_args, $args ) {
+		return 'multiply';
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/Automattic/ElasticPress/pull/25

## Description

Applied the defaults from Jetpack Search to the ElasticPress filters

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Do a search with VIP Search. Note the results.
2. Apply PR.
3. Do the same search with VIP Search.
4. Note the increased date relevancy.