### PR TITLE
Fix TypeError in maybe_wp_debug_log_entries

### DIFF
--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -496,9 +496,9 @@ class Logger {
 	 *
 	 * @since 2020-01-10
 	 *
-	 * @param array $entries.
+	 * @param array $entry.
 	 */
-	public static function maybe_wp_debug_log_entries( array $entries ) : void {
+	public static function maybe_wp_debug_log_entries( array $entry ) : void {
 		if ( ! apply_filters( 'enable_wp_debug_mode_checks', true ) ) {
 			return; // Not applicable.
 		} elseif ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {

--- a/tests/logstash/test-logger.php
+++ b/tests/logstash/test-logger.php
@@ -207,4 +207,36 @@ class Logger_Test extends \WP_UnitTestCase {
 		// No new entries added
 		$this->assertEquals( [], $entries_prop->getValue() );
 	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__process_entries_on_shutdown() {
+		define( 'WP_DEBUG_LOG', '/tmp/test.log' );
+
+		$entries = [
+			[
+				'feature' => 'a8c_vip_test',
+				'site_id' => 1,
+				'blog_id' => 1,
+				'host' => 'example.org',
+				'user_id' => 0,
+				'extra' => '[]',
+				'index' => 'log2logstash',
+				'severity' => 'alert',
+				'feature' => 'test',
+				'message' => 'Test alert',
+				'timestamp' => '2020-03-26 05:29:05',
+				'file' => '/app/logstash/class-logger.php',
+				'line' => '402',
+			],
+		];
+
+		$entries_prop = $this->get_property( 'entries' );
+		$entries_prop->setValue( $entries );
+
+		// Assert no errors thrown. Function does nothing on non VIP Go env
+		$this->assertNull( Logger::process_entries_on_shutdown() );
+	}
 }


### PR DESCRIPTION
## Description

Fixes `TypeError` originating from merging code from #1530 

Fixes #1534 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

1. Checkout PR
1. Make sure your local environment will try to store log data to `debug.log` by setting `VIP_GO_ENV` to `false` and `WP_DEBUG` to `true`
1. Create a log message by calling `Logger::log2logstash()`
1. Confirm there is no `TypeError` in the PHP error log