### PR TITLE
Disable search index validation until index is built

### DIFF
--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -176,9 +176,11 @@ class HealthJob {
 			return false;
 		}
 
+		$enabled = 'production' === VIP_GO_ENV;
+
 		// Don't run the checks if the index is not built
 		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {
-			return false;
+			$enabled = false;
 		}
 
 		/**
@@ -186,6 +188,6 @@ class HealthJob {
 		 *
 		 * @param bool $enable True to enable the healthcheck cron job
 		 */
-		return apply_filters( 'enable_vip_search_healthchecks', 'production' === VIP_GO_ENV );
+		return apply_filters( 'enable_vip_search_healthchecks', $enabled );
 	}
 }

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -177,9 +177,9 @@ class HealthJob {
 		}
 
 		/**
-		 * Filter wether to enable VIP search healthcheck
+		 * Filter whether to enable VIP search healthcheck
 		 *
-		 * @param		bool	$enable		True to enable the healthcheck cron job
+		 * @param bool $enable True to enable the healthcheck cron job
 		 */
 		return apply_filters( 'enable_vip_search_healthchecks', 'production' === VIP_GO_ENV );
 	}

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -176,6 +176,11 @@ class HealthJob {
 			return false;
 		}
 
+		// Don't run the checks if the index is not built
+		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {
+			return false;
+		}
+
 		/**
 		 * Filter whether to enable VIP search healthcheck
 		 *

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -176,7 +176,9 @@ class HealthJob {
 			return false;
 		}
 
-		$enabled = 'production' === VIP_GO_ENV;
+		$enabled_environments = apply_filters( 'vip_search_healthchecks_enabled_environments', array( 'production' ) );
+
+		$enabled = in_array( VIP_GO_ENV, $enabled_environments, true );
 
 		// Don't run the checks if the index is not built
 		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -203,8 +203,8 @@ class HealthJob_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * NOTE - needs to come last for the "is_enabled()" tests, b/c it sets the constant
-	 * which causes it to bail early
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_vip_search_healthjob_is_disabled_when_constant_is_set() {
 		define( 'DISABLE_VIP_SEARCH_HEALTHCHECKS', true );


### PR DESCRIPTION
## Description

Only run index validation when it's expected to be consistent - so not when an index is being built, or no index yet exists.

Depends on https://github.com/Automattic/ElasticPress/pull/26

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Tricky to actually test b/c healthchecks don't run outside production, but can try this:

1. Check out PR.
1. `define( 'VIP_GO_ENV', 'production' );`
1. Start a bulk index - `wp elasticpress index`
1. In a separate `wp shell`, try `\Automattic\VIP\Search\HealthJob::is_enabled()`
