### PR TITLE
Add a singleton instance() method to Search class

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -184,8 +184,7 @@ if ( ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) || // legac
 	defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === VIP_ENABLE_VIP_SEARCH ) {
 	require_once( __DIR__ . '/search/search.php' );
 
-	$search_plugin = new \Automattic\VIP\Search\Search();
-	$search_plugin->init();
+	$search_plugin = \Automattic\VIP\Search\Search::instance();
 
 	// If VIP Search query integration is enabled, disable Jetpack Search
 	if ( ! $search_plugin::ep_skip_query_integration( false ) ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -8,6 +8,8 @@ class Search {
 	public $healthcheck;
 	private $current_host_index;
 
+	private static $_instance;
+
 	/**
 	 * Initialize the VIP Search plugin
 	 */
@@ -17,6 +19,15 @@ class Search {
 		$this->load_dependencies();
 		$this->load_commands();
 		$this->setup_healthchecks();
+	}
+
+	public static function instance() {
+		if ( ! ( static::$_instance instanceof Automattic\VIP\Search\Search ) ) {
+			static::$_instance = new Search();
+			static::$_instance->init();
+		}
+
+		return static::$_instance;
 	}
 
 	protected function load_dependencies() {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -22,7 +22,7 @@ class Search {
 	}
 
 	public static function instance() {
-		if ( ! ( static::$_instance instanceof Automattic\VIP\Search\Search ) ) {
+		if ( ! ( static::$_instance instanceof Search ) ) {
 			static::$_instance = new Search();
 			static::$_instance->init();
 		}


### PR DESCRIPTION
## Description

Adds an optional static `instance()` method to the Search class, to easily access the main instance from anywhere in the code base without relying on globals.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Perform a variety of search operations - ensure everything works normally
