### PR TITLE
Add inspect flag for validate-contents command

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -159,7 +159,7 @@ class Health {
 	 *
 	 * @return array Array containing counts and ids of posts with inconsistent content
 	 */
-	public static function validate_index_posts_content( $start_post_id = 1, $last_post_id = null, $batch_size, $max_diff_size, $silent, $inspect=false ) {
+	public static function validate_index_posts_content( $start_post_id = 1, $last_post_id = null, $batch_size, $max_diff_size, $silent, $inspect = false ) {
 		// If batch size value NOT a numberic value over 0 but less than or equal to PHP_INT_MAX, reset to default
 		//     Otherwise, turn it into an int
 		if ( ! is_numeric( $batch_size ) || 0 >= $batch_size || $batch_size > PHP_INT_MAX ) {
@@ -271,19 +271,19 @@ class Health {
 		$found_document_ids = wp_list_pluck( $documents, 'ID' );
 
 		$diffs = $inspect ? self::get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids )
-		                  : self::simplified_get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids );
+		                  : self::simplified_get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids ); // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed
 
 		// Compare each indexed document with what it _should_ be if it were re-indexed now
 		foreach ( $documents as $document ) {
 			$prepared_document = $indexable->prepare_document( $document['post_id'] );
 
 			$diff = $inspect ? self::diff_document_and_prepared_document( $document, $prepared_document )
-			                 : self::simplified_diff_document_and_prepared_document( $document, $prepared_document );
+			                 : self::simplified_diff_document_and_prepared_document( $document, $prepared_document ); // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed
 
 			if ( $diff ) {
 				$key = self::get_post_key( $document['ID'] );
 				$diffs[ $key ] = $inspect ? $diff
-				                          : self::simplified_format_post_diff( $document['ID'], 'inconsistent' );
+				                          : self::simplified_format_post_diff( $document['ID'], 'inconsistent' ); // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed
 			}
 		}
 

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -221,7 +221,7 @@ class Health {
 			$results = array_merge( $results, $result );
 
 			// Limit $results size
-			if ( count ( $results ) > $max_diff_size ) {
+			if ( count( $results ) > $max_diff_size ) {
 				echo sprintf( "...%s\n", \WP_CLI::colorize( '🛑' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 				$error = new WP_Error( 'diff-size-limit-reached', sprintf( 'Reached diff size limit of %d elements, aborting', $max_diff_size ) );

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -149,7 +149,24 @@ class Health {
 	 *
 	 * @return array Array containing counts and ids of posts with inconsistent content
 	 */
-	public static function validate_index_posts_content( $start_post_id = 1, $last_post_id = null ) {
+	public static function validate_index_posts_content( $start_post_id = 1, $last_post_id = null, $batch_size, $max_diff_size, $silent ) {
+		// If batch size value NOT a numberic value over 0 but less than or equal to PHP_INT_MAX, reset to default
+		//     Otherwise, turn it into an int
+		if ( ! is_numeric( $batch_size ) || 0 >= $batch_size || $batch_size > PHP_INT_MAX ) {
+			$batch_size = self::CONTENT_VALIDATION_BATCH_SIZE;
+		} else {
+			$batch_size = intval( $batch_size );
+		}
+
+		// If max diff size NOT an int over 0, reset to default
+		//     Otherwise convert max diff size to bytes
+		if ( ! is_numeric( $max_diff_size ) || 0 >= $max_diff_size || $max_diff_size > PHP_INT_MAX ) {
+			$max_diff_size = self::CONTENT_VALIDATION_MAX_DIFF_SIZE;
+		} else {
+			$max_diff_size = intval( $max_diff_size );
+			$max_diff_size = $max_diff_size * MB_IN_BYTES;
+		}
+
 		// Get indexable objects
 		$indexable = Indexables::factory()->get( 'post' );
 
@@ -176,44 +193,42 @@ class Health {
 		}
 
 		do {
-			$next_batch_post_id = $start_post_id + self::CONTENT_VALIDATION_BATCH_SIZE;
+			$next_batch_post_id = $start_post_id + $batch_size;
 
 			if ( $last_post_id < $next_batch_post_id ) {
 				$next_batch_post_id = $last_post_id + 1;
 			}
 
-			if ( $is_cli ) {
-				\WP_CLI::line( sprintf( 'Validating posts %d - %d', $start_post_id, $next_batch_post_id - 1 ) );
+			if ( $is_cli && ! $silent ) {
+				echo sprintf( 'Validating posts %d - %d', $start_post_id, $next_batch_post_id - 1 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 			
 			$result = self::validate_index_posts_content_batch( $indexable, $start_post_id, $next_batch_post_id );
 
 			if ( is_wp_error( $result ) ) {
-				$result = [
-					'entity' => $indexable->slug,
-					'start_post_id' => $start_post_id,
-					'error' => $result->get_error_message(),
-				];
+				$result['errors'] = array( sprintf( 'batch %d - %d (entitiy: %s) error: %s', $start_post_id, $next_batch_post_id - 1, $indexable->slug, $result->get_error_message() ) );
 			}
 
 			$results = array_merge( $results, $result );
 
 			// Limit $results size
-			if ( strlen( serialize( $results ) ) > self::CONTENT_VALIDATION_MAX_DIFF_SIZE ) {
-				$error = new WP_Error( 'diff-size-limit-reached', sprintf( 'Reached diff size limit of %d bytes, aborting', self::CONTENT_VALIDATION_MAX_DIFF_SIZE ) );
+			if ( strlen( serialize( $results ) ) > $max_diff_size ) {
+				$error = new WP_Error( 'diff-size-limit-reached', sprintf( 'Reached diff size limit of %d bytes, aborting', $max_diff_size ) );
 
 				$error->add_data( $results, 'diff' );
 
 				return $error;
 			}
 
-			$start_post_id += self::CONTENT_VALIDATION_BATCH_SIZE;
+			$start_post_id += $batch_size; 
 
 			if ( $dynamic_last_post_id ) {
 				// Requery for the last post id after each batch b/c the site is probably growing
 				// while this runs
 				$last_post_id = self::get_last_post_id();
 			}
+
+			echo sprintf( "...%s\n", empty( $result ) ? '✅' : '❌' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} while ( $start_post_id <= $last_post_id );
 
 		return $results;
@@ -244,21 +259,51 @@ class Health {
 		$found_post_ids = wp_list_pluck( $expected_post_rows, 'ID' );
 		$found_document_ids = wp_list_pluck( $documents, 'ID' );
 
-		$diffs = self::get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids );
+		$diffs = self::simplified_get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids );
 
 		// Compare each indexed document with what it _should_ be if it were re-indexed now
 		foreach ( $documents as $document ) {
 			$prepared_document = $indexable->prepare_document( $document['post_id'] );
 
-			$diff = self::diff_document_and_prepared_document( $document, $prepared_document );
+			$diff = self::simplified_diff_document_and_prepared_document( $document, $prepared_document );
 
 			if ( $diff ) {
-				$diffs[ 'post_' . $document['ID'] ] = $diff;
+				$key = self::get_post_key( $document['ID'] );
+				$diffs[ $key ] = self::simplified_format_post_diff( $document['ID'], 'inconsistent' );
 			}
 		}
 
 		return $diffs;
 	}
+
+	public static function simplified_get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids ) {
+		$diffs = [];
+
+		// What's missing in ES?
+		$missing_from_index = array_diff( $found_post_ids, $found_document_ids );
+
+		// If anything is missing from index, record it
+		if ( 0 < count( $missing_from_index ) ) {
+			foreach ( $missing_from_index as $post_id ) {
+				$key = self::get_post_key( $post_id );
+				$diffs[ $key ] = self::simplified_format_post_diff( $post_id, 'missing_from_index' );
+			}
+		}
+
+		// What's in ES but shouldn't be?
+		$extra_in_index = array_diff( $found_document_ids, $found_post_ids );
+
+		// If anything is in the index that shouldn't be, record it
+		if ( 0 < count( $extra_in_index ) ) {
+			foreach ( $extra_in_index as $document_id ) {
+				$key = self::get_post_key( $document_id );
+				$diffs[ $key ] = self::simplified_format_post_diff( $document_id, 'extra_in_index' );
+			}
+		}
+
+		return $diffs;
+	}
+
 
 	public static function get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids ) {
 		$diffs = [];
@@ -313,6 +358,33 @@ class Health {
 		} );
 
 		return $filtered;
+	}
+
+	public static function simplified_diff_document_and_prepared_document( $document, $prepared_document ) {
+		$ignored_keys = array(
+			// This field is proving problematic to reliably diff due to differences in the filters
+			// that run during normal indexing and this validator
+			'post_content_filtered',
+
+			// Meta fields from EP's "magic" formatting, which is non-deterministic and impossible to validate
+			'datetime',
+			'date',
+			'time',
+		);
+
+		foreach ( $document as $key => $value ) {
+			if ( in_array( $key, $ignored_keys, true ) ) {
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				$recursive_diff = self::diff_document_and_prepared_document( $document[ $key ], $prepared_document[ $key ] );
+			} else if ( $prepared_document[ $key ] != $document[ $key ] ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public static function diff_document_and_prepared_document( $document, $prepared_document ) {
@@ -388,4 +460,15 @@ class Health {
 		return new WP_Query( $query_args );
 	}
 
+	private static function simplified_format_post_diff( $id, $issue ) {
+		return array(
+			'id' => $id,
+			'type' => 'post',
+			'issue' => $issue,
+		);
+	}
+
+	private static function get_post_key( $id ) {
+		return sprintf( '%s_%d', 'post', $id );
+	}
 }

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -160,7 +160,7 @@ class Health {
 	 * @return array Array containing counts and ids of posts with inconsistent content
 	 */
 	public static function validate_index_posts_content( $start_post_id = 1, $last_post_id = null, $batch_size, $max_diff_size, $silent, $inspect = false ) {
-		// If batch size value NOT a numberic value over 0 but less than or equal to PHP_INT_MAX, reset to default
+		// If batch size value NOT a numeric value over 0 but less than or equal to PHP_INT_MAX, reset to default
 		//     Otherwise, turn it into an int
 		if ( ! is_numeric( $batch_size ) || 0 >= $batch_size || $batch_size > PHP_INT_MAX ) {
 			$batch_size = self::CONTENT_VALIDATION_BATCH_SIZE;

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -221,7 +221,7 @@ class Health {
 			$results = array_merge( $results, $result );
 
 			// Limit $results size
-			if ( count( $results ) > $max_diff_size ) {
+			if ( count( $results ) > $max_diff_size && ( $is_cli && ! $silent ) ) {
 				echo sprintf( "...%s\n", \WP_CLI::colorize( '🛑' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 				$error = new WP_Error( 'diff-size-limit-reached', sprintf( 'Reached diff size limit of %d elements, aborting', $max_diff_size ) );
@@ -239,7 +239,9 @@ class Health {
 				$last_post_id = self::get_last_post_id();
 			}
 
-			echo sprintf( "...%s\n", empty( $result ) ? '✅' : '❌' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			if ( $is_cli && ! $silent ) {
+				echo sprintf( "...%s\n", empty( $result ) ? '✅' : '❌' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
 		} while ( $start_post_id <= $last_post_id );
 
 		return $results;

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -206,7 +206,7 @@ class Health {
 			$result = self::validate_index_posts_content_batch( $indexable, $start_post_id, $next_batch_post_id );
 
 			if ( is_wp_error( $result ) ) {
-				$result['errors'] = array( sprintf( 'batch %d - %d (entitiy: %s) error: %s', $start_post_id, $next_batch_post_id - 1, $indexable->slug, $result->get_error_message() ) );
+				$result['errors'] = array( sprintf( 'batch %d - %d (entity: %s) error: %s', $start_post_id, $next_batch_post_id - 1, $indexable->slug, $result->get_error_message() ) );
 			}
 
 			$results = array_merge( $results, $result );

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -160,7 +160,7 @@ class Health {
 	 * @return array Array containing counts and ids of posts with inconsistent content
 	 */
 	public static function validate_index_posts_content( $start_post_id = 1, $last_post_id = null, $batch_size, $max_diff_size, $silent ) {
-		// If batch size value NOT a numberic value over 0 but less than or equal to PHP_INT_MAX, reset to default
+		// If batch size value NOT a numeric value over 0 but less than or equal to PHP_INT_MAX, reset to default
 		//     Otherwise, turn it into an int
 		if ( ! is_numeric( $batch_size ) || 0 >= $batch_size || $batch_size > PHP_INT_MAX ) {
 			$batch_size = self::CONTENT_VALIDATION_BATCH_SIZE;

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -124,9 +124,9 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * ---
 	 *
 	 * [--max_diff_size=<int>]
-	 * : Optional max diff size in mb
+	 * : Optional max count of diff before exiting
 	 * ---
-	 * default: 5
+	 * default: 1000
 	 * ---
 	 *
 	 * [--format=<string>]

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -177,7 +177,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	}
 
 	public function render_contents_diff( $diff, $format = 'csv', $max_diff_size, $silent = false ) {
-		if ( ! is_array( $diff ) || empty( $diff ) ) {
+		if ( ! is_array( $diff ) || empty( $diff ) || 0 >= $max_diff_size ) {
 			return;
 		}
 

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -117,13 +117,34 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * [--last_post_id=<int>]
 	 * : Optional last post id to check
 	 *
+	 * [--batch_size=<int>]
+	 * : Optional batch size
+	 * ---
+	 * default: 500
+	 * ---
+	 *
+	 * [--max_diff_size=<int>]
+	 * : Optional max diff size in mb
+	 * ---
+	 * default: 5
+	 * ---
+	 *
+	 * [--format=<string>]
+	 * : Optional one of: table json csv yaml ids count
+	 * ---
+	 * default: csv
+	 * ---
+	 *
+	 * [--silent]
+	 * : Optional silences all non-error output except for the final results
+	 *
 	 * ## EXAMPLES
 	 *     wp vip-search health validate-contents
 	 * 
 	 * @subcommand validate-contents
 	 */
 	public function validate_contents( $args, $assoc_args ) {
-		$results = \Automattic\VIP\Search\Health::validate_index_posts_content( $assoc_args['start_post_id'], $assoc_args['last_post_id'] );
+		$results = \Automattic\VIP\Search\Health::validate_index_posts_content( $assoc_args['start_post_id'], $assoc_args['last_post_id'], $assoc_args['batch_size'], $assoc_args['max_diff_size'], isset( $assoc_args['silent'] ) );
 
 		if ( is_wp_error( $results ) ) {
 			$diff = $results->get_error_data( 'diff' );
@@ -136,20 +157,42 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		}
 
 		if ( empty( $results ) ) {
-			WP_CLI::success( 'No inconsistencies found!' );
-
+			
+			if ( ! isset( $assoc_args['silent'] ) ) {
+				WP_CLI::success( 'No inconsistencies found!' );
+			}
+			
 			exit();
 		}
 
-		// Not empty, so inconsistencies were found...
-		WP_CLI::warning( 'Inconsistencies found!' );
+		if ( ! isset( $assoc_args['silent'] ) ) {
+			// Not empty, so inconsistencies were found...
+			WP_CLI::warning( 'Inconsistencies found!' );
+		}
 
-		$this->render_contents_diff( $results );
+		$this->render_contents_diff( $results, $assoc_args['format'] );
 	}
 
-	public function render_contents_diff( $diff ) {
-		// TODO
+	public function render_contents_diff( $diff, $format = 'csv' ) {
+		if ( ! is_array( $diff ) || empty( $diff ) ) {
+			return;
+		}
 
-		var_dump( $diff );
+		if ( ! in_array( $format, array( 'table', 'json', 'csv', 'yaml', 'ids', 'count' ) ) ) {
+			$format = 'csv';
+		}
+
+		// Array pop without modifying the diff array
+		$d = $this->get_last( $diff );
+	
+		if ( array_key_exists( 'type', $d ) && array_key_exists( 'id', $d ) && array_key_exists( 'issue', $d ) ) {
+			\WP_CLI\Utils\format_items( $format, $diff, array( 'type', 'id', 'issue' ) );
+		} else {
+			var_dump( $diff );
+		}
+	}
+
+	private function get_last( $array ) {
+		return end( $array );
 	}
 }

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -193,8 +193,8 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		} else {
 			WP_CLI::warning( 'Formatting is being ignored!' );
 			$i = 0;
-			foreach( $diff as $d ) {
-				if ( $i === intval( $max_diff_size  ) ) {
+			foreach ( $diff as $d ) {
+				if ( intval( $max_diff_size ) === $i ) {
 					break;
 				}
 


### PR DESCRIPTION
## Description

Depends upon https://github.com/Automattic/vip-go-mu-plugins/pull/1545

Add inspect flag for validate-contents command

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `./bin/phpunit-docker.sh tests/search/includes/classes/test-class-health.php`

-----

1. Have a fully indexes VIP Search instance.
2. Pull down PR.
3. Run `wp vip-search health validate-contents --inspect`
4. It should work.

