### PR TITLE
Tweaks for Jetpack 8.4

### DIFF
--- a/vip-jetpack/css/mandatory-settings.css
+++ b/vip-jetpack/css/mandatory-settings.css
@@ -1,3 +1,7 @@
 .row-actions .wpcom-vip-no-delete {
     color: #666;
 }
+
+.jp-form-fieldset {
+    display: none;
+}

--- a/vip-jetpack/css/mandatory-settings.css
+++ b/vip-jetpack/css/mandatory-settings.css
@@ -1,7 +1,3 @@
 .row-actions .wpcom-vip-no-delete {
     color: #666;
 }
-
-.jp-form-fieldset {
-    display: none;
-}

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -350,6 +350,12 @@ add_filter( 'jetpack_sync_modules', function( $modules ) {
 } );
 
 /**
- * Hide promotions/upgrade cards for now
+ * Hide promotions/upgrade cards for now except for sites that we want to opt into Instant Search
  */
-add_filter( 'jetpack_show_promotions', '__return_false' );
+add_filter( 'jetpack_show_promotions', function ( $is_enabled ) {
+	if ( defined( 'VIP_GO_JETPACK_ENABLE_INSTANT_SEARCH' ) && VIP_GO_JETPACK_ENABLE_INSTANT_SEARCH ) {
+		return $is_enabled;
+	}
+
+	return false;
+} );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -353,7 +353,7 @@ add_filter( 'jetpack_sync_modules', function( $modules ) {
  * Hide promotions/upgrade cards for now except for sites that we want to opt into Instant Search
  */
 add_filter( 'jetpack_show_promotions', function ( $is_enabled ) {
-	if ( defined( 'VIP_GO_JETPACK_ENABLE_INSTANT_SEARCH' ) && VIP_GO_JETPACK_ENABLE_INSTANT_SEARCH ) {
+	if ( defined( 'VIP_JETPACK_ENABLE_INSTANT_SEARCH' ) && true === VIP_JETPACK_ENABLE_INSTANT_SEARCH ) {
 		return $is_enabled;
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -348,3 +348,8 @@ add_filter( 'jetpack_sync_modules', function( $modules ) {
 
 	return $modules;
 } );
+
+/**
+ * Hide promotions/upgrade cards for now
+ */
+add_filter( 'jetpack_show_promotions', '__return_false' );


### PR DESCRIPTION
## Description
A couple of small UI changes to hide some of the Instant Search elements for now

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Pull down PR locally or to sandbox
1. Navigate to Jetpack setting screen (`/wp-admin/admin.php?page=jetpack#/performance`)
1. Under the Search section under the "Add Jetpack Search Widget", confirm that this card/button no longer appears: "Help visitors quickly find answers with highly relevant instant search results and powerful filtering | Upgrade "