### PR TITLE
Fixes an issue with `rename()` breaking files.

### DIFF
--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -543,7 +543,7 @@ class VIP_Filesystem_Stream_Wrapper {
 			}
 
 			// Convert to actual file to upload to new path
-			$file     = $this->string_to_resource( $result, 'r' );
+			$file     = $this->string_to_resource( file_get_contents( $result ), 'r' );
 			$meta     = stream_get_meta_data( $file );
 			$filePath = $meta['uri'];
 

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -543,7 +543,7 @@ class VIP_Filesystem_Stream_Wrapper {
 			}
 
 			// Convert to actual file to upload to new path
-			$file     = $this->string_to_resource( file_get_contents( $result ), 'r' );
+			$file     = fopen( $result, 'r' );
 			$meta     = stream_get_meta_data( $file );
 			$filePath = $meta['uri'];
 

--- a/tests/files/test-vip-filesystem-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-stream-wrapper.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Automattic\VIP\Files;
+
+class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
+	private $stream_wrapper;
+
+	private $api_client_mock;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once( __DIR__ . '/../../files/class-vip-filesystem-stream-wrapper.php' );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->api_client_mock = $this->createMock( Api_Client::class );
+
+		$this->stream_wrapper = new VIP_Filesystem_Stream_Wrapper( $this->api_client_mock ); 
+	}
+
+	public function tearDown() {
+		$this->stream_wrapper = null;
+		$this->api_client_mock = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper function for accessing protected methods.
+	 */
+	protected static function get_method( $name ) {
+		$class = new \ReflectionClass( __NAMESPACE__ . '\VIP_Filesystem_Stream_Wrapper' );
+		$method = $class->getMethod( $name );
+		$method->setAccessible( true );
+		return $method;
+	}
+
+	public function test__rename__same_path() {
+		$path_from = 'vip://wp-content/uploads/file.txt';
+		$path_to = 'vip://wp-content/uploads/file.txt';
+
+		// We bail early so Api_Client should not be touched. 
+		$this->api_client_mock
+			->expects( $this->never() )
+			->method( $this->anything() );
+
+		$actual_result = $this->stream_wrapper->rename( $path_from, $path_to );
+
+		$this->assertTrue( $actual_result, 'Return value from rename() was not true' );
+	}
+
+	public function test__rename__sucess() {
+		$path_from = 'vip://wp-content/uploads/old.txt';
+		$path_to = 'vip://wp-content/uploads/new.txt';
+
+		$tmp_file = tempnam( sys_get_temp_dir(), 'phpunit' );
+
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'get_file' )
+			->with( 'wp-content/uploads/old.txt' )
+			->willReturn( $tmp_file );
+
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'upload_file' )
+			->with( $tmp_file, 'wp-content/uploads/new.txt' ) 
+			->willReturn( '/wp-content/uploads/new.txt' );
+
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'delete_file' )
+			->with( 'wp-content/uploads/old.txt' ) 
+			->willReturn( true );
+
+		$actual_result = $this->stream_wrapper->rename( $path_from, $path_to );
+
+		$this->assertTrue( $actual_result );
+	}
+
+}


### PR DESCRIPTION
Previously, the temporary file name was used for the file contents for the _new_ file.  This will pull the actual file contents and use it instead.

## Description

Currently, when a file goes through PHP's `rename()` the stream wrapper will download a copy, and try to upload a new copy with the new name.  Unfortunately, instead of copying the file it just uploads a new file with a `tempnam()` as its contents.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Grab an uploaded URL from a site.
1. `wp shell` in
1. Do a `rename()` on the file, and then `curl` the _new_ file to see its contents is broken
1. Check out PR and merge the fixes, etc...
1. Do a _new_ `rename()` and `curl` the _new_ file again to see that it's now correct.
