### PR TITLE
Streamwrapper: Check if file is read mode first before flush

### DIFF
--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -241,7 +241,8 @@ class VIP_Filesystem_Stream_Wrapper {
 	public function stream_close() {
 		$this->debug( sprintf( 'stream_close => %s + %s', $this->path, $this->uri ) );
 
-		if ( $this->should_flush_empty ) {
+		// Don't attempt to flush new file when in read mode
+		if ( $this->should_flush_empty && 'r' !== $this->mode ) {
 			$this->stream_flush();
 		}
 


### PR DESCRIPTION
## Description

After merging #1426 , the following errors are spotted in log file after a media upload:

```
[10-Apr-2020 08:41:10 UTC] PHP Warning:  stream_flush failed for wp-content/uploads/2020/04/2B7BACFB-A449-4520-8DFA-C227E776CB93.jpg with error: No writes allowed in "read" mode    #vip-go-streams in /var/www/wp-content/mu-plugins/files/class-vip-filesystem-stream-wrapper.php on line 309
[10-Apr-2020 08:41:10 UTC] PHP Stack trace:
[10-Apr-2020 08:41:10 UTC] PHP   1. {main}() /var/www/wp-admin/async-upload.php:0
[10-Apr-2020 08:41:10 UTC] PHP   2. wp_ajax_upload_attachment() /var/www/wp-admin/async-upload.php:33
[10-Apr-2020 08:41:10 UTC] PHP   3. media_handle_upload() /var/www/wp-admin/includes/ajax-actions.php:2546
[10-Apr-2020 08:41:10 UTC] PHP   4. wp_generate_attachment_metadata() /var/www/wp-admin/includes/media.php:419
[10-Apr-2020 08:41:10 UTC] PHP   5. wp_create_image_subsizes() /var/www/wp-admin/includes/image.php:484
[10-Apr-2020 08:41:10 UTC] PHP   6. wp_read_image_metadata() /var/www/wp-admin/includes/image.php:243
[10-Apr-2020 08:41:10 UTC] PHP   7. apply_filters() /var/www/wp-admin/includes/image.php:861
[10-Apr-2020 08:41:10 UTC] PHP   8. WP_Hook->apply_filters() /var/www/wp-includes/plugin.php:206
[10-Apr-2020 08:41:10 UTC] PHP   9. Automattic\VIP\Files\VIP_Filesystem->filter_wp_read_image_metadata() /var/www/wp-includes/class-wp-hook.php:289
[10-Apr-2020 08:41:10 UTC] PHP  10. file_get_contents() /var/www/wp-content/mu-plugins/files/class-vip-filesystem.php:418
[10-Apr-2020 08:41:10 UTC] PHP  11. Automattic\VIP\Files\VIP_Filesystem_Stream_Wrapper->stream_close() /var/www/wp-content/mu-plugins/files/class-vip-filesystem.php:418
[10-Apr-2020 08:41:10 UTC] PHP  12. Automattic\VIP\Files\VIP_Filesystem_Stream_Wrapper->stream_flush() /var/www/wp-content/mu-plugins/files/class-vip-filesystem-stream-wrapper.php: 245
```
Looks like this is happening because we're not checking the open file mode before attempting to flush the file. It should only flush on `fclose()` when it's in editing mode. i.e.: `w` or `a` mode.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).

## Steps to Test

1. Check out PR.
1. Start a sandbox and upload changes
1. Upload a new file into Media library
1. Ensure no error messages in `php-errors` log
