### PR TITLE
Streamwrapper: Fix bug in file mode validation method

### DIFF
--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -834,14 +834,14 @@ class VIP_Filesystem_Stream_Wrapper {
 					return false;
 				}
 
-				return $stats;
+				return true;
 			} catch ( \Exception $e ) {
 				trigger_error(
 					sprintf(
 						'fopen mode validation failed for mode %s on path %s with error: %s #vip-go-streams',
 						$mode,
 						$path, 
-						$result->get_error_message()
+						$e->getMessage()
 					),
 					E_USER_WARNING
 				);

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -841,7 +841,7 @@ class VIP_Filesystem_Stream_Wrapper {
 						'fopen mode validation failed for mode %s on path %s with error: %s #vip-go-streams',
 						$mode,
 						$path, 
-						$e->getMessage()
+						$e->getMessage() // phpcs:ignore
 					),
 					E_USER_WARNING
 				);

--- a/tests/files/test-vip-filesystem-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-stream-wrapper.php
@@ -2,10 +2,14 @@
 
 namespace Automattic\VIP\Files;
 
+use \WP_Error;
+
 class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
 	private $stream_wrapper;
 
 	private $api_client_mock;
+
+	private $errors;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -19,11 +23,15 @@ class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
 		$this->api_client_mock = $this->createMock( Api_Client::class );
 
 		$this->stream_wrapper = new VIP_Filesystem_Stream_Wrapper( $this->api_client_mock ); 
+
+		set_error_handler( [ $this, 'errorHandler' ] );
 	}
 
 	public function tearDown() {
 		$this->stream_wrapper = null;
 		$this->api_client_mock = null;
+
+		restore_error_handler();
 
 		parent::tearDown();
 	}
@@ -36,6 +44,24 @@ class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
 		$method = $class->getMethod( $name );
 		$method->setAccessible( true );
 		return $method;
+	}
+
+	/**
+	 * Helper functions to test for trigger_error calls
+	 */
+	public function errorHandler( $errno, $errstr, $errfile, $errline, $errcontext ) {
+		$this->errors[] = compact( 'errno', 'errstr', 'errfile', 'errline', 'errcontext' );
+	}
+
+	public function assertError( $errstr, $errno ) {
+		foreach ( $this->errors as $error ) {
+			if ( $error['errstr'] === $errstr
+				&& $error['errno'] === $errno ) {
+				return;
+			}
+		}
+
+		$this->fail( 'Error with level ' . $errno . " and message '" . $errstr . "' not found in " . var_export( $this->errors, TRUE ) );
 	}
 
 	public function test__rename__same_path() {
@@ -81,4 +107,74 @@ class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
 		$this->assertTrue( $actual_result );
 	}
 
+	public function get_test_data__validate_valid_mode() {
+		return [ 
+			'read mode'   => [ 'r' ],
+			'write mode'  => [ 'w' ],
+			'append mode' => [ 'a' ],
+			'x mode' => [ 'x' ],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__validate_valid_mode
+	 */
+	public function test__validate__valid_mode( $mode ) {
+		$this->assertTrue( 
+			$this->stream_wrapper->validate( '/test/path', $mode ) );
+	}
+
+	public function get_test_data__validate_invalid_mode() {
+		return [ 
+			'c mode'   => [ 'c' ],
+			'e mode'  => [ 'e' ],
+		];
+	}
+
+	/**
+	 * @dataProvider get_test_data__validate_invalid_mode
+	 */
+	public function test__validate__invalid_mode( $mode ) {
+		$result = $this->stream_wrapper->validate( '/test/path', $mode );
+
+		$this->assertError( "Mode not supported: { $mode }. Use one 'r', 'w', 'a', or 'x'.", E_USER_NOTICE );
+		$this->assertFalse( $result );
+	}
+
+	public function test__validate__x_mode_file_doesnt_exist() {
+		$path = '/wp-content/uploads/test.txt';
+
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'is_file' )
+			->with( $path, [] )
+			->willReturn( false );
+
+		$this->assertTrue( $this->stream_wrapper->validate( $path, 'x' ) );
+	}
+
+	public function test__validate__x_mode_file_already_exist() {
+		$path = '/wp-content/uploads/test.txt';
+
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'is_file' )
+			->with( $path, [] )
+			->willReturn( true );
+
+		$this->assertFalse( $this->stream_wrapper->validate( $path, 'x' ) );
+	}
+
+	public function test__validate__x_mode_is_file_request_error() {
+		$path = '/wp-content/uploads/test.txt';
+
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'is_file' )
+			->with( $path, [] )
+			->willReturn( new WP_Error( 'is-file-error', 'Test error' ) );
+
+		$this->assertFalse( $this->stream_wrapper->validate( $path, 'x' ) );
+		$this->assertError( "fopen mode validation failed for mode x on path $path with error: Test error #vip-go-streams", E_USER_WARNING );
+	}
 }

--- a/tests/files/test-vip-filesystem-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-stream-wrapper.php
@@ -9,7 +9,7 @@ class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
 
 	private $api_client_mock;
 
-	private $errors;
+	private $errors = [];
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -30,6 +30,8 @@ class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
 	public function tearDown() {
 		$this->stream_wrapper = null;
 		$this->api_client_mock = null;
+
+		$this->errors = [];
 
 		restore_error_handler();
 

--- a/tests/files/test-vip-filesystem-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-stream-wrapper.php
@@ -61,7 +61,7 @@ class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
 			}
 		}
 
-		$this->fail( 'Error with level ' . $errno . " and message '" . $errstr . "' not found in " . var_export( $this->errors, TRUE ) );
+		$this->fail( 'Error with level ' . $errno . " and message '" . $errstr . "' not found in " . var_export( $this->errors, true ) );
 	}
 
 	public function test__rename__same_path() {
@@ -120,8 +120,7 @@ class VIP_Filesystem_Stream_Wrapper_Test extends \WP_UnitTestCase {
 	 * @dataProvider get_test_data__validate_valid_mode
 	 */
 	public function test__validate__valid_mode( $mode ) {
-		$this->assertTrue( 
-			$this->stream_wrapper->validate( '/test/path', $mode ) );
+		$this->assertTrue( $this->stream_wrapper->validate( '/test/path', $mode ) );
 	}
 
 	public function get_test_data__validate_invalid_mode() {


### PR DESCRIPTION
## Description

A bug in the file mode validation method results in it returning an undefined value instead of true.

Fixes #1552  

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

Example:

1. Check out PR.
1. Upload code to sandbox
1. `wp shell`
1. Create a new file with mode `x`: `fopen( 'vip://wp-content/uploads/new-file.txt', 'x' );`
1. Verify file opened properly
