### PR TITLE
Offload queries to database if RPS too high in VIP Search

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -634,7 +634,7 @@ class Search {
 	 * Increment the number of queries that have been passed through VIP Search
 	 */
 	private static function query_count_incr() {
-		if ( ! wp_cache_get( self::$query_count_cache_key ) ) {
+		if ( false === wp_cache_get( self::$query_count_cache_key ) ) {
 			wp_cache_set( self::$query_count_cache_key, 0, 'default', self::$query_count_ttl );
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -636,7 +636,7 @@ class Search {
 	 */
 	private static function query_count_incr() {
 		if ( false === wp_cache_get( self::$query_count_cache_key ) ) {
-			wp_cache_set( self::$query_count_cache_key, 0, 'default', self::$query_count_ttl );
+			wp_cache_set( self::$query_count_cache_key, 0, self::$query_count_cache_group, self::$query_count_ttl );
 		}
 
 		return wp_cache_incr( self::$query_count_cache_key );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -9,11 +9,11 @@ class Search {
 	public $queue;
 	private $current_host_index;
 
-	private static $query_count_cache_key = 'query_count';
-	private static $query_count_cache_group = 'vip_search';
-	private static $query_count_ttl = 300; // 5 minutes in seconds 
-	private static $max_query_count = 3000 + 1; // 10 requests per second plus one for cleanliness of comparing with Search::query_count_incr
-	private static $query_rand_comparison = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
+	private const QUERY_COUNT_CACHE_KEY = 'query_count';
+	private const QUERY_COUNT_CACHE_GROUP = 'vip_search';
+	private const QUERY_COUNT_TTL = 300; // 5 minutes in seconds 
+	private const MAX_QUERY_COUNT = 3000 + 1; // 10 requests per second plus one for cleanliness of comparing with Search::query_count_incr
+	private const QUERY_RAND_COMPARISON = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
 
 	private static $_instance;
 
@@ -351,9 +351,9 @@ class Search {
 
 		// If the query count has exceeded the maximum
 		//     Only allow half of the queries to use VIP Search
-		if ( self::query_count_incr() > self::$max_query_count ) {
+		if ( self::query_count_incr() > self::MAX_QUERY_COUNT ) {
 			// Should be roughly half over time
-			if ( self::$query_rand_comparison >= rand( 1, 10 ) ) {
+			if ( self::QUERY_RAND_COMPARISON >= rand( 1, 10 ) ) {
 				return true;
 			}
 		}
@@ -635,10 +635,10 @@ class Search {
 	 * Increment the number of queries that have been passed through VIP Search
 	 */
 	private static function query_count_incr() {
-		if ( false === wp_cache_get( self::$query_count_cache_key ) ) {
-			wp_cache_set( self::$query_count_cache_key, 0, self::$query_count_cache_group, self::$query_count_ttl );
+		if ( false === wp_cache_get( self::QUERY_COUNT_CACHE_KEY, self::QUERY_COUNT_CACHE_GROUP ) ) {
+			wp_cache_set( self::QUERY_COUNT_CACHE_KEY, 0, self::QUERY_COUNT_CACHE_GROUP, self::QUERY_COUNT_TTL );
 		}
 
-		return wp_cache_incr( self::$query_count_cache_key );
+		return wp_cache_incr( self::QUERY_COUNT_CACHE_KEY, 1, self::QUERY_COUNT_CACHE_GROUP );
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -9,7 +9,8 @@ class Search {
 	public $queue;
 	private $current_host_index;
 
-	private static $query_count_cache_key = 'vip_search_query_count';
+	private static $query_count_cache_key = 'query_count';
+	private static $query_count_cache_group = 'vip_search';
 	private static $query_count_ttl = 300; // 5 minutes in seconds 
 	private static $max_query_count = 3000 + 1; // 10 requests per second plus one for cleanliness of comparing with Search::query_count_incr
 	private static $query_rand_comparison = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.


### PR DESCRIPTION
## Description

Have an object cache value that expires in a reasonable time frame(currently set to 5 minutes).

Increment the value for each request that passes through VIP Search.

If this value gets higher than the define limits, disable query integration for roughly half of the requests.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Checkout PR
2. Change `private static $max_query_count = 3000 + 1;` to `private static $max_query_count = 1;`
3. Run a search with QM/Debug Bar open for ElasticPress.
4. Keep refreshing the page while watching the queries.
5. Roughly half shouldn't go through ElasticPress.
6. Reset `private static $max_query_count` back to normal.
