### PR TITLE
Set default es shard + replica count

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -133,6 +133,9 @@ class Search {
 
 		// Disable indexing of filtered content by default, as it's not searched by default
 		add_filter( 'ep_allow_post_content_filtered_index', '__return_false' );
+
+		// Better shard counts
+		add_filter( 'ep_default_index_number_of_shards', array( $this, 'filter__ep_default_index_number_of_shards' ) );
 		
 		// Date relevancy defaults. Taken from Jetpack Search.
 		// Set to 'gauss'
@@ -479,6 +482,23 @@ class Search {
 		}
 
 		return $formatted_args;
+	}
+
+	/**
+	 * Set the number of shards in the index settings
+	 * 
+	 * NOTE - this can only be changed during index creation, not on an existing index
+	 */
+	public function filter__ep_default_index_number_of_shards( $shards ) {
+		$shards = 1;
+
+		$posts_count = wp_count_posts();
+
+		if ( $posts_count->publish > 1000000 ) {
+			$shards = 4;
+		}
+
+		return $shards;
 	}
 
 	/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -136,6 +136,9 @@ class Search {
 
 		// Better shard counts
 		add_filter( 'ep_default_index_number_of_shards', array( $this, 'filter__ep_default_index_number_of_shards' ) );
+
+		// Better replica counts
+		add_filter( 'ep_default_index_number_of_replicas', array( $this, 'filter__ep_default_index_number_of_replicas' ) );
 		
 		// Date relevancy defaults. Taken from Jetpack Search.
 		// Set to 'gauss'
@@ -499,6 +502,13 @@ class Search {
 		}
 
 		return $shards;
+	}
+
+	/**
+	 * Set the number of replicas for the index
+	 */
+	public function filter__ep_default_index_number_of_replicas( $replicas ) {
+		return 2;
 	}
 
 	/**

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -88,6 +88,15 @@ class Search_Test extends \WP_UnitTestCase {
 		remove_filter( 'wp_count_posts', $return_big_count );
 	}
 
+	public function test__vip_search_filter_ep_default_index_number_of_replicas() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$replicas = apply_filters( 'ep_default_index_number_of_replicas', 1 );
+
+		$this->assertEquals( 2, $replicas );
+	}
+
 	public function vip_search_enforces_disabled_features_data() {
 		return array(
 			array( 'documents' ),

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -59,6 +59,35 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 'index-name', $index_name );
 	}
 
+	public function test__vip_search_filter_ep_default_index_number_of_shards() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$shards = apply_filters( 'ep_default_index_number_of_shards', 5 );
+
+		$this->assertEquals( 1, $shards );
+	}
+
+	public function test__vip_search_filter_ep_default_index_number_of_shards_large_site() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		// Simulate a large site
+		$return_big_count = function( $counts ) {
+			$counts->publish = 2000000;
+
+			return $counts;
+		};
+
+		add_filter( 'wp_count_posts', $return_big_count );
+
+		$shards = apply_filters( 'ep_default_index_number_of_shards', 5 );
+
+		$this->assertEquals( 4, $shards );
+
+		remove_filter( 'wp_count_posts', $return_big_count );
+	}
+
 	public function vip_search_enforces_disabled_features_data() {
 		return array(
 			array( 'documents' ),


### PR DESCRIPTION
## Description

This modifies the default shard + replica counts for ES indexes to the following:

1 shard on most indexes
4 shards on sites with over 1 million posts
2 replicas on all indexes

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Create new index - `wp elasticpress index --setup`
1. Verify that all functionality works as expected
1. Verify shard + index counts with the `/<index>/_settings` API endpoint
