### PR TITLE
Disable EP queries on the HP on some sites

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -338,7 +338,7 @@ class Search {
 	 * When the index is ready to serve requests in production, the `VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION`
 	 * constant should be set to `true`, which will enable query integration for all requests
 	 */
-	static function ep_skip_query_integration( $skip, $query = false ) {
+	static function ep_skip_query_integration( $skip, $query = null ) {
 		if ( isset( $_GET[ 'es' ] ) ) {
 			return false;
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -338,7 +338,7 @@ class Search {
 	 * When the index is ready to serve requests in production, the `VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION`
 	 * constant should be set to `true`, which will enable query integration for all requests
 	 */
-	static function ep_skip_query_integration( $skip, $query = null ) {
+	public static function ep_skip_query_integration( $skip, $query = null ) {
 		if ( isset( $_GET[ 'es' ] ) ) {
 			return false;
 		}


### PR DESCRIPTION
## Description

EP has a bug in the Facets feature where Facets can be incorrectly enabled on regular queries, causing them to be served by ElasticPress.

This works around that (as a temporary measure) for a few sites experiencing this problem by skipping query integration for the main query on them.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Test regular queries
1. Test HP on affected sites, ensure no ES queries are performed
