### PR TITLE
Added whitelist for exact search

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -625,6 +625,17 @@ class Search {
 			return $formatted_args;
 		}
 
+		if ( defined( 'VIP_GO_APP_ID' ) ) {
+			$allow_exact_search_site_ids = array(
+				1284,
+			);
+
+			// Only allow exact search for whitelisted site ids
+			if ( ! in_array( VIP_GO_APP_ID, $allow_exact_search_site_ids, true ) ) {
+				return $formatted_args;
+			}
+		}
+
 		// Replace base 'should' with 'must' and then remove the 'should' from formatted args
 		$formatted_args['query']['bool']['must'] = $formatted_args['query']['bool']['should'];
 		$formatted_args['query']['bool']['must'][0]['multi_match']['operator'] = 'AND';


### PR DESCRIPTION
## Description

Exact search was added to sort out search relevancy on certain sites. Since that also ruined search relevancy for certain search queries on another site but didn't really affect things on other sites, a whitelist for enabling exact search was added for VIP Go sites. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Do a search, note the query body in the ElasticPress debug bar.
2. Pull down PR.
3. Do a search, note the change to the query body in the ElasticPress debug bar.