### PR TITLE
Add deadlock protection to indexing queue

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -319,11 +319,17 @@ class Queue {
 		// Set them as scheduled
 		$job_ids = wp_list_pluck( $jobs, 'job_id' );
 
-		$this->update_jobs( $job_ids, array( 'status' => 'scheduled' ) );
+		$scheduled_time = gmdate( 'Y-m-d H:i:s' );
+
+		$this->update_jobs( $job_ids, array(
+			'status' => 'scheduled',
+			'scheduled_time' => $scheduled_time,
+		) );
 
 		// Set right status on the already queried jobs objects
 		foreach ( $jobs as &$job ) {
 			$job->status = 'scheduled';
+			$job->scheduled_time = $scheduled_time;
 
 			// Set the last index time for rate limiting. Technically the object isn't yet re-indexed, but 
 			// this is close enough for our purpose and prevents repeat jobs from being queued for immediate processing

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -356,7 +356,7 @@ class Queue {
 		$deadlocked_time = time() - self::DEADLOCK_TIME;
 
 		$jobs = $wpdb->get_results( $wpdb->prepare(
-			"SELECT * FROM {$table_name} WHERE `status` = 'scheduled' AND `scheduled_time` <= %s LIMIT %d",
+			"SELECT * FROM {$table_name} WHERE `status` = 'scheduled' AND `scheduled_time` <= %s LIMIT %d", // Cannot prepare table name. @codingStandardsIgnoreLine
 			gmdate( 'Y-m-d H:i:s', $deadlocked_time ),
 			$count
 		) );
@@ -371,7 +371,7 @@ class Queue {
 		// Run this several times, to release potentially many jobs in reasonable batches
 		$batches = 5;
 
-		for( $i = 0; $i < $batches; $i++ ) {
+		for ( $i = 0; $i < $batches; $i++ ) {
 			$deadlocked_jobs = $this->get_deadlocked_jobs( 500 );
 
 			// If none found, we can stop the loop

--- a/search/includes/classes/queue/class-cron.php
+++ b/search/includes/classes/queue/class-cron.php
@@ -129,6 +129,8 @@ class Cron {
 			return;
 		}
 
+		$this->queue->free_deadlocked_jobs();
+
 		// TODO add a "max batches" setting and keep creating batch jobs until none are found or we hit the max
 
 		$this->schedule_batch_job();

--- a/search/includes/classes/queue/class-schema.php
+++ b/search/includes/classes/queue/class-schema.php
@@ -31,7 +31,7 @@ class Schema {
 	public function is_installed() {
 		$db_version = (int) get_transient( self::DB_VERSION_TRANSIENT );
 
-		return version_compare( $db_version, 0, '>' );
+		return version_compare( $db_version, self::DB_VERSION, '>=' );
 	}
 
 	/**

--- a/search/includes/classes/queue/class-schema.php
+++ b/search/includes/classes/queue/class-schema.php
@@ -5,7 +5,7 @@ namespace Automattic\VIP\Search\Queue;
 class Schema {
 	const TABLE_SUFFIX = 'vip_search_index_queue';
 
-	const DB_VERSION = 1;
+	const DB_VERSION = 2;
 	const DB_VERSION_TRANSIENT = 'vip_search_queue_db_version';
 	const DB_VERSION_TRANSIENT_TTL = \DAY_IN_SECONDS; // Long, but not permanent, so the db table will get created _eventually_ if missing
 	const TABLE_CREATE_LOCK = 'vip_search_queue_creating_table';
@@ -127,6 +127,7 @@ class Schema {
 			`start_time` datetime DEFAULT NULL COMMENT 'Datetime when the item can be indexed (but not before) - used for debouncing',
 			`status` varchar(45) NOT NULL COMMENT 'Status of the indexing job',
 			`queued_time` datetime DEFAULT CURRENT_TIMESTAMP,
+  			`scheduled_time` datetime DEFAULT NULL,
 			PRIMARY KEY (`job_id`),
 			UNIQUE KEY `unique_object_and_status` (`object_id`,`object_type`,`status`)
 		) ENGINE=InnoDB";

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -112,7 +112,7 @@ class Cron_Test extends \WP_UnitTestCase {
 
 	public function test_schedule_batch_job() {
 		$mock_queue = $this->getMockBuilder( Queue::class )
-			->setMethods( [ 'checkout_jobs' ] )
+			->setMethods( [ 'checkout_jobs', 'free_deadlocked_jobs' ] )
 			->getMock();
 
 		$mock_job_ids = array( 1, 2 );

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -317,4 +317,42 @@ class Queue_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( array(), $jobs );
 	}
+
+	public function test_get_deadlocked_jobs() {
+		$this->queue->queue_object( 1000, 'post' );
+		$this->queue->queue_object( 2000, 'post' );
+		$this->queue->queue_object( 3000, 'post' );
+
+		// Set the first job to have been scheduled in the recent past, to be flagged as deadlocked
+		$job1 = $this->queue->get_next_job_for_object( 1000, 'post' );
+
+		$deadlocked_time = time() - $this->queue::DEADLOCK_TIME;
+
+		$this->queue->update_job( $job1->job_id, array(
+			'status' => 'scheduled',
+			'scheduled_time' => gmdate( 'Y-m-d H:i:s', $deadlocked_time ),
+		) );
+
+		// Set the second job to have been scheduled in the far past, to be flagged as deadlocked
+		$job2 = $this->queue->get_next_job_for_object( 3000, 'post' );
+
+		$deadlocked_time = time() - $this->queue::DEADLOCK_TIME - ( 3 * DAY_IN_SECONDS );
+
+		$this->queue->update_job( $job2->job_id, array(
+			'status' => 'scheduled',
+			'scheduled_time' => gmdate( 'Y-m-d H:i:s', $deadlocked_time ),
+		) );
+
+		// Now both jobs 1 and 2 should be considered deadlocked
+		$deadlocked_jobs = $this->queue->get_deadlocked_jobs();
+
+		$deadlocked_job_ids = wp_list_pluck( $deadlocked_jobs, 'job_id' );
+
+		$expected_deadlocked_job_ids = array(
+			$job1->job_id,
+			$job2->job_id,
+		);
+
+		$this->assertEquals( $expected_deadlocked_job_ids, $deadlocked_job_ids );
+	}
 }

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -145,7 +145,7 @@ class Queue_Test extends \WP_UnitTestCase {
 		$jobs = $this->queue->checkout_jobs( 10 );
 
 		// Should have the right status and scheduled_time set
-		foreach( $jobs as $job ) {
+		foreach ( $jobs as $job ) {
 			$this->assertEquals( 'scheduled', $job->status, "Job $job->job_id was expected to have status 'scheduled'" );
 			$this->assertEquals( $expected_scheduled_time, $job->scheduled_time, "Job $job->job_id has the wrong scheduled_time" );
 		}

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -140,7 +140,15 @@ class Queue_Test extends \WP_UnitTestCase {
 			$this->queue->queue_object( $object['id'], $object['type'] );
 		}
 			
+		$expected_scheduled_time = gmdate( 'Y-m-d H:i:s' );
+
 		$jobs = $this->queue->checkout_jobs( 10 );
+
+		// Should have the right status and scheduled_time set
+		foreach( $jobs as $job ) {
+			$this->assertEquals( 'scheduled', $job->status, "Job $job->job_id was expected to have status 'scheduled'" );
+			$this->assertEquals( $expected_scheduled_time, $job->scheduled_time, "Job $job->job_id has the wrong scheduled_time" );
+		}
 
 		$object_ids = wp_list_pluck( $jobs, 'object_id' );
 


### PR DESCRIPTION
## Description

Prevent deadlocks in the async indexing queue by recording when a job is scheduled (when a cron job is created to process it), then free up any deadlocked jobs in the "sweeper" job.

Currently it's configured to consider a job deadlocked after 5 minutes, which means, if it was scheduled via a cron job, but hasn't been finished within 5 minutes, it's deadlocked and will be re-scheduled.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR
1. Visit an admin page to trigger the db schema update
1. Manually add an item to the queue table, with status = `scheduled` and a `scheduled_time` in the past (over 5 minutes ago)...this is a "deadlocked" job
1. Run the sweeper cron event manually - `wp cron event run vip_search_queue_sweeper`
1. Check the db table - the job should now have a `scheduled_time` of now.
1. `wp cron event list` - should show the `vip_search_queue_processor` event for the rescheduled job
