### PR TITLE
Add per site/index search stats

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -611,6 +611,26 @@ class Search {
 	}
 
 	/**
+	 * Given an ES url, determine the index name of the request for stats purposes
+	 */
+	public function get_statsd_index_name_for_url( $url ) {
+		$parsed = parse_url( $url );
+
+		$path = explode( '/', trim( $parsed['path'], '/' ) );
+
+		// Index name is _usually_ the first part of the path
+		$index_name = $path[ 0 ];
+
+		// If it starts with underscore but isn't "_all", then we didn't detect the index name
+		// and should return null
+		if ( wp_startswith( $index_name, '_' ) && '_all' !== $index_name ) {
+			return null;
+		}
+
+		return $index_name;
+	}
+
+	/**
 	 * Get the statsd stat prefix for a given "mode"
 	 */
 	public function get_statsd_prefix( $url, $mode = 'other' ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -626,7 +626,7 @@ class Search {
 		$path = explode( '/', trim( $parsed['path'], '/' ) );
 
 		// Index name is _usually_ the first part of the path
-		$index_name = $path[ 0 ];
+		$index_name = $path[0];
 
 		// If it starts with underscore but isn't "_all", then we didn't detect the index name
 		// and should return null

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -633,7 +633,7 @@ class Search {
 	/**
 	 * Get the statsd stat prefix for a given "mode"
 	 */
-	public function get_statsd_prefix( $url, $mode = 'other' ) {
+	public function get_statsd_prefix( $url, $mode = 'other', $app_id = null, $index_name = null ) {
 		$key_parts = array(
 			'com.wordpress', // Global prefix
 			'elasticsearch', // Service name
@@ -654,6 +654,15 @@ class Search {
 
 		// Break up tracking based on mode
 		$key_parts[] = $mode;
+
+		// If app id / index name passed, include those too
+		if ( is_int( $app_id ) ) {
+			$key_parts[] = $app_id;
+		}
+
+		if ( is_string( $index_name ) && ! empty( $index_name ) ) {
+			$key_parts[] = $index_name;
+		}
 
 		// returns prefix only e.g. 'com.wordpress.elasticsearch.bur.9235_vipgo.search'
 		return implode( '.', $key_parts );

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -864,6 +864,41 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected, $prefix );
 	}
 
+	public function get_statsd_prefix_with_site_and_index_data() {
+		return array(
+			array(
+				'https://es-ha-bur.vipv2.net:1234',
+				'search',
+				1,
+				'vip-1-post',
+				'com.wordpress.elasticsearch.bur.ha1234_vipgo.search.1.vip-1-post',
+			),
+			array(
+				'https://es-ha-dca.vipv2.net:4321',
+				'index',
+				2,
+				'vip-2-post-2',
+				'com.wordpress.elasticsearch.dca.ha4321_vipgo.index.2.vip-2-post-2',
+			),
+			array(
+				'https://es-ha-dca.vipv2.net:4321',
+				'index',
+				3,
+				'vip-3-post-2-2',
+				'com.wordpress.elasticsearch.dca.ha4321_vipgo.index.3.vip-3-post-2-2',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_statsd_prefix_with_site_and_index_data
+	 */
+	public function test_get_statsd_prefix_with_site_and_index( $url, $mode, $app_id, $index_name, $expected ) {
+		$prefix = $this->search_instance->get_statsd_prefix( $url, $mode, $app_id, $index_name );
+
+		$this->assertEquals( $expected, $prefix );
+	}
+
 	/**
 	 * Test formatted args structure checks
 	 */

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -797,6 +797,49 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_mode, $mode );
 	}
 
+	public function get_statsd_index_name_for_url_data() {
+		return array(
+			// Search
+			array(
+				'https://host.com/_search',
+				null,
+			),
+			array(
+				'https://host.com/index-name/_search',
+				'index-name',
+			),
+			array(
+				'https://host.com/index-name,index-name-2/_search',
+				'index-name,index-name-2',
+			),
+			array(
+				'https://host.com/_all/_search',
+				'_all',
+			),
+
+			// Other misc operations
+			array(
+				'https://host.com/index-name/_bulk',
+				'index-name',
+			),
+			array(
+				'https://host.com/index-name/_doc',
+				'index-name',
+			),
+		);
+	}
+
+	/**
+	 * Test that we correctly determine the index name from an ES API url for stats purposes
+	 * 
+	 * @dataProvider get_statsd_index_name_for_url_data()
+	 */
+	public function test_get_statsd_index_name_for_url( $url, $expected_index_name ) {
+		$index_name = $this->search_instance->get_statsd_index_name_for_url( $url );
+
+		$this->assertEquals( $expected_index_name, $index_name );
+	}
+
 	public function get_statsd_prefix_data() {
 		return array(
 			array(


### PR DESCRIPTION
## Description

Record Search stats on a per-app and per-index basis.

NOTE - keeps existing "global" stats for backwards compatibility with existing dashboards.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR
1. Run StatsD locally
1. `define( 'VIP_STATSD_HOST', 'docker.for.mac.localhost' );`
1. `define( 'VIP_STATSD_PORT', 8125 );`
1. Run some queries
1. Watch StatsD output - should include metrics for both the global stats, then metrics the site id and index name in them
