### PR TITLE
Added ratelimiting for indexing operations

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -484,6 +484,11 @@ class Queue {
 			$this->queue_object( $object_id, $indexable_slug );
 		}
 
+		// If indexing operations are NOT currently ratelimited, queue up a cron event to process these immediately.
+		if ( false === wp_cache_get( self::INDEX_QUEUEING_ENABLED_KEY, self::INDEX_COUNT_CACHE_GROUP ) ) {
+			$this->cron->schedule_batch_job();
+		}
+		
 		// Empty out the queue now that we've queued those items up
 		$sync_manager->sync_queue = [];
 

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -574,7 +574,7 @@ class Queue {
 
 		$url = $es->get_current_host();
 		$stat = $es->get_statsd_prefix( $url, $statsd_mode );
-		$per_site_stat= $es->get_statsd_prefix( $url, $statsd_mode, FILES_CLIENT_SITE_ID, $statsd_index_name );
+		$per_site_stat = $es->get_statsd_prefix( $url, $statsd_mode, FILES_CLIENT_SITE_ID, $statsd_index_name );
 
 		$statsd = new \Automattic\VIP\StatsD();
 

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -25,7 +25,6 @@ class Queue {
 	private const INDEX_COUNT_TTL = 5 * MINUTE_IN_SECONDS; // Period for indexing operations
 	private const INDEX_QUEUEING_TTL = 1 * HOUR_IN_SECONDS; // Keep indexing op queueing for an hour once ratelimiting is triggered
 
-
 	public function init() {
 		if ( ! $this->is_enabled() ) {
 			return;
@@ -60,7 +59,7 @@ class Queue {
 		// For handling indexing failures
 		add_action( 'ep_after_bulk_index', [ $this, 'action__ep_after_bulk_index' ], 10, 3 );
 
-		add_action( 'pre_ep_index_sync_queue', [ $this, 'ratelimit_indexing' ], 0, 3 );
+		add_filter( 'pre_ep_index_sync_queue', [ $this, 'ratelimit_indexing' ], PHP_INT_MAX, 3 );
 	}
 
 	/**
@@ -522,6 +521,10 @@ class Queue {
 	public function ratelimit_indexing( $bail, $sync_manager, $indexable_slug ) {
 		// Only posts supported right now
 		if ( 'post' !== $indexable_slug ) {
+			return $bail;
+		}
+
+		if ( empty( $sync_manager->sync_queue ) ) {
 			return $bail;
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -7,7 +7,7 @@ use \WP_CLI;
 class Search {
 	public $healthcheck;
 	public $queue;
-	private $current_host_index;
+	private $current_host_index = 0;
 
 	public const QUERY_COUNT_CACHE_KEY = 'query_count';
 	public const QUERY_COUNT_CACHE_GROUP = 'vip_search';
@@ -446,16 +446,16 @@ class Search {
 			return $host;
 		}
 
-		return $this->get_next_host( VIP_ELASTICSEARCH_ENDPOINTS, $failures );
+		return $this->get_next_host( $failures );
 	}
 
 	/**
 	 * Return the next host in the list based on the current host index
 	 */
-	public function get_next_host( $hosts, $failures ) {
-		$this->current_host_index = ( $this->current_host_index + $failures ) % count( $hosts );
+	public function get_next_host( $failures ) {
+		$this->current_host_index += $failures;
 		
-		return $hosts[ $this->current_host_index ];
+		return $this->get_current_host();
 	} 
 
 	/**
@@ -761,6 +761,33 @@ class Search {
 		}
 
 		return $enabled;
+	}
+
+	/**
+	 * Get current Elasticsearch host
+	 *
+	 * @return {string|WP_Error} Returns the host on success or a WP_Error on failure
+	 */
+	public function get_current_host() {
+		if( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) {
+			if ( defined( 'EP_HOST' ) ) {
+				return EP_HOST;
+			}
+
+			return new \WP_Error( 'vip-search-no-host-found', 'No Elasticsearch hosts found' );
+		}
+
+		if ( ! is_array( VIP_ELASTICSEARCH_ENDPOINTS ) ) {
+			return VIP_ELASTICSEARCH_ENDPOINTS;
+		}
+
+		if ( ! is_int( $this->current_host_index ) ) {
+			$this->current_host_index = 0;
+		}
+
+		$this->current_host_index = $this->current_host_index % count( VIP_ELASTICSEARCH_ENDPOINTS );
+
+		return VIP_ELASTICSEARCH_ENDPOINTS[ $this->current_host_index ];
 	}
 
 	/*

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -769,7 +769,7 @@ class Search {
 	 * @return {string|WP_Error} Returns the host on success or a WP_Error on failure
 	 */
 	public function get_current_host() {
-		if( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) {
+		if ( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) {
 			if ( defined( 'EP_HOST' ) ) {
 				return EP_HOST;
 			}

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -570,6 +570,17 @@ class Queue_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the logic for checking if index ratelimiting is turned on works
+	 */
+	public function test__is_indexing_ratelimited() {
+		$this->assertFalse( $this->queue::is_indexing_ratelimited(), 'should be false since the object cache should be empty' );
+
+		$this->queue::turn_on_index_ratelimiting();
+
+		$this->assertTrue( $this->queue::is_indexing_ratelimited(), 'should be true since Queue::turn_on_index_ratelimiting was called' );
+	}
+
+	/**
 	 * Ensure the incrementor for tracking indexing operations counts behaves properly
 	 */
 	public function test__index_count_incr() {

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -439,6 +439,137 @@ class Queue_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that the value passed into the filter is returned if the indexable_slug is not 'post'
+	 */
+	public function test__ratelimit_indexing_should_pass_bail_if_not_post() {
+		$this->assertTrue( $this->queue->ratelimit_indexing( true, '', 'hippo' ), 'should return true since true was passed in' );		
+		$this->assertFalse( $this->queue->ratelimit_indexing( false, '', 'hippo' ), 'should return false since false was passed in' );
+	}
+
+	/**
+	 * Ensure that the value passed into the filter is returned if the sync queue is empty
+	 */
+	public function test__ratelimit_indexing_should_pass_bail_if_sync_queue_empty() {
+		$sync_manager = new \stdClass();
+		$sync_manager->sync_queue = array();
+
+		$this->assertTrue( $this->queue->ratelimit_indexing( true, $sync_manager, 'post' ), 'should return true since true was passed in' );		
+		$this->assertFalse( $this->queue->ratelimit_indexing( false, $sync_manager, 'post' ), 'should return false since false was passed in' );
+	}
+
+	/**
+	 * Ensure that the count in the cache doesn't exist on load
+	 */
+	public function test_ratelimit_indexing_cache_count_should_not_exist_onload() {
+		$this->assertFalse( wp_cache_get( $this->queue::INDEX_COUNT_CACHE_KEY, $this->queue::INDEX_COUNT_CACHE_GROUP ), 'indexing ops count shouldn\'t exist prior to first function call' );
+	}
+	
+	/**
+	 * Ensure that the count in the cache doesn't exist if the ratelimit_indexing returns early
+	 */
+	public function test_ratelimit_indexing_cache_count_should_not_exists_if_early_return() {
+		$sync_manager = new \stdClass();
+		$sync_manager->sync_queue = array();
+
+		$this->queue->ratelimit_indexing( true, '', 'hippo' );
+		$this->queue->ratelimit_indexing( true, $sync_manager, 'post' );
+
+		$this->assertFalse( wp_cache_get( $this->queue::INDEX_COUNT_CACHE_KEY, $this->queue::INDEX_COUNT_CACHE_GROUP ), 'indexing ops count shouldn\'t exist if function calls all returned early' );
+	}
+
+	/**
+	 * Ensure that the queue isn't populated if ratelimiting isn't triggered
+	 */
+	public function test_ratelimit_indexing_queue_should_be_empty_if_no_ratelimiting() {
+		global $wpdb;
+
+		$table_name = $this->queue->schema->get_table_name();
+
+		$sync_manager = new \stdClass();
+		$sync_manager->sync_queue = range( 3, 9 );
+
+		$this->queue::$max_indexing_op_count = PHP_INT_MAX; // Ensure ratelimiting is disabled
+
+		$this->queue->ratelimit_indexing( true, $sync_manager, 'post' );
+
+		$this->assertEquals( 7, wp_cache_get( $this->queue::INDEX_COUNT_CACHE_KEY, $this->queue::INDEX_COUNT_CACHE_GROUP ), 'indexing ops count should be 7' );
+
+		foreach ( $sync_manager->sync_queue as $object_id ) {
+			$results = $wpdb->get_results( 
+				$wpdb->prepare( 
+					"SELECT * FROM `{$table_name}` WHERE `object_id` = %d AND `object_type` = 'post' AND `status` = 'queued'", // Cannot prepare table name. @codingStandardsIgnoreLine
+					$object_id
+				)
+			);
+
+			$this->assertCount( 0, $results, "should be 0 occurrences of post id #$object_id in queue table" );
+		}
+
+		$sync_manager->sync_queue = range( 10, 20 );
+
+		$this->queue->ratelimit_indexing( true, $sync_manager, 'post' );
+
+		$this->assertEquals( 18, wp_cache_get( $this->queue::INDEX_COUNT_CACHE_KEY, $this->queue::INDEX_COUNT_CACHE_GROUP ), 'indexing ops count should be 18' );
+
+		foreach ( $sync_manager->sync_queue as $object_id ) {
+			$results = $wpdb->get_results( 
+				$wpdb->prepare( 
+					"SELECT * FROM `{$table_name}` WHERE `object_id` = %d AND `object_type` = 'post' AND `status` = 'queued'", // Cannot prepare table name. @codingStandardsIgnoreLine
+					$object_id
+				)
+			);
+
+			$this->assertCount( 0, $results, "should be 0 occurrences of post id #$object_id in queue table" );
+		}
+	}
+
+	/**
+	 * Ensure that the queue is populated if ratelimiting is triggered
+	 */
+	public function test_ratelimit_indexing_queue_should_be_populated_if_ratelimiting_enabled() {
+		global $wpdb;
+
+		$table_name = $this->queue->schema->get_table_name();
+
+		$sync_manager = new \stdClass();
+		$sync_manager->sync_queue = range( 3, 9 );
+
+		$this->queue::$max_indexing_op_count = 0; // Ensure ratelimiting is enabled
+
+		$this->queue->ratelimit_indexing( true, $sync_manager, 'post' );
+
+		$this->assertEquals( 7, wp_cache_get( $this->queue::INDEX_COUNT_CACHE_KEY, $this->queue::INDEX_COUNT_CACHE_GROUP ), 'indexing ops count should be 7' );
+
+		foreach ( $sync_manager->sync_queue as $object_id ) {
+			$results = $wpdb->get_results( 
+				$wpdb->prepare( 
+					"SELECT * FROM `{$table_name}` WHERE `object_id` = %d AND `object_type` = 'post' AND `status` = 'queued'", // Cannot prepare table name. @codingStandardsIgnoreLine
+					$object_id
+				)
+			);
+
+			$this->assertCount( 1, $results, "should be 1 occurrence of post id #$object_id in queue table" );
+		}
+
+		$sync_manager->sync_queue = range( 10, 20 );
+
+		$this->queue->ratelimit_indexing( true, $sync_manager, 'post' );
+
+		$this->assertEquals( 18, wp_cache_get( $this->queue::INDEX_COUNT_CACHE_KEY, $this->queue::INDEX_COUNT_CACHE_GROUP ), 'indexing ops count should be 18' );
+
+		foreach ( $sync_manager->sync_queue as $object_id ) {
+			$results = $wpdb->get_results( 
+				$wpdb->prepare( 
+					"SELECT * FROM `{$table_name}` WHERE `object_id` = %d AND `object_type` = 'post' AND `status` = 'queued'", // Cannot prepare table name. @codingStandardsIgnoreLine
+					$object_id
+				)
+			);
+
+			$this->assertCount( 1, $results, "should be 0 occurrences of post id #$object_id in queue table" );
+		}
+	}
+
+	/**
 	 * Ensure the incrementor for tracking indexing operations counts behaves properly
 	 */
 	public function test__index_count_incr() {

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -442,7 +442,7 @@ class Queue_Test extends \WP_UnitTestCase {
 	 * Ensure that the value passed into the filter is returned if the indexable_slug is not 'post'
 	 */
 	public function test__ratelimit_indexing_should_pass_bail_if_not_post() {
-		$this->assertTrue( $this->queue->ratelimit_indexing( true, '', 'hippo' ), 'should return true since true was passed in' );		
+		$this->assertTrue( $this->queue->ratelimit_indexing( true, '', 'hippo' ), 'should return true since true was passed in' );
 		$this->assertFalse( $this->queue->ratelimit_indexing( false, '', 'hippo' ), 'should return false since false was passed in' );
 	}
 
@@ -453,7 +453,7 @@ class Queue_Test extends \WP_UnitTestCase {
 		$sync_manager = new \stdClass();
 		$sync_manager->sync_queue = array();
 
-		$this->assertTrue( $this->queue->ratelimit_indexing( true, $sync_manager, 'post' ), 'should return true since true was passed in' );		
+		$this->assertTrue( $this->queue->ratelimit_indexing( true, $sync_manager, 'post' ), 'should return true since true was passed in' );
 		$this->assertFalse( $this->queue->ratelimit_indexing( false, $sync_manager, 'post' ), 'should return false since false was passed in' );
 	}
 

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -437,4 +437,32 @@ class Queue_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( 3, $count );
 	}
+
+	/**
+	 * Ensure the incrementor for tracking indexing operations counts behaves properly
+	 */
+	public function test__index_count_incr() {
+		$index_count_incr = self::get_method( 'index_count_incr' );
+
+		// Reset cache key
+		wp_cache_delete( $this->queue::INDEX_COUNT_CACHE_KEY, $this->queue::INDEX_COUNT_CACHE_GROUP );
+
+		$this->assertEquals( 1, $index_count_incr->invokeArgs( $this->queue, [] ), 'initial value should be 1' );
+
+		for ( $i = 2; $i < 10; $i++ ) {
+			$this->assertEquals( $i, $index_count_incr->invokeArgs( $this->queue, [] ), 'value should increment with loop' );
+		}
+
+		$this->assertEquals( 14, $index_count_incr->invokeArgs( $this->queue, [ 5 ] ), 'should increment properly without using the default increment of 1' );
+	}
+
+	/**
+	 * Helper function for accessing protected methods.
+	 */
+	protected static function get_method( $name ) {
+		$class = new \ReflectionClass( __NAMESPACE__ . '\Queue' );
+		$method = $class->getMethod( $name );
+		$method->setAccessible( true );
+		return $method;
+	}
 }

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -532,23 +532,19 @@ class Search_Test extends \WP_UnitTestCase {
 	 */
 	public function test__vip_search_get_next_host() {
 		$es = new \Automattic\VIP\Search\Search();
-		$hosts = array(
-			'test0',
-			'test1',
-			'test2', 
-			'test3',
+		define( 'VIP_ELASTICSEARCH_ENDPOINTS',
+			array(
+				'test0',
+				'test1',
+				'test2', 
+				'test3',
+			)
 		);
 
-		$this->assertEquals( 'test0', $es->get_next_host( $hosts, 0 ), 'get_next_host() didn\'t use the same host with 0 total failures and 4 hosts with a starting index of 0' );
-		$this->assertEquals( 'test1', $es->get_next_host( $hosts, 1 ), 'get_next_host() didn\'t get the correct host with 1 total failures and 4 hosts with a starting index of 0' );
-		$this->assertEquals( 'test0', $es->get_next_host( $hosts, 3 ), 'get_next_host() didn\'t restart at the beginning of the list upon reaching the end with 4 total failures and 4 hosts with a starting index of 1' );
-		$this->assertEquals( 'test1', $es->get_next_host( $hosts, 17 ), 'get_next_host() didn\'t match expected result with 21 total failures and 4 hosts. and a starting index of 0' );
-
-		array_push( $hosts, 'test4', 'test5', 'test6' ); // Add some array values
-
-		$this->assertEquals( 'test5', $es->get_next_host( $hosts, 4 ), 'get_next_host() didn\'t get the same host with 25 total failures and 7 hosts with starting index of 1.' );
-		$this->assertEquals( 'test6', $es->get_next_host( $hosts, 1 ), 'get_next_host() didn\'t get the next host with 26 total failure and 7 hosts with starting index of 5' );
-		$this->assertEquals( 'test3', $es->get_next_host( $hosts, 4 ), 'get_next_host() didn\'t get the correct host with 30 total failures and 7 hosts with a starting index of 6' );
+		$this->assertEquals( 'test0', $es->get_next_host( 0 ), 'get_next_host() didn\'t use the same host with 0 total failures and 4 hosts with a starting index of 0' );
+		$this->assertEquals( 'test1', $es->get_next_host( 1 ), 'get_next_host() didn\'t get the correct host with 1 total failures and 4 hosts with a starting index of 0' );
+		$this->assertEquals( 'test0', $es->get_next_host( 3 ), 'get_next_host() didn\'t restart at the beginning of the list upon reaching the end with 4 total failures and 4 hosts with a starting index of 1' );
+		$this->assertEquals( 'test1', $es->get_next_host( 17 ), 'get_next_host() didn\'t match expected result with 21 total failures and 4 hosts. and a starting index of 0' );
 	}
 
 	/*


### PR DESCRIPTION
## Description

Added ratelimiting for indexing operations. A bit more succinct and focused than initial thoughts/test implementations.

Still needs tests and verification.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Checkout PR.
2. `./bin/phpunit-docker.sh tests/search/includes/classes/test-class-queue.php`

-----

1. Checkout PR.
2. Ensure Automattic/Elasticpress is working.
3. Set `$max_indexing_op_count` in `search/includes/classes/class-queue.php` to 0.
4. Add a new post in wp-admin.
5. The post should be added to the queue(`wp_vip_search_index_queue` database table)
