### PR TITLE
Support offloading WP_Query to ES via the 'es' query var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ job-references:
       sudo apt-get update && sudo apt-get install subversion
       sudo -E docker-php-ext-install mysqli
       sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-      sudo apt-get update && sudo apt-get install mysql-client
+      sudo apt-get update && sudo apt-get install libgcc-8-dev=8.3.0-6 mysql-client
       npm install
       composer install -n
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -155,6 +155,9 @@ class Search {
 		add_filter( 'epwr_score_mode', array( $this, 'filter__epwr_score_mode' ), 0, 3 );
 		// Set to 'multiply'
 		add_filter( 'epwr_boost_mode', array( $this, 'filter__epwr_boost_mode' ), 0, 3 );
+
+		// Allow query offloading with the 'es' query var (in addition to default 'ep_integrate')
+		add_filter( 'ep_elasticpress_enabled', array( $this, 'filter__ep_elasticpress_enabled' ), 10, 2 );
 	}
 
 	protected function load_commands() {
@@ -743,6 +746,21 @@ class Search {
 	 */
 	public function filter__epwr_boost_mode( $boost_mode, $formatted_args, $args ) {
 		return 'multiply';
+	}
+
+	/**
+	 * Filter for enabling or disabling ES query offloading for a given WP_Query
+	 * 
+	 * This is used to allow query offloading using the 'es' var (which most VIP sites are already using
+	 * via es-wp-query), in addition to the EP default 'ep_integrate' var
+	 */
+	public function filter__ep_elasticpress_enabled( $enabled, $query ) {
+		// If the WP_Query has an 'es' var that is truthy, enable query offloading via VIP Search
+		if ( isset( $query->query_vars['es'] ) && $query->query_vars['es'] ) {
+			$enabled = true;
+		}
+
+		return $enabled;
 	}
 
 	/*

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -97,6 +97,83 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 2, $replicas );
 	}
 
+	public function vip_search_filter_ep_elasticpress_enabled_data() {
+		return array(
+			// Enabled
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => 1,
+					),
+				),
+				// Expected $enabled
+				true,
+			),
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => true,
+					),
+				),
+				// Expected $enabled
+				true,
+			),
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => '1',
+					),
+				),
+				// Expected $enabled
+				true,
+			),
+
+			// Disabled
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(),
+				),
+				// Expected $enabled
+				false,
+			),
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => 0,
+					),
+				),
+				// Expected $enabled
+				false,
+			),
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => false,
+					),
+				),
+				// Expected $enabled
+				false,
+			),
+		);
+	}
+	/**
+	 * @dataProvider vip_search_filter_ep_elasticpress_enabled_data
+	 */
+	public function test__vip_search_filter_ep_elasticpress_enabled( $query, $expected_enabled ) {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$enabled = apply_filters( 'ep_elasticpress_enabled', false, $query );
+
+		$this->assertEquals( $expected_enabled, $enabled );
+	}
+
 	public function vip_search_enforces_disabled_features_data() {
 		return array(
 			array( 'documents' ),


### PR DESCRIPTION
## Description

Adds compatibility with es-wp-query, which uses `es` as the query var to enable offloading. ElasticPress uses `ep_integrate`, so this PR just lets you use either.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull PR
1. In functions.php (or anywhere), add this to enable query offloading on the main query:

```
add_filter( 'pre_get_posts', function( $query ) {
	if ( ! $query->is_main_query() ) { 
		return $query;
	}

	if ( ! $query->is_category() && ! $query->is_home() ) {
		return $query;
	}

	$query->set( 'es', true );
} );
```

1. Visit several frontend pages (hp, category, etc)
1. Check debug bar - should be recording 1 ES query per page (with arguments matching the normal WP_Query)