### PR TITLE
Add support for query mirroring for offloaded queries

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -158,6 +158,9 @@ class Search {
 
 		// Allow query offloading with the 'es' query var (in addition to default 'ep_integrate')
 		add_filter( 'ep_elasticpress_enabled', array( $this, 'filter__ep_elasticpress_enabled' ), 10, 2 );
+
+		// For testing, mirror certain WP_Query's on certain sites
+		add_filter( 'the_posts', array( $this, 'filter__the_posts' ), 10, 2 );
 	}
 
 	protected function load_commands() {
@@ -233,6 +236,21 @@ class Search {
 			// Also not necessary with blocking=>false, but just in case.
 			'timeout' => 3,
 		] );
+	}
+
+	/**
+	 * Filter that runs at the end of WP_Query, used to transparently mirror certain WP_Query's on certain sites
+	 * for testing / evaluation
+	 */
+	public function filter__the_posts( &$posts, $query ) {
+		// If this query is one that should be transparently mirrored, run the mirroring
+		$should_mirror = $this->should_mirror_wp_query( $query );
+
+		if ( $should_mirror ) {
+			$this->mirror_wp_query( $query );
+		}
+
+		return $posts;
 	}
 
 	public function should_mirror_wp_query( $query ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -327,7 +327,7 @@ class Search {
 			'extra' => array(
 				'query_vars' => $query->query_vars,
 				'diff' => $diff,
-				'uri' => $_SERVER[ 'REQUEST_URI' ],
+				'uri' => isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null,
 			),
 		) );
 	}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -435,6 +435,11 @@ class Search {
 			}
 		}
 
+		// If query is marked for mirroring (for evaluation phase), allow it
+		if ( isset( $query->query_vars['vip_search_mirrored'] ) && $query->query_vars['vip_search_mirrored'] ) {
+			return false;
+		}
+
 		// Legacy constant name
 		$query_integration_enabled_legacy = defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION;
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -160,7 +160,9 @@ class Search {
 		add_filter( 'ep_elasticpress_enabled', array( $this, 'filter__ep_elasticpress_enabled' ), 10, 2 );
 
 		// For testing, mirror certain WP_Query's on certain sites
-		add_filter( 'the_posts', array( $this, 'filter__the_posts' ), 10, 2 );
+		if ( $this->is_query_mirroring_enabled() ) {
+			add_filter( 'the_posts', array( $this, 'filter__the_posts' ), 10, 2 );
+		}
 	}
 
 	protected function load_commands() {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -247,7 +247,7 @@ class Search {
 		$should_mirror = $this->should_mirror_wp_query( $query );
 
 		if ( $should_mirror ) {
-			$this->mirror_wp_query( $query );
+			$this->do_mirror_wp_query( $query );
 		}
 
 		return $posts;

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -270,7 +270,17 @@ class Search {
 	}
 
 	public function do_mirror_wp_query( $query ) {
-		$mirrored_vars = $query->query_vars;
+		$mirrored_query = $this->get_mirrored_wp_query( $query );
+
+		$diff = $this->diff_mirrored_wp_query_results( $query->posts, $mirrored_query->posts );
+
+		if ( ! empty( $diff ) ) {
+			$this->log_mirrored_wp_query_diff( $diff );
+		}
+	}
+
+	public function get_mirrored_wp_query( $query ) {
+		$mirrored_vars = $query->query_vars; // Arrays are passed by value so won't be affecting originals
 
 		// Enable ES integration
 		$mirrored_vars['es'] = true;
@@ -280,11 +290,7 @@ class Search {
 
 		$mirrored_query = new \WP_Query( $mirrored_vars );
 
-		$diff = $this->diff_mirrored_wp_query_results( $query->posts, $mirrored_query->posts );
-
-		if ( ! empty( $diff ) ) {
-			$this->log_mirrored_wp_query_diff( $diff );
-		}
+		return $mirrored_query;
 	}
 
 	public function diff_mirrored_wp_query_results( $original_posts, $mirrored_posts ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -155,6 +155,9 @@ class Search {
 		add_filter( 'epwr_score_mode', array( $this, 'filter__epwr_score_mode' ), 0, 3 );
 		// Set to 'multiply'
 		add_filter( 'epwr_boost_mode', array( $this, 'filter__epwr_boost_mode' ), 0, 3 );
+
+		// Allow query offloading with the 'es' query var (in addition to default 'ep_integrate')
+		add_filter( 'ep_elasticpress_enabled', array( $this, 'filter__ep_elasticpress_enabled' ), 10, 2 );
 	}
 
 	protected function load_commands() {
@@ -743,6 +746,21 @@ class Search {
 	 */
 	public function filter__epwr_boost_mode( $boost_mode, $formatted_args, $args ) {
 		return 'multiply';
+	}
+
+	/**
+	 * Filter for enabling or disabling ES query offloading for a given WP_Query
+	 * 
+	 * This is used to allow query offloading using the 'es' var (which most VIP sites are already using
+	 * via es-wp-query), in addition to the EP default 'ep_integrate' var
+	 */
+	public function filter__ep_elasticpress_enabled( $enabled, $query ) {
+		// If the WP_Query has an 'es' var that is truthy, enable query offloading via VIP Search
+		if ( isset( $query->query_vars['es'] ) && $query->query_vars['es'] ) {
+			$enabled = true;
+		}
+
+		return $enabled;
 	}
 
 	/*

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -235,6 +235,22 @@ class Search {
 		] );
 	}
 
+	public function should_mirror_wp_query( $query ) {
+		// If this was already an ES query, don't mirror
+		if ( isset( $query['es'] ) || isset( $query['ep_integrate'] ) || isset( $query['vip_search_mirrored'] ) || $query->elasticsearch_success ) {
+			return false;
+		}
+
+		// If mirroring is not enabled at all, skip
+		if ( ! $this->is_query_mirroring_enabled() ) {
+			return false;
+		}
+
+		// Is this one of the targeted queries?
+	
+		return false;
+	}
+
 	public function diff_mirrored_wp_query_results( $original_posts, $mirrored_posts ) {
 		// Normalize
 		if ( ! is_array( $original_posts ) ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -242,7 +242,7 @@ class Search {
 	 * Filter that runs at the end of WP_Query, used to transparently mirror certain WP_Query's on certain sites
 	 * for testing / evaluation
 	 */
-	public function filter__the_posts( &$posts, $query ) {
+	public function filter__the_posts( $posts, $query ) {
 		// If this query is one that should be transparently mirrored, run the mirroring
 		$should_mirror = $this->should_mirror_wp_query( $query );
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -251,6 +251,24 @@ class Search {
 		return false;
 	}
 
+	public function do_mirror_wp_query( $query ) {
+		$mirrored_vars = $query->query_vars;
+
+		// Enable ES integration
+		$mirrored_vars['es'] = true;
+
+		// Mark this as a mirrored query (passes check in filter__ep_skip_query_integration() when query integration is otherwise disabled)
+		$mirrored_vars['vip_search_mirrored'] = true;
+
+		$mirrored_query = new \WP_Query( $mirrored_vars );
+
+		$diff = $this->diff_mirrored_wp_query_results( $query, $mirrored_query );
+
+		if ( ! empty( $diff ) ) {
+			$this->log_mirrored_wp_query_diff( $diff );
+		}
+	}
+
 	public function diff_mirrored_wp_query_results( $original_posts, $mirrored_posts ) {
 		// Normalize
 		if ( ! is_array( $original_posts ) ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -202,17 +202,23 @@ class Search {
 		// If this was a regular search page and VIP Search was _not_ used, and if the site is configured to do so,
 		// re-run the same query, but with `es=true`, via JS to test both systems in parallel
 		if ( is_search() && ! isset( $wp_query->elasticsearch_success ) ) {
-			$is_enabled_by_constant = defined( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING' ) && true === VIP_ENABLE_SEARCH_QUERY_MIRRORING;
-
-			$option_value = get_option( 'vip_enable_search_query_mirroring' );
-			$is_enabled_by_option = in_array( $option_value, array( true, 'true', 'yes', 1, '1' ), true );
-
-			$is_mirroring_enabled = $is_enabled_by_constant || $is_enabled_by_option;
+			$is_mirroring_enabled = $this->is_query_mirroring_enabled();
 
 			if ( $is_mirroring_enabled ) {
 				add_action( 'shutdown', [ $this, 'do_mirror_search_request' ] );
 			}
 		}
+	}
+
+	public function is_query_mirroring_enabled() {
+		$is_enabled_by_constant = defined( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING' ) && true === VIP_ENABLE_SEARCH_QUERY_MIRRORING;
+
+		$option_value = get_option( 'vip_enable_search_query_mirroring' );
+		$is_enabled_by_option = in_array( $option_value, array( true, 'true', 'yes', 1, '1' ), true );
+
+		$is_mirroring_enabled = $is_enabled_by_constant || $is_enabled_by_option;
+
+		return $is_mirroring_enabled;
 	}
 
 	public function do_mirror_search_request() {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -280,7 +280,7 @@ class Search {
 
 		$mirrored_query = new \WP_Query( $mirrored_vars );
 
-		$diff = $this->diff_mirrored_wp_query_results( $query, $mirrored_query );
+		$diff = $this->diff_mirrored_wp_query_results( $query->posts, $mirrored_query->posts );
 
 		if ( ! empty( $diff ) ) {
 			$this->log_mirrored_wp_query_diff( $diff );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -275,7 +275,7 @@ class Search {
 		$diff = $this->diff_mirrored_wp_query_results( $query->posts, $mirrored_query->posts );
 
 		if ( ! empty( $diff ) ) {
-			$this->log_mirrored_wp_query_diff( $diff );
+			$this->log_mirrored_wp_query_diff( $query, $diff );
 		}
 	}
 
@@ -319,8 +319,17 @@ class Search {
 		);
 	}
 
-	public function log_mirrored_wp_query_diff( $diff ) {
-
+	public function log_mirrored_wp_query_diff( $query, $diff ) {
+		\Automattic\VIP\Logstash\log2logstash( array(
+			'severity' => 'warning',
+			'feature' => 'vip_search_wp_query_mirroring',
+			'message' => 'Inconsistent mirrored offloaded WP_Query results detected',
+			'extra' => array(
+				'query_vars' => $query->query_vars,
+				'diff' => $diff,
+				'uri' => $_SERVER[ 'REQUEST_URI' ],
+			),
+		) );
 	}
 
 	/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -255,7 +255,7 @@ class Search {
 
 	public function should_mirror_wp_query( $query ) {
 		// If this was already an ES query, don't mirror
-		if ( isset( $query['es'] ) || isset( $query['ep_integrate'] ) || isset( $query['vip_search_mirrored'] ) || $query->elasticsearch_success ) {
+		if ( isset( $query->query_vars['es'] ) || isset( $query->query_vars['ep_integrate'] ) || isset( $query->query_vars['vip_search_mirrored'] ) || isset( $query->elasticsearch_success ) ) {
 			return false;
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -235,6 +235,36 @@ class Search {
 		] );
 	}
 
+	public function diff_mirrored_wp_query_results( $original_posts, $mirrored_posts ) {
+		// Normalize
+		if ( ! is_array( $original_posts ) ) {
+			$original_posts = array();
+		}
+
+		if ( ! is_array( $mirrored_posts ) ) {
+			$mirrored_posts = array();
+		}
+		
+		$original_post_ids = wp_list_pluck( $original_posts, 'ID' );
+		$mirrored_post_ids = wp_list_pluck( $mirrored_posts, 'ID' );
+
+		$missing = array_diff( $original_post_ids, $mirrored_post_ids );
+		$extra = array_diff( $mirrored_post_ids, $original_post_ids );
+
+		if ( empty( $missing ) && empty( $extra ) ) {
+			return null;
+		}
+
+		return array(
+			'missing' => array_values( $missing ),
+			'extra' => array_values( $extra ),
+		);
+	}
+
+	public function log_mirrored_wp_query_diff( $diff ) {
+
+	}
+
 	/**
 	 * Filter ElasticPress index name if using VIP ES infrastructure
 	 */

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -321,7 +321,7 @@ class Search {
 
 		fastcgi_finish_request();
 
-		foreach( $this->mirrored_wp_query_queue as $query ) {
+		foreach ( $this->mirrored_wp_query_queue as $query ) {
 			$this->do_mirror_wp_query( $query );
 		}
 	}

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1205,6 +1205,45 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $should_mirror );
 	}
 
+	public function get_should_mirror_wp_query_when_query_already_offloaded_data() {
+		return array(
+			(object) array(
+				'query_vars' => array(
+					'es' => true,
+				),
+			),
+
+			(object) array(
+				'query_vars' => array(
+					'ep_integrate' => true,
+				),
+			),
+			
+			(object) array(
+				'query_vars' => array(
+					'vip_search_mirrored' => true,
+				),
+			),
+
+			(object) array(
+				'elasticsearch_succes' => true,
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_should_mirror_wp_query_when_query_already_offloaded_data
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__should_mirror_wp_query_when_query_already_offloaded( $query ) {
+		$es = new \Automattic\VIP\Search\Search();
+		
+		$should_mirror = $es->should_mirror_wp_query( $query );
+
+		$this->assertFalse( $should_mirror );
+	}
+
 	public function test__filter_the_posts_no_mirroring() {
 		$search = $this->createMock( \Automattic\VIP\Search\Search::class );
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1077,6 +1077,10 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $es::ep_skip_query_integration( false ), 'should not skip when es query string set' );
 	}
 
+	public function test__ep_skip_query_integration_allow_for_mirrored() {
+		// TODO
+	}
+
 	/*
 	 * Ensure ratelimiting works prioperly with ep_skip_query_integration filter
 	 */

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1117,6 +1117,74 @@ class Search_Test extends \WP_UnitTestCase {
 		}
 	}
 
+	public function test__is_query_mirroring_enabled_no_constant_no_option() {
+		$es = new \Automattic\VIP\Search\Search();
+		
+		$enabled = $es->is_query_mirroring_enabled();
+
+		$this->assertFalse( $enabled );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__is_query_mirroring_enabled_via_option() {
+		update_option( 'vip_enable_search_query_mirroring', true );
+
+		$es = new \Automattic\VIP\Search\Search();
+		
+		$enabled = $es->is_query_mirroring_enabled();
+
+		delete_option( 'vip_enable_search_query_mirroring' );
+
+		$this->assertTrue( $enabled );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__is_query_mirroring_enabled_with_option_false() {
+		update_option( 'vip_enable_search_query_mirroring', false );
+
+		$es = new \Automattic\VIP\Search\Search();
+		
+		$enabled = $es->is_query_mirroring_enabled();
+
+		delete_option( 'vip_enable_search_query_mirroring' );
+
+		$this->assertFalse( $enabled );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__is_query_mirroring_enabled_via_constant() {
+		define( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING', true );
+
+		$es = new \Automattic\VIP\Search\Search();
+		
+		$enabled = $es->is_query_mirroring_enabled();
+
+		$this->assertTrue( $enabled );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__is_query_mirroring_enabled_with_constant_false() {
+		define( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING', false );
+
+		$es = new \Automattic\VIP\Search\Search();
+		
+		$enabled = $es->is_query_mirroring_enabled();
+
+		$this->assertFalse( $enabled );
+	}
+
 	/**
 	 * Helper function for accessing protected methods.
 	 */

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -97,6 +97,83 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 2, $replicas );
 	}
 
+	public function vip_search_filter_ep_elasticpress_enabled_data() {
+		return array(
+			// Enabled
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => 1,
+					),
+				),
+				// Expected $enabled
+				true,
+			),
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => true,
+					),
+				),
+				// Expected $enabled
+				true,
+			),
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => '1',
+					),
+				),
+				// Expected $enabled
+				true,
+			),
+
+			// Disabled
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(),
+				),
+				// Expected $enabled
+				false,
+			),
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => 0,
+					),
+				),
+				// Expected $enabled
+				false,
+			),
+			array(
+				// Fake WP_Query
+				(object) array( 
+					'query_vars' => array(
+						'es' => false,
+					),
+				),
+				// Expected $enabled
+				false,
+			),
+		);
+	}
+	/**
+	 * @dataProvider vip_search_filter_ep_elasticpress_enabled_data
+	 */
+	public function test__vip_search_filter_ep_elasticpress_enabled( $query, $expected_enabled ) {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$enabled = apply_filters( 'ep_elasticpress_enabled', false, $query );
+
+		$this->assertEquals( $expected_enabled, $enabled );
+	}
+
 	public function vip_search_enforces_disabled_features_data() {
 		return array(
 			array( 'documents' ),

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1185,6 +1185,172 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $enabled );
 	}
 
+
+	public function get_diff_mirrored_wp_query_results_data() {
+		return array(
+			// No diff
+			array(
+				// Original
+				array(
+					array(
+						'ID' => 1,
+					),
+					array(
+						'ID' => 2,
+					),
+					array(
+						'ID' => 3,
+					),
+				),
+
+				// Mirrored
+				array(
+					array(
+						'ID' => 1,
+					),
+					array(
+						'ID' => 2,
+					),
+					array(
+						'ID' => 3,
+					),
+				),
+
+				// Expected diff
+				null,
+			),
+
+			// Posts missing from mirrored
+			array(
+				// Original
+				array(
+					array(
+						'ID' => 1,
+					),
+					array(
+						'ID' => 2,
+					),
+					array(
+						'ID' => 3,
+					),
+					array(
+						'ID' => 4,
+					),
+				),
+
+				// Mirrored
+				array(
+					array(
+						'ID' => 1,
+					),
+					array(
+						'ID' => 3,
+					),
+				),
+
+				// Expected diff
+				array(
+					'missing' => array(
+						2,
+						4,
+					),
+					'extra' => array(),
+				),
+			),
+
+			// Extra posts
+			array(
+				// Original
+				array(
+					array(
+						'ID' => 1,
+					),
+					array(
+						'ID' => 3,
+					),
+				),
+
+				// Mirrored
+				array(
+					array(
+						'ID' => 1,
+					),
+					array(
+						'ID' => 2,
+					),
+					array(
+						'ID' => 3,
+					),
+					array(
+						'ID' => 4,
+					),
+				),
+
+				// Expected diff
+				array(
+					'missing' => array(),
+					'extra' => array(
+						2,
+						4,
+					),
+				),
+			),
+
+			// Non-array input
+			array(
+				// Original
+				null,
+
+				// Mirrored
+				array(
+					array(
+						'ID' => 1,
+					),
+				),
+
+				// Expected diff
+				array(
+					'missing' => array(),
+					'extra' => array(
+						1,
+					),
+				),
+			),
+			
+			// Non-array input
+			array(
+				// Original
+				array(
+					array(
+						'ID' => 1,
+					),
+				),
+
+				// Mirrored
+				null,
+
+				// Expected diff
+				array(
+					'missing' => array(
+						1,
+					),
+					'extra' => array(),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_diff_mirrored_wp_query_results_data
+	 */
+	public function test__diff_mirrored_wp_query_results( $original_posts, $mirrored_posts, $expected_diff ) {
+		$es = new \Automattic\VIP\Search\Search();
+		
+		$diff = $es->diff_mirrored_wp_query_results( $original_posts, $mirrored_posts );
+
+		$this->assertEquals( $expected_diff, $diff );
+	}
+
 	/**
 	 * Helper function for accessing protected methods.
 	 */

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1077,8 +1077,34 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $es::ep_skip_query_integration( false ), 'should not skip when es query string set' );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test__ep_skip_query_integration_allow_for_mirrored() {
-		// TODO
+		// Should not start off enabled (or our test tells us nothing)
+		define( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION', false );
+		update_option( 'vip_enable_vip_search_query_integration', false );
+
+		$es = new \Automattic\VIP\Search\Search();
+
+		// Regular query should skip integration
+		$regular_query = new \WP_Query();
+
+		$skipped = $es::ep_skip_query_integration( false, $regular_query );
+
+		$this->assertTrue( $skipped );
+
+		// But a mirrored query should be allowed (not skipped)
+		$mirrored_query = new \WP_Query( array(
+			'vip_search_mirrored' => true,
+		) );
+
+		$skipped = $es::ep_skip_query_integration( false, $mirrored_query );
+
+		$this->assertFalse( $skipped );
+
+		delete_option( 'vip_enable_vip_search_query_integration' );
 	}
 
 	/*

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1224,7 +1224,7 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$es = new \Automattic\VIP\Search\Search();
 
-		$query = new WP_Query();
+		$query = new \WP_Query();
 
 		$should_mirror = $es->should_mirror_wp_query( $query );
 
@@ -1233,26 +1233,34 @@ class Search_Test extends \WP_UnitTestCase {
 
 	public function get_should_mirror_wp_query_when_query_already_offloaded_data() {
 		return array(
-			(object) array(
-				'query_vars' => array(
-					'es' => true,
+			array(
+				(object) array(
+					'query_vars' => array(
+						'es' => true,
+					),
 				),
 			),
 
-			(object) array(
-				'query_vars' => array(
-					'ep_integrate' => true,
+			array(
+				(object) array(
+					'query_vars' => array(
+						'ep_integrate' => true,
+					),
 				),
 			),
 			
-			(object) array(
-				'query_vars' => array(
-					'vip_search_mirrored' => true,
+			array(
+				(object) array(
+					'query_vars' => array(
+						'vip_search_mirrored' => true,
+					),
 				),
 			),
 
-			(object) array(
-				'elasticsearch_succes' => true,
+			array(
+				(object) array(
+					'elasticsearch_succes' => true,
+				),
 			),
 		);
 	}
@@ -1284,7 +1292,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$posts = array();
 		$query = new \stdClass();
 
-		$filtered_posts = $search->filter__the_posts( $posts, $query );
+		$filtered_posts = $es->filter__the_posts( $posts, $query );
 	
 		// Should not have altered the posts array
 		$this->assertEquals( $posts, $filtered_posts );

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1189,6 +1189,59 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $enabled );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__should_mirror_wp_query_when_mirroring_disabled() {
+		define( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING', false );
+
+		$es = new \Automattic\VIP\Search\Search();
+
+		$query = new WP_Query();
+
+		$should_mirror = $es->should_mirror_wp_query( $query );
+
+		$this->assertFalse( $should_mirror );
+	}
+
+	public function test__filter_the_posts_no_mirroring() {
+		$search = $this->createMock( \Automattic\VIP\Search\Search::class );
+
+		$posts = array();
+		$query = new \stdClass();
+
+		$search->expects( $this->once() )
+			->method( 'should_mirror_wp_query' )
+			->with( $query )
+			->will( $this->returnValue( false ) );
+
+		$filtered_posts = $search->filter__the_posts( $posts, $query );
+	
+		// Should not have altered the posts array
+		$this->assertEquals( $posts, $filtered_posts );
+	}
+
+	public function test__filter_the_posts_with_mirroring() {
+		$search = $this->createMock( \Automattic\VIP\Search\Search::class );
+
+		$posts = array();
+		$query = new \stdClass();
+
+		$search->expects( $this->once() )
+			->method( 'should_mirror_wp_query' )
+			->with( $query )
+			->will( $this->returnValue( true ) );
+
+		$search->expects( $this->once() )
+			->method( 'do_mirror_wp_query' )
+			->with( $query );
+
+		$filtered_posts = $search->filter__the_posts( $posts, $query );
+	
+		// Should not have altered the posts array
+		$this->assertEquals( $posts, $filtered_posts );
+	}
 
 	public function get_diff_mirrored_wp_query_results_data() {
 		return array(

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1298,6 +1298,24 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $posts, $filtered_posts );
 	}
 
+	public function test__queue_mirrored_wp_query() {
+		$es = new \Automattic\VIP\Search\Search();
+
+		$queue = self::get_property( 'mirrored_wp_query_queue' )->getValue( $es );
+
+		$this->assertEmpty( $queue );
+
+		$vars = array( 'foo' => 'bar' );
+
+		$query = new \WP_Query( $vars );
+
+		$es->queue_mirrored_wp_query( $query );
+
+		$queue = self::get_property( 'mirrored_wp_query_queue' )->getValue( $es );
+
+		$this->assertContains( $query, $queue );
+	}
+
 	public function test__get_mirrored_wp_query() {
 		$es = new \Automattic\VIP\Search\Search();
 
@@ -1485,5 +1503,17 @@ class Search_Test extends \WP_UnitTestCase {
 		$method = $class->getMethod( $name );
 		$method->setAccessible( true );
 		return $method;
+	}
+
+	/**
+	 * Helper function for accessing protected methods.
+	 */
+	protected static function get_property( $name ) {
+		$class = new \ReflectionClass( __NAMESPACE__ . '\Search' );
+
+		$property = $class->getProperty( $name );
+		$property->setAccessible( true );
+
+		return $property;
 	}
 }


### PR DESCRIPTION
## Description

Adds "query mirroring" functionality for transparently testing the offloading of queries on VIP Search.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull PR
1. Make sure the site is enabling query mirroring - `define( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING', true );`
1. Try some queries and check debug bar - there should be _no_ ES queries yet
1. Enable query mirroring by adding some rules to `should_mirror_wp_query()`:

```
		// Is this one of the targeted queries?
		if ( $query->is_home() || $query->is_category() || $query->is_archive() ) {
			return true;
		}
```

1. Request the HP, a category page, and an archive page
1. Each should run the regular DB query, but also the ES version of it (visible the EP tab of debug bar)
1. (Optional) Add some logging to `do_mirror_wp_query()` to show the diffs:

```
		error_log( 'did mirror' );
		error_log( 'diff is ' . var_export( $diff, true ) );
```