### PR TITLE
Allow user indexing in Search

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -333,7 +333,6 @@ class Search {
 	public function filter__ep_feature_active( $active, $feature_settings, $feature ) {
 		$disabled_features = array(
 			'documents',
-			'users',
 		);
 
 		if ( in_array( $feature->slug, $disabled_features, true ) ) {


### PR DESCRIPTION
## Description

Allows user indexing in Search - will still be disabled by default, but this allows clients to opt-in.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. `wp elasticpress activate-feature users`
1. Check the ElasticPress dashboard in WP Admin to see if the Users feature shows as Enabled (it should)
1. NOTE - can't use `wp elasticpress list-features` to verify this b/c there is a bug - it [doesn't check the filter](https://github.com/Automattic/ElasticPress/blob/c2e7749477e67480f5481c36ba86e4160d100656/includes/classes/Command.php#L137-L143) that the other code uses :(
