### PR TITLE
Enable query mirroring on category+archives for site 2160

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -269,7 +269,12 @@ class Search {
 		}
 
 		// Is this one of the targeted queries?
-	
+		if ( defined( 'VIP_GO_APP_ID' ) ) {
+			if ( 2160 === VIP_GO_APP_ID && $query->is_main_query() && ( $query->is_category() || $query->is_archive() ) ) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
## Description

Enables the WP_Query "query mirroring" (to ES) on site 2160 for category + archive queries, for testing.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Sandbox 2160
1. Navigate around the site (visit a variety of pages, page through a category, page through a year/month)
1. Nothing should be broken :)
