### PR TITLE
Disable healthchecks for 2341

### DIFF
--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -181,7 +181,7 @@ class HealthJob {
 		}
 
 		if ( defined( 'VIP_GO_APP_ID' ) ) {
-			if ( in_array( VIP_GO_APP_ID, self::HEALTH_CHECK_DISABLED_SITES ) ) {
+			if ( in_array( VIP_GO_APP_ID, self::HEALTH_CHECK_DISABLED_SITES, true ) ) {
 				return false;
 			}
 		}

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -23,6 +23,10 @@ class HealthJob {
 	 */
 	const CRON_INTERVAL = 60 * 30; // 30 minutes in seconds
 
+	const HEALTH_CHECK_DISABLED_SITES = array(
+		2341,
+	);
+
 	/**
 	 * Initialize the job class
 	 *
@@ -174,6 +178,12 @@ class HealthJob {
 	public function is_enabled() {
 		if ( defined( 'DISABLE_VIP_SEARCH_HEALTHCHECKS' ) && true === DISABLE_VIP_SEARCH_HEALTHCHECKS ) {
 			return false;
+		}
+
+		if ( defined( 'VIP_GO_APP_ID' ) ) {
+			if ( in_array( VIP_GO_APP_ID, self::HEALTH_CHECK_DISABLED_SITES ) ) {
+				return false;
+			}
 		}
 
 		$enabled_environments = apply_filters( 'vip_search_healthchecks_enabled_environments', array( 'production' ) );

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -215,4 +215,18 @@ class HealthJob_Test extends \WP_UnitTestCase {
 
 		$this->assertFalse( $enabled );
 	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_vip_search_healthjob_is_disabled_when_app_id_matches_disabled_list() {
+		define( 'VIP_GO_APP_ID', 2341 );
+
+		$job = new \Automattic\VIP\Search\HealthJob();
+
+		$enabled = $job->is_enabled();
+
+		$this->assertFalse( $enabled );
+	}
 }


### PR DESCRIPTION
## Description

Disable VIP Search health checks for 2341

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Checkout PR.
2. `./bin/phpunit-docker.sh tests/search/includes/classes/test-class-healthjob.php`
