### PR TITLE
Mirror the main taxonomy query on subset of sites

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -273,6 +273,14 @@ class Search {
 			if ( 2160 === VIP_GO_APP_ID && $query->is_main_query() && ( $query->is_category() || $query->is_archive() ) ) {
 				return true;
 			}
+
+			$offload_main_tax_site_ids = array(
+				929,
+			);
+
+			if ( in_array( VIP_GO_APP_ID, $offload_main_tax_site_ids, true ) && $query->is_main_query() && ( $query->is_category() || $query->is_tax() || $query->is_tag() ) ) {
+				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
## Description

Enable mirrored queries for a small subset of queries, for testing purposes.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Sandbox site
1. View a few category pages
1. Ensure mirrored queries are recorded
