### PR TITLE
Return true if subfolder path is missing trailing slash

### DIFF
--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -112,8 +112,8 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 	}
 
 	private function is_wp_content_subfolder_path( $file_path, $subfolder ) {
-		$upgrade_base = sprintf( '%s/%s/', WP_CONTENT_DIR, $subfolder );
-		return 0 === strpos( $file_path, $upgrade_base );
+		$upgrade_base = sprintf( '%s/%s', WP_CONTENT_DIR, $subfolder );
+		return 0 === strpos( $file_path, $upgrade_base . '/' ) || $file_path === $upgrade_base;
 	}
 
 	private function is_upgrade_path( $file_path ) {


### PR DESCRIPTION
## Description
This should handle the special case where $file_path *is* WP_CONTENT_DIR/$subfolder without a trailing slash. One notable case is when `true !== VIP_GO_ENV` and wp cli is making checks against `get_transport_for_path` for a plugin installation to `WP_CONTENT_DIR/upgrade` (without a trailing slash).

## Checklist
Please make sure the items below have been covered before requesting a review:
- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
Example:
1. In a local environment with a fresh WP install (eg. v5.4.1) ...
1. git clone this patched repo into mu-plugins 
1. run a plugin install via WPCLI (e.g. `wp plugin install classic-editor`)

### Test sample output
```
PHP Warning:  The `/var/www/my-cool-site/wp-content/upgrade` file cannot be managed by the `Automattic\VIP\Files\WP_Filesystem_VIP` class. Writes are only allowed for the `/tmp/` and `/var/www/my-cool-site/wp-content/uploads` directories and reads can be performed everywhere. in /var/www/my-cool-site/wp-content/mu-plugins/files/class-wp-filesystem-vip.php on line 90

Warning: Could not create directory.
Warning: The 'classic-editor' plugin could not be found.
Error: No plugins installed.
```
