### PR TITLE
Add caching layer to stats

### DIFF
--- a/vip-helpers/vip-stats.php
+++ b/vip-helpers/vip-stats.php
@@ -91,8 +91,16 @@ function wpcom_vip_get_post_pageviews( $post_id = null, $num_days = 1, $end_date
 		// Ensure num_days is least 1, but no more than 90
 		$args['num_days'] = max( 1, min( 90, absint( $args['num_days'] ) ) );
 
-		$posts = stats_get_csv( 'postviews', $args );
-		$views = $posts[0]['views'] ?? 0;
+		$cache_key = 'views_' . $args['post_id'] . '_' . $args['num_days'] . '_' . $args['end_date'];
+
+		$views = wp_cache_get( $cache_key, 'vip_stats' );
+
+		if ( false === $views ) {	
+			$posts = stats_get_csv( 'postviews', $args );
+			$views = $posts[0]['views'] ?? 0;
+			wp_cache_set( $cache_key, $views, 'vip_stats', 3600 );
+		}
+		
 	} else {
 		// If Jetpack is not present or not active, fake the data returned
 		$views = mt_rand( 0, 20000 );

--- a/vip-helpers/vip-stats.php
+++ b/vip-helpers/vip-stats.php
@@ -100,7 +100,6 @@ function wpcom_vip_get_post_pageviews( $post_id = null, $num_days = 1, $end_date
 			$views = $posts[0]['views'] ?? 0;
 			wp_cache_set( $cache_key, $views, 'vip_stats', 3600 );
 		}
-		
 	} else {
 		// If Jetpack is not present or not active, fake the data returned
 		$views = mt_rand( 0, 20000 );

--- a/vip-helpers/vip-stats.php
+++ b/vip-helpers/vip-stats.php
@@ -95,7 +95,7 @@ function wpcom_vip_get_post_pageviews( $post_id = null, $num_days = 1, $end_date
 
 		$views = wp_cache_get( $cache_key, 'vip_stats' );
 
-		if ( false === $views ) {	
+		if ( false === $views ) {
 			$posts = stats_get_csv( 'postviews', $args );
 			$views = $posts[0]['views'] ?? 0;
 			wp_cache_set( $cache_key, $views, 'vip_stats', 3600 );


### PR DESCRIPTION
## Description

Due to the way `stats_get_csv` method works, it introduces a read and update operation on each request.

When called frequently this results in a DB write each request, WP.com has added a caching layer to this function, so the cache values mirror that, as per: https://vip-svn.wordpress.com/plugins/vip-helper-stats-wpcom.php L180

# Steps to test

- visit a site calling `wpcom_vip_get_post_pageviews`
- first page load will result in a DB read and write
- visit same page a second time with the PR added and the write should no longer occur