### PR TITLE
Add Search::query_es() helper

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -181,6 +181,16 @@ class Search {
 		add_action( 'init', [ $this->healthcheck, 'init' ] );
 	}
 
+	public function query_es( $type, $es_args = array(), $wp_query_args = array(), $index_name = null ) {
+		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+
+		if ( ! $indexable ) {
+			return new \WP_Error( 'indexable-not-found', 'Invalid query type specified. Must be a valid Indexable from ElasticPress' );
+		}
+
+		return $indexable->query_es( $es_args, $wp_query_args, $index_name );
+	}
+
 	public function action__plugins_loaded() {
 		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
 		// NOTE - must hook in here b/c the wp_get_current_user function required for checking if debug bar is enabled isn't loaded earlier

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -16,6 +16,16 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->search_instance = new \Automattic\VIP\Search\Search();
 	}
 
+	public function test_query_es_with_invalid_type() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$result = $es->query_es( 'foo' );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEquals( 'indexable-not-found', $result->get_error_code() );
+	}
+
 	/**
 	 * Test `ep_index_name` filter for ElasticPress + VIP Search
 	 */


### PR DESCRIPTION
## Description

For running a generic ES query (by $type) against VIP Search.

This will be used to provide 3rd party plugins (like es-wp-query) the ability to query ES directly without needing to worry about the internals of VIP Search.

This is a simple wrapper around the EP Indexable of $type, to hide the implementation details.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. In code, run a query (need ES query) - `Automattic\VIP\Search\Search::instance()->query_es( 'post', $es_args );
1. Verify response is as expected
