### PR TITLE
Add helper info for un-autoloading given option

### DIFF
--- a/wp-cli/alloptions.php
+++ b/wp-cli/alloptions.php
@@ -68,6 +68,7 @@ class VIP_Go_Alloptions extends WPCOM_VIP_CLI_Command {
 		WP_CLI::line( sprintf( 'Size of serialized alloptions for this blog: %s',   size_format( strlen( serialize( $alloptions ) ) ) ) );
 		WP_CLI::line( "\tuse `wp option get <option_name>` to view a big option" );
 		WP_CLI::line( "\tuse `wp option delete <option_name>` to delete a big option" );
+		WP_CLI::line( "\tuse `wp option autoload set <option_name> no` to disable autoload for option" );
 	}
 }
 


### PR DESCRIPTION


## Description

Adds help line to remind how to disable autoload quickly.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Apply patch
2. See output in `wp vip alloptions find`