### PR TITLE
Add allow list for indexing post meta

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1055,7 +1055,7 @@ class Search {
 		 * @param {array} $current_allow_list The current allow list for post meta indexing
 		 * @return {array} $new_allow_list The new allow list for post_meta_indexing
 		 */
-		$client_post_meta_allow_list = apply_filters( 'vip_search_post_meta_allow_list', self::POST_META_DEFAULT_ALLOW_LIST );
+		$client_post_meta_allow_list = apply_filters( 'vip_search_post_meta_allow_list', self::POST_META_DEFAULT_ALLOW_LIST, $post );
 
 		// Only include meta that matches the allow list
 		$new_meta = array_intersect( $current_meta, $client_post_meta_allow_list );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -18,7 +18,7 @@ class Search {
 
 	private const MAX_SEARCH_LENGTH = 255;
 
-	private const DISABLE_POST_META_ALLOW_LIST = array (
+	private const DISABLE_POST_META_ALLOW_LIST = array(
 		2341,
 	);
 
@@ -1087,12 +1087,13 @@ class Search {
 		 * @param {array} $current_allow_list The current allow list for post meta indexing
 		 * @return {array} $new_allow_list The new allow list for post_meta_indexing
 		 */
-		$client_post_meta_allow_list = apply_filter( 'vip_search_post_meta_allow_list', self::POST_META_DEFAULT_ALLOW_LIST );
+		$client_post_meta_allow_list = apply_filters( 'vip_search_post_meta_allow_list', self::POST_META_DEFAULT_ALLOW_LIST );
 
 		// Only include meta that matches the allow list
 		$new_meta = array_intersect( $current_meta, $client_post_meta_allow_list );
 
-		$terms = \get_the_terms( $post );
+		$taxonomies = \get_taxonomies( '', 'names' );
+		$terms = \wp_get_object_terms( $post->ID, $taxonomies );
 
 		$max_field_count = $this->get_maximum_field_count();
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -16,7 +16,7 @@ class Search {
 	public static $query_db_fallback_value = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
 	private const QUERY_COUNT_TTL = 300; // 5 minutes in seconds 
 
-  private const MAX_SEARCH_LENGTH = 255;
+	private const MAX_SEARCH_LENGTH = 255;
   
 	// From https://github.com/Automattic/jetpack/blob/c36432aa890dc24cafee4c4362711ffcafb9c983/packages/sync/src/class-defaults.php#L689-L732
 	public const POST_META_DEFAULT_ALLOW_LIST = array(

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1157,7 +1157,7 @@ class Search {
 		}
 
 		if ( 20000 < $field_count ) {
-			_doing_it_wrong( 'get_maximum_field_count', "ep_total_field_limit was set to $field_count. Maximum value is 20000.", '5.4.2' );
+			_doing_it_wrong( 'get_maximum_field_count', "ep_total_field_limit was set to $field_count. Maximum value is 20000.", '5.4.2' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			$field_count = 20000;
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1157,6 +1157,7 @@ class Search {
 		}
 
 		if ( 20000 < $field_count ) {
+			_doing_it_wrong( 'get_maximum_field_count', "ep_total_field_limit was set to $field_count. Maximum value is 20000.", '5.4.2' );
 			$field_count = 20000;
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -22,46 +22,9 @@ class Search {
 		2341,
 	);
 
-	// From https://github.com/Automattic/jetpack/blob/c36432aa890dc24cafee4c4362711ffcafb9c983/packages/sync/src/class-defaults.php#L689-L732
-	public const POST_META_DEFAULT_ALLOW_LIST = array(
-		'_feedback_akismet_values',
-		'_feedback_email',
-		'_feedback_extra_fields',
-		'_g_feedback_shortcode',
-		'_jetpack_post_thumbnail',
-		'_menu_item_classes',
-		'_menu_item_menu_item_parent',
-		'_menu_item_object',
-		'_menu_item_object_id',
-		'_menu_item_orphaned',
-		'_menu_item_type',
-		'_menu_item_xfn',
-		'_publicize_facebook_user',
-		'_publicize_twitter_user',
-		'_thumbnail_id',
-		'_wp_attached_file',
-		'_wp_attachment_backup_sizes',
-		'_wp_attachment_context',
-		'_wp_attachment_image_alt',
-		'_wp_attachment_is_custom_background',
-		'_wp_attachment_is_custom_header',
-		'_wp_attachment_metadata',
-		'_wp_page_template',
-		'_wp_trash_meta_comments_status',
-		'_wpas_mess',
-		'content_width',
-		'custom_css_add',
-		'custom_css_preprocessor',
-		'enclosure',
-		'imagedata',
-		'nova_price',
-		'publicize_results',
-		'sharing_disabled',
-		'switch_like_status',
-		'videopress_guid',
-		'vimeo_poster_image',
-		'advanced_seo_description',
-	);
+	// Empty for now. Will flesh out once migration path discussions are underway and/or the same meta are added to the filter across many
+	// sites
+	public const POST_META_DEFAULT_ALLOW_LIST = array();
 
 	private static $_instance;
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -17,7 +17,11 @@ class Search {
 	private const QUERY_COUNT_TTL = 300; // 5 minutes in seconds 
 
 	private const MAX_SEARCH_LENGTH = 255;
-  
+
+	private const DISABLE_POST_META_ALLOW_LIST = array (
+		2341,
+	);
+
 	// From https://github.com/Automattic/jetpack/blob/c36432aa890dc24cafee4c4362711ffcafb9c983/packages/sync/src/class-defaults.php#L689-L732
 	public const POST_META_DEFAULT_ALLOW_LIST = array(
 		'_feedback_akismet_values',
@@ -1062,6 +1066,12 @@ class Search {
 	 * respecting the maximum field count gracefully
 	 */
 	public function filter__ep_prepare_meta_data( $current_meta, $post ) {
+		if ( defined( 'FILES_CLIENT_SITE_ID' ) ) {
+			if ( in_array( FILES_CLIENT_SITE_ID, self::DISABLE_POST_META_ALLOW_LIST, true ) ) {
+				return $current_meta;
+			}
+		}
+
 		if ( ! is_array( $current_meta ) ) {
 			return $current_meta;
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1055,6 +1055,7 @@ class Search {
 		 * 
 		 * @hook vip_search_post_meta_allow_list
 		 * @param {array} $current_allow_list The current allow list for post meta indexing
+		 * @param {WP_Post} $post The post whose meta data is being prepared
 		 * @return {array} $new_allow_list The new allow list for post_meta_indexing
 		 */
 		$client_post_meta_allow_list = apply_filters( 'vip_search_post_meta_allow_list', self::POST_META_DEFAULT_ALLOW_LIST, $post );

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1467,6 +1467,9 @@ class Search_Test extends \WP_UnitTestCase {
 			return 1000000;
 		}, PHP_INT_MAX );
 
+		// Don't trigger an error since it's expected
+		\add_filter( 'doing_it_wrong_trigger_error', '__return_false', PHP_INT_MAX );
+
 		$es = new \Automattic\VIP\Search\Search();
 
 		$get_maximum_field_count = self::get_method( 'get_maximum_field_count' );

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1455,7 +1455,7 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$get_maximum_field_count = self::get_method( 'get_maximum_field_count' );
 
-		$this->assertEquals( 33, $get_maximum_field_count->invokeArgs( $es, array() ) );		
+		$this->assertEquals( 33, $get_maximum_field_count->invokeArgs( $es, array() ) );
 	}
 
 	/**
@@ -1471,7 +1471,7 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$get_maximum_field_count = self::get_method( 'get_maximum_field_count' );
 
-		$this->assertEquals( 20000, $get_maximum_field_count->invokeArgs( $es, array() ) );		
+		$this->assertEquals( 20000, $get_maximum_field_count->invokeArgs( $es, array() ) );
 	}
 
 	/**
@@ -1490,7 +1490,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 
 		// From Search::POST_META_DEFAULT_ALLOW_LIST
-		$post_meta = array (
+		$post_meta = array(
 			'_feedback_akismet_values',
 			'_feedback_email',
 			'_feedback_extra_fields',
@@ -1525,7 +1525,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 
 		// From Search::POST_META_DEFAULT_ALLOW_LIST
-		$post_meta = array (
+		$post_meta = array(
 			'_feedback_akismet_values',
 			'_feedback_email',
 			'_feedback_extra_fields',

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1522,23 +1522,95 @@ class Search_Test extends \WP_UnitTestCase {
 			}
 		);
 
-		// Matches allow listed meta
+		// Matches allow list
 		$post_meta = array(
-			'random_post_meta',
-			'another_one',
-			'third',
+			'random_post_meta' => array(
+				'Random value',
+			),
+			'another_one' => array(
+				'4656784',
+			),
+			'third' => array(
+				'true',
+			),
 		);
 
-		$post_meta[] = 'random_thing_not_allow_listed';
+		$post_meta['random_thing_not_allow_listed'] = array( 'Missing' );
 
 		$post = new \WP_Post( new \StdClass() );
 		$post->ID = 0;
 
 		$meta = $es->filter__ep_prepare_meta_data( $post_meta, $post );
 
-		array_pop( $post_meta ); // Remove last added value that should have been excluded by the filter
+		unset( $post_meta['random_thing_not_allow_listed'] ); // Remove last added value that should have been excluded by the filter
 
 		$this->assertEquals( $meta, $post_meta );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__filter__ep_prepare_meta_data_allow_list_should_be_respected_by_default_assoc() {
+		$es = new \Automattic\VIP\Search\Search();
+
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array(
+					'random_post_meta' => true,
+					'another_one' => true,
+					'skipped' => false,
+					'skipped_another' => 4,
+					'skipped_string' => 'Wooo',
+					'third' => true,
+				);
+			}
+		);
+
+		// Matches allow list
+		$post_meta = array(
+			'random_post_meta' => array(
+				'Random value',
+			),
+			'another_one' => array(
+				'4656784',
+			),
+			'skipped' => array(
+				'Skip',
+			),
+			'skipped_another' => array(
+				'Skip',
+			),
+			'skipped_string' => array(
+				'Skip'
+			),
+			'third' => array(
+				'true',
+			),
+		);
+
+		$post_meta['random_thing_not_allow_listed'] = array( 'Missing' );
+
+		$post = new \WP_Post( new \StdClass() );
+		$post->ID = 0;
+
+		$meta = $es->filter__ep_prepare_meta_data( $post_meta, $post );
+
+		$this->assertEquals(
+			$meta,
+			array(
+				'random_post_meta' => array(
+					'Random value',
+				),
+				'another_one' => array(
+					'4656784',
+				),
+				'third' => array(
+					'true',
+				),
+			)
+		);
 	}
 
 	/**

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1492,12 +1492,22 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$es = new \Automattic\VIP\Search\Search();
 
-		// From Search::POST_META_DEFAULT_ALLOW_LIST
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array(
+					'random_post_meta',
+					'another_one',
+					'third',
+				);
+			}
+		);
+
+		// Matches allow listed meta
 		$post_meta = array(
-			'_feedback_akismet_values',
-			'_feedback_email',
-			'_feedback_extra_fields',
-			'_g_feedback_shortcode',
+			'random_post_meta',
+			'another_one',
+			'third',
 		);
 
 		$post = new \WP_Post( new \StdClass() );
@@ -1524,15 +1534,25 @@ class Search_Test extends \WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test__filter__ep_prepare_meta_data_allow_list_should_be_respectedby_default() {
+	public function test__filter__ep_prepare_meta_data_allow_list_should_be_respected_by_default() {
 		$es = new \Automattic\VIP\Search\Search();
 
-		// From Search::POST_META_DEFAULT_ALLOW_LIST
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array(
+					'random_post_meta',
+					'another_one',
+					'third',
+				);
+			}
+		);
+
+		// Matches allow listed meta
 		$post_meta = array(
-			'_feedback_akismet_values',
-			'_feedback_email',
-			'_feedback_extra_fields',
-			'_g_feedback_shortcode',
+			'random_post_meta',
+			'another_one',
+			'third',
 		);
 
 		$post_meta[] = 'random_thing_not_allow_listed';

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1583,7 +1583,7 @@ class Search_Test extends \WP_UnitTestCase {
 				'Skip',
 			),
 			'skipped_string' => array(
-				'Skip'
+				'Skip',
 			),
 			'third' => array(
 				'true',


### PR DESCRIPTION
## Description

Need a way to not index all post meta due to field count restrictions. An allow list set by the user seems to be a good way to about it so that only the meta they actually need are included.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR
2. `/bin/phpunit-docker.sh tests/search/test-class-search.php`

-----

1. Pull down PR.
2. Modify the post meta allow list via the`vip_search_post_meta_allow_list` filter in code.
3. Index posts using those meta and some others.
4. Query the freshly indexed posts and check that the only post meta indexed were the ones indicated in the allow list.

------

1. Pull down PR.
2. Set `FILES_CLIENT_SITE_ID` to one of the values in `Search::DISABLE_POST_META_ALLOW_LIST`
3. Index posts with any meta.
4. Query the freshly indexed posts and check that all post meta has been indexed, even if they aren't indicated on the allow list.