### PR TITLE
docs: update readme with information on cloning submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm run phpcs
 
 ##### PHPUnit
 
-We have a script that runs unit tests in a self-contained Docker environment.  To run these test, execute the following from the project root:
+We have a script that runs unit tests in a self-contained Docker environment.  To run these tests, execute the following from the project root:
 
 ```
 ./bin/phpunit-docker.sh [wp-version]

--- a/README.md
+++ b/README.md
@@ -4,54 +4,64 @@ This is the development repo for mu-plugins on [VIP Go](http://vip.wordpress.com
 
 ## Development
 
+### Cloning with Submodules
 
+This repository contains many git submodules.  Use the following command to clone them recursively:
 
-### PHPDoc
+```bash
+git clone --recurse-submodules -j8 git@github.com:Automattic/vip-go-mu-plugins.git
+```
 
-You can find selective PHPDoc documentation here: https://automattic.github.io/vip-go-mu-plugins/
+The `-j8` allows you to pull down up to 8 in parallel to speed things up.
 
-These are generated via CI by the [`generate-docs.sh`]() script.
+### Dependency Installation
+
+To install the PHP and JavaScript dependencies, execute the following commands:
+
+```bash
+composer install
+npm install
+```
 
 ### Tests
 
-#### PHP Lint
+##### PHP Lint
 
 ```bash
 make lint
 ```
 
-#### PHPCS
+##### PHPCS
 
-We use eslines to incrementally scan changed code. It will automatically run on pre-commit (see `.huskyrc.json`) assuming the dependencies have been installed:
-
-```
-composer install
-npm install
-``` 
+We use eslines to incrementally scan changed code. It will automatically run on pre-commit (see `.huskyrc.json`).
 
 This is also run on Circle CI for all PRs.
 
 If you want too scan the entire codebase:
 
 ```
-composer install
-npm install
 npm run phpcs
 ```
 
-#### PHPUnit
+##### PHPUnit
 
-We have a script that runs unit tests in a self-contained Docker environment.
+We have a script that runs unit tests in a self-contained Docker environment.  To run these test, execute the following from the project root:
 
 ```
-usage: ./bin/phpunit-docker.sh [wp-version]
+./bin/phpunit-docker.sh [wp-version]
 ```
 
 You can either pass a version number to test against a specific version, or leave it blank to test against the latest version.
 
-#### CI
+##### CI
 
 PHP Linting and PHPUnit tests are run by Circle CI as part of PRs and merges. See [`.circleci/config.yml`](https://github.com/Automattic/vip-go-mu-plugins/blob/master/.circleci/config.yml) for more.
+
+### PHPDoc
+
+You can find selective PHPDoc documentation here: https://automattic.github.io/vip-go-mu-plugins/
+
+These are generated via CI by the [`generate-docs.sh`]() script.
 
 ## Deployment
 


### PR DESCRIPTION
## Description

In setting up the repository on my local environment and attempting to get the tests to pass, I thought that the README could use some additional information on git submodules.  I also refactored some of the ordering of the information so that it would flow better with a typical setup.

The goal is to get folks up and running and contributing faster.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

View the `README.md` file and move through the information in order to achieve a fully installed repository, with all submodules, and unit tests passing.