### PR TITLE
fix: provide correct linting command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install
 ##### PHP Lint
 
 ```bash
-make lint
+npm run phplint
 ```
 
 ##### PHPCS
@@ -39,7 +39,7 @@ This is also run on Circle CI for all PRs.
 
 If you want too scan the entire codebase:
 
-```
+```bash
 npm run phpcs
 ```
 
@@ -47,7 +47,7 @@ npm run phpcs
 
 We have a script that runs unit tests in a self-contained Docker environment.  To run these tests, execute the following from the project root:
 
-```
+```bash
 ./bin/phpunit-docker.sh [wp-version]
 ```
 


### PR DESCRIPTION
## Description

The command provided in the readme `make lint` doesn't exist.
This change provides the correct npm based command.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

In `master` run `make lint` and see the error message about not makefile.

In `correct-linting-command` see the correct documentation on running `npm run phplint`