### PR TITLE
Increase vip_safe_wp_remote_request timeouts

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -762,7 +762,7 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 			_doing_it_wrong( __FUNCTION__, 'Remote POST request timeouts are capped at 30 seconds in WP-CLI for performance and stability reasons.', null );
 			$timeout = 30;
 		}
-	} elseif( \is_admin() && $is_post_request ) {
+	} elseif ( \is_admin() && $is_post_request ) {
 		if ( 15 < $timeout ) {
 			_doing_it_wrong( __FUNCTION__, 'Remote POST request timeouts are capped at 15 seconds for admin requests for performance and stability reasons.', null );
 			$timeout = 15;

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -752,13 +752,11 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	$threshold = abs( $threshold );
 
 	// Default max timeout is 5s. 
-	// For POST requests, this needs to be a bit higher due to Elasticsearch and other things. 
-	// For POST requests through WP-CLI, this needs to be event higher to makes things like VIP Search commands works more consitently without tinkering.
+	// For POST requests for admins, this needs to be a bit higher due to Elasticsearch and other things. 
+	// For POST requests for admins through WP-CLI, this needs to be event higher to makes things like VIP Search commands works more consitently without tinkering.
 	$timeout = (int) $timeout;
-	if ( $timeout > 5 ) {
-		// Allow higher timeouts for POST requests
+	if ( \is_admin() ) {
 		if ( 0 === strcasecmp( 'POST', $parsed_args['method'] ) ) {
-			// Allow even higher timeouts for POST requests through WP-CLI
 			if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				if ( 30 < $timeout ) {
 					_doing_it_wrong( __FUNCTION__, 'Remote POST request timeouts are capped at 30 seconds in WP-CLI for performance and stability reasons.', null );
@@ -770,7 +768,9 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 					$timeout = 15;
 				}
 			}
-		} else {
+		}
+	} else {
+		if ( $timeout > 5 ) {
 			_doing_it_wrong( __FUNCTION__, 'Remote request timeouts are capped at 5 seconds for performance and stability reasons.', null );
 			$timeout = 5;
 		}

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -752,22 +752,20 @@ function vip_safe_wp_remote_request( $url, $fallback_value='', $threshold=3, $ti
 	$threshold = abs( $threshold );
 
 	// Default max timeout is 5s. 
+	// For POST requests for through WP-CLI, this needs to be event higher to makes things like VIP Search commands works more consitently without tinkering.
 	// For POST requests for admins, this needs to be a bit higher due to Elasticsearch and other things. 
-	// For POST requests for admins through WP-CLI, this needs to be event higher to makes things like VIP Search commands works more consitently without tinkering.
 	$timeout = (int) $timeout;
-	if ( \is_admin() ) {
-		if ( 0 === strcasecmp( 'POST', $parsed_args['method'] ) ) {
-			if ( defined( 'WP_CLI' ) && WP_CLI ) {
-				if ( 30 < $timeout ) {
-					_doing_it_wrong( __FUNCTION__, 'Remote POST request timeouts are capped at 30 seconds in WP-CLI for performance and stability reasons.', null );
-					$timeout = 30;
-				}
-			} else {
-				if ( 15 < $timeout ) {
-					_doing_it_wrong( __FUNCTION__, 'Remote POST request timeouts are capped at 15 seconds for performance and stability reasons.', null );
-					$timeout = 15;
-				}
-			}
+	$is_post_request = 0 === strcasecmp( 'POST', $parsed_args['method'] );
+
+	if ( defined( 'WP_CLI' ) && WP_CLI && $is_post_request ) {
+		if ( 30 < $timeout ) {
+			_doing_it_wrong( __FUNCTION__, 'Remote POST request timeouts are capped at 30 seconds in WP-CLI for performance and stability reasons.', null );
+			$timeout = 30;
+		}
+	} elseif( \is_admin() && $is_post_request ) {
+		if ( 15 < $timeout ) {
+			_doing_it_wrong( __FUNCTION__, 'Remote POST request timeouts are capped at 15 seconds for admin requests for performance and stability reasons.', null );
+			$timeout = 15;
 		}
 	} else {
 		if ( $timeout > 5 ) {


### PR DESCRIPTION
## Description

Increase timeouts for POST requests since the flat 5s timeout causes some problems with ElasticPress and related WP-CLI commands.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Attempt to use `vip_safe_wp_remote_request` with a timeout over 5s. You should be limited to 5s and receive a `_doing_it_wrong`.
2. Pull down PR.
3. Attempt a POST request via `vip_safe_wp_remote_request` with a 15s timeout. You shouldn't get any warnings or have any issues.
4. Attempt a POST request via `vip_safe_wp_remote_request` with a 20s timeout. You should get a `doing_it_wrong` and have the timeout set to 15s.
5.  Attempt a POST request via `vip_safe_wp_remote_request` with a 30s timeout through WP-CLI. You shouldn't get any warnings or have any issues.
6.  Attempt a POST request via `vip_safe_wp_remote_request` with a 35s timeout through WP-CLI. You should get a `doing_it_wrong` and have the timeout set to 30s.