### PR TITLE
Increase timeouts for bulk ES operations

### DIFF
--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -364,7 +364,7 @@ class Search_Test extends \WP_UnitTestCase {
 	public function test__vip_search_get_http_timeout_for_query( $query, $expected_timeout ) {
 		$es = new \Automattic\VIP\Search\Search();
 
-		$timeout = $es->get_http_timeout_for_query( $query );
+		$timeout = $es->get_http_timeout_for_query( $query, array() );
 
 		$this->assertEquals( $expected_timeout, $timeout );
 	}


### PR DESCRIPTION
## Description

Depends on: https://github.com/Automattic/vip-go-mu-plugins/pull/1608

Use the new timeout limits to increase the timeouts for bulk Elasticsearch operations.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR.
2. `echo` the timeout before the return in `get_http_timeout_for_query`.
3. Run `wp vip-search health validate-counts`, should be 2.
4. Run `wp elasticpress index`, should be 30.
5. Revert `echo` change. 
