### PR TITLE
is_proxied_automattician: Check constant exists

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1380,7 +1380,7 @@ function is_automattician( $user_id = false ) {
  * @return bool True, if the current request is made via the Automattic proxy
  */
 function is_proxied_automattician() {
-	return A8C_PROXIED_REQUEST && is_automattician();
+	return is_proxied_request() && is_automattician();
 }
 
 /**


### PR DESCRIPTION
## Description

The `is_proxied_request()` checks whether the `A8C_PROXIED_REQUEST` constant is defined, before checking it is `=== true`.

The `is_proxied_automattician()` only checked whether the constant was truthy. It did not check if the constant was defined.

It makes sense for `is_proxied_automattician()` (the purpose of which is to check for both a proxied request AND that the currently logged-in user appears to be an Automattician) to use `is_proxied_request()` internally.

Note, that technically this slightly tightens the behaviour, from allowing a truthy definition (like `'a string'` or `1`) to requiring it to be a boolean `true`.

The constant may be defined in secret file as true, but [falls back](https://github.com/Automattic/vip-go-mu-plugins/blob/4511c412617032b71e820f7adc997c9358c35905/000-vip-init.php#L59-L64) to `false` if not. Considering VIP control the secrets file, and `is_proxied_request()` already checks `=== true`, then it seems reasonable to carry this behaviour through to `is_proxied_automattician()` as well.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] ~This change has relevant unit tests (if applicable).~
- [ ] ~This change has relevant documentation additions / updates (if applicable).~

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Wrap an echo in `is_proxied_automattician()`, and check that it only echoes when the request is made using the A8C proxy and you are logged in as an Automattician.
