### PR TITLE
Increment stat in statsd when query is ratelimited

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -616,11 +616,35 @@ class Search {
 		if ( self::query_count_incr() > self::$max_query_count ) {
 			// Should be roughly half over time
 			if ( self::$query_db_fallback_value >= rand( 1, 10 ) ) {
+				self::record_ratelimited_query_stat();
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	public static function record_ratelimited_query_stat() {
+		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
+
+		if ( ! $indexable ) {
+			return;
+		}
+
+		// Can't use $this in static context
+		$es = \Search::instance();
+		
+		$statsd_mode = 'query_ratelimited';
+		$statsd_index_name = $indexable->get_index_name();
+
+		$url = $es->get_current_host();
+		$stat = $es->get_statsd_prefix( $url, $statsd_mode );
+		$per_site_stat = $es->get_statsd_prefix( $url, $statsd_mode, FILES_CLIENT_SITE_ID, $statsd_index_name );
+
+		$statsd = new \Automattic\VIP\StatsD();
+
+		$statsd->increment( $stat );
+		$statsd->increment( $per_site_stat );
 	}
 
 	/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -632,7 +632,7 @@ class Search {
 		}
 
 		// Can't use $this in static context
-		$es = \Search::instance();
+		$es = self::instance();
 		
 		$statsd_mode = 'query_ratelimited';
 		$statsd_index_name = $indexable->get_index_name();

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1041,6 +1041,7 @@ class Search_Test extends \WP_UnitTestCase {
 	 */
 	public function test__rate_limit_ep_query_integration() {
 		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
 
 		add_option( 'vip_enable_vip_search_query_integration', true );
 		define( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION', true );


### PR DESCRIPTION
## Description

Add/increment a stat when a query is rate limited.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR
2. Run StatsD locally
3. Add somewhere it will run `define( 'VIP_STATSD_HOST', 'docker.for.mac.localhost' );`
4. Add somewhere it will run `define( 'VIP_STATSD_PORT', 8125 );`
5. Change `private static $max_query_count = 50000 + 1;` to `private static $max_query_count = 1;`
6. Run a search with QM/Debug Bar open for ElasticPress.
7. Keep refreshing the page while watching the queries.
8. Roughly half shouldn't go through ElasticPress.
9. Watch StatsD output - should include metrics for both the global stats, then metrics the site id and index name in them