### PR TITLE
Wire up the `_encloseme` meta cleanup class

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -205,6 +205,12 @@ add_action( 'init', function() {
 	\Automattic\VIP\Config\Sync::instance();
 } );
 
+// Load _encloseme meta cleanup scheduler
+require_once( __DIR__ . '/lib/class-vip-encloseme-cleanup.php' );
+
+$enclosemeCleaner = new VIP_Encloseme_Cleanup();
+$enclosemeCleaner->init();
+
 // Add custom header for VIP
 add_filter( 'wp_headers', function( $headers ) {
 	$headers['X-hacker'] = 'If you\'re reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header.';

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -208,8 +208,8 @@ add_action( 'init', function() {
 // Load _encloseme meta cleanup scheduler
 require_once( __DIR__ . '/lib/class-vip-encloseme-cleanup.php' );
 
-$enclosemeCleaner = new VIP_Encloseme_Cleanup();
-$enclosemeCleaner->init();
+$encloseme_cleaner = new VIP_Encloseme_Cleanup();
+$encloseme_cleaner->init();
 
 // Add custom header for VIP
 add_filter( 'wp_headers', function( $headers ) {


### PR DESCRIPTION
## Description

Require the `VIP_Encloseme_Cleanup` class and then call the `init()` method to get things going.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Checkout PR
1. Sandbox a site and copy changed files
1. Edit config file to include `define( 'ENABLE_VIP_ENCLOSEME_CLEANUP_ENV', true );`
1. `wp cron-control events list`
1. Ensure `vip_encloseme_cleanup_hook` is in the list of events
