### PR TITLE
Add queue size stat to statsd after processing a batch

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -485,14 +485,12 @@ class Queue {
 
 		$url = $es->get_current_host();
 		$stat = $es->get_statsd_prefix( $url, $statsd_mode );
-		$per_site_stat = $es->get_statsd_prefix( $url, $statsd_mode, FILES_CLIENT_SITE_ID, $statsd_index_name );
 
 		$count = $this->get_total_queue_size();
 
 		$statsd = new \Automattic\VIP\StatsD();
 
 		$statsd->gauge( $stat, $count );
-		$statsd->gauge( $per_site_stat, $count );
 	}
 	
 	/**

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -283,7 +283,7 @@ class Queue {
 			}
 		}
 
-		$job_count = $wpdb->get_var( $query ); // Cannot prepare table name. @codingStandardsIgnoreLine
+		$job_count = $wpdb->get_var( $query ); // Query may change depending on status/object type @codingStandardsIgnoreLine
 
 		return intval( $job_count );
 	}

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -484,13 +484,12 @@ class Queue {
 		$es = \Automattic\VIP\Search\Search::instance();
 
 		$url = $es->get_current_host();
-		$stat = $es->get_statsd_prefix( $url, $statsd_mode );
+		$per_site_stat = $es->get_statsd_prefix( $url, $statsd_mode, FILES_CLIENT_SITE_ID, $statsd_index_name );
 
 		$count = $this->get_total_queue_size();
 
 		$statsd = new \Automattic\VIP\StatsD();
-
-		$statsd->gauge( $stat, $count );
+		$statsd->gauge( $per_site_stat, $count );
 	}
 	
 	/**

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -283,9 +283,9 @@ class Queue {
 			}
 		}
 
-		$job_count = $wpdb->get_var( $query );
+		$job_count = $wpdb->get_var( $query ); // Cannot prepare table name. @codingStandardsIgnoreLine
 
-		return intval( $job_count ); 	
+		return intval( $job_count );
 	}
 
 	public function count_jobs_due_now( $object_type = 'post' ) {

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -598,6 +598,27 @@ class Queue_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 14, $index_count_incr->invokeArgs( $this->queue, [ 5 ] ), 'should increment properly without using the default increment of 1' );
 	}
 
+	public function test__record_queue_count_stat_should_be_0_by_default() {
+		$this->assertEquals( 0, $this->queue->get_total_queue_size() );
+	}
+
+	public function test__record_queue_count_stat_should_return_the_queue_count() {
+		global $wpdb;
+
+		$table_name = $this->queue->schema->get_table_name();
+
+		foreach ( range( 0, 9 ) as $object_id ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO $table_name ( `object_id` ) VALUES ( %d )", // Cannot prepare table name. @codingStandardsIgnoreLine
+					$object_id
+				)
+			);
+		}
+
+		$this->assertEquals( 10, $this->queue->get_total_queue_size() );
+	}
+
 	/**
 	 * Helper function for accessing protected methods.
 	 */

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -598,11 +598,11 @@ class Queue_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 14, $index_count_incr->invokeArgs( $this->queue, [ 5 ] ), 'should increment properly without using the default increment of 1' );
 	}
 
-	public function test__record_queue_count_stat_should_be_0_by_default() {
-		$this->assertEquals( 0, $this->queue->get_total_queue_size() );
+	public function test__count_jobs_all_should_be_0_by_default() {
+		$this->assertEquals( 0, $this->queue->count_jobs( 'all', 'all' ) );
 	}
 
-	public function test__record_queue_count_stat_should_return_the_queue_count() {
+	public function test__count_jobs_all_should_return_the_queue_count() {
 		global $wpdb;
 
 		$table_name = $this->queue->schema->get_table_name();
@@ -616,7 +616,36 @@ class Queue_Test extends \WP_UnitTestCase {
 			);
 		}
 
-		$this->assertEquals( 10, $this->queue->get_total_queue_size() );
+		$this->assertEquals( 10, $this->queue->count_jobs( 'all', 'all' ) );
+	}
+
+	public function test__count_jobs_all_statuses_should_return_proper_count_by_object_type() {
+		global $wpdb;
+
+		$table_name = $this->queue->schema->get_table_name();
+
+		// Add junk rows that shouldn't be picked up in count_jobs
+		foreach ( range( 0, 9 ) as $object_id ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO $table_name ( `object_id` ) VALUES ( %d )", // Cannot prepare table name. @codingStandardsIgnoreLine
+					$object_id
+				)
+			);
+		}
+
+		foreach ( range( 0, 2 ) as $object_id ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO $table_name ( `object_id`, `object_type` ) VALUES ( %d, %s )", // Cannot prepare table name. @codingStandardsIgnoreLine
+					$object_id,
+					'random object type'
+				)
+			);
+		}
+
+		$this->assertEquals( 13, $this->queue->count_jobs( 'all', 'all' ), 'total queue size should be 13' );
+		$this->assertEquals( 3, $this->queue->count_jobs( 'all', 'random object type' ), "queue size for 'random object type' should be 3" );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Add a gauge to keep track of queue size as it's processed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

### Setup statsd

1. Run StatsD locally
2. Add somewhere it will run `define( 'VIP_STATSD_HOST', 'docker.for.mac.localhost' );`
3. Add somewhere it will run `define( 'VIP_STATSD_PORT', 8125 );`

### If you don't have the `wp_vip_search_index_queue` table

1. Open wp shell and execute 2 and 3:
2. ` \Automattic\VIP\Search\Search::instance()->init();`
3. ` \Automattic\VIP\Search\Search::instance()->queue->schema->prepare_table();`

### Continuing...

1. Pull down PR.
2. Open wp shell and execute 3 and 4:
3. ` \Automattic\VIP\Search\Search::instance()->init();`
4. ` \Automattic\VIP\Search\Search::instance()->queue->count_jobs( 'all', 'all' );`
5. Insert a number of rows into `wp_vip_search_index_queue`(make sure some have the 'post' object type) and execute 6:
6. `\Automattic\VIP\Search\Search::instance()->queue->count_jobs( 'all', 'all' );`
7. The result of 6 should match the inserted number in 5.
8. `\Automattic\VIP\Search\Search::instance()->queue->record_queue_count_stat( \ElasticPress\Indexables::factory()->get( 'post' ) );`
9. There should be a new statsd gauge in the output for queue size where the stat matches the number of rows inserted in 5 that have an indexable.
10. Change the queue size, try different object types, and recheck.