### PR TITLE
Truncate search strings to a reasonable length

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -907,13 +907,13 @@ class Search {
 		return $formatted_args;
 	}
 
-	public function truncate_search_string_length( $query_object ) {
-		if ( $query_object->is_search() ) {
-			$search = $query_object->query['s'];
+	public function truncate_search_string_length( $query ) {
+		if ( $query->is_search() ) {
+			$search = $query->get( 's' );
 
 			$truncated_search = substr( $search, 0, self::MAX_SEARCH_LENGTH );
 			
-			$query_object->set( 's', $truncated_search );
+			$query->set( 's', $truncated_search );
 		}
 	}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -907,7 +907,7 @@ class Search {
 		return $formatted_args;
 	}
 
-	public function truncate_search_string_length( $query ) {
+	public function truncate_search_string_length( &$query ) {
 		if ( $query->is_search() ) {
 			$search = $query->get( 's' );
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -167,7 +167,6 @@ class Search {
 
 		// Truncate search strings to a reasonable length
 		add_action( 'parse_query', array( $this, 'truncate_search_string_length' ), PHP_INT_MAX );
-
 	}
 
 	protected function load_commands() {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -16,6 +16,8 @@ class Search {
 	public static $query_db_fallback_value = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
 	private const QUERY_COUNT_TTL = 300; // 5 minutes in seconds 
 
+	private const MAX_SEARCH_LENGTH = 255;
+
 	private static $_instance;
 
 	/**
@@ -162,6 +164,10 @@ class Search {
 			add_filter( 'the_posts', array( $this, 'filter__the_posts' ), 10, 2 );
 			add_action( 'shutdown', array( $this, 'action__shutdown_do_mirrored_wp_queries' ) );
 		}
+
+		// Truncate search strings to a reasonable length
+		add_action( 'parse_query', array( $this, 'truncate_search_string_length' ), PHP_INT_MAX );
+
 	}
 
 	protected function load_commands() {
@@ -899,6 +905,16 @@ class Search {
 		unset( $formatted_args['query']['bool']['should'] );
 
 		return $formatted_args;
+	}
+
+	public function truncate_search_string_length( $query_object ) {
+		if ( $query_object->is_search() ) {
+			$search = $query_object->query['s'];
+
+			$truncated_search = substr( $search, 0, self::MAX_SEARCH_LENGTH );
+			
+			$query_object->set( 's', $truncated_search );
+		}
 	}
 
 	/*

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1424,6 +1424,23 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_diff, $diff );
 	}
 
+	public function test__truncate_search_string_length() {
+		$es = new \Automattic\VIP\Search\Search();
+
+		$expected_search_string = '1nAtu5t4QRo9XmU5VeKFOCTfQN62FrbvvoQXkU1782KOThAlt50NipM7V4dZNGG4eO54HsOQlJaBPStXPRoxWPHqdrHGsGkNQJJshYseaePxCJuGmY7kYp941TUoNF3GhSBEzjajNu0iwdCWrPMLxSJ5XXBltNM9of2LKvwa1hNPOXLka1tyAi8PSZlS53RbGhv7egKOYPyyPpR6mZlzJhx6nXXlZ5t3BtRdQOIvGho6HjdYwdd1hMyHHv1qpgg';
+		$provided_search_string = '1nAtu5t4QRo9XmU5VeKFOCTfQN62FrbvvoQXkU1782KOThAlt50NipM7V4dZNGG4eO54HsOQlJaBPStXPRoxWPHqdrHGsGkNQJJshYseaePxCJuGmY7kYp941TUoNF3GhSBEzjajNu0iwdCWrPMLxSJ5XXBltNM9of2LKvwa1hNPOXLka1tyAi8PSZlS53RbGhv7egKOYPyyPpR6mZlzJhx6nXXlZ5t3BtRdQOIvGho6HjdYwdd1hMyHHv1qpgg' .
+			'g5oMk1nWsx5fJ0B3bAFYKt1Y5dOA0Q4lQUqj8mf1LjcmR73wQwujc1GQfgCKj9X9Ktr6LrDtN5zAJFQboAJa7fZ9AiGxbJqUrLFs';
+
+		$wp_query_mock = new \WP_Query();
+
+		$wp_query_mock->set( 's', $provided_search_string );
+		$wp_query_mock->is_search = true;
+
+		$es->truncate_search_string_length( $wp_query_mock );
+
+		$this->assertEquals( $expected_search_string, $wp_query_mock->get( 's' ) );
+	}
+
 	/**
 	 * Helper function for accessing protected methods.
 	 */
@@ -1435,7 +1452,7 @@ class Search_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Helper function for accessing protected methods.
+	 * Helper function for accessing protected properties.
 	 */
 	protected static function get_property( $name ) {
 		$class = new \ReflectionClass( __NAMESPACE__ . '\Search' );


### PR DESCRIPTION
## Description

This issue was initially because of a bug that resulted in hanging when search strings were longer than a certain length.

That's been resolved, but we should still limit search string lengths. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Search with a string longer than 255. It shouldn't be truncated.
2. Pull down PR.
3. Search with a string longer than 255. It should be truncated to 255 in general and also in ElasticPress query monitor/debug bar.
