### PR TITLE
Add opsgenie alerts for AllOptions

### DIFF
--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -68,13 +68,13 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 
 	$irc_alert_level = 2; // ALERT
 
-	$opsgenie_alert_level = "P4";
+	$opsgenie_alert_level = 'P4';
 	if ( $blocked ) {
 		$msg = "This site is now BLOCKED from loading until option sizes are under control.";
 
 		// If site is blocked, then the IRC alert is CRITICAL
 		$irc_alert_level = 3;
-		$opsgenie_alert_level = "P3";
+		$opsgenie_alert_level = 'P3';
 	} else {
 		$msg = "Site will be blocked from loading if option sizes get too much bigger.";
 	}

--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -68,13 +68,13 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 
 	$irc_alert_level = 2; // ALERT
 
-	$opsgenie_alert_level = "P2";
+	$opsgenie_alert_level = "P4";
 	if ( $blocked ) {
 		$msg = "This site is now BLOCKED from loading until option sizes are under control.";
 
 		// If site is blocked, then the IRC alert is CRITICAL
 		$irc_alert_level = 3;
-		$opsgenie_alert_level = "P1";
+		$opsgenie_alert_level = "P3";
 	} else {
 		$msg = "Site will be blocked from loading if option sizes get too much bigger.";
 	}

--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -6,6 +6,8 @@
  * Author: Automattic
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */
+require_once( WP_CONTENT_DIR . '/mu-plugins/lib/utils/class-alerts.php' );
+use Automattic\VIP\Utils\Alerts;
 
 add_action( 'plugins_loaded', 'wpcom_vip_sanity_check_alloptions' );
 
@@ -66,11 +68,13 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 
 	$irc_alert_level = 2; // ALERT
 
+	$opsgenie_alert_level = "P2";
 	if ( $blocked ) {
 		$msg = "This site is now BLOCKED from loading until option sizes are under control.";
 
 		// If site is blocked, then the IRC alert is CRITICAL
 		$irc_alert_level = 3;
+		$opsgenie_alert_level = "P1";
 	} else {
 		$msg = "Site will be blocked from loading if option sizes get too much bigger.";
 	}
@@ -117,6 +121,22 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 			wpcom_vip_irc( '#nagios-vip', $to_irc, $irc_alert_level, 'a8c-alloptions' );
 			if ( 'production' === $environment ) {
 				wpcom_vip_irc( '#vip-deploy-on-call', $to_irc , $irc_alert_level, 'a8c-alloptions' );
+
+				// Send to OpsGenie
+				$alerts = Alerts::instance();
+				$alerts->opsgenie(
+					$subject,
+					array( 
+						'alias'       => 'alloptions/' . $site_id,
+						'description' => 'The size of AllOptions is reaching the max limit of 1 MB.',
+						'entity'      => $site_id,
+						'priority'    => $opsgenie_alert_level,
+						'source'      => 'sites/alloptions-size',
+					),
+					'alloptions-size-alert',
+					'10'
+				);
+
 			}
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -12,7 +12,7 @@ class Search {
 
 	public const QUERY_COUNT_CACHE_KEY = 'query_count';
 	public const QUERY_COUNT_CACHE_GROUP = 'vip_search';
-	public static $max_query_count = 3000 + 1; // 10 requests per second plus one for cleanliness of comparing with Search::query_count_incr
+	public static $max_query_count = 50000 + 1; // 10 requests per second plus one for cleanliness of comparing with Search::query_count_incr
 	public static $query_db_fallback_value = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
 	private const QUERY_COUNT_TTL = 300; // 5 minutes in seconds 
 


### PR DESCRIPTION
## Description
Add OpsGenie Alerts for AllOptions! 😄

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

I tried testing this on my sandbox but there was a problem with this:
https://github.com/Automattic/vip-go-mu-plugins/blob/9c293f8325d1b4d51a15e947591e6cae4cc67a68/lib/utils/class-alerts.php#L280

The `is_int` check wasn't passing because it was a string.  

If I bypass that, I get this error (I removed the URL, IP_ADDRESS and PORT):

```
[12-Jun-2020 22:42:21 UTC] Warning: vip_safe_wp_remote_request: Blog ID 1: Requesting http://{IP_ADDRESS}:{PORT}/v1.0/alerts with method POST and a timeout of 1 failed. Result: O:8:"WP_Error":2:{s:6:"errors";a:1:{s:19:"http_request_failed";a:1:{i:0;s:78:"cURL error 7: Failed to connect to {IP_ADDRESS} port {PORT}: Connection refused";}}s:10:"error_data";a:0:{}} in /var/www/wp-content/mu-plugins/vip-helpers/vip-utils.php on line 804 [{URL}/?v=dfjnaiwufho7] [wp-content/mu-plugins/vip-helpers/vip-utils.php:804 trigger_error(), wp-content/mu-plugins/lib/utils/class-alerts.php:58 vip_safe_wp_remote_request(), wp-content/mu-plugins/lib/utils/class-alerts.php:252 Automattic\VIP\Utils\Alerts->send(), wp-content/mu-plugins/lib/utils/class-alerts.php:353 Automattic\VIP\Utils\Alerts->send_to_opsgenie(), wp-content/mu-plugins/alloptions-limit.php:137 Automattic\VIP\Utils\Alerts::opsgenie(), wp-content/mu-plugins/alloptions-limit.php:40 wpcom_vip_sanity_check_alloptions_notify(), wp-includes/class-wp-hook.php:287 wpcom_vip_sanity_check_alloptions(), wp-includes/class-wp-hook.php:311 WP_Hook->apply_filters(), wp-includes/plugin.php:478 WP_Hook->do_action(), wp-settings.php:403 do_action('plugins_loaded'), wp-config.php:11 require_once('wp-settings.php'), wp-load.php:37 require_once('wp-config.php'), wp-blog-header.php:13 require_once('wp-load.php'), index.php:17 require('wp-blog-header.php')]
[12-Jun-2020 22:42:21 UTC] Error sending alert: There was an error connecting to the alerts service
```

cc @hanifn is there something I need to do differently to test this on my sandbox?