### PR TITLE
Alias elasticpress commands to vip-search

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -45,6 +45,9 @@ class Search {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 			require_once __DIR__ . '/commands/class-queuecommand.php';
+
+			// Remove elasticpress command
+			WP_CLI::add_hook( 'before_add_command:elasticpress', [ $this, 'abort_elasticpress_add_command' ] );
 		}
 
 		// Load ElasticPress
@@ -168,6 +171,7 @@ class Search {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'vip-search health', __NAMESPACE__ . '\Commands\HealthCommand' );
 			WP_CLI::add_command( 'vip-search queue', __NAMESPACE__ . '\Commands\QueueCommand' );
+			WP_CLI::add_command( 'vip-search', '\ElasticPress\Command' );
 		}
 	}
 
@@ -968,6 +972,13 @@ class Search {
 		$this->current_host_index = $this->current_host_index % count( VIP_ELASTICSEARCH_ENDPOINTS );
 
 		return VIP_ELASTICSEARCH_ENDPOINTS[ $this->current_host_index ];
+	}
+
+	/*
+	 * Hook for WP CLI before_add_command:elasticpress
+	 */
+	public function abort_elasticpress_add_command( $addition ) {
+		$addition->abort( 'elasticpress command aliased to vip-search' );
 	}
 
 	/*


### PR DESCRIPTION
## Description

Having multiple commands for search management doesn't make a lot of sense. 

Since the ElasticPress dashboard is also hidden, it makes sense to just alias the commands to vip-search.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR.
2. `wp` shouldn't list elasticpress as a command.
3. `wp vip-search` should list all former elasticpress commands in addition to vip-search specific commands.
