### PR TITLE
Update es-wp-query subtree

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -205,6 +205,12 @@ add_action( 'init', function() {
 	\Automattic\VIP\Config\Sync::instance();
 } );
 
+// Load _encloseme meta cleanup scheduler
+require_once( __DIR__ . '/lib/class-vip-encloseme-cleanup.php' );
+
+$encloseme_cleaner = new VIP_Encloseme_Cleanup();
+$encloseme_cleaner->init();
+
 // Add custom header for VIP
 add_filter( 'wp_headers', function( $headers ) {
 	$headers['X-hacker'] = 'If you\'re reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header.';


### PR DESCRIPTION
## Description

Brings over the latest changes from es-wp-query (fix for post_type in VIP Search mapping and fixing total records count in ES 7)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Offload a query with `es => true` and make sure it still works.
