### PR TITLE
Only mirror tax query if it's also not a search query

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -304,7 +304,7 @@ class Search {
 				929,
 			);
 
-			if ( in_array( VIP_GO_APP_ID, $offload_main_tax_site_ids, true ) && $query->is_main_query() && ( $query->is_category() || $query->is_tax() || $query->is_tag() ) ) {
+			if ( in_array( VIP_GO_APP_ID, $offload_main_tax_site_ids, true ) && $query->is_main_query() && ! $query->is_search() && ( $query->is_category() || $query->is_tax() || $query->is_tag() ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## Description

Our automatic query mirroring for testing es-wp-query has a bug in that it offloads search queries that also have a taxonomy component. Since search queries will always differ somewhat, we can't reliably validate the results and they should be omitted.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Apply PR
1. Run a taxonomy query on a site with offloading enabled (like `?s&tag=something`)
1. Everything should work fine
