### PR TITLE
Expand list of sites with mirrored tax queries

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -302,6 +302,7 @@ class Search {
 
 			$offload_main_tax_site_ids = array(
 				929,
+				1281,
 			);
 
 			if ( in_array( VIP_GO_APP_ID, $offload_main_tax_site_ids, true ) && $query->is_main_query() && ! $query->is_search() && ( $query->is_category() || $query->is_tax() || $query->is_tag() ) ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -303,6 +303,10 @@ class Search {
 			$offload_main_tax_site_ids = array(
 				929,
 				1281,
+				1284,
+				1286,
+				1513,
+				2161,
 			);
 
 			if ( in_array( VIP_GO_APP_ID, $offload_main_tax_site_ids, true ) && $query->is_main_query() && ! $query->is_search() && ( $query->is_category() || $query->is_tax() || $query->is_tag() ) ) {


### PR DESCRIPTION
## Description

Expands the list of sites that are mirroring taxonomy queries, for testing.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Checkout PR
1. On one of the listed sites, visit some taxonomy pages - `/category/something` and make sure everything looks good
