### PR TITLE
Remove elasticpress wpcli load abort

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -47,9 +47,6 @@ class Search {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 			require_once __DIR__ . '/commands/class-queuecommand.php';
-
-			// Remove elasticpress command. Need a better way.
-			//WP_CLI::add_hook( 'before_add_command:elasticpress', [ $this, 'abort_elasticpress_add_command' ] );
 		}
 
 		// Load ElasticPress
@@ -1011,13 +1008,6 @@ class Search {
 		$this->current_host_index = $this->current_host_index % count( VIP_ELASTICSEARCH_ENDPOINTS );
 
 		return VIP_ELASTICSEARCH_ENDPOINTS[ $this->current_host_index ];
-	}
-
-	/*
-	 * Hook for WP CLI before_add_command:elasticpress
-	 */
-	public function abort_elasticpress_add_command( $addition ) {
-		$addition->abort( 'elasticpress command aliased to vip-search' );
 	}
 
 	/*


### PR DESCRIPTION
## Description

Warning about the command abort shows on all WP CLI commands on sites with VIP Search enabled, even in production environments.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR.
2. Run a wp command.
3. You shouldn't get `Warning: Aborting the addition of the command 'elasticpress' with reason: elasticpress command aliased to vip-search.`
