### PR TITLE
Enable logs delivery to Elasticsearch debug index for CLI containers

### DIFF
--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -487,7 +487,7 @@ class Logger {
 
 			// Log to file
 			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( $json_data . "\n", 3, '/tmp/logstash.log' );
+			error_log( $json_data . "\n", 3, ( is_dir( '/chroot' ) ? '/chroot' : '' ) . '/tmp/logstash.log' );
 		}
 	}
 


### PR DESCRIPTION
## Description
Currently, logs captured with `\Automattic\VIP\Logstash\Logger::log2logstash()` function within CLI containers don't get delivered to Elasticsearch Vip Go debug index. This happens due to CLI containers not yet running their tasks within a chroot. 
To fix that, the logs file could be forced to be placed within the `/chroot` directory. 

Thanks to @darthhexx for explaining this and providing a solution.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Check out PR.
1. Make sure the `VIP_GO_ENV` is set to `true`.
1. Make sure you have the chroot implemented and `/chroot/tmp/` directory exists. 
1. Enter WP shell `wp shell` and run `\Automattic\VIP\Logstash\Logger::log2logstash(['severity' => 'info', 'feature' => 'test', 'message' => 'hello']);`
1. Confirm the similar output added in the `/chroot/tmp/logstash.log` file:
```
{"site_id":1,"blog_id":1,"host":"","severity":"info","feature":"a8c_vip_test","message":"hello","user_id":0,"extra":"[]","timestamp":"2020-06-18 06:23:28","index":"log2logstash","file":"\/var\/www\/html\/wp-content\/mu-plugins\/logstash\/class-logger.php","line":"401"}
```