### PR TITLE
Stub Cache class, implement Advanced Post Cache compatibility.

### DIFF
--- a/search/includes/classes/class-cache.php
+++ b/search/includes/classes/class-cache.php
@@ -28,7 +28,7 @@ class Cache {
 			return;
 		}
 
-		if ( ! is_a( $query, 'WP_Query' ) ) {
+		if ( 'WP_Query' !== get_class( $query ) ) {
 			return;
 		}
 

--- a/search/includes/classes/class-cache.php
+++ b/search/includes/classes/class-cache.php
@@ -1,0 +1,71 @@
+<?php
+namespace Automattic\VIP\Search;
+
+class Cache {
+	function __construct() {
+		add_action( 'pre_get_posts', array( $this, 'disable_apc_for_ep_enabled_requests' ), 0 );
+	}
+
+	/**
+	 * Advanced Post Cache and ElasticPress do not work well together.
+	 * APC caches post IDs populates the $wp_query->posts by running `get_post` on each cached post id during `posts_request`,
+	 * ElasticPress runs on `posts_pre_query` which fires after `posts_request`. Here we disable APC if this query is offloaded to EP.
+	 * 
+	 *
+	 * On the other hand, if a non-ElasticPress query is run, and we disabled
+	 * Advanced Post Cache earlier, we enable it again, to make use of its caching
+	 * features.
+	 *
+	 *
+	 * @param WP_Query $query The query to examine.
+	 */
+	function disable_apc_for_ep_enabled_requests( &$query ) {
+		global $advanced_post_cache_object;
+
+		static $disabled_apc = false;
+
+		if ( ! is_a( $advanced_post_cache_object, 'Advanced_Post_Cache' ) ) {
+			return;
+		}
+
+		if ( \ElasticPress\Indexables::factory()->get( 'post' )->elasticpress_enabled( $query ) && ! apply_filters( 'ep_skip_query_integration', false, $query ) ) {
+			if ( true === $disabled_apc ) {
+				// Already disabled, don't try again.
+				return;
+			}
+
+			/*
+			* An ElasticPress-enabled query is being run. Disable Advanced Post Cache
+			* entirely.
+			*
+			* Note that there is one action-hook that is not deactivated: The switch_blog
+			* action is not deactivated, because it might be called in-between
+			* ElasticPress-enabled query, and a non-ElasticPress query, and because it
+			* does not have an effect on WP_Query()-results directly.
+			*/
+			remove_filter( 'posts_request', array( $advanced_post_cache_object, 'posts_request' ) );
+			remove_filter( 'posts_results', array( $advanced_post_cache_object, 'posts_results' ) );
+
+			remove_filter( 'post_limits_request', array( $advanced_post_cache_object, 'post_limits_request' ), 999 );
+
+			remove_filter( 'found_posts_query', array( $advanced_post_cache_object, 'found_posts_query' ) );
+			remove_filter( 'found_posts', array( $advanced_post_cache_object, 'found_posts' ) );
+
+			$disabled_apc = true;
+		} else {
+			// A non-ES query.
+			if ( true === $disabled_apc ) {
+				/*
+				* Earlier, we disabled Advanced Post Cache
+				* entirely, but now a non-ElasticPress query is
+				* being run, and in such cases it might be useful
+				* to have the Cache enabled. Here we enable
+				* it again.
+				*/
+				$advanced_post_cache_object->__construct();
+
+				$disabled_apc = false;
+			}
+		}
+	}
+}

--- a/search/includes/classes/class-cache.php
+++ b/search/includes/classes/class-cache.php
@@ -28,6 +28,10 @@ class Cache {
 			return;
 		}
 
+		if ( ! is_a( $query, 'WP_Query' ) ) {
+			return;
+		}
+
 		if ( \ElasticPress\Indexables::factory()->get( 'post' )->elasticpress_enabled( $query ) && ! apply_filters( 'ep_skip_query_integration', false, $query ) ) {
 			if ( true === $disabled_apc ) {
 				// Already disabled, don't try again.

--- a/search/includes/classes/class-cache.php
+++ b/search/includes/classes/class-cache.php
@@ -2,7 +2,7 @@
 namespace Automattic\VIP\Search;
 
 class Cache {
-	function __construct() {
+	public function __construct() {
 		add_action( 'pre_get_posts', array( $this, 'disable_apc_for_ep_enabled_requests' ), 0 );
 	}
 
@@ -19,7 +19,7 @@ class Cache {
 	 *
 	 * @param WP_Query $query The query to examine.
 	 */
-	function disable_apc_for_ep_enabled_requests( &$query ) {
+	public function disable_apc_for_ep_enabled_requests( &$query ) {
 		global $advanced_post_cache_object;
 
 		static $disabled_apc = false;

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -65,6 +65,10 @@ class Search {
 
 		$this->queue = new Queue();
 		$this->queue->init();
+
+		// Caching layer
+		require_once __DIR__ . '/class-cache.php';
+		$this->cache = new Cache();
 	}
 
 	protected function setup_constants() {

--- a/tests/search/includes/classes/test-class-cache.php
+++ b/tests/search/includes/classes/test-class-cache.php
@@ -16,7 +16,8 @@ class Cache_Test extends \WP_UnitTestCase {
 			'found_posts',
 		];
 
-		$this->es = \Automattic\VIP\Search\Search::instance();
+		$this->es = new \Automattic\VIP\Search\Search();
+		$this->es->init();
 		\ElasticPress\register_indexable_posts();
 
 		add_filter( 'ep_skip_query_integration', '__return_false', 100 );

--- a/tests/search/includes/classes/test-class-cache.php
+++ b/tests/search/includes/classes/test-class-cache.php
@@ -1,0 +1,55 @@
+<?php
+namespace Automattic\VIP\Search;
+
+use \WP_Query;
+class Cache_Test extends \WP_UnitTestCase {
+	public function setUp() {
+		global $wpdb;
+		require_once __DIR__ . '/../../../../search/search.php';
+		include_once __DIR__ . '/../../../../advanced-post-cache/advanced-post-cache.php';
+
+		$this->apc_filters = [
+			'posts_request',
+			'posts_results',
+			'post_limits_request',
+			'found_posts_query',
+			'found_posts',
+		];
+
+		$this->es = \Automattic\VIP\Search\Search::instance();
+		\ElasticPress\register_indexable_posts();
+
+		add_filter( 'ep_skip_query_integration', '__return_false', 100 );
+	}
+
+	public function test_apc_compat_pre_get_posts_wired() {
+		$this->assertInternalType( 'int', has_action( 'pre_get_posts', array( $this->es->cache, 'disable_apc_for_ep_enabled_requests' ) ) );
+	}
+
+	public function test_disable_enable_apc() {
+		if ( ! class_exists( 'Advanced_Post_Cache' ) ) {
+			$this->markTestSkipped( 'Advanced Post Cache is not available' );
+		}
+
+		// All of APC's filters should be unhooked for EP queries
+		$q = new WP_Query( [
+			's' => 'test',
+			'ep_integrate' => true,
+		] );
+
+		$filters = array_filter( $this->apc_filters, function( $filter ) { 
+			return false !== has_filter( $filter, [ $GLOBALS['advanced_post_cache_object'], $filter ] );
+		} );
+		
+		$this->assertEmpty( $filters, 'Failed to remove APC filters' );
+
+		// All of APC's filters should be re-enabled for any non-EP query
+		$q = new WP_Query( [ 'posts_per_page' => 10 ] );
+
+		$filters = array_filter( $this->apc_filters, function( $filter ) { 
+			return false !== has_filter( $filter, [ $GLOBALS['advanced_post_cache_object'], $filter ] );
+		} );
+		
+		$this->assertEquals( count( $this->apc_filters ), count( $filters ), 'Failed to re-attach APC filters' );
+	}
+}


### PR DESCRIPTION
## Description

To better handle and tweak any potential cache improvements it was decided to introduce `Automattic\VIP\Search\Cache` class. Currently, it doesn't do much except the Advanced Post Cache compatibility. 

That is, it disables APC for any EP-enabled query. APC disabling is pretty much a copy-pasta from es-wp-query adapters.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Add a breakpoint or a good old `exit('here')` in`Advanced_Post_Cache::posts_request` (advanced-post-cache/advanced-post-cache.php:109)
1. Load the test site with `?s=hello`
1. Verify that breakpoint/exit doesn't fire for the search query.
1. Verify that breakpoint/exit fires for any non-search query.
