### PR TITLE
Set proper global states for Automattic\VIP\Search\Cache_Test

### DIFF
--- a/tests/search/includes/classes/test-class-cache.php
+++ b/tests/search/includes/classes/test-class-cache.php
@@ -2,7 +2,15 @@
 namespace Automattic\VIP\Search;
 
 use \WP_Query;
+
 class Cache_Test extends \WP_UnitTestCase {
+	/**
+	 * Make tests run in separate processes since we're testing state
+	 * related to plugin init, including various constants.
+	 */
+	protected $preserveGlobalState = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+	protected $runTestInSeparateProcess = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+	
 	public function setUp() {
 		global $wpdb;
 		require_once __DIR__ . '/../../../../search/search.php';


### PR DESCRIPTION
## Description

Broken tests were committed to master. Just a minor issue involving global state.

## Steps to Test

1. `~$ ./bin/phpunit-docker.sh`
2. Tests will fail.
3. Pull down PR.
4. `./bin/phpunit-docker.sh`
5. Tests will pass.