### PR TITLE
Only load es wp query when needed

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -218,10 +218,12 @@ class Search {
 
 		// Load es-wp-query, if not already loaded. This is done during plugins_loaded so we don't conflict
 		// with sites that have included this plugin themselves
-		if ( ! class_exists( '\\ES_WP_Query' ) ) {
+		if ( ! class_exists( '\\ES_WP_Query_Shoehorn' ) ) {
 			require_once __DIR__ . '/../../es-wp-query/es-wp-query.php';
 
-			if ( function_exists( 'es_wp_query_load_adapter' ) ) {
+			// If no other adapter has loaded, load ours. This is to prevent fatals (duplicate function/class definitions) if sites
+			// try to load other adapters before ours
+			if ( ! class_exists( '\\ES_WP_Query' ) && function_exists( 'es_wp_query_load_adapter' ) ) {
 				es_wp_query_load_adapter( 'vip-search' );
 			}
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -167,7 +167,7 @@ class Search {
 		add_filter( 'epwr_boost_mode', array( $this, 'filter__epwr_boost_mode' ), 0, 3 );
 
 		// For testing, mirror certain WP_Query's on certain sites
-		if ( $this->is_query_mirroring_enabled() ) {
+		if ( self::is_query_mirroring_enabled() ) {
 			add_filter( 'the_posts', array( $this, 'filter__the_posts' ), 10, 2 );
 			add_action( 'shutdown', array( $this, 'action__shutdown_do_mirrored_wp_queries' ) );
 		}
@@ -241,7 +241,7 @@ class Search {
 		// If this was a regular search page and VIP Search was _not_ used, and if the site is configured to do so,
 		// re-run the same query, but with `es=true`, via JS to test both systems in parallel
 		if ( is_search() && ! isset( $wp_query->elasticsearch_success ) ) {
-			$is_mirroring_enabled = $this->is_query_mirroring_enabled();
+			$is_mirroring_enabled = self::is_query_mirroring_enabled();
 
 			if ( $is_mirroring_enabled ) {
 				add_action( 'shutdown', [ $this, 'do_mirror_search_request' ] );
@@ -249,7 +249,7 @@ class Search {
 		}
 	}
 
-	public function is_query_mirroring_enabled() {
+	public static function is_query_mirroring_enabled() {
 		$is_enabled_by_constant = defined( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING' ) && true === VIP_ENABLE_SEARCH_QUERY_MIRRORING;
 
 		$option_value = get_option( 'vip_enable_search_query_mirroring' );
@@ -296,7 +296,7 @@ class Search {
 		}
 
 		// If mirroring is not enabled at all, skip
-		if ( ! $this->is_query_mirroring_enabled() ) {
+		if ( ! self::is_query_mirroring_enabled() ) {
 			return false;
 		}
 
@@ -361,7 +361,7 @@ class Search {
 	}
 
 	public function action__shutdown_do_mirrored_wp_queries() {
-		if ( ! $this->is_query_mirroring_enabled() ) {
+		if ( ! self::is_query_mirroring_enabled() ) {
 			return;
 		}
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1056,6 +1056,60 @@ class Search_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure we don't load es-wp-query by default (if it's not enabled)
+	 */
+	public function test__should_load_es_wp_query_default() {
+		$should = \Automattic\VIP\Search\Search::should_load_es_wp_query();
+
+		$this->assertFalse( $should );
+	}
+
+	/**
+	 * Ensure we don't load es-wp-query if it is already loaded
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__should_load_es_wp_query_already_loaded() {
+		// To cause should_load_es_wp_query() to otherwise return true
+		define( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING', true );
+
+		require_once __DIR__ . '/../../search/es-wp-query/es-wp-query.php';
+
+		$should = \Automattic\VIP\Search\Search::should_load_es_wp_query();
+
+		$this->assertFalse( $should );
+	}
+
+	/**
+	 * Ensure we do load es-wp-query when mirroring is enabled
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__should_load_es_wp_query_with_query_mirroring() {
+		define( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING', true );
+
+		$should = \Automattic\VIP\Search\Search::should_load_es_wp_query();
+
+		$this->assertTrue( $should );
+	}
+
+	/**
+	 * Ensure we do load es-wp-query when query integration is enabled
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__should_load_es_wp_query_query_integration() {
+		define( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION', true );
+
+		$should = \Automattic\VIP\Search\Search::should_load_es_wp_query();
+
+		$this->assertTrue( $should );
+	}
+
+	/**
 	 * Ensure the incrementor for tracking request counts behaves properly
 	 */
 	public function test__query_count_incr() {

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1073,9 +1073,7 @@ class Search_Test extends \WP_UnitTestCase {
 	}
 
 	public function test__is_query_mirroring_enabled_no_constant_no_option() {
-		$es = new \Automattic\VIP\Search\Search();
-		
-		$enabled = $es->is_query_mirroring_enabled();
+		$enabled = \Automattic\VIP\Search\Search::is_query_mirroring_enabled();
 
 		$this->assertFalse( $enabled );
 	}
@@ -1086,10 +1084,8 @@ class Search_Test extends \WP_UnitTestCase {
 	 */
 	public function test__is_query_mirroring_enabled_via_option() {
 		update_option( 'vip_enable_search_query_mirroring', true );
-
-		$es = new \Automattic\VIP\Search\Search();
 		
-		$enabled = $es->is_query_mirroring_enabled();
+		$enabled = \Automattic\VIP\Search\Search::is_query_mirroring_enabled();
 
 		delete_option( 'vip_enable_search_query_mirroring' );
 
@@ -1102,10 +1098,8 @@ class Search_Test extends \WP_UnitTestCase {
 	 */
 	public function test__is_query_mirroring_enabled_with_option_false() {
 		update_option( 'vip_enable_search_query_mirroring', false );
-
-		$es = new \Automattic\VIP\Search\Search();
 		
-		$enabled = $es->is_query_mirroring_enabled();
+		$enabled = \Automattic\VIP\Search\Search::is_query_mirroring_enabled();
 
 		delete_option( 'vip_enable_search_query_mirroring' );
 
@@ -1118,10 +1112,8 @@ class Search_Test extends \WP_UnitTestCase {
 	 */
 	public function test__is_query_mirroring_enabled_via_constant() {
 		define( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING', true );
-
-		$es = new \Automattic\VIP\Search\Search();
 		
-		$enabled = $es->is_query_mirroring_enabled();
+		$enabled = \Automattic\VIP\Search\Search::is_query_mirroring_enabled();
 
 		$this->assertTrue( $enabled );
 	}
@@ -1132,10 +1124,8 @@ class Search_Test extends \WP_UnitTestCase {
 	 */
 	public function test__is_query_mirroring_enabled_with_constant_false() {
 		define( 'VIP_ENABLE_SEARCH_QUERY_MIRRORING', false );
-
-		$es = new \Automattic\VIP\Search\Search();
 		
-		$enabled = $es->is_query_mirroring_enabled();
+		$enabled = \Automattic\VIP\Search\Search::is_query_mirroring_enabled();
 
 		$this->assertFalse( $enabled );
 	}


### PR DESCRIPTION
## Description

Modifies how we load es-wp-query so that we only load it if query integration or query mirroring are enabled. This lets us enable Search on sites that are still using es-wp-query with other adapters, to get content indexed and evaluated before disabling the other adapter.

This refactors the es-wp-query loading logic into a standalone function with tests.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Run some regular queries, like `?s=test` (should not break anything)
1. With query mirroring and integration disabled, try offloading a WP_Query with `'es' => true` in the args...it should not hit ES
1. Enable query mirroring or integration and repeat, it _should_ now hit ES
