### PR TITLE
Only send inconsistency alert in IRC in case it spans over two healthchecks.

### DIFF
--- a/search/includes/classes/class-cache.php
+++ b/search/includes/classes/class-cache.php
@@ -2,6 +2,8 @@
 namespace Automattic\VIP\Search;
 
 class Cache {
+	const CACHE_GROUP_KEY = 'vip-search';
+
 	public function __construct() {
 		add_action( 'pre_get_posts', array( $this, 'disable_apc_for_ep_enabled_requests' ), 0 );
 	}

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -171,7 +171,7 @@ class HealthJob {
 		// We only want to send an alert if a consistency check didn't correct itself in two intervals.
 		if ( $type ) {
 			$cache_key = "healthcheck_alert_seen:{$type}";
-			if ( false === wp_cache_get( $cache_key, 'vip-search' ) ) {
+			if ( false === wp_cache_get( $cache_key, Cache::CACHE_GROUP_KEY ) ) {
 				wp_cache_set( $cache_key, 1, Cache::CACHE_GROUP_KEY, round( self::CRON_INTERVAL * 1.5 ) );
 				return false;
 			}

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -150,7 +150,7 @@ class HealthJob {
 					$result[ 'diff' ]
 				);
 
-				$this->send_alert( '#vip-go-es-alerts', $message, 2, $result['type'] );
+				$this->send_alert( '#vip-go-es-alerts', $message, 2, "{$result['entity']}:{$result['type']}" );
 			}
 		}
 	}

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -170,13 +170,13 @@ class HealthJob {
 	public function send_alert( $channel, $message, $level, $type = '' ) {
 		// We only want to send an alert if a consistency check didn't correct itself in two intervals.
 		if ( $type ) {
-			$cache_key = "healthcheck:{$type}";
+			$cache_key = "healthcheck_alert_seen:{$type}";
 			if ( false === wp_cache_get( $cache_key, 'vip-search' ) ) {
-				wp_cache_set( $cache_key, 1, 'vip-search', self::CRON_INTERVAL * 2 );
+				wp_cache_set( $cache_key, 1, Cache::CACHE_GROUP_KEY, round( self::CRON_INTERVAL * 1.5 ) );
 				return false;
 			}
 
-			wp_cache_delete( $cache_key, 'vip-search' );
+			wp_cache_delete( $cache_key, Cache::CACHE_GROUP_KEY );
 		}
 
 		return wpcom_vip_irc( $channel, $message, $level );

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -103,7 +103,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 						$results[0]['diff']
 					),
 					2,
-					$results[0]['type'],
+					"{$results[0]['entity']}:{$results[0]['type']}",
 				),
 				array(
 					'#vip-go-es-alerts',
@@ -117,7 +117,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 						$results[1]['diff']
 					),
 					2,
-					$results[1]['type'],
+					"{$results[1]['entity']}:{$results[1]['type']}",
 				),
 				// NOTE - we've skipped the 3rd result here b/c it has a diff of 0 and shouldn't alert
 				array(

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -102,7 +102,8 @@ class HealthJob_Test extends \WP_UnitTestCase {
 						$results[ 0 ][ 'es_total' ],
 						$results[ 0 ][ 'diff' ]
 					),
-					2
+					2,
+					$results[ 0 ][ 'type' ],
 				),
 				array(
 					'#vip-go-es-alerts',
@@ -115,7 +116,8 @@ class HealthJob_Test extends \WP_UnitTestCase {
 						$results[ 1 ][ 'es_total' ],
 						$results[ 1 ][ 'diff' ]
 					),
-					2
+					2,
+					$results[ 1 ][ 'type' ],
 				),
 				// NOTE - we've skipped the 3rd result here b/c it has a diff of 0 and shouldn't alert
 				array(

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -96,28 +96,28 @@ class HealthJob_Test extends \WP_UnitTestCase {
 					sprintf(
 						'Index inconsistencies found for %s: (entity: %s, type: %s, DB count: %s, ES count: %s, Diff: %s)',
 						home_url(),
-						$results[ 0 ][ 'entity' ],
-						$results[ 0 ][ 'type' ],
-						$results[ 0 ][ 'db_total' ],
-						$results[ 0 ][ 'es_total' ],
-						$results[ 0 ][ 'diff' ]
+						$results[0]['entity'],
+						$results[0]['type'],
+						$results[0]['db_total'],
+						$results[0]['es_total'],
+						$results[0]['diff']
 					),
 					2,
-					$results[ 0 ][ 'type' ],
+					$results[0]['type'],
 				),
 				array(
 					'#vip-go-es-alerts',
 					sprintf(
 						'Index inconsistencies found for %s: (entity: %s, type: %s, DB count: %s, ES count: %s, Diff: %s)',
 						home_url(),
-						$results[ 1 ][ 'entity' ],
-						$results[ 1 ][ 'type' ],
-						$results[ 1 ][ 'db_total' ],
-						$results[ 1 ][ 'es_total' ],
-						$results[ 1 ][ 'diff' ]
+						$results[1]['entity'],
+						$results[1]['type'],
+						$results[1]['db_total'],
+						$results[1]['es_total'],
+						$results[1]['diff']
 					),
 					2,
-					$results[ 1 ][ 'type' ],
+					$results[1]['type'],
 				),
 				// NOTE - we've skipped the 3rd result here b/c it has a diff of 0 and shouldn't alert
 				array(


### PR DESCRIPTION
## Description

To decrease alerting noise we should only alert when an index inconsistency persists across at least two intervals.
