### PR TITLE
Add ending IRC notification for encloseme cleanup

### DIFF
--- a/lib/class-vip-encloseme-cleanup.php
+++ b/lib/class-vip-encloseme-cleanup.php
@@ -61,6 +61,7 @@ class VIP_Encloseme_Cleanup {
 
 		wpcom_vip_irc( '#vip-go-encloseme-meta-cleanup', sprintf( 'Starting _encloseme meta cleanup for %s.', get_site_url() ) );
 
+        $total = 0;
 		for ( $count = 0; $count < 10; $count++ ) {
 			if ( ! defined( 'ENABLE_VIP_ENCLOSEME_CLEANUP_ENV' ) ) { // Constant not set, bail.
 				break;
@@ -81,8 +82,12 @@ class VIP_Encloseme_Cleanup {
 			foreach ( $pids as $pid ) {
 				delete_post_meta( $pid[0], '_encloseme' );
 			}
+
+            $total += count( $pids );
 	
 			sleep( 3 );
 		} 
+
+		wpcom_vip_irc( '#vip-go-encloseme-meta-cleanup', sprintf( 'Deleted %s _encloseme meta entries for %s.', $total, get_site_url() ) );
 	}
 }

--- a/lib/class-vip-encloseme-cleanup.php
+++ b/lib/class-vip-encloseme-cleanup.php
@@ -61,7 +61,7 @@ class VIP_Encloseme_Cleanup {
 
 		wpcom_vip_irc( '#vip-go-encloseme-meta-cleanup', sprintf( 'Starting _encloseme meta cleanup for %s.', get_site_url() ) );
 
-        $total = 0;
+		$total = 0;
 		for ( $count = 0; $count < 10; $count++ ) {
 			if ( ! defined( 'ENABLE_VIP_ENCLOSEME_CLEANUP_ENV' ) ) { // Constant not set, bail.
 				break;
@@ -83,7 +83,7 @@ class VIP_Encloseme_Cleanup {
 				delete_post_meta( $pid[0], '_encloseme' );
 			}
 
-            $total += count( $pids );
+			$total += count( $pids );
 	
 			sleep( 3 );
 		} 


### PR DESCRIPTION
## Description

Add an additional IRC alert notification for when the cleanup job has ended a round of meta deletions.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Upload to sandboxed site
1. Add `define( 'ENABLE_VIP_ENCLOSEME_CLEANUP_ENV', true);` to `vip-config.php`
1. `wp cron-control events list`
1. Ensure that the cleanup job is in the list of cron events.
