### PR TITLE
Fixes filtering the photon domain with a scheme mismatch

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -1001,16 +1001,19 @@ class A8C_Files_Utils {
 	public static function filter_photon_domain( $photon_url, $image_url ) {
 			$home_url = home_url();
 			$site_url = site_url();
+		
+			$image_url_parsed = parse_url( $image_url );
+			$home_url_parsed = parse_url( $home_url );
+			$site_url_parsed = parse_url( $site_url );
 
-			if ( wp_startswith( $image_url, $home_url ) ) {
+			if ( $image_url_parsed[ 'host' ] === $home_url_parsed[ 'host' ] ) {
 				return $home_url;
 			}
 
-			if ( wp_startswith( $image_url, $site_url ) ) {
+			if ( $image_url_parsed[ 'host' ] === $site_url_parsed[ 'host' ] ) {
 				return $site_url;
 			}
 
-			$image_url_parsed = parse_url( $image_url );
 			if ( wp_endswith( $image_url_parsed['host'], '.go-vip.co' ) || wp_endswith( $image_url_parsed['host'], '.go-vip.net' ) ) {
 				return $image_url_parsed['scheme'] . '://' . $image_url_parsed['host'];
 			}

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -999,26 +999,26 @@ class A8C_Files {
 
 class A8C_Files_Utils {
 	public static function filter_photon_domain( $photon_url, $image_url ) {
-			$home_url = home_url();
-			$site_url = site_url();
-		
-			$image_url_parsed = parse_url( $image_url );
-			$home_url_parsed = parse_url( $home_url );
-			$site_url_parsed = parse_url( $site_url );
+		$home_url = home_url();
+		$site_url = site_url();
 
-			if ( $image_url_parsed[ 'host' ] === $home_url_parsed[ 'host' ] ) {
-				return $home_url;
-			}
+		$image_url_parsed = parse_url( $image_url );
+		$home_url_parsed = parse_url( $home_url );
+		$site_url_parsed = parse_url( $site_url );
 
-			if ( $image_url_parsed[ 'host' ] === $site_url_parsed[ 'host' ] ) {
-				return $site_url;
-			}
+		if ( $image_url_parsed['host'] === $home_url_parsed['host'] ) {
+			return $home_url;
+		}
 
-			if ( wp_endswith( $image_url_parsed['host'], '.go-vip.co' ) || wp_endswith( $image_url_parsed['host'], '.go-vip.net' ) ) {
-				return $image_url_parsed['scheme'] . '://' . $image_url_parsed['host'];
-			}
+		if ( $image_url_parsed['host'] === $site_url_parsed['host'] ) {
+			return $site_url;
+		}
 
-			return $photon_url;
+		if ( wp_endswith( $image_url_parsed['host'], '.go-vip.co' ) || wp_endswith( $image_url_parsed['host'], '.go-vip.net' ) ) {
+			return $image_url_parsed['scheme'] . '://' . $image_url_parsed['host'];
+		}
+
+		return $photon_url;
 	}
 
 	public static function strip_dimensions_from_url_path( $url ) {


### PR DESCRIPTION
If the home_url is `https://...` and the site loads on `http://...`, we offload to Photon erroneously. The goal here is just to ensure that the image is indeed hosted on this site, so a simple host match should suffice.