### PR TITLE
Add vip_search_post_taxonomies_allow_list filter

### DIFF
--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -14,7 +14,6 @@ class Search_Test extends \WP_UnitTestCase {
 		require_once __DIR__ . '/../../search/search.php';
 
 		$this->search_instance = new \Automattic\VIP\Search\Search();
-		$this->search_instance->init();
 	}
 
 	public function test_query_es_with_invalid_type() {

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -14,6 +14,7 @@ class Search_Test extends \WP_UnitTestCase {
 		require_once __DIR__ . '/../../search/search.php';
 
 		$this->search_instance = new \Automattic\VIP\Search\Search();
+		$this->search_instance->init();
 	}
 
 	public function test_query_es_with_invalid_type() {

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1572,6 +1572,9 @@ class Search_Test extends \WP_UnitTestCase {
 	 * @dataProvider get_filter__ep_sync_taxonomies_default_data
 	 */
 	public function test__filter__ep_sync_taxonomies_default( $input_taxonomies ) {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
 		$post = new \stdClass();
 
 		$filtered_taxonomies = apply_filters( 'ep_sync_taxonomies', $input_taxonomies, $post );
@@ -1588,6 +1591,9 @@ class Search_Test extends \WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__filter__ep_sync_taxonomies_added() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
 		$post = new \stdClass();
 
 		$start_taxonomies = array(
@@ -1625,6 +1631,9 @@ class Search_Test extends \WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__filter__ep_sync_taxonomies_removed() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
 		$post = new \stdClass();
 
 		$start_taxonomies = array(

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1542,6 +1542,119 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( 787, apply_filters( 'ep_total_field_limit', 5000 ) );
 	}
+
+	public function get_filter__ep_sync_taxonomies_default_data() {
+		return array(
+			array(
+				array(),
+			),
+			array(
+				array(
+					(object) array(
+						'name' => 'category',
+					),
+				),
+			),
+			array(
+				array(
+					(object) array(
+						'name' => 'category',
+					),
+					(object) array(
+						'name' => 'post_tag',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_filter__ep_sync_taxonomies_default_data
+	 */
+	public function test__filter__ep_sync_taxonomies_default( $input_taxonomies ) {
+		$post = new \stdClass();
+
+		$filtered_taxonomies = apply_filters( 'ep_sync_taxonomies', $input_taxonomies, $post );
+
+		$input_taxonomy_names = wp_list_pluck( $input_taxonomies, 'name' );
+		$filtered_taxonomy_names = wp_list_pluck( $filtered_taxonomies, 'name' );
+
+		// No change expected
+		$this->assertEquals( $input_taxonomy_names, $filtered_taxonomy_names );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__filter__ep_sync_taxonomies_added() {
+		$post = new \stdClass();
+
+		$start_taxonomies = array(
+			(object) array(
+				'name' => 'category',
+			),
+		);
+
+		\add_filter(
+			'vip_search_post_taxonomies_allow_list',
+			function( $taxonomies ) {
+				$taxonomies[] = 'post_tag';
+				$taxonomies[] = 'post_tag';
+
+				return $taxonomies;
+			}
+		);
+
+		$filtered_taxonomies = apply_filters( 'ep_sync_taxonomies', $start_taxonomies, $post );
+
+		// Pull out just the names, for easier comparison
+		$filtered_taxonomy_names = wp_list_pluck( $filtered_taxonomies, 'name' );
+
+		$expected_taxonomy_names = array(
+			'category',
+			'post_tag',
+		);
+
+		// Should now include the additional taxonomies
+		$this->assertEquals( $expected_taxonomy_names, $filtered_taxonomy_names );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__filter__ep_sync_taxonomies_removed() {
+		$post = new \stdClass();
+
+		$start_taxonomies = array(
+			(object) array(
+				'name' => 'category',
+			),
+			(object) array(
+				'name' => 'post_tag',
+			),
+		);
+
+		\add_filter(
+			'vip_search_post_taxonomies_allow_list',
+			function( $taxonomies ) {
+				return array( 'post_tag' );
+			}
+		);
+
+		$filtered_taxonomies = apply_filters( 'ep_sync_taxonomies', $start_taxonomies, $post );
+
+		// Pull out just the names, for easier comparison
+		$filtered_taxonomy_names = wp_list_pluck( $filtered_taxonomies, 'name' );
+
+		$expected_taxonomy_names = array(
+			'post_tag',
+		);
+
+		// Should now not include the removed taxonomies
+		$this->assertEquals( $expected_taxonomy_names, $filtered_taxonomy_names );
+	}
 	
 	/**
 	 * @runInSeparateProcess


### PR DESCRIPTION
## Description

The new `vip_search_post_taxonomies_allow_list` filter is a more convenient way to define which taxonomies are allowed to be indexed for a post. Compared to `ep_sync_taxonomies`, which is an array of taxonomy objects, the new filter is an array of taxonomy names, which is easier to add/remove from (no traversing the list to see if a taxonomy is or isn't already included).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR
1. Implement `vip_search_taxonomies_allow_list`- `add_filter( 'vip_search_taxonomies_allow_list, function( $taxonomies ) { return array( 'category' ); } );`
1. Index some content (can just edit a post)
1. Check that post in the index (`\ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id )` - that document should only have the `category` terms, and not any `post_tag` terms
