### PR TITLE
Prevent Woocommerce logs from being written to the Files Service

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -98,6 +98,13 @@ if ( false !== VIP_GO_ENV ) {
 define( 'WPCOM_VIP_PRIVATE_DIR', $private_dir_path );
 unset( $private_dir_path );
 
+if ( ! defined( 'WC_LOG_DIR' ) ) {
+	/**
+	 * @constant WC_LOG_DIR Write Woocommerce logs to the /tmp directory to prevent them from being copied to the Files Service
+	 */
+	define( 'WC_LOG_DIR', '/tmp' );
+}
+
 // Define these values just in case
 defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) or define( 'WPCOM_VIP_MACHINE_USER_LOGIN', 'vip' );
 defined( 'WPCOM_VIP_MACHINE_USER_NAME' )  or define( 'WPCOM_VIP_MACHINE_USER_NAME', 'VIP' );

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -98,13 +98,6 @@ if ( false !== VIP_GO_ENV ) {
 define( 'WPCOM_VIP_PRIVATE_DIR', $private_dir_path );
 unset( $private_dir_path );
 
-if ( ! defined( 'WC_LOG_DIR' ) ) {
-	/**
-	 * @constant WC_LOG_DIR Write Woocommerce logs to the /tmp directory to prevent them from being copied to the Files Service
-	 */
-	define( 'WC_LOG_DIR', '/tmp' );
-}
-
 // Define these values just in case
 defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) or define( 'WPCOM_VIP_MACHINE_USER_LOGIN', 'vip' );
 defined( 'WPCOM_VIP_MACHINE_USER_NAME' )  or define( 'WPCOM_VIP_MACHINE_USER_NAME', 'VIP' );

--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -19,6 +19,16 @@ if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) ) {
 }
 
 /**
+ * Woocommerce log location
+ *
+ * @constant WC_LOG_DIR Write Woocommerce logs to the /tmp directory to prevent
+ * them from being copied to the Files Service.
+ */
+if ( ! defined( 'WC_LOG_DIR' ) ) {
+	define( 'WC_LOG_DIR', '/tmp' );
+}
+
+/**
  * AMP for WordPress (https://github.com/ampproject/amp-wp)
  * Make sure the `amp` query var has an explicit value.
  * Avoids issues when filtering the deprecated `query_string` hook.


### PR DESCRIPTION
By default the WC log location is in the uploads directory, which is copied to the Files Service on VIP Go. The Files Service is not an appropriate location for logs because files are public and each new log line creates a new copy of the previous file along with the new line. We'll need to follow up with a way to clean up these files at end up in the /tmp directory.