### PR TITLE
Return error codes for failed login attempts

### DIFF
--- a/security.php
+++ b/security.php
@@ -53,6 +53,7 @@ function wpcom_vip_track_auth_attempt( $username, $cache_group, $cache_expiry ) 
 }
 
 function wpcom_vip_login_limiter( $username ) {
+	http_response_code( 403 );
 	wpcom_vip_track_auth_attempt( $username, CACHE_GROUP_LOGIN_LIMIT, MINUTE_IN_SECONDS * 5 );
 }
 add_action( 'wp_login_failed', 'wpcom_vip_login_limiter' );
@@ -114,6 +115,7 @@ function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
 	}
 
 	if ( is_wp_error( $login_limit_error ) ) {
+		http_response_code( 429 );
 		return new IXR_Error( 429, $login_limit_error->get_error_message() );
 	}
 


### PR DESCRIPTION
We should return 403 for failed XMLRPC login attempts and 429 after the rate limit kicks in. By default the response codes is 200 in both of these situations. Using the proper codes will make it easier to limit abuse at various levels of the stack.

I tested by attempting to login via xmlrpc with the wrong username and password. The first attempts get the 403 response code. The 429 code correctly comes in after the rate limit has been exceeded. I haven't seen any issues with headers already being sent.

I also tested the regular login page just to make sure there were no new issues there and it still works as expected.