### PR TITLE
Added statsd gauge for post index current field count

### DIFF
--- a/search/includes/classes/class-fieldcountgaugejob.php
+++ b/search/includes/classes/class-fieldcountgaugejob.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Search;
 
+require_once( __DIR__ . '/../../../config/class-sync.php' );
+
 class FieldCountGaugeJob {
 	const CRON_EVENT_NAME = 'vip_config_sync_cron';
 

--- a/search/includes/classes/class-fieldcountgaugejob.php
+++ b/search/includes/classes/class-fieldcountgaugejob.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+class FieldCountGaugeJob {
+	/**
+	 * The name of the scheduled cron event to run the gauge setting
+	 */
+	const CRON_EVENT_NAME = 'vip_search_field_count_gauge_set';
+
+	/**
+	 * Custom cron interval name
+	 */
+	const CRON_INTERVAL_NAME = 'vip_search_field_count_gauge_interval';
+
+	/**
+	 * Custom cron interval value
+	 */
+	const CRON_INTERVAL = 1 * \DAY_IN_SECONDS; // 30 minutes in seconds
+
+	const FIELD_COUNT_GAUGE_DISABLED_SITES = array();
+
+	/**
+	 * Initialize the job class
+	 *
+	 * @access public
+	 */
+	public function init() {
+		// We always add this action so that the job can unregister itself if it no longer should be running
+		add_action( self::CRON_EVENT_NAME, [ $this, 'set_field_count_gauge' ] );
+
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		// Add the custom cron schedule
+		add_filter( 'cron_schedules', [ $this, 'filter_cron_schedules' ], 10, 1 );
+
+		$this->schedule_job();
+	}
+
+	/**
+	 * Schedule health check job
+	 *
+	 * Add the event name to WP cron schedule and then add the action
+	 */
+	public function schedule_job() {
+		if ( ! \wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
+			\wp_schedule_event( time(), self::CRON_INTERVAL_NAME, self::CRON_EVENT_NAME );
+		}
+	}
+
+	/**
+	 * Disable health check job
+	 *
+	 * Remove the ES health check job from the events list
+	 */
+	public function disable_job() {
+		if ( \wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
+			\wp_clear_scheduled_hook( self::CRON_EVENT_NAME );
+		}
+	}
+
+	/**
+	 * Filter `cron_schedules` output
+	 *
+	 * Add the custom interval to WP cron schedule
+	 *
+	 * @param array $schedule
+	 *
+	 * @return mixed
+	 */
+	public function filter_cron_schedules( $schedule ) {
+		if ( isset( $schedule[ self::CRON_INTERVAL_NAME ] ) ) {
+			return $schedule;
+		}
+
+		$schedule[ self::CRON_INTERVAL_NAME ] = [
+			'interval' => self::CRON_INTERVAL,
+			'display' => __( 'VIP Search set field count gauge time interval' ),
+		];
+
+		return $schedule;
+	}
+
+	/**
+	 * Is health check job enabled
+	 *
+	 * @return bool True if job is enabled. Else, false
+	 */
+	public function is_enabled() {
+		if ( defined( 'DISABLE_VIP_SEARCH_FIELD_COUNT_GAUGE' ) && true === DISABLE_VIP_SEARCH_FIELD_COUNT_GAUGE ) {
+			return false;
+		}
+
+		if ( defined( 'VIP_GO_APP_ID' ) ) {
+			if ( in_array( VIP_GO_APP_ID, self::FIELD_COUNT_GAUGE_DISABLED_SITES, true ) ) {
+				return false;
+			}
+		}
+
+		$enabled_environments = apply_filters( 'vip_search_field_count_gauge_enabled_environments', array( 'production' ) );
+
+		$enabled = in_array( VIP_GO_ENV, $enabled_environments, true );
+
+		// Don't run the checks if the index is not built.
+		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {
+			$enabled = false;
+		}
+
+		/**
+		 * Filter whether to enable VIP search healthcheck
+		 *
+		 * @param bool $enable True to enable the healthcheck cron job
+		 */
+		return apply_filters( 'enable_vip_search_field_count_gauge', $enabled );
+	}
+
+	/**
+	 * Set the field count gauge for posts for the current site 
+	 */
+	public function set_field_count_gauge() {
+		\Automattic\VIP\Search\Search::instance()->set_field_count_gauge();
+	}
+}

--- a/search/includes/classes/class-fieldcountgaugejob.php
+++ b/search/includes/classes/class-fieldcountgaugejob.php
@@ -9,7 +9,7 @@ class FieldCountGaugeJob {
 
 	public function init() {
 		// We always add this action so that the job can unregister itself if it no longer should be running
-		add_action( self::CRON_EVENT_NAME, [ $this, 'set_field_count_gauge' ] );
+		add_action( \Automattic\VIP\Config\Sync::CRON_EVENT_NAME, [ $this, 'set_field_count_gauge' ] );
 	}
 
 	/**

--- a/search/includes/classes/class-fieldcountgaugejob.php
+++ b/search/includes/classes/class-fieldcountgaugejob.php
@@ -3,117 +3,13 @@
 namespace Automattic\VIP\Search;
 
 class FieldCountGaugeJob {
-	/**
-	 * The name of the scheduled cron event to run the gauge setting
-	 */
-	const CRON_EVENT_NAME = 'vip_search_field_count_gauge_set';
-
-	/**
-	 * Custom cron interval name
-	 */
-	const CRON_INTERVAL_NAME = 'vip_search_field_count_gauge_interval';
-
-	/**
-	 * Custom cron interval value
-	 */
-	const CRON_INTERVAL = 1 * \DAY_IN_SECONDS; // 30 minutes in seconds
+	const CRON_EVENT_NAME = 'vip_config_sync_cron';
 
 	const FIELD_COUNT_GAUGE_DISABLED_SITES = array();
 
-	/**
-	 * Initialize the job class
-	 *
-	 * @access public
-	 */
 	public function init() {
 		// We always add this action so that the job can unregister itself if it no longer should be running
 		add_action( self::CRON_EVENT_NAME, [ $this, 'set_field_count_gauge' ] );
-
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-
-		// Add the custom cron schedule
-		add_filter( 'cron_schedules', [ $this, 'filter_cron_schedules' ], 10, 1 );
-
-		$this->schedule_job();
-	}
-
-	/**
-	 * Schedule health check job
-	 *
-	 * Add the event name to WP cron schedule and then add the action
-	 */
-	public function schedule_job() {
-		if ( ! \wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
-			\wp_schedule_event( time(), self::CRON_INTERVAL_NAME, self::CRON_EVENT_NAME );
-		}
-	}
-
-	/**
-	 * Disable health check job
-	 *
-	 * Remove the ES health check job from the events list
-	 */
-	public function disable_job() {
-		if ( \wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
-			\wp_clear_scheduled_hook( self::CRON_EVENT_NAME );
-		}
-	}
-
-	/**
-	 * Filter `cron_schedules` output
-	 *
-	 * Add the custom interval to WP cron schedule
-	 *
-	 * @param array $schedule
-	 *
-	 * @return mixed
-	 */
-	public function filter_cron_schedules( $schedule ) {
-		if ( isset( $schedule[ self::CRON_INTERVAL_NAME ] ) ) {
-			return $schedule;
-		}
-
-		$schedule[ self::CRON_INTERVAL_NAME ] = [
-			'interval' => self::CRON_INTERVAL,
-			'display' => __( 'VIP Search set field count gauge time interval' ),
-		];
-
-		return $schedule;
-	}
-
-	/**
-	 * Is health check job enabled
-	 *
-	 * @return bool True if job is enabled. Else, false
-	 */
-	public function is_enabled() {
-		if ( defined( 'DISABLE_VIP_SEARCH_FIELD_COUNT_GAUGE' ) && true === DISABLE_VIP_SEARCH_FIELD_COUNT_GAUGE ) {
-			return false;
-		}
-
-		if ( defined( 'VIP_GO_APP_ID' ) ) {
-			if ( in_array( VIP_GO_APP_ID, self::FIELD_COUNT_GAUGE_DISABLED_SITES, true ) ) {
-				return false;
-			}
-		}
-
-		$enabled_environments = apply_filters( 'vip_search_field_count_gauge_enabled_environments', array( 'production' ) );
-
-		$enabled = in_array( VIP_GO_ENV, $enabled_environments, true );
-
-		// Don't run the checks if the index is not built.
-		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {
-			$enabled = false;
-		}
-
-		/**
-		 * Filter whether to enable VIP search healthcheck
-		 *
-		 * @param bool $enable True to enable the healthcheck cron job
-		 */
-		return apply_filters( 'enable_vip_search_field_count_gauge', $enabled );
 	}
 
 	/**

--- a/search/includes/classes/class-fieldcountgaugejob.php
+++ b/search/includes/classes/class-fieldcountgaugejob.php
@@ -5,8 +5,6 @@ namespace Automattic\VIP\Search;
 class FieldCountGaugeJob {
 	const CRON_EVENT_NAME = 'vip_config_sync_cron';
 
-	const FIELD_COUNT_GAUGE_DISABLED_SITES = array();
-
 	public function init() {
 		// We always add this action so that the job can unregister itself if it no longer should be running
 		add_action( \Automattic\VIP\Config\Sync::CRON_EVENT_NAME, [ $this, 'set_field_count_gauge' ] );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -219,7 +219,7 @@ class Search {
 		add_action( 'init', [ $this->healthcheck, 'init' ] );
 	}
 
-	protected function setup_regular_stat_collection() {/
+	protected function setup_regular_stat_collection() {
 		$this->field_count_gauge = new FieldCountGaugeJob();
 		$this->field_count_gauge->init();
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -215,9 +215,7 @@ class Search {
 
 	protected function setup_regular_stat_collection() {
 		$this->field_count_gauge = new FieldCountGaugeJob();
-
-		// Hook into init action to ensure cron-control has already been loaded
-		add_action( 'init', array( $this->field_count_gauge, 'init' ) );
+		$this->field_count_gauge->init();
 	}
 
 	public function query_es( $type, $es_args = array(), $wp_query_args = array(), $index_name = null ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -6,6 +6,7 @@ use \WP_CLI;
 
 class Search {
 	public $healthcheck;
+	public $field_count_gauge;
 	public $queue;
 	private $mirrored_wp_query_queue = array();
 	private $current_host_index = 0;
@@ -37,6 +38,7 @@ class Search {
 		$this->load_dependencies();
 		$this->load_commands();
 		$this->setup_healthchecks();
+		$this->setup_regular_stat_collection();
 	}
 
 	public static function instance() {
@@ -65,6 +67,9 @@ class Search {
 
 		// Load health check cron job
 		require_once __DIR__ . '/class-health-job.php';
+
+		// Load field count gauge cron job
+		require_once __DIR__ . '/class-fieldcountgaugejob.php';
 
 		// Load our custom dashboard
 		require_once __DIR__ . '/class-dashboard.php';
@@ -206,6 +211,13 @@ class Search {
 	
 		// Hook into init action to ensure cron-control has already been loaded
 		add_action( 'init', [ $this->healthcheck, 'init' ] );
+	}
+
+	protected function setup_regular_stat_collection() {
+		$this->field_count_gauge = new FieldCountGaugeJob();
+
+		// Hook into init action to ensure cron-control has already been loaded
+		add_action( 'init', array( $this->field_count_gauge, 'init' ) );
 	}
 
 	public function query_es( $type, $es_args = array(), $wp_query_args = array(), $index_name = null ) {
@@ -708,6 +720,76 @@ class Search {
 
 		$statsd->increment( $stat );
 		$statsd->increment( $per_site_stat );
+	}
+
+	/**
+	 * Set a gauge in statsd with the field count of the sites post index
+	 */
+	public function set_field_count_gauge() {
+		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
+
+		if ( ! $indexable ) {
+			return;
+		}
+
+		$current_field_count = $this->get_current_field_count( $indexable );
+
+		if ( is_null( $current_field_count ) ) {
+			return;
+		}
+
+		$statsd_mode = 'field_count';
+		$statsd_index_name = $indexable->get_index_name();
+
+		$url = $this->get_current_host();
+		$per_site_stat = $this->get_statsd_prefix( $url, $statsd_mode, FILES_CLIENT_SITE_ID, $statsd_index_name );
+
+		$statsd = new \Automattic\VIP\StatsD();
+
+		$statsd->gauge( $per_site_stat, $current_field_count );
+	}
+
+	/**
+	 * Get the current field count of an indexable
+	 *
+	 * @param {\ElasticPress\Indexable} $indexable The indexable you want to get the current index field count of
+	 * @return {null|int} The current field count
+	 */
+	public function get_current_field_count( \ElasticPress\Indexable $indexable ) {
+		if ( ! $indexable ) {
+			return;
+		}
+
+		$index_name = $indexable->get_index_name();
+		$path = "$index_name/_mapping";
+
+		// Send a request to get all current mappings
+		$raw = \ElasticPress\Elasticsearch::factory()->remote_request( $path );
+
+		// Elasticsearch responses are in JSON
+		$body = json_decode( $raw['body'], true );
+
+		// If JSON wasn't parsed correctly
+		if ( ! is_array( $body ) || empty( $body ) ) {
+			return;
+		}
+
+		// If JSON structure indicates an error
+		if ( array_key_exists( 'error', $body ) ) {
+			return;
+		}
+
+		$fields = array();
+
+		// The occurrences of 'type' in the results is equal to the number of fields in use.
+		// Since the assoc array can be pretty deeply nested, array_walk_recursive and a type check was used
+		array_walk_recursive( $body, function( $value, $key, $fields ) {
+			if ( 'type' === $key ) {
+				array_push( $fields[0], $key ); // Why reference to [0]? It doesn't want to work otherwise presently.
+			}
+		}, array( &$fields ) );
+
+		return count( $fields );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Need to keep track of field counts in Elasticsearch so we can add an alert if someone exceeds it.

Added a custom interval so it can be adjusted easily. Chose to update each day right now as it shouldn't change too frequently with the post meta allow list for indexing in place.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- N/A This change has relevant unit tests (if applicable). _Don't see anything unit test would be able to test right now aside from invalid indexables, which is already tested to death_
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Run StatsD locally
2. Add somewhere it will run `define( 'VIP_STATSD_HOST', 'docker.for.mac.localhost' );`
3. Add somewhere it will run `define( 'VIP_STATSD_PORT', 8125 );`
3. Apply PR.
4. Get value of `\Automattic\VIP\Config\Sync::CRON_EVENT_NAME`, currently `vip_config_sync_cron`
4. `wp cron event schedule vip_config_sync_cron`
5. `wp cron event run vip_config_sync_cron`
6. Compare 7 and 8. They should be equal. 
7. StatsD gauge, something like `'com.wordpress.elasticsearch.unknown.unknown.field_count.200508.vip-200508-post-1': 183` 
8. Directly check against Elasticsearch, something like `curl -s -XGET localhost:9200/index/_mapping?pretty | grep -w 'type' | wc -l`
