### PR TITLE
Reduce _encloseme meta cleanup interval time

### DIFF
--- a/lib/class-vip-encloseme-cleanup.php
+++ b/lib/class-vip-encloseme-cleanup.php
@@ -24,8 +24,8 @@ class VIP_Encloseme_Cleanup {
 		}
 
 		$schedule[ self::CRON_INTERVAL ] = [
-			'interval' => 1200,
-			'display' => __( 'Once every twenty minutes.' ),
+			'interval' => 600,
+			'display' => __( 'Once every ten minutes.' ),
 		];
 		
 		return $schedule;


### PR DESCRIPTION
## Description

Reduce the interval between jobs from 20 minutes to 10 minutes.
During testing, we've found that 10000 post meta gets deleted in just about 1 minute so setting the interval to 20 minutes appears a little overkill.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Upload changed files to a sandboxed site
1. ensure `define( 'ENABLE_VIP_ENCLOSEME_CLEANUP_ENV', true );` is in `vip-config.php`
1. `wp cron-control events list`
1. Ensure job is in events list and interval is set to 10 minutes
