### PR TITLE
Add stat tracking for queue wait times

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -660,6 +660,41 @@ class Queue {
 		return wp_cache_set( self::INDEX_QUEUEING_ENABLED_KEY, true, self::INDEX_COUNT_CACHE_GROUP, self::INDEX_QUEUEING_TTL );
 	}
 
+	/**
+	 * Get the current average queue wait time
+	 *
+	 * @return {int} The current average wait time in seconds.
+	 */
+	public function get_average_queue_wait_time() {
+		global $wpdb;
+
+		// If run without having the queue enabled, queue wait times are 0
+		if ( ! $this->is_enabled() ) {
+			return 0;
+		}
+
+		// If schema is null, init likely not run yet
+		// Happens when cron is scheduled/run via wp commands
+		if ( is_null( $this->schema ) ) {
+			$this->init();
+		}
+
+		$table_name = $this->schema->get_table_name();
+
+		$average_wait_time = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT FLOOR( AVG( TIMESTAMPDIFF( SECOND, queued_time, NOW() ) ) ) AS average_wait_time FROM $table_name WHERE 1" // Cannot prepare table name. @codingStandardsIgnoreLine
+			)
+		);
+
+		// Null value will usually mean empty table 
+		if ( is_null( $average_wait_time ) || ! is_numeric( $average_wait_time ) ) {
+			return 0;
+		}
+
+		return intval( $average_wait_time );
+	}
+
 	/*
 	 * Increment the number of indexing operations that have been passed through VIP Search
 	 */

--- a/search/includes/classes/class-queuewaittimejob.php
+++ b/search/includes/classes/class-queuewaittimejob.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+class QueueWaitTimeJob {
+	const CRON_EVENT_NAME = 'vip_config_sync_cron';
+
+	const FIELD_COUNT_GAUGE_DISABLED_SITES = array();
+
+	public function init() {
+		// We always add this action so that the job can unregister itself if it no longer should be running
+		add_action( self::CRON_EVENT_NAME, [ $this, 'set_queue_wait_time_gauge' ] );
+	}
+
+	/**
+	 * Set the queue wait time gauge for posts for the current site 
+	 */
+	public function set_queue_wait_time_gauge() {
+		\Automattic\VIP\Search\Search::instance()->set_queue_wait_time_gauge();
+	}
+}


### PR DESCRIPTION
## Description

Added a stat to get the average time jobs have been sitting in the queue.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Run StatsD locally
2. Add somewhere it will run `define( 'VIP_STATSD_HOST', 'docker.for.mac.localhost' );`
3. Add somewhere it will run `define( 'VIP_STATSD_PORT', 8125 );`
3. Add somewhere it will run `define( 'VIP_SEARCH_ENABLE_ASYNC_INDEXING', true );`
4. Apply PR.
5. Populate `wp_vip_search_index_queue` with rows with different `queued_time`s.
6. Execute: `SELECT FLOOR( AVG( TIMESTAMPDIFF( SECOND, queued_time, NOW() ) ) ) AS average_wait_time FROM wp_vip_search_index_queue WHERE 1`
7. `wp cron event schedule vip_config_sync_cron`
8. `wp cron event run vip_config_sync_cron`
9. Compare StatsD output for the gauge(should be something like `com.wordpress.elasticsearch.unknown.unknown.queue_wait_time.200508.vip-200508-post-1`) with the output from the SQL execution. They should be equal.
