### PR TITLE
Add random stagger to _encloseme meta cleanup start time

### DIFF
--- a/lib/class-vip-encloseme-cleanup.php
+++ b/lib/class-vip-encloseme-cleanup.php
@@ -40,7 +40,12 @@ class VIP_Encloseme_Cleanup {
 		}
 
 		if ( false === $completed && ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			wp_schedule_event( time(), self::CRON_INTERVAL, self::CRON_HOOK );
+            // Random jitter value to stagger the event start timing so that
+            // we don't get a sudden cascade of alerts when we add a new batch
+            // of sites.
+            $jitter = rand( 0, 10 ) * 60;
+
+			wp_schedule_event( time() + $jitter, self::CRON_INTERVAL, self::CRON_HOOK );
 		}
 	}
 

--- a/lib/class-vip-encloseme-cleanup.php
+++ b/lib/class-vip-encloseme-cleanup.php
@@ -40,10 +40,10 @@ class VIP_Encloseme_Cleanup {
 		}
 
 		if ( false === $completed && ! wp_next_scheduled( self::CRON_HOOK ) ) {
-            // Random jitter value to stagger the event start timing so that
-            // we don't get a sudden cascade of alerts when we add a new batch
-            // of sites.
-            $jitter = rand( 0, 10 ) * 60;
+			// Random jitter value to stagger the event start timing so that
+			// we don't get a sudden cascade of alerts when we add a new batch
+			// of sites.
+			$jitter = rand( 0, 10 ) * 60;
 
 			wp_schedule_event( time() + $jitter, self::CRON_INTERVAL, self::CRON_HOOK );
 		}


### PR DESCRIPTION
## Description

Adds a random jitter element to stagger the cleanup start timing to prevent seeing a cascade of alerts when we add a new batch of sites to the cleanup list.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Upload changes to sandboxed site
1. ensure `define( 'ENABLE_VIP_ENCLOSEME_CLEANUP_ENV', true );` is in `vip-config.php`
1. `wp cron-control events list`
1. ensure that the `vip_encloseme_cleanup_hook` action is scheduled to start between 1 to 10 minutes from "now"
