### PR TITLE
Fix index healthchecks during indexing

### DIFF
--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -101,6 +101,11 @@ class HealthJob {
 			return;
 		}
 
+		// Don't run the checks if the index is not built.
+		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {
+			return;
+		}
+
 		$users_feature = \ElasticPress\Features::factory()->get_registered_feature( 'users' );
 
 		if ( $users_feature instanceof \ElasticPress\Feature && $users_feature->is_active() ) {
@@ -201,11 +206,6 @@ class HealthJob {
 		$enabled_environments = apply_filters( 'vip_search_healthchecks_enabled_environments', array( 'production' ) );
 
 		$enabled = in_array( VIP_GO_ENV, $enabled_environments, true );
-
-		// Don't run the checks if the index is not built.
-		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {
-			$enabled = false;
-		}
 
 		/**
 		 * Filter whether to enable VIP search healthcheck

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -21,6 +21,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 
 	public function test__vip_search_healthjob_check_health_with_inactive_features() {
 		add_filter( 'enable_vip_search_healthchecks', '__return_true' );
+		update_option( 'ep_last_sync', time() ); // So EP thinks we've done an index before
 
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();


### PR DESCRIPTION
## Description

Previously, later filters (such as from client code) would override our code that prevented checks from running during indexing. We're not actually _disabling_ checking entirely, just temporarily skipping while indexing is happening, so this code path should not be filterable.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Tricky to test...need to think about that.
