### PR TITLE
Add Search versioning CLI commands

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -57,6 +57,7 @@ class Search {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 			require_once __DIR__ . '/commands/class-queuecommand.php';
+			require_once __DIR__ . '/commands/class-versioncommand.php';
 
 			// Remove elasticpress command. Need a better way.
 			//WP_CLI::add_hook( 'before_add_command:elasticpress', [ $this, 'abort_elasticpress_add_command' ] );
@@ -206,6 +207,7 @@ class Search {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'vip-search health', __NAMESPACE__ . '\Commands\HealthCommand' );
 			WP_CLI::add_command( 'vip-search queue', __NAMESPACE__ . '\Commands\QueueCommand' );
+			WP_CLI::add_command( 'vip-search index-versions', __NAMESPACE__ . '\Commands\VersionCommand' );
 			WP_CLI::add_command( 'vip-search', '\ElasticPress\Command' );
 		}
 	}

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -171,6 +171,24 @@ class Versioning {
 	}
 
 	/**
+	 * Retrieve details about a given index version
+	 * 
+	 * @param \ElasticPress\Indexable $indexable The Indexable for which to retrieve the index version
+	 * @return array Array of index versions
+	 */
+	public function get_version( Indexable $indexable, $version_number ) {
+		$slug = $indexable->slug;
+	
+		$versions = $this->get_versions( $indexable );
+
+		if ( ! isset( $versions[ $version_number ] ) ) {
+			return null;
+		}
+
+		return $versions[ $version_number ];
+	}
+
+	/**
 	 * Retrieve details about available index versions
 	 * 
 	 * @param \ElasticPress\Indexable $indexable The Indexable for which to create a new version

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -191,14 +191,13 @@ class Versioning {
 	public function get_next_version_number( $versions ) {
 		$new_version = null;
 
-		// If site has no versions yet (1 version), the next version is 2
-		if ( empty( $versions ) || ! is_array( $versions ) ) {
-			$new_version = 2;
-		} else {
+
+		if ( ! empty( $versions ) && is_array( $versions ) ) {
 			$new_version = max( array_keys( $versions ) );
 		}
 
-		if ( ! is_int( $new_version ) || $new_version <= 2 ) {
+		// If site has no versions yet (1 version), the next version is 2
+		if ( ! is_int( $new_version ) || $new_version < 2 ) {
 			$new_version = 2;
 		} else {
 			$new_version++;

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -148,19 +148,28 @@ class Versioning {
 	
 		$versions = $this->get_versions( $indexable );
 
-		$new_version = $this->get_next_version_number( $versions );
+		$new_version_number = $this->get_next_version_number( $versions );
 
-		if ( ! $new_version ) {
+		if ( ! $new_version_number ) {
 			return new WP_Error( 'unable-to-get-next-version', 'Unable to determine next index version' );
 		}
 
-		$versions[ $new_version ] = array(
-			'number' => $new_version,
+		$new_version = array(
+			'number' => $new_version_number,
 			'active' => false,
 			'created_time' => time(),
+			'activated_time' => null,
 		);
 
-		return $this->update_versions( $indexable, $versions );
+		$versions[ $new_version_number ] = $new_version;
+
+		$result = $this->update_versions( $indexable, $versions );
+
+		if ( true !== $result ) {
+			return $result;
+		}
+
+		return $new_version;
 	}
 
 	/**

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -130,11 +130,44 @@ class Versioning {
 					'number' => 1,
 					'active' => true,
 					'created_time' => null, // We don't know when it was actually created
+					'activated_time' => null,
 				),
 			);
 		}
 
-		return $versions[ $slug ];
+		// Normalize the versions to ensure consistency (have all fields, etc)
+		return array_map( array( $this, 'normalize_version' ), $versions[ $slug ] );
+	}
+
+	/**
+	 * Normalize the fields of a version, to handle old or incomplete data
+	 * 
+	 * This is important to keep the data stored in the option consistent and current when changes to the structure are needed
+	 * 
+	 * @param array The index version to normalize
+	 * @return array The index version, with all data normalized
+	 */
+	public function normalize_version( $version ) {
+		$version_fields = array(
+			'number',
+			'active',
+			'created_time',
+			'activated_time',
+		);
+
+		if ( ! is_array( $version ) ) {
+			$version = array();
+		}
+
+		$keys = array_keys( $version );
+
+		$missing_keys = array_diff( $version_fields, $keys );
+
+		foreach ( $missing_keys as $key ) {
+			$version[ $key ] = null;
+		}
+
+		return $version;
 	}
 
 	/**

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -28,7 +28,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 * @subcommand add
 	 */
 	public function add( $args, $assoc_args ) {
-		$type = $args[ 0 ];
+		$type = $args[0];
 	
 		$search = \Automattic\VIP\Search\Search::instance();
 
@@ -68,7 +68,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list( $args, $assoc_args ) {
-		$type = $args[ 0 ];
+		$type = $args[0];
 	
 		$search = \Automattic\VIP\Search\Search::instance();
 
@@ -104,8 +104,8 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 * @subcommand activate
 	 */
 	public function activate( $args, $assoc_args ) {
-		$type = $args[ 0 ];
-		$new_version_number = intval( $args[ 1 ] );
+		$type = $args[0];
+		$new_version_number = intval( $args[1] );
 
 		if ( $new_version_number <= 0 ) {
 			return WP_CLI::error( 'New version number must be a positive int' );

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Automattic\VIP\Search\Commands;
+
+use \WP_CLI;
+use \WP_CLI\Utils;
+
+/**
+ * Commands to view and manage index versions
+ *
+ * @package Automattic\VIP\Search
+ */
+class VersionCommand extends \WPCOM_VIP_CLI_Command {
+	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
+	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
+
+	/**
+	 * Register a new index version
+	 *
+	 * ## OPTIONS
+	 * 
+	 * <type>
+	 * : The index type (the slug of the Indexable, such as 'post', 'user', etc)
+	 *
+	 * ## EXAMPLES
+	 *     wp vip-search index-versions add post
+	 *
+	 * @subcommand add
+	 */
+	public function add( $args, $assoc_args ) {
+		$search = \Automattic\VIP\Search\Search::instance();
+
+		$indexable = \ElasticPress\Indexables::factory()->get( $assoc_args['type'] );
+
+		$result = $search->versioning->add_version( $indexable );
+
+		if ( is_wp_error( $result ) ) {
+			return WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( false === $result ) {
+			return WP_CLI::error( 'Failed to register the new index version' );
+		}
+	
+		$versions = $search->versioning->get_versions( $indexable );
+
+		if ( ! count( $versions ) ) {
+			return WP_CLI::error( 'No versions found after registering new version' );
+		}
+
+		// New version will be last on the list
+
+		$new_version = end( $versions );
+
+		WP_CLI::success( sprintf( 'Registered new index version %d. The new index has not yet been created', $new_version ) );
+	}
+}

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -28,9 +28,11 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 * @subcommand add
 	 */
 	public function add( $args, $assoc_args ) {
+		$type = $args[ 0 ];
+	
 		$search = \Automattic\VIP\Search\Search::instance();
 
-		$indexable = \ElasticPress\Indexables::factory()->get( $assoc_args['type'] );
+		$indexable = \ElasticPress\Indexables::factory()->get( $type );
 
 		$result = $search->versioning->add_version( $indexable );
 
@@ -52,6 +54,6 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		$new_version = end( $versions );
 
-		WP_CLI::success( sprintf( 'Registered new index version %d. The new index has not yet been created', $new_version ) );
+		WP_CLI::success( sprintf( 'Registered new index version %d. The new index has not yet been created', $new_version['number'] ) );
 	}
 }

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -52,6 +52,51 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	}
 
 	/**
+	 * Get details about a version of an index
+	 *
+	 * ## OPTIONS
+	 * 
+	 * <type>
+	 * : The index type (the slug of the Indexable, such as 'post', 'user', etc)
+	 * 
+	 * <version_number>
+	 * : The version number to retrieve
+	 *
+	 * ## EXAMPLES
+	 *     wp vip-search index-versions get post 2
+	 *
+	 * @subcommand get
+	 */
+	public function get( $args, $assoc_args ) {
+		$type = $args[0];
+		$version_number = intval( $args[1] );
+
+		if ( $version_number <= 0 ) {
+			return WP_CLI::error( 'New version number must be a positive int' );
+		}
+	
+		$search = \Automattic\VIP\Search\Search::instance();
+
+		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+
+		if ( ! $indexable ) {
+			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
+		}
+
+		$version = $search->versioning->get_version( $indexable, $version_number );
+
+		if ( is_wp_error( $version ) ) {
+			return WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( ! $version ) {
+			return WP_CLI::error( sprintf( 'Failed to get index version %d for type %s. Does it exist?', $version_number, $type ) );
+		}
+
+		\WP_CLI\Utils\format_items( $assoc_args['format'], array( $version ), array( 'number', 'active', 'created_time', 'activated_time' ) );
+	}
+
+	/**
 	 * List all registered index versions
 	 *
 	 * ## OPTIONS

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -139,4 +139,41 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		WP_CLI::success( sprintf( 'Successfully activated index version %d for type %s', $new_version_number, $type ) );
 	}
+
+	/**
+	 * Get details about the currently active index version
+	 *
+	 * ## OPTIONS
+	 * 
+	 * <type>
+	 * : The index type (the slug of the Indexable, such as 'post', 'user', etc)
+	 *
+	 * ## EXAMPLES
+	 *     wp vip-search index-versions get-active post
+	 *
+	 * @subcommand get-active
+	 */
+	public function get_active( $args, $assoc_args ) {
+		$type = $args[0];
+	
+		$search = \Automattic\VIP\Search\Search::instance();
+
+		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+
+		if ( ! $indexable ) {
+			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
+		}
+
+		$version = $search->versioning->get_active_version( $indexable );
+
+		if ( is_wp_error( $version ) ) {
+			return WP_CLI::error( $version->get_error_message() );
+		}
+
+		if ( ! is_array( $version ) ) {
+			return WP_CLI::error( 'Failed to retrieve the active index version' );
+		}
+		
+		\WP_CLI\Utils\format_items( $assoc_args['format'], array( $version ), array( 'number', 'active', 'created_time', 'activated_time' ) );
+	}
 }

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -34,6 +34,10 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		$indexable = \ElasticPress\Indexables::factory()->get( $type );
 
+		if ( ! $indexable ) {
+			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
+		}
+
 		$new_version = $search->versioning->add_version( $indexable );
 
 		if ( is_wp_error( $result ) ) {
@@ -69,6 +73,10 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 		$search = \Automattic\VIP\Search\Search::instance();
 
 		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+
+		if ( ! $indexable ) {
+			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
+		}
 
 		$versions = $search->versioning->get_versions( $indexable );
 

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -46,4 +46,36 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		WP_CLI::success( sprintf( 'Registered new index version %d. The new index has not yet been created', $new_version['number'] ) );
 	}
+
+	/**
+	 * List all registered index versions
+	 *
+	 * ## OPTIONS
+	 * 
+	 * <type>
+	 * : The index type (the slug of the Indexable, such as 'post', 'user', etc)
+	 *
+	 * [--format=<string>]
+	 * : Optional one of: table json csv yaml ids count
+	 *
+	 * ## EXAMPLES
+	 *     wp vip-search index-versions list post
+	 *
+	 * @subcommand list
+	 */
+	public function list( $args, $assoc_args ) {
+		$type = $args[ 0 ];
+	
+		$search = \Automattic\VIP\Search\Search::instance();
+
+		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+
+		$versions = $search->versioning->get_versions( $indexable );
+
+		if ( is_wp_error( $versions ) ) {
+			return WP_CLI::error( $result->get_error_message() );
+		}
+
+		\WP_CLI\Utils\format_items( $assoc_args['format'], $versions, array( 'number', 'active', 'created_time', 'activated_time' ) );
+	}
 }

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -34,7 +34,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		$indexable = \ElasticPress\Indexables::factory()->get( $type );
 
-		$result = $search->versioning->add_version( $indexable );
+		$new_version = $search->versioning->add_version( $indexable );
 
 		if ( is_wp_error( $result ) ) {
 			return WP_CLI::error( $result->get_error_message() );
@@ -43,16 +43,6 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 		if ( false === $result ) {
 			return WP_CLI::error( 'Failed to register the new index version' );
 		}
-	
-		$versions = $search->versioning->get_versions( $indexable );
-
-		if ( ! count( $versions ) ) {
-			return WP_CLI::error( 'No versions found after registering new version' );
-		}
-
-		// New version will be last on the list
-
-		$new_version = end( $versions );
 
 		WP_CLI::success( sprintf( 'Registered new index version %d. The new index has not yet been created', $new_version['number'] ) );
 	}

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -275,9 +275,11 @@ class Versioning_Test extends \WP_UnitTestCase {
 		self::$version_instance->update_versions( $indexable, $versions );
 
 		// Add the new version
-		$succeeded = self::$version_instance->add_version( $indexable );
+		$new_version = self::$version_instance->add_version( $indexable );
 
-		$this->assertTrue( $succeeded, 'Adding a new version failed, but it should have succeeded' );
+		$expected_new_version = end( $expected_new_versions );
+
+		$this->assertEquals( $expected_new_version[ 'number' ], $new_version['number'], 'The returned new version does not match the expected new version' );
 
 		$new_versions = self::$version_instance->get_versions( $indexable );
 
@@ -514,7 +516,8 @@ class Versioning_Test extends \WP_UnitTestCase {
 
 		$result = self::$version_instance->add_version( $indexable );
 
-		$this->assertTrue( $result, 'Failed to add new version of index' );
+		$this->assertNotFalse( $result, 'Failed to add new version of index' );
+		$this->assertNotInstanceOf( \WP_Error::class, $result, 'Got WP_Error when adding new index version' );
 
 		// Defaults to active index (1 in our case)
 		$this->assertEquals( 1, self::$version_instance->get_current_version_number( $indexable ), 'Default (non-overridden) version number is wrong' );

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -538,4 +538,46 @@ class Versioning_Test extends \WP_UnitTestCase {
 		// Back to the active index
 		$this->assertEquals( 1, self::$version_instance->get_current_version_number( $indexable ), 'Version number is wrong after resetting to default' );
 	}
+
+	public function normalize_version_data() {
+		return array(
+			// No data at all
+			array(
+				// Input version
+				array(),
+				// Expected (normalized) version
+				array(
+					'number' => null,
+					'active' => null,
+					'activated_time' => null,
+					'created_time' => null,
+				),
+			),
+
+			// Partial data
+			array(
+				// Input version
+				array(
+					'number' => 2,
+					'active' => false,
+				),
+				// Expected (normalized) version
+				array(
+					'number' => 2,
+					'active' => false,
+					'activated_time' => null,
+					'created_time' => null,
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider normalize_version_data
+	 */
+	public function test_normalize_version( $input, $expected ) {
+		$normalized = self::$version_instance->normalize_version( $input );
+
+		$this->assertEquals( $expected, $normalized );
+	}
 }

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -580,4 +580,18 @@ class Versioning_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $normalized );
 	}
+
+	public function test_get_version() {
+		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
+
+		$one = self::$version_instance->get_version( $indexable, 1 );
+
+		$this->assertEquals( 1, $one['number'], 'Wrong version number for returned version (expected 1)' );
+
+		$new = self::$version_instance->add_version( $indexable );
+
+		$new_retrieved = self::$version_instance->get_version( $indexable, $new['number'] );
+
+		$this->assertEquals( $new['number'], $new_retrieved['number'], 'Wrong version number for returned version on newly created version' );
+	}
 }

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -28,6 +28,19 @@ class Versioning_Test extends \WP_UnitTestCase {
 			array(
 				// Input array of versions
 				array(
+					1 => array(
+						'number' => 1,
+					),
+					2 => array(
+						'number' => 2,
+					),
+				),
+				// Expected next version
+				3,
+			),
+			array(
+				// Input array of versions
+				array(
 					2 => array(
 						'number' => 2,
 					),
@@ -194,6 +207,38 @@ class Versioning_Test extends \WP_UnitTestCase {
 					),
 					4 => array(
 						'number' => 4,
+						'active' => false,
+					),
+				),
+			),
+
+			// Current version is 2
+			array(
+				// Input array of versions
+				array(
+					1 => array(
+						'number' => 1,
+						'active' => false,
+					),
+					2 => array(
+						'number' => 2,
+						'active' => true,
+					),
+				),
+				// Indexable slug
+				'post',
+				// Expected new versions
+				array(
+					1 => array(
+						'number' => 1,
+						'active' => false,
+					),
+					2 => array(
+						'number' => 2,
+						'active' => true,
+					),
+					3 => array(
+						'number' => 3,
 						'active' => false,
 					),
 				),

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -279,7 +279,7 @@ class Versioning_Test extends \WP_UnitTestCase {
 
 		$expected_new_version = end( $expected_new_versions );
 
-		$this->assertEquals( $expected_new_version[ 'number' ], $new_version['number'], 'The returned new version does not match the expected new version' );
+		$this->assertEquals( $expected_new_version['number'], $new_version['number'], 'The returned new version does not match the expected new version' );
 
 		$new_versions = self::$version_instance->get_versions( $indexable );
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -171,9 +171,10 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
 
-		$succeeded = $es->versioning->add_version( $indexable );
+		$new_version = $es->versioning->add_version( $indexable );
 
-		$this->assertTrue( $succeeded, 'Adding a new version failed, but it should have succeeded' );
+		$this->assertNotFalse( $new_version, 'Failed to add new version of index' );
+		$this->assertNotInstanceOf( \WP_Error::class, $new_version, 'Got WP_Error when adding new index version' );
 
 		// Override the version
 		$override_result = $es->versioning->set_current_version_number( $indexable, 2 );


### PR DESCRIPTION
## Description

CLI commands to manage index versions. There are 5 new commands added:

```
wp vip-search index-versions list <type>
wp vip-search index-versions add <type>
wp vip-search index-versions get <type> <version_number>
wp vip-search index-versions activate <type> <version_number>
wp vip-search index-versions get-active <type>
```

Not yet implemented is anything related to actually pulling data from the ES index itself (if it exists, doc counts, etc) or removing index versions, which can be part of a future PR.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. First, ensure you're starting off with no indexes present, to represent existing production sites - `wp option delete vip_search_index_versions`
1. Then list them:

```
wp vip-search index-versions list post

+--------+--------+--------------+----------------+
| number | active | created_time | activated_time |
+--------+--------+--------------+----------------+
| 1      | 1      |              |                |
+--------+--------+--------------+----------------+
```
1. Note that in the above, the created/activated time are reported as null/empty b/c we don't have data for when the first index was created
1. Then attempt to add a new version: 
```wp vip-search index-versions add post

Registered new index version 2. The new index has not yet been created
```
1. List them again:
```
wp vip-search index-versions list post

+--------+--------+--------------+----------------+
| number | active | created_time | activated_time |
+--------+--------+--------------+----------------+
| 1      | 1      |              |                |
| 2      |        | 1594077504   |                |
+--------+--------+--------------+----------------+
```
1. And it should be retrievable:
```
wp vip-search index-versions get post 2

+--------+--------+--------------+----------------+
| number | active | created_time | activated_time |
+--------+--------+--------------+----------------+
| 2      |        | 1594077504   | 1594077562     |
+--------+--------+--------------+----------------+
```
1. Now let's activate version 2:
```
wp vip-search index-versions activate post 2

Are you sure you want to activate index version 2 for type post? [y/n] y
Success: Successfully activated index version 2 for type post
```
1. And the new active index should be 2:
```
wp vip-search index-versions get-active post

+--------+--------+--------------+----------------+
| number | active | created_time | activated_time |
+--------+--------+--------------+----------------+
| 2      | 1      | 1594077504   | 1594077562     |
+--------+--------+--------------+----------------+
```
1. Then try it with various bad inputs - invalid indexable types, non-existant version numbers