### PR TITLE
Fix/alerts endpoint

### DIFF
--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -129,7 +129,7 @@ function wpcom_vip_sanity_check_alloptions_notify( $size, $blocked = false ) {
 					array( 
 						'alias'       => 'alloptions/' . $site_id,
 						'description' => 'The size of AllOptions is reaching the max limit of 1 MB.',
-						'entity'      => $site_id,
+						'entity'      => (string) $site_id,
 						'priority'    => $opsgenie_alert_level,
 						'source'      => 'sites/alloptions-size',
 					),

--- a/lib/utils/class-alerts.php
+++ b/lib/utils/class-alerts.php
@@ -246,7 +246,6 @@ class Alerts {
 		$details[ 'message' ] = $message;
 
 		$body = [
-			'message'   => $message,
 			'ops_alert' => $details,
 		];
 

--- a/lib/utils/class-alerts.php
+++ b/lib/utils/class-alerts.php
@@ -246,6 +246,7 @@ class Alerts {
 		$details[ 'message' ] = $message;
 
 		$body = [
+			'message'   => $message,
 			'ops_alert' => $details,
 		];
 


### PR DESCRIPTION
## Two fixes

1. We need to make sure `entity` is always a string and not an integer
2. Our alerts endpoint also requires a top level `messege` in the body of the request we're sending.

## Steps to Test

1. Use `vip @{site-id} ` to use CLI in production on a test site
2. Use `wp shell`
3. You can test sending this alert with dummy data like this:

`
vip_safe_wp_remote_request( 'http://{ALERT_SERVICE_ADDRESS}:{ALERTS_SERVICE_PORT}/v1.0/alert', new WP_Error( 'test', 'test' ), 3, 1, 10, [ 'method' => 'POST', 'body' => json_encode( [  'message' => 'Alerts test!!', 'ops_alert' =>  array( 'message'     => 'Alerts Message', 'alias' => 'alloptions/1269','description' => 'The size of AllOptions is reaching the max limit of 1 MB.','entity'      => '1269','priority'    => 'P4','source'      => 'sites/alloptions-size-test',) ] ), ]);
`

I was able to create an alert in OpsGenie when sending that request to our Alerts Service.

Testing on a sandbox will not work due to firewall restrictions.

cc @rinatkhaziev 