### PR TITLE
Reindex post if post meta is in allow list

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -204,7 +204,7 @@ class Search {
 		add_filter( 'ep_total_field_limit', array( $this, 'limit_field_limit' ), PHP_INT_MAX );
 	
 		// Check if meta is on allow list. If not, don't re-index
-		add_filter( 'ep_skip_post_meta_sync', array( $this, 'filter__ep_skip_post_meta_sync' ), PHP_INT_MAX, 4 );
+		add_filter( 'ep_skip_post_meta_sync', array( $this, 'filter__ep_skip_post_meta_sync' ), PHP_INT_MAX, 5 );
 	}
 
 	protected function load_commands() {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1355,7 +1355,7 @@ class Search {
 			return true;
 		}
 
-		return false;	
+		return false;
 	}
 
 	/*

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1778,22 +1778,26 @@ class Search_Test extends \WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test__maybe_ep_action_queue_meta_sync_should_set_ep_post_sync_kill_to_true_if_meta_not_in_allow_list() {
+	public function test__maybe_ep_action_queue_meta_sync_should_set_ep_skip_post_meta_sync_to_true_if_meta_not_in_allow_list() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		$post = \get_post( $post_id );
 
 		$es = \Automattic\VIP\Search\Search::instance();
 
-		$es->maybe_ep_action_queue_meta_sync( 40, $post_id, 'random_key', 'random_value' );
+		$es->maybe_ep_action_queue_meta_sync( $post, 40, 'random_key', 'random_value' );
 
-		$this->assertTrue( apply_filters( 'ep_post_sync_kill', false, $post_id, $post_id ) );
+		$this->assertTrue( apply_filters( 'ep_skip_post_meta_sync', false ) );
 	}
 
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test__maybe_ep_action_queue_meta_sync_should_set_ep_post_sync_kill_to_false_if_meta_is_in_allow_list() {
+	public function test__maybe_ep_action_queue_meta_sync_should_set_ep_skip_post_meta_sync_to_false_if_meta_is_in_allow_list() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		$post = \get_post( $post_id );
 
 		\add_filter(
 			'vip_search_post_meta_allow_list',
@@ -1806,9 +1810,9 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$es = \Automattic\VIP\Search\Search::instance();
 
-		$es->maybe_ep_action_queue_meta_sync( 40, $post_id, 'random_key', 'random_value' );
+		$es->maybe_ep_action_queue_meta_sync( $post, 40, 'random_key', 'random_value' );
 
-		$this->assertFalse( apply_filters( 'ep_post_sync_kill', false, $post_id, $post_id ) );
+		$this->assertFalse( apply_filters( 'ep_skip_post_meta_sync', false ) );
 	}
 
 	/**

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1778,23 +1778,21 @@ class Search_Test extends \WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test__maybe_ep_action_queue_meta_sync_should_set_ep_skip_post_meta_sync_to_true_if_meta_not_in_allow_list() {
+	public function test__filter__ep_skip_post_meta_sync_should_return_true_if_meta_not_in_allow_list() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
 
 		$post = \get_post( $post_id );
 
 		$es = \Automattic\VIP\Search\Search::instance();
 
-		$es->maybe_ep_action_queue_meta_sync( $post, 40, 'random_key', 'random_value' );
-
-		$this->assertTrue( apply_filters( 'ep_skip_post_meta_sync', false ) );
+		$this->assertTrue( $es->filter__ep_skip_post_meta_sync( false, $post, 40, 'random_key', 'random_value' ) );
 	}
 
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test__maybe_ep_action_queue_meta_sync_should_set_ep_skip_post_meta_sync_to_false_if_meta_is_in_allow_list() {
+	public function test__filter__ep_skip_post_meta_sync_should_return_false_if_meta_is_in_allow_list() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
 
 		$post = \get_post( $post_id );
@@ -1810,9 +1808,30 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$es = \Automattic\VIP\Search\Search::instance();
 
-		$es->maybe_ep_action_queue_meta_sync( $post, 40, 'random_key', 'random_value' );
+		$this->assertFalse( $es->filter__ep_skip_post_meta_sync( false, $post, 40, 'random_key', 'random_value' ) );
+	}
 
-		$this->assertFalse( apply_filters( 'ep_skip_post_meta_sync', false ) );
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__filter__ep_skip_post_meta_sync_should_return_true_if_a_previous_filter_is_true() {
+		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		$post = \get_post( $post_id );
+
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array(
+					'random_key',
+				);
+			}
+		);
+
+		$es = \Automattic\VIP\Search\Search::instance();
+
+		$this->assertTrue( $es->filter__ep_skip_post_meta_sync( true, $post, 40, 'random_key', 'random_value' ) );
 	}
 
 	/**

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1775,6 +1775,43 @@ class Search_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__maybe_ep_action_queue_meta_sync_should_set_ep_post_sync_kill_to_true_if_meta_not_in_allow_list() {
+		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		$es = \Automattic\VIP\Search\Search::instance();
+
+		$es->maybe_ep_action_queue_meta_sync( 40, $post_id, 'random_key', 'random_value' );
+
+		$this->assertTrue( apply_filters( 'ep_post_sync_kill', false, $post_id, $post_id ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__maybe_ep_action_queue_meta_sync_should_set_ep_post_sync_kill_to_false_if_meta_is_in_allow_list() {
+		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array(
+					'random_key',
+				);
+			}
+		);
+
+		$es = \Automattic\VIP\Search\Search::instance();
+
+		$es->maybe_ep_action_queue_meta_sync( 40, $post_id, 'random_key', 'random_value' );
+
+		$this->assertFalse( apply_filters( 'ep_post_sync_kill', false, $post_id, $post_id ) );
+	}
+
+	/**
 	 * Helper function for accessing protected methods.
 	 */
 	protected static function get_method( $name ) {

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1984,6 +1984,66 @@ class Search_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__ep_skip_post_meta_sync_filter_should_return_true_if_meta_not_in_allow_list() {
+		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		$post = \get_post( $post_id );
+
+		$es = \Automattic\VIP\Search\Search::instance();
+
+		$this->assertTrue( apply_filters( 'ep_skip_post_meta_sync', false, $post, 40, 'random_key', 'random_value' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__ep_skip_post_meta_sync_filter_should_return_false_if_meta_is_in_allow_list() {
+		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		$post = \get_post( $post_id );
+
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array(
+					'random_key',
+				);
+			}
+		);
+
+		$es = \Automattic\VIP\Search\Search::instance();
+
+		$this->assertFalse( apply_filters( 'ep_skip_post_meta_sync', false, $post, 40, 'random_key', 'random_value' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__ep_skip_post_meta_sync_filter_should_return_true_if_a_previous_filter_is_true() {
+		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		$post = \get_post( $post_id );
+
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array(
+					'random_key',
+				);
+			}
+		);
+
+		\Automattic\VIP\Search\Search::instance();
+
+		$this->assertTrue( apply_filters( 'ep_skip_post_meta_sync', true, $post, 40, 'random_key', 'random_value' ) );
+	}
+
+	/**
 	 * Helper function for accessing protected methods.
 	 */
 	protected static function get_method( $name ) {


### PR DESCRIPTION
## Description

Depends upon https://github.com/Automattic/ElasticPress/pull/44

Since the post meta allow list has been added, posts should not be re-indexed if meta not on that list are changed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `./bin/phpunit-docker.sh tests/search/test-class-search.php`

------

1. Apply PR. Ensure https://github.com/Automattic/ElasticPress/pull/44 is applied as well.
2. Ensure VIP Search in enabled and you have a properly consistent index.
3. Add some post meta to a post that isn't on the allow list. The post should not have been re-indexed
4. Change the value of that meta. The post should not have been re-indexed.
5. Delete the meta. The post should not have been re-indexed.
6. Add some post meta to a post that is on the allow list. The post should be re-indexed.
7. Change the value of that meta. The post should be re-indexed.
8. Delete the meta. The post should be re-indexed.

