### PR TITLE
Search: Add version support to index CLI command

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -60,6 +60,7 @@ class Search {
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 			require_once __DIR__ . '/commands/class-queuecommand.php';
 			require_once __DIR__ . '/commands/class-versioncommand.php';
+			require_once __DIR__ . '/commands/class-corecommand.php';
 
 			// Remove elasticpress command. Need a better way.
 			//WP_CLI::add_hook( 'before_add_command:elasticpress', [ $this, 'abort_elasticpress_add_command' ] );
@@ -214,7 +215,7 @@ class Search {
 			WP_CLI::add_command( 'vip-search health', __NAMESPACE__ . '\Commands\HealthCommand' );
 			WP_CLI::add_command( 'vip-search queue', __NAMESPACE__ . '\Commands\QueueCommand' );
 			WP_CLI::add_command( 'vip-search index-versions', __NAMESPACE__ . '\Commands\VersionCommand' );
-			WP_CLI::add_command( 'vip-search', '\ElasticPress\Command' );
+			WP_CLI::add_command( 'vip-search', __NAMESPACE__ . '\Commands\CoreCommand' );
 		}
 	}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -53,19 +53,6 @@ class Search {
 	}
 
 	protected function load_dependencies() {
-		/**
-		 * Load ES Health command class
-		 */
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			require_once __DIR__ . '/commands/class-healthcommand.php';
-			require_once __DIR__ . '/commands/class-queuecommand.php';
-			require_once __DIR__ . '/commands/class-versioncommand.php';
-			require_once __DIR__ . '/commands/class-corecommand.php';
-
-			// Remove elasticpress command. Need a better way.
-			//WP_CLI::add_hook( 'before_add_command:elasticpress', [ $this, 'abort_elasticpress_add_command' ] );
-		}
-
 		// Load ElasticPress
 		require_once __DIR__ . '/../../elasticpress/elasticpress.php';
 
@@ -94,6 +81,19 @@ class Search {
 		// Index versioning
 		require_once __DIR__ . '/class-versioning.php';
 		$this->versioning = new Versioning();
+
+		/**
+		 * Load CLI commands
+		 */
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			require_once __DIR__ . '/commands/class-healthcommand.php';
+			require_once __DIR__ . '/commands/class-queuecommand.php';
+			require_once __DIR__ . '/commands/class-versioncommand.php';
+			require_once __DIR__ . '/commands/class-corecommand.php';
+
+			// Remove elasticpress command. Need a better way.
+			//WP_CLI::add_hook( 'before_add_command:elasticpress', [ $this, 'abort_elasticpress_add_command' ] );
+		}
 	}
 
 	protected function setup_constants() {

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -22,7 +22,7 @@ class Versioning {
 	 * @param \ElasticPress\Indexable $indexable The Indexable type for which to temporarily set the current index version
 	 * @return bool|WP_Error True on success, or WP_Error on failure
 	 */
-	public function set_current_version_number( Indexable $indexable, $version_number ) {
+	public function set_current_version_number( Indexable $indexable, int $version_number ) {
 		// Validate that the requested version is known
 		$versions = $this->get_versions( $indexable );
 
@@ -176,7 +176,7 @@ class Versioning {
 	 * @param \ElasticPress\Indexable $indexable The Indexable for which to retrieve the index version
 	 * @return array Array of index versions
 	 */
-	public function get_version( Indexable $indexable, $version_number ) {
+	public function get_version( Indexable $indexable, int $version_number ) {
 		$slug = $indexable->slug;
 	
 		$versions = $this->get_versions( $indexable );
@@ -281,7 +281,7 @@ class Versioning {
 	 * @param int $version_number The new index version to activate
 	 * @return bool|WP_Error Boolean indicating success, or WP_Error on error 
 	 */
-	public function activate_version( Indexable $indexable, $version_number ) {
+	public function activate_version( Indexable $indexable, int $version_number ) {
 		$versions = $this->get_versions( $indexable );
 
 		// If this wasn't a valid version, abort with error

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -10,7 +10,7 @@ use \WP_CLI\Utils;
  *
  * @package Automattic\VIP\Search
  */
-class CoreCommand extends \WPCOM_VIP_CLI_Command {
+class CoreCommand extends \ElasticPress\Command {
 	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
 	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
 

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Automattic\VIP\Search\Commands;
+
+use \WP_CLI;
+use \WP_CLI\Utils;
+
+/**
+ * Core commands for interacting with VIP Search
+ *
+ * @package Automattic\VIP\Search
+ */
+class CoreCommand extends \WPCOM_VIP_CLI_Command {
+	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
+	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
+
+	protected function _maybe_setup_index_version( &$assoc_args ) {
+		if ( $assoc_args[ 'version' ] ) {
+			$version = intval( $assoc_args['version'] );
+
+			// If version is specified, the indexable must also be specified, as different indexables can have different versions
+			if ( ! isset( $assoc_args['indexables'] ) ) {
+				return WP_CLI::error( 'The --indexables argument is required when specifying --version, as each indexable has separate versioning' );
+			}
+
+			// Additionally, --version is not compatible with --network-wide in non-network mode, because subsites will also have different versions
+			if ( isset( $assoc_args['network-wide'] ) && ! $search->is_network_mode() ) {
+				return WP_CLI::error( 'The --network-wide argument is not compatible with --version when not using network mode (the `EP_IS_NETWORK` constant), as subsites can have differing index versions' );
+			}
+
+			// For each indexable specified, override the version
+			$indexable_slugs = explode( ',', str_replace( ' ', '', $assoc_args['indexables'] ) );
+
+			$search = \Automattic\VIP\Search\Search::instance();
+
+			foreach ( $indexable_slugs as $slug ) {
+				$indexable = \ElasticPress\Indexables::factory()->get( $slug );
+
+				if ( ! $indexable ) {
+					return WP_CLI::error( sprintf( 'Indexable %s not found - is the feature active?' ) );
+				}
+
+				$result = $search->versioning->set_current_version_number( $indexable, $version );
+
+				if ( is_wp_error( $result ) ) {
+					return WP_CLI::error( sprintf( 'Error setting version number: %s', $result->get_error_message() ) );
+				}
+			}
+		}
+
+		// Unset our --version param, otherwise WP_CLI complains that it's unknown
+		unset( $assoc_args['version'] );
+	}
+
+	/**
+	 * Index all posts for a site or network wide
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--version]
+	 * : The index version to index into. Used to build up a new index in parallel with the currently active index version
+	 *
+	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--version]
+	 *
+	 * @param array $args Positional CLI args.
+	 * @since 0.1.2
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function index( $args, $assoc_args ) {
+		$this->_maybe_setup_index_version( $assoc_args );
+
+		array_unshift( $args, 'elasticpress', 'index' );
+
+		WP_CLI::run_command( $args, $assoc_args );
+	}
+}

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -15,7 +15,7 @@ class CoreCommand extends \ElasticPress\Command {
 	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
 
 	protected function _maybe_setup_index_version( &$assoc_args ) {
-		if ( $assoc_args[ 'version' ] ) {
+		if ( $assoc_args['version'] ) {
 			$version = intval( $assoc_args['version'] );
 
 			// If version is specified, the indexable must also be specified, as different indexables can have different versions


### PR DESCRIPTION
## Description

Adds support for index versioning to the `wp vip-search index` command.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Add a new index version - `wp vip-search index-versions add post`
1. Build that new index - `wp vip-search index --setup --indexables=post --version=<new_version_number>`
1. Switch to the new index - `wp vip-search index-versions activate post <new_version_number>`
1. Try some searches - should get the same results as on the old index, but requests go to the new one
1. Try switching back to the previous version - `wp vip-search index-versions activate post <previous_version_number>`
1. Everything should work fine