### PR TITLE
Async indexing now enabled by default

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -46,12 +46,7 @@ class Queue {
 	}
 
 	public function is_enabled() {
-		$enabled_by_constant = defined( 'VIP_SEARCH_ENABLE_ASYNC_INDEXING' ) && true === VIP_SEARCH_ENABLE_ASYNC_INDEXING;
-
-		$option_value = get_option( 'vip_enable_search_indexing_queue' );
-		$is_enabled_by_option = in_array( $option_value, array( true, 'true', 'yes', 1, '1' ), true );
-
-		return $enabled_by_constant || $is_enabled_by_option;
+		return true;
 	}
 
 	public function setup_hooks() {


### PR DESCRIPTION
## Description

Since the testing period on async indexing is over, it should be on by default.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).