### PR TITLE
Fix queue sweeper cron and stats

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -470,7 +470,7 @@ class Queue {
 			// Mark them as done in queue
 			$this->delete_jobs( $jobs );
 
-			$this->record_processed_from_queue_stat( count( $jobs ), $indexable );
+			$this->record_processed_from_queue_stat( count( $ids ), $indexable );
 
 			$this->record_queue_count_stat( $indexable );
 		}

--- a/search/includes/classes/queue/class-cron.php
+++ b/search/includes/classes/queue/class-cron.php
@@ -64,7 +64,8 @@ class Cron {
 		// Add the custom cron schedule
 		add_filter( 'cron_schedules', [ $this, 'filter_cron_schedules' ], 10, 1 );
 
-		$this->schedule_sweeper_job();
+		// Hook into init action to ensure cron-control has already been loaded
+		add_action( 'init', [ $this, 'schedule_sweeper_job' ] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

The queue sweeper cron wasn't being registered properly and wasn't running.

Once it was running, it was apparent the stats were off.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

