### PR TITLE
Upgrade to Jetpack 8.7

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 8.6.1
+ * Version: 8.7.0.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack


### PR DESCRIPTION
## Description

Upgrade Jetpack to 8.7.0.1

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Visit Jetpack Dashboard and ensure version is reported as 8.7.0.1
1. Run `wp plugin list` and verify JP is 8.7.0.1
1. Test various site functionality (posting, reading) to ensure no issues
