### PR TITLE
Search: update query integration argument from 'es' to 'vip_search_enabled' to eliminate the chances of conflicts with client code

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -627,7 +627,7 @@ class Search {
 	 *
 	 * This function determines if VIP Search should take over queries (search, 'ep_integrate' => true, and 'es' => true)
 	 *
-	 * The integration can be tested at any time by setting an `es` query argument (?es=true).
+	 * The integration can be tested at any time by setting an `es` query argument (?vip_search_enabled=true).
 	 * 
 	 * When the index is ready to serve requests in production, the `VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION`
 	 * constant should be set to `true`, which will enable query integration for all requests

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -15,6 +15,7 @@ class Search {
 
 	public const QUERY_COUNT_CACHE_KEY = 'query_count';
 	public const QUERY_COUNT_CACHE_GROUP = 'vip_search';
+	public const QUERY_INTEGRATION_FORCE_ENABLE_KEY = 'vip_search_enabled';
 	public static $max_query_count = 50000 + 1; // 10 requests per second plus one for cleanliness of comparing with Search::query_count_incr
 	public static $query_db_fallback_value = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
 	private const QUERY_COUNT_TTL = 300; // 5 minutes in seconds 
@@ -269,7 +270,7 @@ class Search {
 		global $wp_query;
 
 		// Avoid infinite loops because our requests load the URL with this param.
-		if ( isset( $_GET['es'] ) ) {
+		if ( isset( $_GET[ self::QUERY_INTEGRATION_FORCE_ENABLE_KEY ] ) ) {
 			return;
 		}
 
@@ -325,7 +326,7 @@ class Search {
 	public function do_mirror_search_request() {
 		fastcgi_finish_request();
 
-		$vip_search_url = home_url( add_query_arg( 'es', 'true' ) );
+		$vip_search_url = home_url( add_query_arg( self::QUERY_INTEGRATION_FORCE_ENABLE_KEY, 'true' ) );
 
 		wp_remote_request( $vip_search_url, [
 			'user-agent' => sprintf( 'VIP Search Query Mirror; %s', home_url() ),
@@ -632,7 +633,7 @@ class Search {
 	 * constant should be set to `true`, which will enable query integration for all requests
 	 */
 	public static function is_query_integration_enabled() {
-		if ( isset( $_GET['es'] ) ) {
+		if ( isset( $_GET[ self::QUERY_INTEGRATION_FORCE_ENABLE_KEY ] ) ) {
 			return true;
 		}
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1126,7 +1126,7 @@ class Search_Test extends \WP_UnitTestCase {
 	 */
 	public function test__is_query_integration_enabled_via_query_param() {
 		// Set es query string to test override
-		$_GET['es'] = true;
+		$_GET[ \Automattic\VIP\Search\Search::QUERY_INTEGRATION_FORCE_ENABLE_KEY ] = true;
 
 		$this->assertTrue( \Automattic\VIP\Search\Search::is_query_integration_enabled() );
 	}
@@ -1190,14 +1190,14 @@ class Search_Test extends \WP_UnitTestCase {
 
 		add_option( 'vip_enable_vip_search_query_integration', true );
 		define( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION', true );
-		$_GET['es'] = true;
+		$_GET[ \Automattic\VIP\Search\Search::QUERY_INTEGRATION_FORCE_ENABLE_KEY ] = true;
 
 		$this->assertFalse( $es::rate_limit_ep_query_integration( false ), 'the default value should be false' );
 		$this->assertTrue( $es::rate_limit_ep_query_integration( true ), 'should honor filters that skip query integrations' );
 
 		// Force ratelimiting to apply
 		$es::$max_query_count = 0;
-		
+
 		// Force this request to be ratelimited
 		$es::$query_db_fallback_value = 11;
 


### PR DESCRIPTION
There was at least one instance where 'es' GET argument conflicted with client code, this PR should eliminate that by changing the argument to more specific `vip_search_enabled`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [NA] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Make sure query integration is not enabled either via the constant or the option.
1. Go to a site, pass `?vip_search_enabled=true&s={SEARCH_TERM}`
1. Verify in QM that the query is offloaded
