### PR TITLE
Search: Switch to admin_menu hook for altering menu

### DIFF
--- a/search/includes/classes/class-dashboard.php
+++ b/search/includes/classes/class-dashboard.php
@@ -5,13 +5,13 @@ namespace Automattic\VIP\Search;
 class Dashboard {
 
 	function __construct() {
-		add_action( 'admin_init', array( __CLASS__, 'admin_init' ) );
+		add_action( 'admin_menu', array( __CLASS__, 'admin_menu' ) );
 	}
 
 	/**
 	 * Disable the Elasticpress dashboard
 	 */
-	static function admin_init() {
+	static function admin_menu() {
 		if ( ! is_automattician() ) {
 			remove_menu_page( 'elasticpress' );
 		}

--- a/search/includes/classes/class-dashboard.php
+++ b/search/includes/classes/class-dashboard.php
@@ -3,19 +3,18 @@
 namespace Automattic\VIP\Search;
 
 class Dashboard {
-
-	function __construct() {
+	public function __construct() {
 		add_action( 'admin_menu', array( __CLASS__, 'admin_menu' ) );
 	}
 
 	/**
 	 * Disable the Elasticpress dashboard
 	 */
-	static function admin_menu() {
+	public static function admin_menu() {
 		if ( ! is_automattician() ) {
 			remove_menu_page( 'elasticpress' );
 		}
 	}
 }
 
-new Dashboard;
+new Dashboard();


### PR DESCRIPTION
## Description

Per docs for `remove_menu_page()`, menu changes should be done on the admin_menu hook:

> This function should be called on the admin_menu action hook. Calling it elsewhere might cause issues: either the function is not defined or the global $menu variable used but this function is not yet declared.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin`
1. Note that the EP submenu item still doesn't render
