### PR TITLE
Remove Query Monitor submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "http-concat"]
 	path = http-concat
 	url = https://github.com/Automattic/nginx-http-concat.git
-[submodule "query-monitor"]
-	path = query-monitor
-	url = https://github.com/johnbillion/query-monitor.git
 [submodule "cron-control"]
 	path = cron-control
 	url = https://github.com/Automattic/Cron-Control.git

--- a/bin/upgrade-plugin.sh
+++ b/bin/upgrade-plugin.sh
@@ -27,7 +27,7 @@ update_wporg_plugin() {
 }
 
 case $PLUGIN_SLUG in
-	vaultpress | akismet | debug-bar)
+	vaultpress | akismet | debug-bar | query-monitor)
 		update_wporg_plugin
 		;;
 	

--- a/query-monitor/LICENSE
+++ b/query-monitor/LICENSE
@@ -1,0 +1,339 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {{description}}
+    Copyright (C) {{year}}  {{fullname}}
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/query-monitor/assets/query-monitor-dark.css
+++ b/query-monitor/assets/query-monitor-dark.css
@@ -1,0 +1,986 @@
+/**
+ * The dark colour scheme for Query Monitor.
+ *
+ * @package query-monitor
+ */
+/* === Admin Toolbar === */
+#wpadminbar .quicklinks .menupop ul li.qm-true > a {
+  color: #8c8 !important;
+}
+#wpadminbar .quicklinks .menupop ul li.qm-true > a:focus, #wpadminbar .quicklinks .menupop ul li.qm-true > a:hover {
+  color: #52b552 !important;
+}
+#wpadminbar .qm-alert {
+  background-color: #f60;
+}
+#wpadminbar #wp-admin-bar-query-monitor-notices a,
+#wpadminbar .qm-notice {
+  background-color: #740;
+}
+#wpadminbar #wp-admin-bar-query-monitor-deprecateds a,
+#wpadminbar .qm-deprecated {
+  background-color: #3c3c3c;
+}
+#wpadminbar #wp-admin-bar-query-monitor-stricts a,
+#wpadminbar .qm-strict {
+  background-color: #3c3c3c;
+}
+#wpadminbar #wp-admin-bar-query-monitor-expensive a,
+#wpadminbar .qm-expensive {
+  background-color: #b60;
+}
+#wpadminbar #wp-admin-bar-query-monitor-logger-warning a,
+#wpadminbar #wp-admin-bar-query-monitor-warnings a,
+#wpadminbar .qm-warning {
+  background-color: #c00;
+}
+#wpadminbar #wp-admin-bar-query-monitor-logger-warning a:hover,
+#wpadminbar #wp-admin-bar-query-monitor-warnings a:hover,
+#wpadminbar .qm-warning:hover {
+  background-color: #b00;
+  color: #ddd !important;
+}
+#wpadminbar #wp-admin-bar-query-monitor-errors a,
+#wpadminbar .qm-error {
+  background-color: #c00;
+}
+
+#wp-admin-bar-query-monitor *,
+#wp-admin-bar-query-monitor {
+  direction: ltr !important;
+  text-align: left !important;
+}
+
+body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover):not(.hover) .ab-label,
+#wp-admin-bar-query-monitor-deprecateds a,
+#wp-admin-bar-query-monitor-stricts a,
+#wp-admin-bar-query-monitor-notices a,
+#wp-admin-bar-query-monitor-expensive a,
+#wp-admin-bar-query-monitor-logger-warning a,
+#wp-admin-bar-query-monitor-warnings a,
+#wp-admin-bar-query-monitor-errors a {
+  color: #eee !important;
+}
+
+#wp-admin-bar-query-monitor small {
+  font-size: 11px !important;
+}
+
+#wp-admin-bar-query-monitor.hover a small,
+#wp-admin-bar-query-monitor.hover a .ab-label {
+  text-shadow: none !important;
+}
+
+#wp-admin-bar-query-monitor-placeholder,
+#wp-admin-bar-query-monitor-default {
+  display: none;
+}
+
+#wpadminbar #wp-admin-bar-query-monitor .ab-icon {
+  font: 18px/44px 'Open Sans', sans-serif !important;
+  /* @todo remove open sans */
+  width: auto !important;
+  padding: 0 10px !important;
+  color: #aaa !important;
+  display: none !important;
+}
+
+@media screen and (max-width: 782px) {
+  /* force menu icon to show up */
+  #wpadminbar #wp-admin-bar-query-monitor .ab-icon {
+    display: block !important;
+  }
+
+  /* hide menu text */
+  #wpadminbar #wp-admin-bar-query-monitor .ab-label {
+    display: none !important;
+  }
+}
+/* === Main QM Panel === */
+#query-monitor,
+#query-monitor dl,
+#query-monitor dt,
+#query-monitor dd,
+#query-monitor button,
+#query-monitor label,
+#query-monitor select,
+#query-monitor table,
+#query-monitor td,
+#query-monitor th,
+#query-monitor ul,
+#query-monitor ol,
+#query-monitor li,
+#query-monitor code,
+#query-monitor a,
+#query-monitor h1,
+#query-monitor h2,
+#query-monitor h3,
+#query-monitor h4,
+#query-monitor h5,
+#query-monitor h6,
+#query-monitor p {
+  /* reset */
+  background: transparent !important;
+  color: #bbc8d4 !important;
+  box-sizing: border-box !important;
+  text-align: left !important;
+  font-style: normal !important;
+  font-weight: normal !important;
+  font-size: 12px !important;
+  line-height: 18px !important;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  vertical-align: baseline !important;
+  text-shadow: none !important;
+  text-transform: none !important;
+  -webkit-font-smoothing: auto !important;
+  letter-spacing: normal !important;
+  border-radius: 0 !important;
+  transition: none !important;
+  word-wrap: normal !important;
+  word-break: normal !important;
+  outline: none !important;
+  box-shadow: none !important;
+  text-indent: 0 !important;
+}
+
+#query-monitor {
+  background: #23282d !important;
+  margin: 0 !important;
+  border-top: 1px solid #bbc8d4 !important;
+  text-align: left !important;
+  display: none;
+  position: fixed;
+  z-index: 99998 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  width: 100% !important;
+  direction: ltr !important;
+}
+
+#query-monitor.qm-show,
+#query-monitor.qm-peek {
+  height: 27px;
+  display: flex;
+  flex-direction: column !important;
+}
+
+#query-monitor.qm-show {
+  height: 40%;
+}
+
+#query-monitor #qm-wrapper {
+  display: flex;
+  flex-grow: 1 !important;
+  /* Fix nested scrolling in Firefox. See https://bugzilla.mozilla.org/show_bug.cgi?id=1043520: */
+  min-height: 0;
+}
+#query-monitor #qm-title {
+  background: #32373c !important;
+  border-bottom: 1px solid #bbc8d4 !important;
+  cursor: ns-resize !important;
+  align-items: center !important;
+  display: flex !important;
+  padding: 0 0 0 5px !important;
+  height: 27px !important;
+  flex-shrink: 0 !important;
+  -moz-user-select: none !important;
+  -ms-user-select: none !important;
+  -webkit-user-select: none !important;
+  user-select: none !important;
+}
+#query-monitor #qm-title .qm-title-heading {
+  flex-grow: 1 !important;
+  border-right: 1px solid #bbb !important;
+  margin-right: 8px !important;
+}
+#query-monitor #qm-title div.qm-title-heading {
+  display: none;
+}
+#query-monitor #qm-title .qm-title-button {
+  flex-shrink: 0 !important;
+}
+#query-monitor #qm-title .dashicons {
+  transition: none !important;
+}
+#query-monitor #qm-title .qm-button-container-settings .dashicons,
+#query-monitor #qm-title .qm-button-container-pin .dashicons {
+  font-size: 17px !important;
+  margin: 3px 0 2px !important;
+}
+#query-monitor #qm-title .qm-button-container-close .dashicons {
+  margin: 2px 0 3px !important;
+}
+#query-monitor #qm-title button {
+  color: #bbc8d4 !important;
+  background: transparent !important;
+  cursor: pointer !important;
+  margin: 0 0 0 0px !important;
+  display: inline-block !important;
+  padding: 0px 4px !important;
+}
+#query-monitor #qm-title button:focus,
+#query-monitor #qm-title button:hover {
+  color: #32373c !important;
+  background: #bbc8d4 !important;
+}
+#query-monitor #qm-title button:active {
+  background: #ccc !important;
+}
+#query-monitor #qm-title button.qm-button-active {
+  color: #3879d9 !important;
+}
+#query-monitor #qm-title .qm-button-container-pin.qm-button-active .dashicons {
+  transform: rotate(-45deg) !important;
+}
+#query-monitor #qm-title .qm-button-container-pin.qm-button-active .dashicons:before {
+  margin-left: 2px !important;
+}
+#query-monitor .qm {
+  display: none !important;
+}
+#query-monitor #qm-panel-menu {
+  overflow-y: scroll !important;
+  flex-shrink: 0 !important;
+  background: #23282d !important;
+  overscroll-behavior: contain !important;
+}
+#query-monitor #qm-panel-menu ul {
+  padding: 0 !important;
+  margin: 0 !important;
+  list-style: none !important;
+}
+#query-monitor #qm-panel-menu li {
+  padding: 0 !important;
+  margin: 0 !important;
+}
+#query-monitor #qm-panel-menu li button {
+  display: block !important;
+  padding: 8px 28px 8px 6px !important;
+  color: #bbc8d4 !important;
+  text-decoration: none !important;
+  border-bottom: 1px solid #32373c !important;
+  position: relative !important;
+  border-right: 1px solid #bbc8d4 !important;
+  background: #23282d !important;
+  width: 100% !important;
+  cursor: pointer !important;
+}
+#query-monitor #qm-panel-menu li button:focus,
+#query-monitor #qm-panel-menu li button:hover {
+  background: #def !important;
+  color: #222 !important;
+}
+#query-monitor #qm-panel-menu li button:focus {
+  text-decoration: underline !important;
+}
+#query-monitor #qm-panel-menu li button.qm-selected-menu {
+  background: #0073aa !important;
+  color: #fff !important;
+  text-shadow: 0 -1px 1px #006291, 1px 0 1px #006291, 0 1px 1px #006291, -1px 0 1px #006291 !important;
+}
+#query-monitor #qm-panel-menu li button.qm-selected-menu:focus {
+  background: #0084c4 !important;
+  color: #fff !important;
+}
+#query-monitor #qm-panel-menu li button.qm-selected-menu:after {
+  right: -1px;
+  border: solid 8px transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+  border-right-color: #23282d;
+  top: 50%;
+  margin-top: -8px;
+}
+#query-monitor #qm-panels {
+  flex-grow: 1 !important;
+  overflow-y: scroll !important;
+  overscroll-behavior: contain !important;
+}
+#query-monitor .qm.qm-panel-show {
+  display: block !important;
+}
+#query-monitor .qm:focus {
+  outline: 0 !important;
+  /* @TODO might not need this any more */
+}
+#query-monitor .qm-non-tabular {
+  padding: 10px 20px !important;
+}
+#query-monitor .qm-boxed {
+  display: flex !important;
+  flex-wrap: wrap !important;
+}
+#query-monitor .qm-boxed:not(#qm-broken) + .qm-boxed {
+  border-top: 1px solid #bbc8d4 !important;
+  padding-top: 10px !important;
+}
+#query-monitor .qm-boxed-wrap {
+  flex-wrap: wrap !important;
+}
+#query-monitor .qm .qm-none {
+  margin: 2em !important;
+}
+#query-monitor .qm .qm-none p {
+  text-align: center !important;
+  font-style: italic !important;
+}
+#query-monitor .qm table {
+  color: #bbc8d4 !important;
+  border-collapse: collapse !important;
+  box-shadow: none !important;
+  width: 100% !important;
+  table-layout: auto !important;
+  margin: 0 !important;
+  border: none !important;
+  border-bottom: 1px solid #23282d !important;
+}
+#query-monitor .qm table + table {
+  margin-top: 5px !important;
+  border-top: 1px solid #23282d !important;
+}
+#query-monitor #qm-conditionals table,
+#query-monitor #qm-overview table {
+  table-layout: fixed !important;
+}
+#query-monitor .qm tr {
+  border: none !important;
+}
+#query-monitor .qm tbody th,
+#query-monitor .qm tbody td,
+#query-monitor .qm tfoot th,
+#query-monitor .qm tfoot td {
+  border: 1px solid #23282d !important;
+  padding: 5px 5px 4px 5px !important;
+}
+#query-monitor .qm tbody th,
+#query-monitor .qm tbody td {
+  border-top: none !important;
+  border-bottom: none !important;
+}
+#query-monitor .qm thead th {
+  box-shadow: 0px 1px 0px #23282d !important;
+  border: 1px solid #23282d !important;
+  border-top: none !important;
+  padding: 5px !important;
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  top: 0 !important;
+  background: #32373c !important;
+  z-index: 1 !important;
+}
+#query-monitor .qm thead .qm-th {
+  display: flex !important;
+}
+#query-monitor .qm tfoot tr td,
+#query-monitor .qm tfoot tr th {
+  box-shadow: inset 0px 1px 0px #23282d !important;
+  border: 1px solid #23282d !important;
+  border-bottom: none !important;
+  background: #32373c !important;
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  bottom: 0 !important;
+}
+#query-monitor .qm th:first-child,
+#query-monitor .qm td:first-child {
+  border-left: none !important;
+}
+#query-monitor .qm th:last-child,
+#query-monitor .qm td:last-child {
+  border-right: none !important;
+}
+#query-monitor .qm tfoot td.qm-num,
+#query-monitor .qm tfoot th.qm-num,
+#query-monitor .qm thead td.qm-num,
+#query-monitor .qm thead th.qm-num {
+  width: 5.5em !important;
+}
+#query-monitor .qm th.qm-num,
+#query-monitor .qm td.qm-num {
+  text-align: right !important;
+}
+#query-monitor .qm td.qm-row-sql {
+  min-width: 25em !important;
+}
+#query-monitor .qm tr.qm-warn td.qm-col-status,
+#query-monitor .qm td.qm-url,
+#query-monitor .qm th.qm-col-message,
+#query-monitor .qm td.qm-row-component {
+  min-width: 15em !important;
+}
+#query-monitor .qm td.qm-has-toggle p,
+#query-monitor .qm td .qm-toggler {
+  padding: 0 22px 0 0 !important;
+  position: relative !important;
+}
+#query-monitor .qm td.qm-has-toggle:not(.qm-toggled-on) .qm-supplemental {
+  display: none;
+}
+#query-monitor .qm .qm-inner-toggle {
+  padding: 4px 6px !important;
+}
+
+.qm-has-inner .qm-toggled > table {
+  border-top: 1px solid #23282d !important;
+}
+
+.qm-inner {
+  border-collapse: collapse !important;
+  margin: 0 !important;
+  border-style: hidden !important;
+  width: 100% !important;
+}
+
+#query-monitor .qm td.qm-has-inner .qm-toggler,
+#query-monitor .qm td.qm-has-inner {
+  padding: 0 !important;
+}
+#query-monitor .qm-non-tabular h3 {
+  margin: 0 0 15px 0 !important;
+  font-size: 14px !important;
+}
+#query-monitor .qm-non-tabular h4 {
+  margin: 20px 0 10px !important;
+  font-size: 12px !important;
+}
+#query-monitor .qm-non-tabular p {
+  margin-bottom: 10px !important;
+}
+#query-monitor .qm-non-tabular dd {
+  margin: 0 0 10px 10px !important;
+}
+#query-monitor .qm-non-tabular h3 a {
+  float: right !important;
+}
+#query-monitor .qm-non-tabular .qm-item {
+  display: inline-block !important;
+  margin: 0 20px 5px 0 !important;
+}
+#query-monitor .qm-non-tabular .qm-section {
+  margin: 0 0 30px 0 !important;
+}
+#query-monitor .qm-non-tabular .qm-boxed .qm-section {
+  margin: 0 20px 10px 0 !important;
+  border-right: 1px solid #bbc8d4 !important;
+  padding: 10px 20px 10px 0 !important;
+}
+#query-monitor .qm-non-tabular .qm-boxed .qm-section:last-child {
+  margin-right: 0 !important;
+  border-right: none !important;
+  padding-right: 20px !important;
+}
+#query-monitor .qm-non-tabular table {
+  border-bottom-color: #23282d !important;
+}
+#query-monitor .qm ol,
+#query-monitor .qm ul {
+  list-style: none !important;
+}
+#query-monitor .qm li {
+  display: list-item !important;
+  list-style: none !important;
+}
+#query-monitor .qm li::before {
+  content: '' !important;
+}
+#query-monitor .qm .qm-has-toggle ol.qm-numbered li {
+  list-style: none !important;
+}
+#query-monitor .qm .qm-toggled-on ol.qm-numbered li,
+#query-monitor .qm ol.qm-numbered li {
+  list-style: decimal inside !important;
+}
+#query-monitor .qm code,
+#query-monitor .qm pre {
+  font-size: 11px !important;
+  line-height: 18px !important;
+  font-family: Menlo, Monaco, Consolas, monospace !important;
+}
+#query-monitor .qm pre {
+  background: transparent !important;
+  margin: 0 !important;
+  width: auto !important;
+  height: auto !important;
+  padding: 0 !important;
+}
+#query-monitor .qm .qm-true code,
+#query-monitor .qm p.qm-true,
+#query-monitor .qm span.qm-true,
+#query-monitor .qm td.qm-true {
+  color: #4a4 !important;
+}
+#query-monitor .qm .qm-false code,
+#query-monitor .qm span.qm-false,
+#query-monitor .qm td.qm-false {
+  color: #999 !important;
+}
+#query-monitor .qm code,
+#query-monitor .qm .qm-nowrap {
+  white-space: nowrap !important;
+}
+#query-monitor .qm .qm-wrap code,
+#query-monitor .qm .qm-wrap {
+  word-wrap: break-word !important;
+  word-break: break-all !important;
+  white-space: normal !important;
+}
+#query-monitor .qm .qm-sticky {
+  position: sticky !important;
+  top: 36px !important;
+}
+#query-monitor .qm .qm-current,
+#query-monitor .qm td.qm-has-toggle p,
+#query-monitor .qm .qm-nonselectsql code,
+#query-monitor .qm .qm-nonselectsql {
+  color: #a6a !important;
+}
+#query-monitor .qm .qm-info {
+  color: #777 !important;
+}
+#query-monitor .qm .qm-supplemental {
+  margin-right: 0.75em !important;
+  margin-left: 0.75em !important;
+}
+#query-monitor .qm td .qm-toggled {
+  display: none;
+}
+#query-monitor .qm button.qm-button,
+#query-monitor .qm .qm-toggle {
+  color: #fff !important;
+  font-weight: normal !important;
+  background: #0085ba !important;
+  cursor: pointer !important;
+  border: 1px solid #0073a1 !important;
+  border-radius: 2px !important;
+  text-shadow: 0 -1px 1px #0073a1, 1px 0 1px #0073a1, 0 1px 1px #0073a1, -1px 0 1px #0073a1 !important;
+}
+#query-monitor .qm .qm-toggle {
+  padding: 0 !important;
+  font-family: Menlo, Monaco, Consolas, monospace !important;
+  position: absolute !important;
+  top: 0 !important;
+  right: 0 !important;
+  left: auto !important;
+  bottom: auto !important;
+  text-align: center !important;
+  line-height: 16px !important;
+  height: 18px !important;
+  width: 18px !important;
+}
+#query-monitor .qm button {
+  cursor: pointer !important;
+}
+#query-monitor .qm button.qm-button {
+  padding: 4px 10px !important;
+}
+#query-monitor .qm .qm-has-inner .qm-toggle {
+  top: 5px !important;
+  right: 5px !important;
+}
+#query-monitor .qm button.qm-button:hover,
+#query-monitor .qm button.qm-button:focus,
+#query-monitor .qm .qm-toggle:focus,
+#query-monitor .qm .qm-toggle:hover {
+  text-decoration: none !important;
+  color: #fff !important;
+  background: #0094ce !important;
+}
+#query-monitor .qm tbody tr.qm-odd td,
+#query-monitor .qm tbody tr.qm-odd th {
+  background: #32373c !important;
+}
+
+.qm-debug-bar tbody tr:hover th,
+.qm-debug-bar tbody tr:hover td {
+  background: #fff !important;
+  /* transparent? */
+}
+
+#query-monitor .qm-non-tabular .qm-warn,
+#query-monitor .qm thead tr .qm-warn,
+#query-monitor .qm tbody tr .qm-warn {
+  background-color: #800 !important;
+  color: #fff0f0 !important;
+}
+#query-monitor .qm tbody tr th.qm-warn,
+#query-monitor .qm tbody tr td.qm-warn,
+#query-monitor .qm tbody tr.qm-warn td,
+#query-monitor .qm tbody tr.qm-warn th {
+  background-color: #800 !important;
+  box-shadow: inset 0 -1px #ffd6d6 !important;
+  border-color: #ffd6d6 !important;
+  color: #fff0f0 !important;
+}
+#query-monitor .qm-non-tabular .qm-warn code,
+#query-monitor .qm tbody .qm-warn li,
+#query-monitor .qm tbody .qm-warn .qm-info,
+#query-monitor .qm tbody .qm-warn code {
+  color: #fff0f0 !important;
+  background-color: transparent !important;
+}
+#query-monitor .qm .qm-notice {
+  background: #def !important;
+  border: 1px solid #aad5ff !important;
+  padding: 10px 20px 0 !important;
+  margin: 0 0 10px 0 !important;
+}
+#query-monitor .qm .dashicons {
+  font-size: 16px !important;
+  width: 16px !important;
+  height: 16px !important;
+  margin-right: 0.3em !important;
+  transition: none !important;
+}
+#query-monitor .qm .qm-dashicons-yes {
+  color: #fff !important;
+  background-color: #0a0 !important;
+  border-radius: 50% !important;
+}
+#query-monitor .qm tbody tr.qm-hovered th,
+#query-monitor .qm tbody tr.qm-hovered td,
+#query-monitor .qm tbody tr:hover th,
+#query-monitor .qm tbody tr:hover td {
+  background: #3e444a !important;
+}
+#query-monitor .qm thead th.qm-filtered select.qm-filter {
+  background-color: #57572a !important;
+  color: #bbc8d4 !important;
+}
+#query-monitor .qm tbody tr td.qm-highlight,
+#query-monitor .qm tbody tr.qm-highlight td {
+  background-color: #57572a !important;
+  box-shadow: inset 0 -1px #660 !important;
+  border-color: #660 !important;
+  color: #bbc8d4 !important;
+}
+
+#query-monitor .qm tbody .qm-warn a code,
+#qm-title a,
+#query-monitor .qm a code,
+#query-monitor .qm a {
+  color: #30ceff !important;
+  text-decoration: none !important;
+  cursor: pointer !important;
+}
+#query-monitor .qm tbody .qm-warn a code:after, #query-monitor .qm tbody .qm-warn a code:focus, #query-monitor .qm tbody .qm-warn a code:hover,
+#qm-title a:after,
+#qm-title a:focus,
+#qm-title a:hover,
+#query-monitor .qm a code:after,
+#query-monitor .qm a code:focus,
+#query-monitor .qm a code:hover,
+#query-monitor .qm a:after,
+#query-monitor .qm a:focus,
+#query-monitor .qm a:hover {
+  text-decoration: underline !important;
+  color: #4092d2 !important;
+}
+
+#query-monitor .qm a.qm-external-link:after,
+#query-monitor .qm a.qm-link:after,
+#query-monitor .qm a.qm-edit-link:after,
+#query-monitor .qm a.qm-filter-trigger:after {
+  font-family: dashicons !important;
+  text-decoration: none !important;
+  visibility: hidden !important;
+  display: inline-block !important;
+  font-size: 13px !important;
+  line-height: 15px !important;
+  position: relative !important;
+  top: 2px !important;
+  left: 2px !important;
+}
+
+#query-monitor .qm a.qm-external-link:after,
+#query-monitor.qm-touch .qm a.qm-link:after,
+#query-monitor .qm a.qm-link:hover:after,
+#query-monitor .qm a.qm-link:focus:after,
+#query-monitor.qm-touch .qm a.qm-edit-link:after,
+#query-monitor .qm a.qm-edit-link:hover:after,
+#query-monitor .qm a.qm-edit-link:focus:after,
+#query-monitor.qm-touch .qm a.qm-filter-trigger:after,
+#query-monitor .qm a.qm-filter-trigger:hover:after,
+#query-monitor .qm a.qm-filter-trigger:focus:after {
+  visibility: visible !important;
+}
+
+#query-monitor .qm a.qm-filter-trigger:after {
+  content: '\f536' !important;
+}
+
+#query-monitor .qm a.qm-edit-link:after {
+  content: '\f464' !important;
+}
+
+#query-monitor .qm a.qm-external-link:after,
+#query-monitor .qm a.qm-link:after {
+  content: '\f504' !important;
+}
+
+#query-monitor #qm-ajax-errors {
+  display: none;
+}
+
+/* Filters */
+#query-monitor button,
+#query-monitor select {
+  margin: 0 !important;
+  height: auto !important;
+  width: auto !important;
+  background: none !important;
+}
+
+#query-monitor .qm label {
+  cursor: pointer !important;
+  color: #bbc8d4 !important;
+  font-weight: normal !important;
+  font-size: 12px !important;
+  font-style: normal !important;
+  margin: 0 !important;
+}
+
+#query-monitor .qm thead label {
+  flex-grow: 1 !important;
+}
+
+#query-monitor .qm .qm-filter-container {
+  display: flex !important;
+}
+
+#query-monitor .qm .qm-filter-container label {
+  cursor: default !important;
+}
+
+#query-monitor .qm .qm-filter-container div {
+  /* Some themes use Select2 etc on all selects. This hides that. */
+  display: none !important;
+}
+
+#query-monitor .qm select.qm-filter {
+  display: block !important;
+  margin: 0 0 0 5px !important;
+  outline: 1px solid #bbc8d4 !important;
+  border: none !important;
+  padding: 0 !important;
+  background: #32373c !important;
+  color: #bbc8d4 !important;
+  height: auto !important;
+  width: auto !important;
+  float: none !important;
+  cursor: pointer !important;
+  -webkit-appearance: menulist !important;
+  -moz-appearance: menulist !important;
+  appearance: menulist !important;
+  letter-spacing: normal !important;
+  max-width: 10em !important;
+}
+
+#query-monitor .qm select.qm-filter:hover {
+  background: #32373c !important;
+}
+
+.qm-hide,
+.qm-hide-scripts-host,
+.qm-hide-styles-host,
+.qm-hide-user,
+.qm-hide-result,
+.qm-hide-name,
+.qm-hide-type,
+.qm-hide-caller,
+.qm-hide-component {
+  display: none !important;
+}
+
+/* Sorters */
+#query-monitor .qm thead th.qm-sortable-column {
+  cursor: pointer !important;
+}
+
+#query-monitor .qm thead th.qm-sortable-column:hover {
+  background: #32373c !important;
+}
+
+#query-monitor .qm .qm-sort-heading {
+  flex-grow: 1 !important;
+}
+
+#query-monitor .qm .qm-sort-controls {
+  text-align: right !important;
+  flex-shrink: 0 !important;
+}
+
+#query-monitor .qm .qm-sortable-column .qm-sort-arrow {
+  font-family: dashicons !important;
+  font-size: 23px !important;
+  color: #ccc !important;
+  margin: 0 !important;
+  width: 16px !important;
+  height: 10px !important;
+  display: block !important;
+}
+
+#query-monitor .qm .qm-sorted-desc .qm-sort-arrow,
+#query-monitor .qm .qm-sorted-asc .qm-sort-arrow {
+  color: #bbc8d4 !important;
+}
+
+#query-monitor .qm thead th.qm-sortable-column:hover .qm-sort-arrow {
+  color: #0073aa !important;
+}
+
+#query-monitor .qm .qm-sortable-column .qm-sort-arrow:before {
+  content: "\f140" !important;
+  top: 4px !important;
+  right: 0 !important;
+  position: absolute !important;
+}
+
+#query-monitor .qm .qm-sortable-column.qm-sorted-asc .qm-sort-arrow:before {
+  content: "\f142" !important;
+}
+
+#query-monitor .qm button:focus,
+#query-monitor .qm a:focus,
+#query-monitor .qm select:focus {
+  box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8) !important;
+}
+
+#query-monitor .qm-screen-reader-text,
+#query-monitor .screen-reader-text {
+  position: absolute !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  height: 1px !important;
+  width: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  border: 0 !important;
+}
+
+@media screen and (max-width: 782px) {
+  #query-monitor #qm-panel-menu,
+  #query-monitor #qm-title h1.qm-title-heading {
+    display: none;
+  }
+
+  #query-monitor #qm-title div.qm-title-heading {
+    display: block;
+  }
+}
+/* State Toggle */
+#query-monitor [data-qm-state="off"] [data-qm-state-visibility="on"],
+#query-monitor [data-qm-state="on"] [data-qm-state-visibility="off"] {
+  display: none;
+}
+
+/* No-JS tweaks */
+.qm-no-js .qm-sort-controls,
+.qm-no-js .qm-toggle,
+.qm-no-js select.qm-filter {
+  display: none !important;
+}
+
+/* Debug bar add-ons */
+#query-monitor .qm.qm-debug-bar textarea,
+#query-monitor .qm.qm-debug-bar pre {
+  padding: 10px !important;
+  border: 1px solid #bbc8d4 !important;
+  margin: 4px 0 !important;
+}
+
+#query-monitor .qm.qm-debug-bar textarea {
+  resize: vertical !important;
+}
+
+#query-monitor .qm.qm-debug-bar .left {
+  float: left !important;
+}
+
+#query-monitor .qm.qm-debug-bar .right {
+  float: right !important;
+}
+
+#query-monitor .qm.qm-debug-bar h2 {
+  font-size: 14px !important;
+  margin: 4px 6px 15px !important;
+}
+
+#query-monitor .qm.qm-debug-bar h3 {
+  float: left !important;
+  /* why */
+  min-width: 150px !important;
+  padding: 5px 10px 15px !important;
+  clear: none !important;
+  text-align: center !important;
+  font-size: 14px !important;
+  margin: 3px 8px 15px 0 !important;
+}
+
+#query-monitor .qm.qm-debug-bar h3 small {
+  font-size: 14px !important;
+}
+
+#query-monitor .qm.qm-debug-bar h3 span {
+  white-space: nowrap !important;
+  display: block !important;
+  margin-bottom: 8px !important;
+}
+
+#query-monitor .qm.qm-debug-bar h4 {
+  margin: 15px 6px 5px !important;
+  font-size: 13px !important;
+}
+
+#query-monitor .qm.qm-debug-bar .qm-debug-bar-output {
+  position: relative !important;
+}
+
+#query-monitor .qm.qm-debug-bar .qm-debug-bar-output table {
+  margin-top: 4px !important;
+  margin-bottom: 4px !important;
+}
+
+#query-monitor #debug-menu-target-Debug_Bar_Console {
+  min-height: 400px !important;
+}
+
+#query-monitor #debug-menu-target-Debug_Bar_Cache_Lookup,
+#query-monitor #debug-menu-target-Debug_Bar_Rewrite_Rules,
+#query-monitor #debug-menu-target-Debug_Bar_Widgets {
+  margin: 4px 6px !important;
+}
+
+#query-monitor #debug-menu-target-Debug_Bar_Rewrite_Rules_Panel .filterui,
+#query-monitor #debug-menu-target-Debug_Bar_Rewrite_Rules_Panel .dbrr {
+  margin: 0 !important;
+}
+
+/* Broken output handling */
+#query-monitor.qm-broken #qm-title {
+  cursor: default !important;
+}
+
+#query-monitor #qm-broken,
+#query-monitor.qm-broken .qm-title-button {
+  display: none !important;
+}
+
+#query-monitor.qm-broken #qm-broken,
+#query-monitor.qm-broken .qm {
+  display: block !important;
+}
+
+#query-monitor.qm-broken .qm {
+  margin-bottom: 50px !important;
+}
+
+#query-monitor.qm-broken #qm-broken h2 {
+  padding: 20px !important;
+}

--- a/query-monitor/assets/query-monitor.css
+++ b/query-monitor/assets/query-monitor.css
@@ -1,0 +1,986 @@
+/**
+ * The standard colour scheme for Query Monitor.
+ *
+ * @package query-monitor
+ */
+/* === Admin Toolbar === */
+#wpadminbar .quicklinks .menupop ul li.qm-true > a {
+  color: #8c8 !important;
+}
+#wpadminbar .quicklinks .menupop ul li.qm-true > a:focus, #wpadminbar .quicklinks .menupop ul li.qm-true > a:hover {
+  color: #52b552 !important;
+}
+#wpadminbar .qm-alert {
+  background-color: #f60;
+}
+#wpadminbar #wp-admin-bar-query-monitor-notices a,
+#wpadminbar .qm-notice {
+  background-color: #740;
+}
+#wpadminbar #wp-admin-bar-query-monitor-deprecateds a,
+#wpadminbar .qm-deprecated {
+  background-color: #3c3c3c;
+}
+#wpadminbar #wp-admin-bar-query-monitor-stricts a,
+#wpadminbar .qm-strict {
+  background-color: #3c3c3c;
+}
+#wpadminbar #wp-admin-bar-query-monitor-expensive a,
+#wpadminbar .qm-expensive {
+  background-color: #b60;
+}
+#wpadminbar #wp-admin-bar-query-monitor-logger-warning a,
+#wpadminbar #wp-admin-bar-query-monitor-warnings a,
+#wpadminbar .qm-warning {
+  background-color: #c00;
+}
+#wpadminbar #wp-admin-bar-query-monitor-logger-warning a:hover,
+#wpadminbar #wp-admin-bar-query-monitor-warnings a:hover,
+#wpadminbar .qm-warning:hover {
+  background-color: #b00;
+  color: #ddd !important;
+}
+#wpadminbar #wp-admin-bar-query-monitor-errors a,
+#wpadminbar .qm-error {
+  background-color: #c00;
+}
+
+#wp-admin-bar-query-monitor *,
+#wp-admin-bar-query-monitor {
+  direction: ltr !important;
+  text-align: left !important;
+}
+
+body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover):not(.hover) .ab-label,
+#wp-admin-bar-query-monitor-deprecateds a,
+#wp-admin-bar-query-monitor-stricts a,
+#wp-admin-bar-query-monitor-notices a,
+#wp-admin-bar-query-monitor-expensive a,
+#wp-admin-bar-query-monitor-logger-warning a,
+#wp-admin-bar-query-monitor-warnings a,
+#wp-admin-bar-query-monitor-errors a {
+  color: #eee !important;
+}
+
+#wp-admin-bar-query-monitor small {
+  font-size: 11px !important;
+}
+
+#wp-admin-bar-query-monitor.hover a small,
+#wp-admin-bar-query-monitor.hover a .ab-label {
+  text-shadow: none !important;
+}
+
+#wp-admin-bar-query-monitor-placeholder,
+#wp-admin-bar-query-monitor-default {
+  display: none;
+}
+
+#wpadminbar #wp-admin-bar-query-monitor .ab-icon {
+  font: 18px/44px 'Open Sans', sans-serif !important;
+  /* @todo remove open sans */
+  width: auto !important;
+  padding: 0 10px !important;
+  color: #aaa !important;
+  display: none !important;
+}
+
+@media screen and (max-width: 782px) {
+  /* force menu icon to show up */
+  #wpadminbar #wp-admin-bar-query-monitor .ab-icon {
+    display: block !important;
+  }
+
+  /* hide menu text */
+  #wpadminbar #wp-admin-bar-query-monitor .ab-label {
+    display: none !important;
+  }
+}
+/* === Main QM Panel === */
+#query-monitor,
+#query-monitor dl,
+#query-monitor dt,
+#query-monitor dd,
+#query-monitor button,
+#query-monitor label,
+#query-monitor select,
+#query-monitor table,
+#query-monitor td,
+#query-monitor th,
+#query-monitor ul,
+#query-monitor ol,
+#query-monitor li,
+#query-monitor code,
+#query-monitor a,
+#query-monitor h1,
+#query-monitor h2,
+#query-monitor h3,
+#query-monitor h4,
+#query-monitor h5,
+#query-monitor h6,
+#query-monitor p {
+  /* reset */
+  background: transparent !important;
+  color: #222 !important;
+  box-sizing: border-box !important;
+  text-align: left !important;
+  font-style: normal !important;
+  font-weight: normal !important;
+  font-size: 12px !important;
+  line-height: 18px !important;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  vertical-align: baseline !important;
+  text-shadow: none !important;
+  text-transform: none !important;
+  -webkit-font-smoothing: auto !important;
+  letter-spacing: normal !important;
+  border-radius: 0 !important;
+  transition: none !important;
+  word-wrap: normal !important;
+  word-break: normal !important;
+  outline: none !important;
+  box-shadow: none !important;
+  text-indent: 0 !important;
+}
+
+#query-monitor {
+  background: #fff !important;
+  margin: 0 !important;
+  border-top: 1px solid #aaa !important;
+  text-align: left !important;
+  display: none;
+  position: fixed;
+  z-index: 99998 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  width: 100% !important;
+  direction: ltr !important;
+}
+
+#query-monitor.qm-show,
+#query-monitor.qm-peek {
+  height: 27px;
+  display: flex;
+  flex-direction: column !important;
+}
+
+#query-monitor.qm-show {
+  height: 40%;
+}
+
+#query-monitor #qm-wrapper {
+  display: flex;
+  flex-grow: 1 !important;
+  /* Fix nested scrolling in Firefox. See https://bugzilla.mozilla.org/show_bug.cgi?id=1043520: */
+  min-height: 0;
+}
+#query-monitor #qm-title {
+  background: #f3f3f3 !important;
+  border-bottom: 1px solid #aaa !important;
+  cursor: ns-resize !important;
+  align-items: center !important;
+  display: flex !important;
+  padding: 0 0 0 5px !important;
+  height: 27px !important;
+  flex-shrink: 0 !important;
+  -moz-user-select: none !important;
+  -ms-user-select: none !important;
+  -webkit-user-select: none !important;
+  user-select: none !important;
+}
+#query-monitor #qm-title .qm-title-heading {
+  flex-grow: 1 !important;
+  border-right: 1px solid #bbb !important;
+  margin-right: 8px !important;
+}
+#query-monitor #qm-title div.qm-title-heading {
+  display: none;
+}
+#query-monitor #qm-title .qm-title-button {
+  flex-shrink: 0 !important;
+}
+#query-monitor #qm-title .dashicons {
+  transition: none !important;
+}
+#query-monitor #qm-title .qm-button-container-settings .dashicons,
+#query-monitor #qm-title .qm-button-container-pin .dashicons {
+  font-size: 17px !important;
+  margin: 3px 0 2px !important;
+}
+#query-monitor #qm-title .qm-button-container-close .dashicons {
+  margin: 2px 0 3px !important;
+}
+#query-monitor #qm-title button {
+  color: #666 !important;
+  background: transparent !important;
+  cursor: pointer !important;
+  margin: 0 0 0 0px !important;
+  display: inline-block !important;
+  padding: 0px 4px !important;
+}
+#query-monitor #qm-title button:focus,
+#query-monitor #qm-title button:hover {
+  color: #000 !important;
+  background: #e6e6e6 !important;
+}
+#query-monitor #qm-title button:active {
+  background: #ccc !important;
+}
+#query-monitor #qm-title button.qm-button-active {
+  color: #3879d9 !important;
+}
+#query-monitor #qm-title .qm-button-container-pin.qm-button-active .dashicons {
+  transform: rotate(-45deg) !important;
+}
+#query-monitor #qm-title .qm-button-container-pin.qm-button-active .dashicons:before {
+  margin-left: 2px !important;
+}
+#query-monitor .qm {
+  display: none !important;
+}
+#query-monitor #qm-panel-menu {
+  overflow-y: scroll !important;
+  flex-shrink: 0 !important;
+  background: #ececec !important;
+  overscroll-behavior: contain !important;
+}
+#query-monitor #qm-panel-menu ul {
+  padding: 0 !important;
+  margin: 0 !important;
+  list-style: none !important;
+}
+#query-monitor #qm-panel-menu li {
+  padding: 0 !important;
+  margin: 0 !important;
+}
+#query-monitor #qm-panel-menu li button {
+  display: block !important;
+  padding: 8px 28px 8px 6px !important;
+  color: #333 !important;
+  text-decoration: none !important;
+  border-bottom: 1px solid #ddd !important;
+  position: relative !important;
+  border-right: 1px solid #aaa !important;
+  background: #f3f3f3 !important;
+  width: 100% !important;
+  cursor: pointer !important;
+}
+#query-monitor #qm-panel-menu li button:focus,
+#query-monitor #qm-panel-menu li button:hover {
+  background: #def !important;
+  color: #222 !important;
+}
+#query-monitor #qm-panel-menu li button:focus {
+  text-decoration: underline !important;
+}
+#query-monitor #qm-panel-menu li button.qm-selected-menu {
+  background: #0073aa !important;
+  color: #fff !important;
+  text-shadow: 0 -1px 1px #006291, 1px 0 1px #006291, 0 1px 1px #006291, -1px 0 1px #006291 !important;
+}
+#query-monitor #qm-panel-menu li button.qm-selected-menu:focus {
+  background: #0084c4 !important;
+  color: #fff !important;
+}
+#query-monitor #qm-panel-menu li button.qm-selected-menu:after {
+  right: -1px;
+  border: solid 8px transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+  border-right-color: #fff;
+  top: 50%;
+  margin-top: -8px;
+}
+#query-monitor #qm-panels {
+  flex-grow: 1 !important;
+  overflow-y: scroll !important;
+  overscroll-behavior: contain !important;
+}
+#query-monitor .qm.qm-panel-show {
+  display: block !important;
+}
+#query-monitor .qm:focus {
+  outline: 0 !important;
+  /* @TODO might not need this any more */
+}
+#query-monitor .qm-non-tabular {
+  padding: 10px 20px !important;
+}
+#query-monitor .qm-boxed {
+  display: flex !important;
+  flex-wrap: wrap !important;
+}
+#query-monitor .qm-boxed:not(#qm-broken) + .qm-boxed {
+  border-top: 1px solid #ddd !important;
+  padding-top: 10px !important;
+}
+#query-monitor .qm-boxed-wrap {
+  flex-wrap: wrap !important;
+}
+#query-monitor .qm .qm-none {
+  margin: 2em !important;
+}
+#query-monitor .qm .qm-none p {
+  text-align: center !important;
+  font-style: italic !important;
+}
+#query-monitor .qm table {
+  color: #222 !important;
+  border-collapse: collapse !important;
+  box-shadow: none !important;
+  width: 100% !important;
+  table-layout: auto !important;
+  margin: 0 !important;
+  border: none !important;
+  border-bottom: 1px solid #e0e0e0 !important;
+}
+#query-monitor .qm table + table {
+  margin-top: 5px !important;
+  border-top: 1px solid #e0e0e0 !important;
+}
+#query-monitor #qm-conditionals table,
+#query-monitor #qm-overview table {
+  table-layout: fixed !important;
+}
+#query-monitor .qm tr {
+  border: none !important;
+}
+#query-monitor .qm tbody th,
+#query-monitor .qm tbody td,
+#query-monitor .qm tfoot th,
+#query-monitor .qm tfoot td {
+  border: 1px solid #e0e0e0 !important;
+  padding: 5px 5px 4px 5px !important;
+}
+#query-monitor .qm tbody th,
+#query-monitor .qm tbody td {
+  border-top: none !important;
+  border-bottom: none !important;
+}
+#query-monitor .qm thead th {
+  box-shadow: 0px 1px 0px #e0e0e0 !important;
+  border: 1px solid #e0e0e0 !important;
+  border-top: none !important;
+  padding: 5px !important;
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  top: 0 !important;
+  background: #fff !important;
+  z-index: 1 !important;
+}
+#query-monitor .qm thead .qm-th {
+  display: flex !important;
+}
+#query-monitor .qm tfoot tr td,
+#query-monitor .qm tfoot tr th {
+  box-shadow: inset 0px 1px 0px #e0e0e0 !important;
+  border: 1px solid #e0e0e0 !important;
+  border-bottom: none !important;
+  background: #f3f3f3 !important;
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  bottom: 0 !important;
+}
+#query-monitor .qm th:first-child,
+#query-monitor .qm td:first-child {
+  border-left: none !important;
+}
+#query-monitor .qm th:last-child,
+#query-monitor .qm td:last-child {
+  border-right: none !important;
+}
+#query-monitor .qm tfoot td.qm-num,
+#query-monitor .qm tfoot th.qm-num,
+#query-monitor .qm thead td.qm-num,
+#query-monitor .qm thead th.qm-num {
+  width: 5.5em !important;
+}
+#query-monitor .qm th.qm-num,
+#query-monitor .qm td.qm-num {
+  text-align: right !important;
+}
+#query-monitor .qm td.qm-row-sql {
+  min-width: 25em !important;
+}
+#query-monitor .qm tr.qm-warn td.qm-col-status,
+#query-monitor .qm td.qm-url,
+#query-monitor .qm th.qm-col-message,
+#query-monitor .qm td.qm-row-component {
+  min-width: 15em !important;
+}
+#query-monitor .qm td.qm-has-toggle p,
+#query-monitor .qm td .qm-toggler {
+  padding: 0 22px 0 0 !important;
+  position: relative !important;
+}
+#query-monitor .qm td.qm-has-toggle:not(.qm-toggled-on) .qm-supplemental {
+  display: none;
+}
+#query-monitor .qm .qm-inner-toggle {
+  padding: 4px 6px !important;
+}
+
+.qm-has-inner .qm-toggled > table {
+  border-top: 1px solid #e0e0e0 !important;
+}
+
+.qm-inner {
+  border-collapse: collapse !important;
+  margin: 0 !important;
+  border-style: hidden !important;
+  width: 100% !important;
+}
+
+#query-monitor .qm td.qm-has-inner .qm-toggler,
+#query-monitor .qm td.qm-has-inner {
+  padding: 0 !important;
+}
+#query-monitor .qm-non-tabular h3 {
+  margin: 0 0 15px 0 !important;
+  font-size: 14px !important;
+}
+#query-monitor .qm-non-tabular h4 {
+  margin: 20px 0 10px !important;
+  font-size: 12px !important;
+}
+#query-monitor .qm-non-tabular p {
+  margin-bottom: 10px !important;
+}
+#query-monitor .qm-non-tabular dd {
+  margin: 0 0 10px 10px !important;
+}
+#query-monitor .qm-non-tabular h3 a {
+  float: right !important;
+}
+#query-monitor .qm-non-tabular .qm-item {
+  display: inline-block !important;
+  margin: 0 20px 5px 0 !important;
+}
+#query-monitor .qm-non-tabular .qm-section {
+  margin: 0 0 30px 0 !important;
+}
+#query-monitor .qm-non-tabular .qm-boxed .qm-section {
+  margin: 0 20px 10px 0 !important;
+  border-right: 1px solid #ddd !important;
+  padding: 10px 20px 10px 0 !important;
+}
+#query-monitor .qm-non-tabular .qm-boxed .qm-section:last-child {
+  margin-right: 0 !important;
+  border-right: none !important;
+  padding-right: 20px !important;
+}
+#query-monitor .qm-non-tabular table {
+  border-bottom-color: #e0e0e0 !important;
+}
+#query-monitor .qm ol,
+#query-monitor .qm ul {
+  list-style: none !important;
+}
+#query-monitor .qm li {
+  display: list-item !important;
+  list-style: none !important;
+}
+#query-monitor .qm li::before {
+  content: '' !important;
+}
+#query-monitor .qm .qm-has-toggle ol.qm-numbered li {
+  list-style: none !important;
+}
+#query-monitor .qm .qm-toggled-on ol.qm-numbered li,
+#query-monitor .qm ol.qm-numbered li {
+  list-style: decimal inside !important;
+}
+#query-monitor .qm code,
+#query-monitor .qm pre {
+  font-size: 11px !important;
+  line-height: 18px !important;
+  font-family: Menlo, Monaco, Consolas, monospace !important;
+}
+#query-monitor .qm pre {
+  background: transparent !important;
+  margin: 0 !important;
+  width: auto !important;
+  height: auto !important;
+  padding: 0 !important;
+}
+#query-monitor .qm .qm-true code,
+#query-monitor .qm p.qm-true,
+#query-monitor .qm span.qm-true,
+#query-monitor .qm td.qm-true {
+  color: #4a4 !important;
+}
+#query-monitor .qm .qm-false code,
+#query-monitor .qm span.qm-false,
+#query-monitor .qm td.qm-false {
+  color: #999 !important;
+}
+#query-monitor .qm code,
+#query-monitor .qm .qm-nowrap {
+  white-space: nowrap !important;
+}
+#query-monitor .qm .qm-wrap code,
+#query-monitor .qm .qm-wrap {
+  word-wrap: break-word !important;
+  word-break: break-all !important;
+  white-space: normal !important;
+}
+#query-monitor .qm .qm-sticky {
+  position: sticky !important;
+  top: 36px !important;
+}
+#query-monitor .qm .qm-current,
+#query-monitor .qm td.qm-has-toggle p,
+#query-monitor .qm .qm-nonselectsql code,
+#query-monitor .qm .qm-nonselectsql {
+  color: #a0a !important;
+}
+#query-monitor .qm .qm-info {
+  color: #777 !important;
+}
+#query-monitor .qm .qm-supplemental {
+  margin-right: 0.75em !important;
+  margin-left: 0.75em !important;
+}
+#query-monitor .qm td .qm-toggled {
+  display: none;
+}
+#query-monitor .qm button.qm-button,
+#query-monitor .qm .qm-toggle {
+  color: #fff !important;
+  font-weight: normal !important;
+  background: #0085ba !important;
+  cursor: pointer !important;
+  border: 1px solid #0073a1 !important;
+  border-radius: 2px !important;
+  text-shadow: 0 -1px 1px #0073a1, 1px 0 1px #0073a1, 0 1px 1px #0073a1, -1px 0 1px #0073a1 !important;
+}
+#query-monitor .qm .qm-toggle {
+  padding: 0 !important;
+  font-family: Menlo, Monaco, Consolas, monospace !important;
+  position: absolute !important;
+  top: 0 !important;
+  right: 0 !important;
+  left: auto !important;
+  bottom: auto !important;
+  text-align: center !important;
+  line-height: 16px !important;
+  height: 18px !important;
+  width: 18px !important;
+}
+#query-monitor .qm button {
+  cursor: pointer !important;
+}
+#query-monitor .qm button.qm-button {
+  padding: 4px 10px !important;
+}
+#query-monitor .qm .qm-has-inner .qm-toggle {
+  top: 5px !important;
+  right: 5px !important;
+}
+#query-monitor .qm button.qm-button:hover,
+#query-monitor .qm button.qm-button:focus,
+#query-monitor .qm .qm-toggle:focus,
+#query-monitor .qm .qm-toggle:hover {
+  text-decoration: none !important;
+  color: #fff !important;
+  background: #0094ce !important;
+}
+#query-monitor .qm tbody tr.qm-odd td,
+#query-monitor .qm tbody tr.qm-odd th {
+  background: #f7f7f7 !important;
+}
+
+.qm-debug-bar tbody tr:hover th,
+.qm-debug-bar tbody tr:hover td {
+  background: #fff !important;
+  /* transparent? */
+}
+
+#query-monitor .qm-non-tabular .qm-warn,
+#query-monitor .qm thead tr .qm-warn,
+#query-monitor .qm tbody tr .qm-warn {
+  background-color: #fff0f0 !important;
+  color: #800 !important;
+}
+#query-monitor .qm tbody tr th.qm-warn,
+#query-monitor .qm tbody tr td.qm-warn,
+#query-monitor .qm tbody tr.qm-warn td,
+#query-monitor .qm tbody tr.qm-warn th {
+  background-color: #fff0f0 !important;
+  box-shadow: inset 0 -1px #ffd6d6 !important;
+  border-color: #ffd6d6 !important;
+  color: #800 !important;
+}
+#query-monitor .qm-non-tabular .qm-warn code,
+#query-monitor .qm tbody .qm-warn li,
+#query-monitor .qm tbody .qm-warn .qm-info,
+#query-monitor .qm tbody .qm-warn code {
+  color: #800 !important;
+  background-color: transparent !important;
+}
+#query-monitor .qm .qm-notice {
+  background: #def !important;
+  border: 1px solid #aad5ff !important;
+  padding: 10px 20px 0 !important;
+  margin: 0 0 10px 0 !important;
+}
+#query-monitor .qm .dashicons {
+  font-size: 16px !important;
+  width: 16px !important;
+  height: 16px !important;
+  margin-right: 0.3em !important;
+  transition: none !important;
+}
+#query-monitor .qm .qm-dashicons-yes {
+  color: #fff !important;
+  background-color: #0a0 !important;
+  border-radius: 50% !important;
+}
+#query-monitor .qm tbody tr.qm-hovered th,
+#query-monitor .qm tbody tr.qm-hovered td,
+#query-monitor .qm tbody tr:hover th,
+#query-monitor .qm tbody tr:hover td {
+  background: #eef3fa !important;
+}
+#query-monitor .qm thead th.qm-filtered select.qm-filter {
+  background-color: #ffd !important;
+  color: #222 !important;
+}
+#query-monitor .qm tbody tr td.qm-highlight,
+#query-monitor .qm tbody tr.qm-highlight td {
+  background-color: #ffd !important;
+  box-shadow: inset 0 -1px #eec !important;
+  border-color: #eec !important;
+  color: #222 !important;
+}
+
+#query-monitor .qm tbody .qm-warn a code,
+#qm-title a,
+#query-monitor .qm a code,
+#query-monitor .qm a {
+  color: #0073aa !important;
+  text-decoration: none !important;
+  cursor: pointer !important;
+}
+#query-monitor .qm tbody .qm-warn a code:after, #query-monitor .qm tbody .qm-warn a code:focus, #query-monitor .qm tbody .qm-warn a code:hover,
+#qm-title a:after,
+#qm-title a:focus,
+#qm-title a:hover,
+#query-monitor .qm a code:after,
+#query-monitor .qm a code:focus,
+#query-monitor .qm a code:hover,
+#query-monitor .qm a:after,
+#query-monitor .qm a:focus,
+#query-monitor .qm a:hover {
+  text-decoration: underline !important;
+  color: #0096dd !important;
+}
+
+#query-monitor .qm a.qm-external-link:after,
+#query-monitor .qm a.qm-link:after,
+#query-monitor .qm a.qm-edit-link:after,
+#query-monitor .qm a.qm-filter-trigger:after {
+  font-family: dashicons !important;
+  text-decoration: none !important;
+  visibility: hidden !important;
+  display: inline-block !important;
+  font-size: 13px !important;
+  line-height: 15px !important;
+  position: relative !important;
+  top: 2px !important;
+  left: 2px !important;
+}
+
+#query-monitor .qm a.qm-external-link:after,
+#query-monitor.qm-touch .qm a.qm-link:after,
+#query-monitor .qm a.qm-link:hover:after,
+#query-monitor .qm a.qm-link:focus:after,
+#query-monitor.qm-touch .qm a.qm-edit-link:after,
+#query-monitor .qm a.qm-edit-link:hover:after,
+#query-monitor .qm a.qm-edit-link:focus:after,
+#query-monitor.qm-touch .qm a.qm-filter-trigger:after,
+#query-monitor .qm a.qm-filter-trigger:hover:after,
+#query-monitor .qm a.qm-filter-trigger:focus:after {
+  visibility: visible !important;
+}
+
+#query-monitor .qm a.qm-filter-trigger:after {
+  content: '\f536' !important;
+}
+
+#query-monitor .qm a.qm-edit-link:after {
+  content: '\f464' !important;
+}
+
+#query-monitor .qm a.qm-external-link:after,
+#query-monitor .qm a.qm-link:after {
+  content: '\f504' !important;
+}
+
+#query-monitor #qm-ajax-errors {
+  display: none;
+}
+
+/* Filters */
+#query-monitor button,
+#query-monitor select {
+  margin: 0 !important;
+  height: auto !important;
+  width: auto !important;
+  background: none !important;
+}
+
+#query-monitor .qm label {
+  cursor: pointer !important;
+  color: #222 !important;
+  font-weight: normal !important;
+  font-size: 12px !important;
+  font-style: normal !important;
+  margin: 0 !important;
+}
+
+#query-monitor .qm thead label {
+  flex-grow: 1 !important;
+}
+
+#query-monitor .qm .qm-filter-container {
+  display: flex !important;
+}
+
+#query-monitor .qm .qm-filter-container label {
+  cursor: default !important;
+}
+
+#query-monitor .qm .qm-filter-container div {
+  /* Some themes use Select2 etc on all selects. This hides that. */
+  display: none !important;
+}
+
+#query-monitor .qm select.qm-filter {
+  display: block !important;
+  margin: 0 0 0 5px !important;
+  outline: 1px solid #aaa !important;
+  border: none !important;
+  padding: 0 !important;
+  background: #fff !important;
+  color: #222 !important;
+  height: auto !important;
+  width: auto !important;
+  float: none !important;
+  cursor: pointer !important;
+  -webkit-appearance: menulist !important;
+  -moz-appearance: menulist !important;
+  appearance: menulist !important;
+  letter-spacing: normal !important;
+  max-width: 10em !important;
+}
+
+#query-monitor .qm select.qm-filter:hover {
+  background: #f3f3f3 !important;
+}
+
+.qm-hide,
+.qm-hide-scripts-host,
+.qm-hide-styles-host,
+.qm-hide-user,
+.qm-hide-result,
+.qm-hide-name,
+.qm-hide-type,
+.qm-hide-caller,
+.qm-hide-component {
+  display: none !important;
+}
+
+/* Sorters */
+#query-monitor .qm thead th.qm-sortable-column {
+  cursor: pointer !important;
+}
+
+#query-monitor .qm thead th.qm-sortable-column:hover {
+  background: #f3f3f3 !important;
+}
+
+#query-monitor .qm .qm-sort-heading {
+  flex-grow: 1 !important;
+}
+
+#query-monitor .qm .qm-sort-controls {
+  text-align: right !important;
+  flex-shrink: 0 !important;
+}
+
+#query-monitor .qm .qm-sortable-column .qm-sort-arrow {
+  font-family: dashicons !important;
+  font-size: 23px !important;
+  color: #ccc !important;
+  margin: 0 !important;
+  width: 16px !important;
+  height: 10px !important;
+  display: block !important;
+}
+
+#query-monitor .qm .qm-sorted-desc .qm-sort-arrow,
+#query-monitor .qm .qm-sorted-asc .qm-sort-arrow {
+  color: #222 !important;
+}
+
+#query-monitor .qm thead th.qm-sortable-column:hover .qm-sort-arrow {
+  color: #0073aa !important;
+}
+
+#query-monitor .qm .qm-sortable-column .qm-sort-arrow:before {
+  content: "\f140" !important;
+  top: 4px !important;
+  right: 0 !important;
+  position: absolute !important;
+}
+
+#query-monitor .qm .qm-sortable-column.qm-sorted-asc .qm-sort-arrow:before {
+  content: "\f142" !important;
+}
+
+#query-monitor .qm button:focus,
+#query-monitor .qm a:focus,
+#query-monitor .qm select:focus {
+  box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8) !important;
+}
+
+#query-monitor .qm-screen-reader-text,
+#query-monitor .screen-reader-text {
+  position: absolute !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  height: 1px !important;
+  width: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  border: 0 !important;
+}
+
+@media screen and (max-width: 782px) {
+  #query-monitor #qm-panel-menu,
+  #query-monitor #qm-title h1.qm-title-heading {
+    display: none;
+  }
+
+  #query-monitor #qm-title div.qm-title-heading {
+    display: block;
+  }
+}
+/* State Toggle */
+#query-monitor [data-qm-state="off"] [data-qm-state-visibility="on"],
+#query-monitor [data-qm-state="on"] [data-qm-state-visibility="off"] {
+  display: none;
+}
+
+/* No-JS tweaks */
+.qm-no-js .qm-sort-controls,
+.qm-no-js .qm-toggle,
+.qm-no-js select.qm-filter {
+  display: none !important;
+}
+
+/* Debug bar add-ons */
+#query-monitor .qm.qm-debug-bar textarea,
+#query-monitor .qm.qm-debug-bar pre {
+  padding: 10px !important;
+  border: 1px solid #ddd !important;
+  margin: 4px 0 !important;
+}
+
+#query-monitor .qm.qm-debug-bar textarea {
+  resize: vertical !important;
+}
+
+#query-monitor .qm.qm-debug-bar .left {
+  float: left !important;
+}
+
+#query-monitor .qm.qm-debug-bar .right {
+  float: right !important;
+}
+
+#query-monitor .qm.qm-debug-bar h2 {
+  font-size: 14px !important;
+  margin: 4px 6px 15px !important;
+}
+
+#query-monitor .qm.qm-debug-bar h3 {
+  float: left !important;
+  /* why */
+  min-width: 150px !important;
+  padding: 5px 10px 15px !important;
+  clear: none !important;
+  text-align: center !important;
+  font-size: 14px !important;
+  margin: 3px 8px 15px 0 !important;
+}
+
+#query-monitor .qm.qm-debug-bar h3 small {
+  font-size: 14px !important;
+}
+
+#query-monitor .qm.qm-debug-bar h3 span {
+  white-space: nowrap !important;
+  display: block !important;
+  margin-bottom: 8px !important;
+}
+
+#query-monitor .qm.qm-debug-bar h4 {
+  margin: 15px 6px 5px !important;
+  font-size: 13px !important;
+}
+
+#query-monitor .qm.qm-debug-bar .qm-debug-bar-output {
+  position: relative !important;
+}
+
+#query-monitor .qm.qm-debug-bar .qm-debug-bar-output table {
+  margin-top: 4px !important;
+  margin-bottom: 4px !important;
+}
+
+#query-monitor #debug-menu-target-Debug_Bar_Console {
+  min-height: 400px !important;
+}
+
+#query-monitor #debug-menu-target-Debug_Bar_Cache_Lookup,
+#query-monitor #debug-menu-target-Debug_Bar_Rewrite_Rules,
+#query-monitor #debug-menu-target-Debug_Bar_Widgets {
+  margin: 4px 6px !important;
+}
+
+#query-monitor #debug-menu-target-Debug_Bar_Rewrite_Rules_Panel .filterui,
+#query-monitor #debug-menu-target-Debug_Bar_Rewrite_Rules_Panel .dbrr {
+  margin: 0 !important;
+}
+
+/* Broken output handling */
+#query-monitor.qm-broken #qm-title {
+  cursor: default !important;
+}
+
+#query-monitor #qm-broken,
+#query-monitor.qm-broken .qm-title-button {
+  display: none !important;
+}
+
+#query-monitor.qm-broken #qm-broken,
+#query-monitor.qm-broken .qm {
+  display: block !important;
+}
+
+#query-monitor.qm-broken .qm {
+  margin-bottom: 50px !important;
+}
+
+#query-monitor.qm-broken #qm-broken h2 {
+  padding: 20px !important;
+}

--- a/query-monitor/assets/query-monitor.js
+++ b/query-monitor/assets/query-monitor.js
@@ -1,0 +1,593 @@
+/**
+ * Front-end functionality for Query Monitor.
+ *
+ * @package query-monitor
+ */
+
+var QM_i18n = {
+
+	// http://core.trac.wordpress.org/ticket/20491
+
+	number_format : function( number, decimals ) {
+
+		if ( isNaN( number ) ) {
+			return;
+		}
+
+		if ( ! decimals ) {
+			decimals = 0;
+		}
+
+		number = parseFloat( number );
+
+		var num_float = number.toFixed( decimals ),
+			num_int   = Math.floor( number ),
+			num_str   = num_int.toString(),
+			fraction  = num_float.substring( num_float.indexOf( '.' ) + 1, num_float.length ),
+			o = '';
+
+		if ( num_str.length > 3 ) {
+			for ( i = num_str.length; i > 3; i -= 3 ) {
+				o = qm_number_format.thousands_sep + num_str.slice( i - 3, i ) + o;
+			}
+			o = num_str.slice( 0, i ) + o;
+		} else {
+			o = num_str;
+		}
+
+		if ( decimals ) {
+			o = o + qm_number_format.decimal_point + fraction;
+		}
+
+		return o;
+
+	}
+
+};
+
+if ( window.jQuery ) {
+
+	jQuery( function($) {
+		var minheight = 100;
+		var maxheight = ( $(window).height() - 50 );
+		var container = $('#query-monitor');
+		var container_storage_key = 'qm-container-height';
+		var container_pinned_key = 'qm-container-pinned';
+
+		if ( $('#query-monitor').hasClass('qm-peek') ) {
+			minheight = 27;
+		}
+
+		$('#query-monitor').removeClass('qm-no-js').addClass('qm-js');
+
+		var link_click = function(e){
+			var href = $( this ).attr('href') || $( this ).data('qm-href');
+			show_panel( href );
+			$(href).focus();
+			$('#wp-admin-bar-query-monitor').removeClass('hover');
+			e.preventDefault();
+		};
+
+		var stripes = function( table ) {
+			table.each(function() {
+				$(this).find('tbody tr').removeClass('qm-odd').not('[class*="qm-hide-"]').filter(':even').addClass('qm-odd');
+			} );
+		};
+
+		var show_panel = function( panel ) {
+			$('#query-monitor').addClass('qm-show').removeClass('qm-hide');
+			$( '.qm' ).removeClass('qm-panel-show');
+			$('#qm-panels').scrollTop(0);
+			$( panel ).addClass('qm-panel-show');
+
+			if ( container.height() < minheight ) {
+				container.height( minheight );
+			}
+
+			$('#qm-panel-menu').find('button').removeClass('qm-selected-menu');
+			var selected_menu = $('#qm-panel-menu').find('[data-qm-href="' + panel + '"]').addClass('qm-selected-menu');
+
+			if ( selected_menu.length ) {
+				var selected_menu_pos = selected_menu.position();
+				var menu_height = $('#qm-panel-menu').height();
+				var menu_scroll = $('#qm-panel-menu').scrollTop();
+
+				if ( ( selected_menu_pos.top > ( menu_height + menu_scroll ) ) || ( selected_menu_pos.top < menu_scroll ) ) {
+					$('#qm-panel-menu').scrollTop( selected_menu_pos.top - ( menu_height / 2 ) );
+				}
+			}
+
+			$('.qm-title-heading select').val(panel);
+
+			if ( localStorage.getItem( container_pinned_key ) ) {
+				localStorage.setItem( container_pinned_key, panel );
+			}
+
+			var filters = $( panel ).find('.qm-filter');
+
+			if ( filters.length ) {
+				filters.change();
+			} else {
+				stripes( $(panel).find('table') );
+			}
+
+		};
+
+		if ( $('#wp-admin-bar-query-monitor').length ) {
+
+			var admin_bar_menu_container = document.createDocumentFragment();
+
+			if ( window.qm && window.qm.menu ) {
+				$('#wp-admin-bar-query-monitor')
+					.addClass(qm.menu.top.classname)
+					.attr('dir','ltr')
+					.find('a').eq(0)
+					.html(qm.menu.top.title)
+				;
+
+				$.each( qm.menu.sub, function( i, el ) {
+
+					var new_menu = $('#wp-admin-bar-query-monitor-placeholder')
+						.clone()
+						.attr('id','wp-admin-bar-' + el.id)
+					;
+					new_menu
+						.find('a').eq(0)
+						.html(el.title)
+						.attr('href',el.href)
+					;
+
+					if ( ( typeof el.meta != 'undefined' ) && ( typeof el.meta.classname != 'undefined' ) ) {
+						new_menu.addClass(el.meta.classname);
+					}
+
+					admin_bar_menu_container.appendChild( new_menu.get(0) );
+
+				} );
+
+				$('#wp-admin-bar-query-monitor ul').append(admin_bar_menu_container);
+			}
+
+			$('#wp-admin-bar-query-monitor').find('a').on('click',link_click);
+
+			$('#wp-admin-bar-query-monitor,#wp-admin-bar-query-monitor-default').show();
+
+		} else {
+			$('#query-monitor').addClass('qm-peek').removeClass('qm-hide');
+			$('#qm-overview').addClass('qm-panel-show');
+		}
+
+		$('#qm-panel-menu').find('button').on('click',link_click);
+
+		$('#query-monitor').find('.qm-filter').on('change',function(e){
+
+			var filter = $(this).attr('data-filter'),
+				table  = $(this).closest('table'),
+				tr     = table.find('tbody tr[data-qm-' + filter + ']'),
+				// Escape the following chars with a backslash before passing into jQ selectors: [ ] ( ) ' " \
+				val    = $(this).val().replace(/[[\]()'"\\]/g, "\\$&"),
+				total  = tr.removeClass('qm-hide-' + filter).length,
+				hilite = $(this).attr('data-highlight'),
+				time   = 0;
+
+			key = $(this).attr('id');
+			if ( val ) {
+				localStorage.setItem( key, $(this).val() );
+			} else {
+				localStorage.removeItem( key );
+			}
+
+			if ( hilite ) {
+				table.find('tr').removeClass('qm-highlight');
+			}
+
+			if ( $(this).val() !== '' ) {
+				if ( hilite ) {
+					tr.filter('[data-qm-' + hilite + '*="' + val + '"]').addClass('qm-highlight');
+				}
+				tr.not('[data-qm-' + filter + '*="' + val + '"]').addClass('qm-hide-' + filter);
+				$(this).closest('th').addClass('qm-filtered');
+			} else {
+				$(this).closest('th').removeClass('qm-filtered');
+			}
+
+			var matches = tr.filter(':visible');
+			matches.each(function(i){
+				var row_time = $(this).attr('data-qm-time');
+				if ( row_time ) {
+					time += parseFloat( row_time );
+				}
+			});
+			if ( time ) {
+				time = QM_i18n.number_format( time, 4 );
+			}
+
+			if ( table.find('.qm-filtered').length ) {
+				var count = matches.length + ' / ' + tr.length;
+			} else {
+				var count = matches.length;
+			}
+
+			table.find('.qm-items-number').text(count);
+			table.find('.qm-items-time').text(time);
+
+			stripes(table);
+		});
+
+		$('#query-monitor').find('.qm-filter').each(function () {
+			var key = $(this).attr('id');
+			var value = localStorage.getItem( key );
+			if ( value !== null ) {
+				// Escape the following chars with a backslash before passing into jQ selectors: [ ] ( ) ' " \
+				var val = value.replace(/[[\]()'"\\]/g, "\\$&");
+				if ( ! $(this).find('option[value="' + val + '"]').length ) {
+					$('<option>').attr('value',value).text(value).appendTo(this);
+				}
+				$(this).val(value).change();
+			}
+		});
+
+		$('#query-monitor').find('.qm-filter-trigger').on('click',function(e){
+			var filter = $(this).data('qm-filter'),
+				value  = $(this).data('qm-value'),
+				target = $(this).data('qm-target');
+			$('#qm-' + target).find('.qm-filter').not('[data-filter="' + filter + '"]').val('').removeClass('qm-highlight').change();
+			$('#qm-' + target).find('[data-filter="' + filter + '"]').val(value).addClass('qm-highlight').change();
+			show_panel( '#qm-' + target );
+			$('#qm-' + target).focus();
+			e.preventDefault();
+		});
+
+		$('#query-monitor').find('.qm-toggle').on('click',function(e){
+			var el = $(this);
+			var currentState = el.attr('aria-expanded');
+			var newState = 'true';
+			if (currentState === 'true') {
+				newState = 'false';
+			}
+			el.attr('aria-expanded', newState);
+			var toggle = $(this).closest('td').find('.qm-toggled');
+			if ( currentState === 'true' ) {
+				if ( toggle.length ) {
+					toggle.slideToggle(200,function(){
+						el.closest('td').removeClass('qm-toggled-on');
+						el.text(el.attr('data-on'));
+					});
+				} else {
+					el.closest('td').removeClass('qm-toggled-on');
+					el.text(el.attr('data-on'));
+				}
+			} else {
+				el.closest('td').addClass('qm-toggled-on');
+				el.text(el.attr('data-off'));
+				toggle.slideToggle(200);
+			}
+			e.preventDefault();
+		});
+
+		$('#query-monitor').find('.qm-highlighter').on('mouseenter',function(e){
+
+			var subject = $(this).data('qm-highlight');
+			var table   = $(this).closest('table');
+
+			if ( ! subject ) {
+				return;
+			}
+
+			$(this).addClass('qm-highlight');
+
+			$.each( subject.split(' '), function( i, el ){
+				table.find('tr[data-qm-subject="' + el + '"]').addClass('qm-highlight');
+			});
+
+		}).on('mouseleave',function(e){
+
+			$(this).removeClass('qm-highlight');
+			$(this).closest('table').find('tr').removeClass('qm-highlight');
+
+		});
+
+		$('.qm').find('tbody a,tbody button').on('focus',function(e){
+			$(this).closest('tr').addClass('qm-hovered');
+		}).on('blur',function(e){
+			$(this).closest('tr').removeClass('qm-hovered');
+		});
+
+		$('#query-monitor').find('.qm table').on('sorted.qm',function(){
+			stripes( $(this) );
+		});
+
+		$( document ).ajaxSuccess( function( event, response, options ) {
+
+			var errors = response.getResponseHeader( 'X-QM-php_errors-error-count' );
+
+			if ( ! errors ) {
+				return event;
+			}
+
+			errors = parseInt( errors, 10 );
+
+			if ( window.console ) {
+				console.group( qm_l10n.ajax_error );
+			}
+
+			for ( var key = 1; key <= errors; key++ ) {
+
+				error = $.parseJSON( response.getResponseHeader( 'X-QM-php_errors-error-' + key ) );
+
+				if ( window.console ) {
+					console.error( error );
+				}
+
+				if ( $('#wp-admin-bar-query-monitor').length ) {
+					if ( ! qm.ajax_errors[error.type] ) {
+						$('#wp-admin-bar-query-monitor')
+							.addClass('qm-' + error.type)
+							.find('a').first().append('<span class="ab-label qm-ajax-' + error.type + '"> &nbsp; Ajax: ' + error.type + '</span>')
+						;
+					}
+				}
+
+				qm.ajax_errors[error.type] = true;
+
+			}
+
+			if ( window.console ) {
+				console.groupEnd();
+			}
+
+			$( '#qm-ajax-errors' ).show();
+
+			return event;
+
+		} );
+
+		$('.qm-auth').on('click',function(e){
+			var state = $('#qm-settings').data('qm-state');
+			var action = ( 'off' === state ? 'on' : 'off' );
+
+			$.ajax(qm_l10n.ajaxurl,{
+				type : 'POST',
+				context : this,
+				data : {
+					action : 'qm_auth_' + action,
+					nonce  : qm_l10n.auth_nonce[action]
+				},
+				success : function(response){
+					$(this).text( $(this).data('qm-text-' + action) );
+					$('#qm-settings').attr('data-qm-state',action).data('qm-state',action);
+				},
+				dataType : 'json',
+				xhrFields: {
+					withCredentials: true
+				}
+			});
+
+			e.preventDefault();
+		});
+
+		$.qm.tableSort({target: $('.qm-sortable')});
+
+		var startY, resizerHeight, toolbarHeight;
+
+		toolbarHeight = $('#wpadminbar').outerHeight();
+
+		$(document).on('mousedown', '#qm-title', function(event) {
+			resizerHeight = $(this).outerHeight() - 1;
+			startY        = container.outerHeight() + event.clientY;
+
+			$(document).on('mousemove', qm_do_resizer_drag);
+			$(document).on('mouseup', qm_stop_resizer_drag);
+		});
+
+		function qm_do_resizer_drag(event) {
+			var h = ( startY - event.clientY );
+			if ( h >= resizerHeight && h < ( $(window).height() - toolbarHeight ) ) {
+				container.height( h );
+			}
+		}
+
+		function qm_stop_resizer_drag(event) {
+			$(document).off('mousemove', qm_do_resizer_drag);
+			$(document).off('mouseup', qm_stop_resizer_drag);
+
+			localStorage.setItem( container_storage_key, container.height() );
+		}
+
+		var h = localStorage.getItem( container_storage_key );
+		if ( h !== null && ! $('#query-monitor').hasClass('qm-peek') ) {
+			if ( h < minheight ) {
+				h = minheight;
+			}
+			if ( h > maxheight ) {
+				h = maxheight;
+			}
+			container.height( h );
+		}
+
+		$(window).on('resize', function(){
+			var maxheight = ( $(window).height() - toolbarHeight );
+			var h = container.height();
+
+			if ( h < minheight ) {
+				container.height( minheight );
+			}
+			if ( h > maxheight ) {
+				container.height( maxheight );
+			}
+			localStorage.setItem( container_storage_key, container.height() );
+		});
+
+		$('.qm-button-container-close').click(function(){
+			$('#query-monitor').removeClass('qm-show').height('');
+			localStorage.removeItem( container_pinned_key );
+			$('.qm-button-container-pin').removeClass( 'qm-button-active' );
+		});
+
+		$('.qm-button-container-pin').click(function(){
+			if ( $(this).hasClass( 'qm-button-active' ) ) {
+				localStorage.removeItem( container_pinned_key );
+			} else {
+				localStorage.setItem( container_pinned_key, '#' + $('.qm-panel-show').first().attr('id') );
+			}
+
+			$(this).toggleClass( 'qm-button-active' );
+		});
+
+		$('.qm-button-container-settings').click(function(){
+			show_panel( '#qm-settings' );
+			$('#qm-settings').focus();
+		});
+
+		var pinned = localStorage.getItem( container_pinned_key );
+		if ( pinned && $( pinned ).length ) {
+			show_panel( pinned );
+			// Don't auto-focus the pinned QM panel
+			$('.qm-button-container-pin').addClass( 'qm-button-active' );
+		}
+
+		$('.qm-title-heading select').change(function(){
+			show_panel( $(this).val() );
+			$($(this).val()).focus();
+		});
+
+	} );
+
+	/**
+	 * Table sorting library.
+	 *
+	 * This is a modified version of jQuery table-sort v0.1.1
+	 * https://github.com/gajus/table-sort
+	 *
+	 * Licensed under the BSD.
+	 * https://github.com/gajus/table-sort/blob/master/LICENSE
+	 *
+	 * Author: Gajus Kuizinas <g.kuizinas@anuary.com>
+	 */
+	(function ($) {
+		$.qm = $.qm || {};
+		$.qm.tableSort = function (settings) {
+			// @param	object	columns	NodeList table colums.
+			// @param	integer	row_width	defines the number of columns per row.
+			var table_to_array	= function (columns, row_width) {
+				columns = Array.prototype.slice.call(columns, 0);
+
+				var rows      = [];
+				var row_index = 0;
+
+				for (var i = 0, j = columns.length; i < j; i += row_width) {
+					var row	= [];
+
+					for (var k = 0; k < row_width; k++) {
+						var e = columns[i + k];
+						var data = e.dataset.qmSortWeight;
+
+						if (data === undefined) {
+							data = e.textContent || e.innerText;
+						}
+
+						var number = parseFloat(data);
+
+						data = isNaN(number) ? data : number;
+
+						row.push(data);
+					}
+
+					rows.push({index: row_index++, data: row});
+				}
+
+				return rows;
+			};
+
+			if ( ! settings.target || ! ( settings.target instanceof $) ) {
+				throw 'Target is not defined or it is not instance of jQuery.';
+			}
+
+			settings.target.each(function () {
+				var table = $(this);
+
+				table.find('.qm-sortable-column').on('click', function (e) {
+					var desc = ! $(this).hasClass('qm-sorted-desc');
+					var index = $(this).index();
+
+					table.find('thead th').removeClass('qm-sorted-asc qm-sorted-desc').attr('aria-sort','none');
+
+					if ( desc ) {
+						$(this).addClass('qm-sorted-desc').attr('aria-sort','descending');
+					} else {
+						$(this).addClass('qm-sorted-asc').attr('aria-sort','ascending');
+					}
+
+					table.find('tbody').each(function () {
+						var tbody = $(this);
+						var rows = this.rows;
+						var columns = this.querySelectorAll('th,td');
+
+						if (this.data_matrix === undefined) {
+							this.data_matrix = table_to_array(columns, $(rows[0]).find('th,td').length);
+						}
+
+						var data = this.data_matrix;
+
+						data.sort(function (a, b) {
+							if (a.data[index] == b.data[index]) {
+								return 0;
+							}
+
+							return (desc ? a.data[index] > b.data[index] : a.data[index] < b.data[index]) ? -1 : 1;
+						});
+
+						// Detach the tbody to prevent unnecessary overhead related
+						// to the browser environment.
+						tbody = tbody.detach();
+
+						// Convert NodeList into an array.
+						rows = Array.prototype.slice.call(rows, 0);
+
+						var last_row = rows[data[data.length - 1].index];
+
+						for (var i = 0, j = data.length - 1; i < j; i++) {
+							tbody[0].insertBefore(rows[data[i].index], last_row);
+
+							// Restore the index.
+							data[i].index = i;
+						}
+
+						// Restore the index.
+						data[data.length - 1].index = data.length - 1;
+
+						table.append(tbody);
+					});
+
+					table.trigger('sorted.qm');
+
+					e.preventDefault();
+				});
+			});
+		};
+	})(jQuery);
+
+}
+
+window.addEventListener('load', function() {
+	if ( ( 'undefined' === typeof jQuery ) || ! window.jQuery ) {
+		/* Fallback for running without jQuery (`QM_NO_JQUERY`) */
+		document.getElementById( 'query-monitor' ).className += ' qm-broken';
+		console.error( document.getElementById( 'qm-broken' ).textContent );
+
+		if ( 'undefined' === typeof jQuery ) {
+			console.error( 'QM error from JS: undefined jQuery' );
+		}
+
+		if ( ! window.jQuery ) {
+			console.error( 'QM error from JS: no jQuery' );
+		}
+
+		var menu_item = document.getElementById( 'wp-admin-bar-query-monitor' );
+		if ( menu_item ) {
+			menu_item.addEventListener( 'click', function() {
+				document.getElementById( 'query-monitor' ).className += ' qm-show';
+			} );
+		}
+	}
+} );

--- a/query-monitor/classes/Activation.php
+++ b/query-monitor/classes/Activation.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Plugin activation handler.
+ *
+ * @package query-monitor
+ */
+
+class QM_Activation extends QM_Plugin {
+
+	protected function __construct( $file ) {
+
+		# PHP version handling
+		if ( ! self::php_version_met() ) {
+			add_action( 'all_admin_notices', array( $this, 'php_notice' ) );
+			return;
+		}
+
+		# Filters
+		add_filter( 'pre_update_option_active_plugins',               array( $this, 'filter_active_plugins' ) );
+		add_filter( 'pre_update_site_option_active_sitewide_plugins', array( $this, 'filter_active_sitewide_plugins' ) );
+
+		# Activation and deactivation
+		register_activation_hook( $file, array( $this, 'activate' ) );
+		register_deactivation_hook( $file, array( $this, 'deactivate' ) );
+
+		# Parent setup:
+		parent::__construct( $file );
+
+	}
+
+	public function activate( $sitewide = false ) {
+
+		if ( ! file_exists( $db = WP_CONTENT_DIR . '/db.php' ) && function_exists( 'symlink' ) ) {
+			@symlink( plugin_dir_path( $this->file ) . 'wp-content/db.php', $db ); // @codingStandardsIgnoreLine
+		}
+
+		if ( $sitewide ) {
+			update_site_option( 'active_sitewide_plugins', get_site_option( 'active_sitewide_plugins' ) );
+		} else {
+			update_option( 'active_plugins', get_option( 'active_plugins' ) );
+		}
+
+	}
+
+	public function deactivate() {
+
+		// Remove legacy capability handling:
+		if ( $admins = QM_Util::get_admins() ) {
+			$admins->remove_cap( 'view_query_monitor' );
+		}
+
+		# Only delete db.php if it belongs to Query Monitor
+		if ( file_exists( WP_CONTENT_DIR . '/db.php' ) && class_exists( 'QM_DB' ) ) {
+			unlink( WP_CONTENT_DIR . '/db.php' ); // @codingStandardsIgnoreLine
+		}
+
+	}
+
+	public function filter_active_plugins( $plugins ) {
+
+		// this needs to run on the cli too
+
+		if ( empty( $plugins ) ) {
+			return $plugins;
+		}
+
+		$f = preg_quote( basename( $this->plugin_base() ) );
+
+		return array_merge(
+			preg_grep( '/' . $f . '$/', $plugins ),
+			preg_grep( '/' . $f . '$/', $plugins, PREG_GREP_INVERT )
+		);
+
+	}
+
+	public function filter_active_sitewide_plugins( $plugins ) {
+
+		if ( empty( $plugins ) ) {
+			return $plugins;
+		}
+
+		$f = $this->plugin_base();
+
+		if ( isset( $plugins[ $f ] ) ) {
+
+			unset( $plugins[ $f ] );
+
+			return array_merge( array(
+				$f => time(),
+			), $plugins );
+
+		} else {
+			return $plugins;
+		}
+
+	}
+
+	public function php_notice() {
+		?>
+		<div id="qm_php_notice" class="error">
+			<p>
+				<span class="dashicons dashicons-warning" style="color:#dd3232" aria-hidden="true"></span>
+				<?php
+				echo esc_html( sprintf(
+					/* Translators: 1: Minimum required PHP version, 2: Current PHP version. */
+					__( 'The Query Monitor plugin requires PHP version %1$s or higher. This site is running version %2$s.', 'query-monitor' ),
+					self::$minimum_php_version,
+					PHP_VERSION
+				) );
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	public static function init( $file = null ) {
+
+		static $instance = null;
+
+		if ( ! $instance ) {
+			$instance = new QM_Activation( $file );
+		}
+
+		return $instance;
+
+	}
+
+}

--- a/query-monitor/classes/Backtrace.php
+++ b/query-monitor/classes/Backtrace.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Function call backtrace container.
+ *
+ * @package query-monitor
+ */
+
+if ( ! class_exists( 'QM_Backtrace' ) ) {
+class QM_Backtrace {
+
+	protected static $ignore_class = array(
+		'wpdb'           => true,
+		'QueryMonitor'   => true,
+		'W3_Db'          => true,
+		'Debug_Bar_PHP'  => true,
+		'WP_Hook'        => true,
+	);
+	protected static $ignore_method = array();
+	protected static $ignore_func = array(
+		'include_once'         => true,
+		'require_once'         => true,
+		'include'              => true,
+		'require'              => true,
+		'call_user_func_array' => true,
+		'call_user_func'       => true,
+		'trigger_error'        => true,
+		'_doing_it_wrong'      => true,
+		'_deprecated_argument' => true,
+		'_deprecated_file'     => true,
+		'_deprecated_function' => true,
+		'dbDelta'              => true,
+	);
+	protected static $show_args = array(
+		'do_action'                  => 1,
+		'apply_filters'              => 1,
+		'do_action_ref_array'        => 1,
+		'apply_filters_ref_array'    => 1,
+		'get_template_part'          => 2,
+		'get_extended_template_part' => 2,
+		'load_template'              => 'dir',
+		'dynamic_sidebar'            => 1,
+		'get_header'                 => 1,
+		'get_sidebar'                => 1,
+		'get_footer'                 => 1,
+		'class_exists'               => 2,
+		'current_user_can'           => 3,
+		'user_can'                   => 4,
+		'current_user_can_for_blog'  => 4,
+		'author_can'                 => 4,
+	);
+	protected static $filtered = false;
+	protected $trace           = null;
+	protected $filtered_trace  = null;
+	protected $calling_line    = 0;
+	protected $calling_file    = '';
+
+	public function __construct( array $args = array() ) {
+		$args = array_merge( array(
+			'ignore_current_filter' => true,
+			'ignore_frames'         => 0,
+		), $args );
+		$this->trace = debug_backtrace( false );
+		$this->ignore( 1 ); # Self-awareness
+
+		/**
+		 * If error_handler() is in the trace, QM fails later when it tries
+		 * to get $lowest['file'] in get_filtered_trace()
+		 */
+		if ( 'error_handler' === $this->trace[0]['function'] ) {
+			$this->ignore( 1 );
+		}
+
+		if ( $args['ignore_frames'] ) {
+			$this->ignore( $args['ignore_frames'] );
+		}
+		if ( $args['ignore_current_filter'] ) {
+			$this->ignore_current_filter();
+		}
+
+		foreach ( $this->trace as $k => $frame ) {
+			if ( ! isset( $frame['args'] ) ) {
+				continue;
+			}
+
+			if ( isset( $frame['function'] ) && isset( self::$show_args[ $frame['function'] ] ) ) {
+				$show = self::$show_args[ $frame['function'] ];
+
+				if ( 'dir' === $show ) {
+					$show = 1;
+				}
+
+				$frame['args'] = array_slice( $frame['args'], 0, $show );
+
+			} else {
+				unset( $frame['args'] );
+			}
+
+			$this->trace[ $k ] = $frame;
+		}
+	}
+
+	public function get_stack() {
+
+		$trace = $this->get_filtered_trace();
+		$stack = wp_list_pluck( $trace, 'display' );
+
+		return $stack;
+
+	}
+
+	public function get_caller() {
+
+		$trace = $this->get_filtered_trace();
+
+		return reset( $trace );
+
+	}
+
+	public function get_component() {
+
+		$components = array();
+
+		foreach ( $this->trace as $frame ) {
+			try {
+
+				if ( isset( $frame['class'] ) ) {
+					if ( ! class_exists( $frame['class'], false ) ) {
+						continue;
+					}
+					if ( ! method_exists( $frame['class'], $frame['function'] ) ) {
+						continue;
+					}
+					$ref = new ReflectionMethod( $frame['class'], $frame['function'] );
+					$file = $ref->getFileName();
+				} elseif ( isset( $frame['function'] ) && function_exists( $frame['function'] ) ) {
+					$ref = new ReflectionFunction( $frame['function'] );
+					$file = $ref->getFileName();
+				} elseif ( isset( $frame['file'] ) ) {
+					$file = $frame['file'];
+				} else {
+					continue;
+				}
+
+				$comp = QM_Util::get_file_component( $file );
+				$components[ $comp->type ] = $comp;
+
+				if ( 'plugin' === $comp->type ) {
+					// If the component is a plugin then it can't be anything else,
+					// so short-circuit and return early.
+					return $comp;
+				}
+			} catch ( ReflectionException $e ) {
+				# nothing
+			}
+		}
+
+		foreach ( QM_Util::get_file_dirs() as $type => $dir ) {
+			if ( isset( $components[ $type ] ) ) {
+				return $components[ $type ];
+			}
+		}
+
+		# This should not happen
+
+	}
+
+	public function get_trace() {
+		return $this->trace;
+	}
+
+	public function get_display_trace() {
+		return array_reverse( $this->get_filtered_trace() );
+	}
+
+	public function get_filtered_trace() {
+
+		if ( ! isset( $this->filtered_trace ) ) {
+
+			$trace = array_map( array( $this, 'filter_trace' ), $this->trace );
+			$trace = array_values( array_filter( $trace ) );
+
+			if ( empty( $trace ) && ! empty( $this->trace ) ) {
+				$lowest                 = $this->trace[0];
+				$file                   = QM_Util::standard_dir( $lowest['file'], '' );
+				$lowest['calling_file'] = $lowest['file'];
+				$lowest['calling_line'] = $lowest['line'];
+				$lowest['function']     = $file;
+				$lowest['display']      = $file;
+				$lowest['id']           = $file;
+				unset( $lowest['class'], $lowest['args'], $lowest['type'] );
+				$trace[0] = $lowest;
+			}
+
+			$this->filtered_trace = $trace;
+
+		}
+
+		return $this->filtered_trace;
+
+	}
+
+	public function ignore( $num ) {
+		for ( $i = 0; $i < absint( $num ); $i++ ) {
+			unset( $this->trace[ $i ] );
+		}
+		$this->trace = array_values( $this->trace );
+		return $this;
+	}
+
+	public function ignore_current_filter() {
+
+		if ( isset( $this->trace[2] ) and isset( $this->trace[2]['function'] ) ) {
+			if ( in_array( $this->trace[2]['function'], array( 'apply_filters', 'do_action' ), true ) ) {
+				$this->ignore( 3 ); # Ignore filter and action callbacks
+			}
+		}
+
+	}
+
+	public function filter_trace( array $trace ) {
+
+		if ( ! self::$filtered and function_exists( 'did_action' ) and did_action( 'plugins_loaded' ) ) {
+
+			# Only run apply_filters on these once
+			self::$ignore_class  = apply_filters( 'qm/trace/ignore_class',  self::$ignore_class );
+			self::$ignore_method = apply_filters( 'qm/trace/ignore_method', self::$ignore_method );
+			self::$ignore_func   = apply_filters( 'qm/trace/ignore_func',   self::$ignore_func );
+			self::$show_args     = apply_filters( 'qm/trace/show_args',     self::$show_args );
+			self::$filtered = true;
+
+		}
+
+		$return = $trace;
+
+		if ( isset( $trace['class'] ) ) {
+			if ( isset( self::$ignore_class[ $trace['class'] ] ) ) {
+				$return = null;
+			} elseif ( isset( self::$ignore_method[ $trace['class'] ][ $trace['function'] ] ) ) {
+				$return = null;
+			} elseif ( 0 === strpos( $trace['class'], 'QM' ) ) {
+				$return = null;
+			} else {
+				$return['id']      = $trace['class'] . $trace['type'] . $trace['function'] . '()';
+				$return['display'] = QM_Util::shorten_fqn( $trace['class'] . $trace['type'] . $trace['function'] ) . '()';
+			}
+		} else {
+			if ( isset( self::$ignore_func[ $trace['function'] ] ) ) {
+				$return = null;
+			} elseif ( isset( self::$show_args[ $trace['function'] ] ) ) {
+				$show = self::$show_args[ $trace['function'] ];
+
+				if ( 'dir' === $show ) {
+					if ( isset( $trace['args'][0] ) ) {
+						$arg = QM_Util::standard_dir( $trace['args'][0], '' );
+						$return['id']      = $trace['function'] . '()';
+						$return['display'] = QM_Util::shorten_fqn( $trace['function'] ) . "('{$arg}')";
+					}
+				} else {
+					$args = array();
+					for ( $i = 0; $i < $show; $i++ ) {
+						if ( isset( $trace['args'][ $i ] ) ) {
+							if ( is_string( $trace['args'][ $i ] ) ) {
+								$args[] = '\'' . $trace['args'][ $i ] . '\'';
+							} else {
+								$args[] = QM_Util::display_variable( $trace['args'][ $i ] );
+							}
+						}
+					}
+					$return['id']      = $trace['function'] . '()';
+					$return['display'] = QM_Util::shorten_fqn( $trace['function'] ) . '(' . implode( ',', $args ) . ')';
+				}
+			} else {
+				$return['id']      = $trace['function'] . '()';
+				$return['display'] = QM_Util::shorten_fqn( $trace['function'] ) . '()';
+			}
+		}
+
+		if ( $return ) {
+
+			$return['calling_file'] = $this->calling_file;
+			$return['calling_line'] = $this->calling_line;
+
+		}
+
+		if ( isset( $trace['line'] ) ) {
+			$this->calling_line = $trace['line'];
+		}
+		if ( isset( $trace['file'] ) ) {
+			$this->calling_file = $trace['file'];
+		}
+
+		return $return;
+
+	}
+
+}
+} else {
+
+	add_action( 'init', 'QueryMonitor::symlink_warning' );
+
+}

--- a/query-monitor/classes/Collector.php
+++ b/query-monitor/classes/Collector.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Abstract data collector.
+ *
+ * @package query-monitor
+ */
+
+if ( ! class_exists( 'QM_Collector' ) ) {
+abstract class QM_Collector {
+
+	protected $timer;
+	protected $data = array(
+		'types'           => array(),
+		'component_times' => array(),
+	);
+	protected static $hide_qm = null;
+
+	public function __construct() {}
+
+	final public function id() {
+		return "qm-{$this->id}";
+	}
+
+	abstract public function name();
+
+	protected function log_type( $type ) {
+
+		if ( isset( $this->data['types'][ $type ] ) ) {
+			$this->data['types'][ $type ]++;
+		} else {
+			$this->data['types'][ $type ] = 1;
+		}
+
+	}
+
+	protected function maybe_log_dupe( $sql, $i ) {
+
+		$sql = str_replace( array( "\r\n", "\r", "\n" ), ' ', $sql );
+		$sql = str_replace( array( "\t", '`' ), '', $sql );
+		$sql = preg_replace( '/ +/', ' ', $sql );
+		$sql = trim( $sql );
+
+		$this->data['dupes'][ $sql ][] = $i;
+
+	}
+
+	protected function log_component( $component, $ltime, $type ) {
+
+		if ( ! isset( $this->data['component_times'][ $component->name ] ) ) {
+			$this->data['component_times'][ $component->name ] = array(
+				'component' => $component->name,
+				'ltime'     => 0,
+				'types'     => array(),
+			);
+		}
+
+		$this->data['component_times'][ $component->name ]['ltime'] += $ltime;
+
+		if ( isset( $this->data['component_times'][ $component->name ]['types'][ $type ] ) ) {
+			$this->data['component_times'][ $component->name ]['types'][ $type ]++;
+		} else {
+			$this->data['component_times'][ $component->name ]['types'][ $type ] = 1;
+		}
+
+	}
+
+	public static function timer_stop_float() {
+		global $timestart;
+		return microtime( true ) - $timestart;
+	}
+
+	public static function format_bool_constant( $constant ) {
+		// @TODO this should be in QM_Util
+
+		if ( ! defined( $constant ) ) {
+			/* translators: Undefined PHP constant */
+			return __( 'undefined', 'query-monitor' );
+		} elseif ( ! constant( $constant ) ) {
+			return 'false';
+		} else {
+			return 'true';
+		}
+	}
+
+	final public function get_data() {
+		return $this->data;
+	}
+
+	final public function set_id( $id ) {
+		$this->id = $id;
+	}
+
+	public static function format_user( WP_User $user_object ) {
+		$user = get_object_vars( $user_object->data );
+		unset(
+			$user['user_pass'],
+			$user['user_activation_key']
+		);
+		$user['roles'] = $user_object->roles;
+
+		return $user;
+	}
+
+	public static function hide_qm() {
+		if ( null === self::$hide_qm ) {
+			self::$hide_qm = ( defined( 'QM_HIDE_SELF' ) && QM_HIDE_SELF );
+		}
+
+		return self::$hide_qm;
+	}
+
+	public function filter_remove_qm( array $item ) {
+		$component = $item['trace']->get_component();
+		return ( 'query-monitor' !== $component->context );
+	}
+
+	public function process() {}
+
+	public function post_process() {}
+
+	public function tear_down() {}
+
+	public function get_timer() {
+		return $this->timer;
+	}
+
+	public function set_timer( QM_Timer $timer ) {
+		$this->timer = $timer;
+	}
+
+}
+}

--- a/query-monitor/classes/Collectors.php
+++ b/query-monitor/classes/Collectors.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Container for data collectors.
+ *
+ * @package query-monitor
+ */
+
+if ( ! class_exists( 'QM_Collectors' ) ) {
+class QM_Collectors implements IteratorAggregate {
+
+	private $items = array();
+	private $processed = false;
+
+	public function getIterator() {
+		return new ArrayIterator( $this->items );
+	}
+
+	public static function add( QM_Collector $collector ) {
+		$collectors = self::init();
+		$collectors->items[ $collector->id ] = $collector;
+	}
+
+	public static function get( $id ) {
+		$collectors = self::init();
+		if ( isset( $collectors->items[ $id ] ) ) {
+			return $collectors->items[ $id ];
+		}
+		return false;
+	}
+
+	public static function init() {
+		static $instance;
+
+		if ( ! $instance ) {
+			$instance = new QM_Collectors;
+		}
+
+		return $instance;
+
+	}
+
+	public function process() {
+		if ( $this->processed ) {
+			return;
+		}
+
+		foreach ( $this as $collector ) {
+			$collector->tear_down();
+
+			$timer = new QM_Timer;
+			$timer->start();
+
+			$collector->process();
+
+			$collector->set_timer( $timer->stop() );
+		}
+
+		foreach ( $this as $collector ) {
+			$collector->post_process();
+		}
+
+		$this->processed = true;
+	}
+
+}
+}

--- a/query-monitor/classes/Dispatcher.php
+++ b/query-monitor/classes/Dispatcher.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Abstract dispatcher.
+ *
+ * @package query-monitor
+ */
+
+if ( ! class_exists( 'QM_Dispatcher' ) ) {
+abstract class QM_Dispatcher {
+
+	public function __construct( QM_Plugin $qm ) {
+		$this->qm = $qm;
+
+		if ( ! defined( 'QM_COOKIE' ) ) {
+			define( 'QM_COOKIE', 'query_monitor_' . COOKIEHASH );
+		}
+
+		add_action( 'init', array( $this, 'init' ) );
+
+	}
+
+	abstract public function is_active();
+
+	final public function should_dispatch() {
+
+		$e = error_get_last();
+
+		# Don't dispatch if a fatal has occurred:
+		if ( ! empty( $e ) and ( $e['type'] & ( E_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR ) ) ) {
+			return false;
+		}
+
+		# Allow users to disable this dispatcher
+		if ( ! apply_filters( "qm/dispatch/{$this->id}", true ) ) {
+			return false;
+		}
+
+		return $this->is_active();
+
+	}
+
+	public function get_outputters( $outputter_id ) {
+		$collectors = QM_Collectors::init();
+		$collectors->process();
+
+		$this->outputters = apply_filters( "qm/outputter/{$outputter_id}", array(), $collectors );
+
+		return $this->outputters;
+	}
+
+	public function init() {
+		// @TODO should be abstract?
+		// nothing
+	}
+
+	protected function before_output() {
+		// nothing
+	}
+
+	protected function after_output() {
+		// nothing
+	}
+
+	public function user_can_view() {
+
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			return false;
+		}
+
+		if ( current_user_can( 'view_query_monitor' ) ) {
+			return true;
+		}
+
+		return self::user_verified();
+
+	}
+
+	public static function user_verified() {
+		if ( isset( $_COOKIE[QM_COOKIE] ) ) { // @codingStandardsIgnoreLine
+			return self::verify_cookie( wp_unslash( $_COOKIE[QM_COOKIE] ) ); // @codingStandardsIgnoreLine
+		}
+		return false;
+	}
+
+	public static function verify_cookie( $value ) {
+		if ( $old_user_id = wp_validate_auth_cookie( $value, 'logged_in' ) ) {
+			return user_can( $old_user_id, 'view_query_monitor' );
+		}
+		return false;
+	}
+
+}
+}

--- a/query-monitor/classes/Dispatchers.php
+++ b/query-monitor/classes/Dispatchers.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Container for dispatchers.
+ *
+ * @package query-monitor
+ */
+
+class QM_Dispatchers implements IteratorAggregate {
+
+	private $items = array();
+
+	public function getIterator() {
+		return new ArrayIterator( $this->items );
+	}
+
+	public static function add( QM_Dispatcher $dispatcher ) {
+		$dispatchers = self::init();
+		$dispatchers->items[ $dispatcher->id ] = $dispatcher;
+	}
+
+	public static function get( $id ) {
+		$dispatchers = self::init();
+		if ( isset( $dispatchers->items[ $id ] ) ) {
+			return $dispatchers->items[ $id ];
+		}
+		return false;
+	}
+
+	public static function init() {
+		static $instance;
+
+		if ( ! $instance ) {
+			$instance = new QM_Dispatchers;
+		}
+
+		return $instance;
+
+	}
+
+}

--- a/query-monitor/classes/Output.php
+++ b/query-monitor/classes/Output.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Abstract output handler.
+ *
+ * @package query-monitor
+ */
+
+if ( ! class_exists( 'QM_Output' ) ) {
+abstract class QM_Output {
+
+	protected $collector;
+	protected $timer;
+
+	public function __construct( QM_Collector $collector ) {
+		$this->collector = $collector;
+	}
+
+	abstract public function get_output();
+
+	public function output() {
+		// nothing
+	}
+
+	public function get_collector() {
+		return $this->collector;
+	}
+
+	final public function get_timer() {
+		return $this->timer;
+	}
+
+	final public function set_timer( QM_Timer $timer ) {
+		$this->timer = $timer;
+	}
+
+}
+}

--- a/query-monitor/classes/Plugin.php
+++ b/query-monitor/classes/Plugin.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Abstract plugin wrapper.
+ *
+ * @package query-monitor
+ */
+
+if ( ! class_exists( 'QM_Plugin' ) ) {
+abstract class QM_Plugin {
+
+	private $plugin = array();
+	public static $minimum_php_version = '5.3.6';
+
+	/**
+	 * Class constructor
+	 *
+	 * @author John Blackbourn
+	 **/
+	protected function __construct( $file ) {
+		$this->file = $file;
+	}
+
+	/**
+	 * Returns the URL for for a file/dir within this plugin.
+	 *
+	 * @param $file string The path within this plugin, e.g. '/js/clever-fx.js'
+	 * @return string URL
+	 * @author John Blackbourn
+	 **/
+	final public function plugin_url( $file = '' ) {
+		return $this->_plugin( 'url', $file );
+	}
+
+	/**
+	 * Returns the filesystem path for a file/dir within this plugin.
+	 *
+	 * @param $file string The path within this plugin, e.g. '/js/clever-fx.js'
+	 * @return string Filesystem path
+	 * @author John Blackbourn
+	 **/
+	final public function plugin_path( $file = '' ) {
+		return $this->_plugin( 'path', $file );
+	}
+
+	/**
+	 * Returns a version number for the given plugin file.
+	 *
+	 * @param $file string The path within this plugin, e.g. '/js/clever-fx.js'
+	 * @return string Version
+	 * @author John Blackbourn
+	 **/
+	final public function plugin_ver( $file ) {
+		return filemtime( $this->plugin_path( $file ) );
+	}
+
+	/**
+	 * Returns the current plugin's basename, eg. 'my_plugin/my_plugin.php'.
+	 *
+	 * @return string Basename
+	 * @author John Blackbourn
+	 **/
+	final public function plugin_base() {
+		return $this->_plugin( 'base' );
+	}
+
+	/**
+	 * Populates and returns the current plugin info.
+	 *
+	 * @author John Blackbourn
+	 **/
+	final private function _plugin( $item, $file = '' ) {
+		if ( ! array_key_exists( $item, $this->plugin ) ) {
+			switch ( $item ) {
+				case 'url':
+					$this->plugin[ $item ] = plugin_dir_url( $this->file );
+					break;
+				case 'path':
+					$this->plugin[ $item ] = plugin_dir_path( $this->file );
+					break;
+				case 'base':
+					$this->plugin[ $item ] = plugin_basename( $this->file );
+					break;
+			}
+		}
+		return $this->plugin[ $item ] . ltrim( $file, '/' );
+	}
+
+	public static function php_version_met() {
+		static $met = null;
+
+		if ( null === $met ) {
+			$met = version_compare( PHP_VERSION, self::$minimum_php_version, '>=' );
+		}
+
+		return $met;
+	}
+
+}
+}

--- a/query-monitor/classes/QM.php
+++ b/query-monitor/classes/QM.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * A convenience class for wrapping certain user-facing functionality.
+ *
+ * @package query-monitor
+ */
+
+class QM {
+
+	public static function emergency( $message, array $context = array() ) {
+		do_action( 'qm/emergency', $message, $context );
+	}
+
+	public static function alert( $message, array $context = array() ) {
+		do_action( 'qm/alert', $message, $context );
+	}
+
+	public static function critical( $message, array $context = array() ) {
+		do_action( 'qm/critical', $message, $context );
+	}
+
+	public static function error( $message, array $context = array() ) {
+		do_action( 'qm/error', $message, $context );
+	}
+
+	public static function warning( $message, array $context = array() ) {
+		do_action( 'qm/warning', $message, $context );
+	}
+
+	public static function notice( $message, array $context = array() ) {
+		do_action( 'qm/notice', $message, $context );
+	}
+
+	public static function info( $message, array $context = array() ) {
+		do_action( 'qm/info', $message, $context );
+	}
+
+	public static function debug( $message, array $context = array() ) {
+		do_action( 'qm/debug', $message, $context );
+	}
+
+	public static function log( $level, $message, array $context = array() ) {
+		$logger = QM_Collectors::get( 'logger' );
+		$logger->log( $level, $message, $context );
+	}
+}

--- a/query-monitor/classes/QueryMonitor.php
+++ b/query-monitor/classes/QueryMonitor.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * The main Query Monitor plugin class.
+ *
+ * @package query-monitor
+ */
+
+class QueryMonitor extends QM_Plugin {
+
+	protected function __construct( $file ) {
+
+		# Actions
+		add_action( 'plugins_loaded', array( $this, 'action_plugins_loaded' ) );
+		add_action( 'init',           array( $this, 'action_init' ) );
+		add_action( 'members_register_caps',       array( $this, 'action_register_members_caps' ) );
+		add_action( 'members_register_cap_groups', array( $this, 'action_register_members_groups' ) );
+
+		# Filters
+		add_filter( 'user_has_cap',   array( $this, 'filter_user_has_cap' ), 10, 4 );
+		add_filter( 'ure_built_in_wp_caps',         array( $this, 'filter_ure_caps' ) );
+		add_filter( 'ure_capabilities_groups_tree', array( $this, 'filter_ure_groups' ) );
+
+		# Parent setup:
+		parent::__construct( $file );
+
+		# Load and register built-in collectors:
+		$collectors = array();
+		foreach ( glob( $this->plugin_path( 'collectors/*.php' ) ) as $file ) {
+			$key = basename( $file, '.php' );
+			$collectors[ $key ] = $file;
+		}
+
+		foreach ( apply_filters( 'qm/built-in-collectors', $collectors ) as $file ) {
+			include $file;
+		}
+
+	}
+
+	/**
+	 * Filter a user's capabilities so they can be altered at runtime.
+	 *
+	 * This is used to:
+	 *  - Grant the 'view_query_monitor' capability to the user if they have the ability to manage options.
+	 *
+	 * This does not get called for Super Admins.
+	 *
+	 * @param bool[]   $user_caps     Array of key/value pairs where keys represent a capability name and boolean values
+	 *                                represent whether the user has that capability.
+	 * @param string[] $required_caps Required primitive capabilities for the requested capability.
+	 * @param array    $args {
+	 *     Arguments that accompany the requested capability check.
+	 *
+	 *     @type string    $0 Requested capability.
+	 *     @type int       $1 Concerned user ID.
+	 *     @type mixed  ...$2 Optional second and further parameters.
+	 * }
+	 * @param WP_User  $user          Concerned user object.
+	 * @return bool[] Concerned user's capabilities.
+	 */
+	public function filter_user_has_cap( array $user_caps, array $required_caps, array $args, WP_User $user ) {
+		if ( 'view_query_monitor' !== $args[0] ) {
+			return $user_caps;
+		}
+
+		if ( array_key_exists( 'view_query_monitor', $user_caps ) ) {
+			return $user_caps;
+		}
+
+		if ( ! is_multisite() && user_can( $args[1], 'manage_options' ) ) {
+			$user_caps['view_query_monitor'] = true;
+		}
+
+		return $user_caps;
+	}
+
+	public function action_plugins_loaded() {
+
+		# Register additional collectors:
+		foreach ( apply_filters( 'qm/collectors', array(), $this ) as $collector ) {
+			QM_Collectors::add( $collector );
+		}
+
+		# Load dispatchers:
+		foreach ( glob( $this->plugin_path( 'dispatchers/*.php' ) ) as $file ) {
+			include $file;
+		}
+
+		# Register built-in and additional dispatchers:
+		foreach ( apply_filters( 'qm/dispatchers', array(), $this ) as $dispatcher ) {
+			QM_Dispatchers::add( $dispatcher );
+		}
+
+	}
+
+	public function action_init() {
+		load_plugin_textdomain( 'query-monitor', false, dirname( $this->plugin_base() ) . '/languages' );
+	}
+
+	public static function symlink_warning() {
+		$db = WP_CONTENT_DIR . '/db.php';
+		trigger_error( sprintf(
+			/* translators: %s: Symlink file location */
+			esc_html__( 'The symlink at %s is no longer pointing to the correct location. Please remove the symlink, then deactivate and reactivate Query Monitor.', 'query-monitor' ),
+			'<code>' . esc_html( $db ) . '</code>'
+		), E_USER_WARNING );
+	}
+
+	/**
+	 * Registers the Query Monitor user capability group for the Members plugin.
+	 *
+	 * @link https://wordpress.org/plugins/members/
+	 */
+	public function action_register_members_groups() {
+		members_register_cap_group( 'query_monitor', array(
+			'label'    => __( 'Query Monitor', 'query-monitor' ),
+			'caps'     => array(
+				'view_query_monitor',
+			),
+			'icon'     => 'dashicons-admin-tools',
+			'priority' => 30,
+		) );
+	}
+
+	/**
+	 * Registers the View Query Monitor user capability for the Members plugin.
+	 *
+	 * @link https://wordpress.org/plugins/members/
+	 */
+	public function action_register_members_caps() {
+		members_register_cap( 'view_query_monitor', array(
+			'label' => _x( 'View Query Monitor', 'Human readable label for the user capability required to view Query Monitor.', 'query-monitor' ),
+			'group' => 'query_monitor',
+		) );
+	}
+
+	/**
+	 * Registers the Query Monitor user capability group for the User Role Editor plugin.
+	 *
+	 * @link https://wordpress.org/plugins/user-role-editor/
+	 *
+	 * @param array[] $groups Array of existing groups.
+	 * @return array[] Updated array of groups.
+	 */
+	public function filter_ure_groups( array $groups ) {
+		$groups['query_monitor'] = array(
+			'caption' => esc_html__( 'Query Monitor', 'query-monitor' ),
+			'parent'  => 'custom',
+			'level'   => 2,
+		);
+
+		return $groups;
+	}
+
+	/**
+	 * Registers the View Query Monitor user capability for the User Role Editor plugin.
+	 *
+	 * @link https://wordpress.org/plugins/user-role-editor/
+	 *
+	 * @param array[] $caps Array of existing capabilities.
+	 * @return array[] Updated array of capabilities.
+	 */
+	public function filter_ure_caps( array $caps ) {
+		$caps['view_query_monitor'] = array(
+			'custom',
+			'query_monitor',
+		);
+
+		return $caps;
+	}
+
+	public static function init( $file = null ) {
+
+		static $instance = null;
+
+		if ( ! $instance ) {
+			$instance = new QueryMonitor( $file );
+		}
+
+		return $instance;
+
+	}
+
+}

--- a/query-monitor/classes/Timer.php
+++ b/query-monitor/classes/Timer.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Timer that collects timing and memory usage.
+ *
+ * @package query-monitor
+ */
+
+class QM_Timer {
+
+	protected $start = null;
+	protected $end   = null;
+	protected $trace = null;
+	protected $laps  = array();
+
+	public function start( array $data = null ) {
+		$this->trace = new QM_Backtrace;
+		$this->start = array(
+			'time'   => microtime( true ),
+			'memory' => memory_get_usage(),
+			'data'   => $data,
+		);
+		return $this;
+	}
+
+	public function stop( array $data = null ) {
+
+		$this->end = array(
+			'time'   => microtime( true ),
+			'memory' => memory_get_usage(),
+			'data'   => $data,
+		);
+
+		return $this;
+
+	}
+
+	public function lap( array $data = null, $name = null ) {
+
+		$lap = array(
+			'time'   => microtime( true ),
+			'memory' => memory_get_usage(),
+			'data'   => $data,
+		);
+
+		if ( ! isset( $name ) ) {
+			/* translators: %d: Timing lap number */
+			$i = sprintf( __( 'Lap %d', 'query-monitor' ), count( $this->laps ) + 1 );
+		} else {
+			$i = $name;
+		}
+
+		$this->laps[ $i ] = $lap;
+
+		return $this;
+
+	}
+
+	public function get_laps() {
+
+		$laps = array();
+		$prev = $this->start;
+
+		foreach ( $this->laps as $lap_id => $lap ) {
+
+			$lap['time_used']   = $lap['time'] - $prev['time'];
+			$lap['memory_used'] = $lap['memory'] - $prev['memory'];
+
+			$laps[ $lap_id ] = $prev = $lap;
+
+		}
+
+		return $laps;
+
+	}
+
+	public function get_time() {
+		return $this->end['time'] - $this->start['time'];
+	}
+
+	public function get_memory() {
+		return $this->end['memory'] - $this->start['memory'];
+	}
+
+	public function get_trace() {
+		return $this->trace;
+	}
+
+	public function end( array $data = null ) {
+		return $this->stop( $data );
+	}
+
+}

--- a/query-monitor/classes/Util.php
+++ b/query-monitor/classes/Util.php
@@ -1,0 +1,448 @@
+<?php
+/**
+ * General utilities class.
+ *
+ * @package query-monitor
+ */
+
+if ( ! class_exists( 'QM_Util' ) ) {
+class QM_Util {
+
+	protected static $file_components = array();
+	protected static $file_dirs       = array();
+	protected static $abspath         = null;
+	protected static $contentpath     = null;
+	protected static $sort_field      = null;
+
+	private function __construct() {}
+
+	public static function convert_hr_to_bytes( $size ) {
+
+		# Annoyingly, wp_convert_hr_to_bytes() is defined in a file that's only
+		# loaded in the admin area, so we'll use our own version.
+		# See also http://core.trac.wordpress.org/ticket/17725
+
+		$bytes = (float) $size;
+
+		if ( $bytes ) {
+			$last = strtolower( substr( $size, -1 ) );
+			$pos = strpos( ' kmg', $last, 1 );
+			if ( $pos ) {
+				$bytes *= pow( 1024, $pos );
+			}
+			$bytes = round( $bytes );
+		}
+
+		return $bytes;
+
+	}
+
+	public static function standard_dir( $dir, $path_replace = null ) {
+
+		$dir = self::normalize_path( $dir );
+
+		if ( is_string( $path_replace ) ) {
+			if ( ! self::$abspath ) {
+				self::$abspath     = self::normalize_path( ABSPATH );
+				self::$contentpath = self::normalize_path( dirname( WP_CONTENT_DIR ) . '/' );
+			}
+			$dir = str_replace( array(
+				self::$abspath,
+				self::$contentpath,
+			), $path_replace, $dir );
+		}
+
+		return $dir;
+
+	}
+
+	public static function normalize_path( $path ) {
+		if ( function_exists( 'wp_normalize_path' ) ) {
+			$path = wp_normalize_path( $path );
+		} else {
+			$path = str_replace( '\\', '/', $path );
+			$path = str_replace( '//', '/', $path );
+		}
+
+		return $path;
+	}
+
+	public static function get_file_dirs() {
+		if ( empty( self::$file_dirs ) ) {
+			self::$file_dirs['plugin']     = self::standard_dir( WP_PLUGIN_DIR );
+			self::$file_dirs['mu-vendor']  = self::standard_dir( WPMU_PLUGIN_DIR . '/vendor' );
+			self::$file_dirs['go-plugin']  = self::standard_dir( WPMU_PLUGIN_DIR . '/shared-plugins' );
+			self::$file_dirs['mu-plugin']  = self::standard_dir( WPMU_PLUGIN_DIR );
+			self::$file_dirs['vip-plugin'] = self::standard_dir( get_theme_root() . '/vip/plugins' );
+
+			if ( defined( 'WPCOM_VIP_CLIENT_MU_PLUGIN_DIR' ) ) {
+				self::$file_dirs['vip-client-mu-plugin'] = self::standard_dir( WPCOM_VIP_CLIENT_MU_PLUGIN_DIR );
+			}
+
+			self::$file_dirs['theme']      = null;
+			self::$file_dirs['stylesheet'] = self::standard_dir( get_stylesheet_directory() );
+			self::$file_dirs['template']   = self::standard_dir( get_template_directory() );
+			self::$file_dirs['other']      = self::standard_dir( WP_CONTENT_DIR );
+			self::$file_dirs['core']       = self::standard_dir( ABSPATH );
+			self::$file_dirs['unknown']    = null;
+		}
+		return self::$file_dirs;
+	}
+
+	public static function get_file_component( $file ) {
+
+		# @TODO turn this into a class (eg QM_File_Component)
+
+		$file = self::standard_dir( $file );
+
+		if ( isset( self::$file_components[ $file ] ) ) {
+			return self::$file_components[ $file ];
+		}
+
+		foreach ( self::get_file_dirs() as $type => $dir ) {
+			// this slash makes paths such as plugins-mu match mu-plugin not plugin
+			if ( $dir && ( 0 === strpos( $file, trailingslashit( $dir ) ) ) ) {
+				break;
+			}
+		}
+
+		$context = $type;
+
+		switch ( $type ) {
+			case 'plugin':
+			case 'mu-plugin':
+			case 'mu-vendor':
+				$plug = str_replace( '/vendor/', '/', $file );
+				$plug = plugin_basename( $plug );
+				if ( strpos( $plug, '/' ) ) {
+					$plug = explode( '/', $plug );
+					$plug = reset( $plug );
+				} else {
+					$plug = basename( $plug );
+				}
+				if ( 'plugin' !== $type ) {
+					/* translators: %s: Plugin name */
+					$name = sprintf( __( 'MU Plugin: %s', 'query-monitor' ), $plug );
+				} else {
+					/* translators: %s: Plugin name */
+					$name = sprintf( __( 'Plugin: %s', 'query-monitor' ), $plug );
+				}
+				$context = $plug;
+				break;
+			case 'go-plugin':
+			case 'vip-plugin':
+			case 'vip-client-mu-plugin':
+				$plug = str_replace( self::$file_dirs[ $type ], '', $file );
+				$plug = trim( $plug, '/' );
+				if ( strpos( $plug, '/' ) ) {
+					$plug = explode( '/', $plug );
+					$plug = reset( $plug );
+				} else {
+					$plug = basename( $plug );
+				}
+				if ( 'vip-client-mu-plugin' === $type ) {
+					/* translators: %s: Plugin name */
+					$name = sprintf( __( 'VIP Client MU Plugin: %s', 'query-monitor' ), $plug );
+				} else {
+					/* translators: %s: Plugin name */
+					$name = sprintf( __( 'VIP Plugin: %s', 'query-monitor' ), $plug );
+				}
+				$context = $plug;
+				break;
+			case 'stylesheet':
+				if ( is_child_theme() ) {
+					$name = __( 'Child Theme', 'query-monitor' );
+				} else {
+					$name = __( 'Theme', 'query-monitor' );
+				}
+				$type = 'theme';
+				break;
+			case 'template':
+				$name = __( 'Parent Theme', 'query-monitor' );
+				$type = 'theme';
+				break;
+			case 'other':
+				// Anything else that's within the content directory should appear as
+				// `wp-content/{dir}` or `wp-content/{file}`
+				$name    = self::standard_dir( $file );
+				$name    = str_replace( dirname( self::$file_dirs['other'] ), '', $name );
+				$parts   = explode( '/', trim( $name, '/' ) );
+				$name    = $parts[0] . '/' . $parts[1];
+				$context = $file;
+				break;
+			case 'core':
+				$name = __( 'Core', 'query-monitor' );
+				break;
+			case 'unknown':
+			default:
+				$name = __( 'Unknown', 'query-monitor' );
+				break;
+		}
+
+		return self::$file_components[ $file ] = (object) compact( 'type', 'name', 'context' );
+
+	}
+
+	public static function populate_callback( array $callback ) {
+
+		if ( is_string( $callback['function'] ) and ( false !== strpos( $callback['function'], '::' ) ) ) {
+			$callback['function'] = explode( '::', $callback['function'] );
+		}
+
+		try {
+
+			if ( is_array( $callback['function'] ) ) {
+				if ( is_object( $callback['function'][0] ) ) {
+					$class  = get_class( $callback['function'][0] );
+					$access = '->';
+				} else {
+					$class  = $callback['function'][0];
+					$access = '::';
+				}
+
+				$callback['name'] = QM_Util::shorten_fqn( $class . $access . $callback['function'][1] ) . '()';
+				$ref = new ReflectionMethod( $class, $callback['function'][1] );
+			} elseif ( is_object( $callback['function'] ) ) {
+				if ( is_a( $callback['function'], 'Closure' ) ) {
+					$ref  = new ReflectionFunction( $callback['function'] );
+					$file = QM_Util::standard_dir( $ref->getFileName(), '' );
+					if ( 0 === strpos( $file, '/' ) ) {
+						$file = basename( $ref->getFileName() );
+					}
+					/* translators: 1: Line number, 2: File name */
+					$callback['name'] = sprintf( __( 'Closure on line %1$d of %2$s', 'query-monitor' ), $ref->getStartLine(), $file );
+				} else {
+					// the object should have a __invoke() method
+					$class = get_class( $callback['function'] );
+					$callback['name'] = QM_Util::shorten_fqn( $class ) . '->__invoke()';
+					$ref = new ReflectionMethod( $class, '__invoke' );
+				}
+			} else {
+				$callback['name'] = QM_Util::shorten_fqn( $callback['function'] ) . '()';
+				$ref = new ReflectionFunction( $callback['function'] );
+			}
+
+			$callback['file'] = $ref->getFileName();
+			$callback['line'] = $ref->getStartLine();
+
+			// https://github.com/facebook/hhvm/issues/5856
+			$name = trim( $ref->getName() );
+
+			if ( '__lambda_func' === $name || 0 === strpos( $name, 'lambda_' ) ) {
+				if ( preg_match( '|(?P<file>.*)\((?P<line>[0-9]+)\)|', $callback['file'], $matches ) ) {
+					$callback['file'] = $matches['file'];
+					$callback['line'] = $matches['line'];
+					$file = trim( QM_Util::standard_dir( $callback['file'], '' ), '/' );
+					/* translators: 1: Line number, 2: File name */
+					$callback['name'] = sprintf( __( 'Anonymous function on line %1$d of %2$s', 'query-monitor' ), $callback['line'], $file );
+				} else {
+					// https://github.com/facebook/hhvm/issues/5807
+					unset( $callback['line'], $callback['file'] );
+					$callback['name'] = $name . '()';
+					$callback['error'] = new WP_Error( 'unknown_lambda', __( 'Unable to determine source of lambda function', 'query-monitor' ) );
+				}
+			}
+
+			if ( ! empty( $callback['file'] ) ) {
+				$callback['component'] = self::get_file_component( $callback['file'] );
+			} else {
+				$callback['component'] = (object) array(
+					'type'    => 'php',
+					'name'    => 'PHP',
+					'context' => '',
+				);
+			}
+		} catch ( ReflectionException $e ) {
+
+			$callback['error'] = new WP_Error( 'reflection_exception', $e->getMessage() );
+
+		}
+
+		return $callback;
+
+	}
+
+	public static function is_ajax() {
+		if ( defined( 'DOING_AJAX' ) and DOING_AJAX ) {
+			return true;
+		}
+		return false;
+	}
+
+	public static function is_async() {
+		if ( self::is_ajax() ) {
+			return true;
+		}
+		if ( isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && 'xmlhttprequest' === strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) ) { // @codingStandardsIgnoreLine
+			return true;
+		}
+		return false;
+	}
+
+	public static function get_admins() {
+		if ( is_multisite() ) {
+			return false;
+		} else {
+			return get_role( 'administrator' );
+		}
+	}
+
+	public static function is_multi_network() {
+		global $wpdb;
+
+		if ( function_exists( 'is_multi_network' ) ) {
+			return is_multi_network();
+		}
+
+		if ( ! is_multisite() ) {
+			return false;
+		}
+
+		// @codingStandardsIgnoreStart
+		$num_sites = $wpdb->get_var( "
+			SELECT COUNT(*)
+			FROM {$wpdb->site}
+		" );
+		// @codingStandardsIgnoreEnd
+
+		return ( $num_sites > 1 );
+	}
+
+	public static function get_client_version( $client ) {
+
+		$client = intval( $client );
+
+		$hello = $client % 10000;
+
+		$major = intval( floor( $client / 10000 ) );
+		$minor = intval( floor( $hello / 100 ) );
+		$patch = intval( $hello % 100 );
+
+		return compact( 'major', 'minor', 'patch' );
+
+	}
+
+	public static function get_query_type( $sql ) {
+		$sql = $type = trim( $sql );
+
+		if ( 0 === strpos( $sql, '/*' ) ) {
+			// Strip out leading comments such as `/*NO_SELECT_FOUND_ROWS*/` before calculating the query type
+			$type = preg_replace( '|^/\*[^\*/]+\*/|', '', $sql );
+		}
+
+		$type = preg_split( '/\b/', trim( $type ), 2, PREG_SPLIT_NO_EMPTY );
+		$type = strtoupper( $type[0] );
+
+		return $type;
+	}
+
+	public static function display_variable( $value ) {
+		if ( is_string( $value ) ) {
+			return $value;
+		} elseif ( is_bool( $value ) ) {
+			return ( $value ) ? 'true' : 'false';
+		} elseif ( is_scalar( $value ) ) {
+			return $value;
+		} elseif ( is_object( $value ) ) {
+			$class = get_class( $value );
+
+			switch ( true ) {
+
+				case ( $value instanceof WP_Post ):
+				case ( $value instanceof WP_User ):
+					return sprintf( '%s (ID: %s)', $class, $value->ID );
+					break;
+
+				case ( $value instanceof WP_Term ):
+					return sprintf( '%s (term_id: %s)', $class, $value->term_id );
+					break;
+
+				case ( $value instanceof WP_Comment ):
+					return sprintf( '%s (comment_ID: %s)', $class, $value->comment_ID );
+					break;
+
+				case ( $value instanceof WP_Error ):
+					return sprintf( '%s (%s)', $class, $value->get_error_code() );
+					break;
+
+				case ( $value instanceof WP_Role ):
+				case ( $value instanceof WP_Post_Type ):
+				case ( $value instanceof WP_Taxonomy ):
+					return sprintf( '%s (%s)', $class, $value->name );
+					break;
+
+				case ( $value instanceof WP_Network ):
+					return sprintf( '%s (id: %s)', $class, $value->id );
+					break;
+
+				case ( $value instanceof WP_Site ):
+					return sprintf( '%s (blog_id: %s)', $class, $value->blog_id );
+					break;
+
+				case ( $value instanceof WP_Theme ):
+					return sprintf( '%s (%s)', $class, $value->get_stylesheet() );
+					break;
+
+				default:
+					return $class;
+					break;
+
+			}
+		} else {
+			return gettype( $value );
+		}
+	}
+
+	/**
+	 * Shortens a fully qualified name to reduce the length of the names of long namespaced symbols.
+	 *
+	 * This initialises portions that do not form the first or last portion of the name. For example:
+	 *
+	 *     Inpsyde\Wonolog\HookListener\HookListenersRegistry->hook_callback()
+	 *
+	 * becomes:
+	 *
+	 *     Inpsyde\W\H\HookListenersRegistry->hook_callback()
+	 *
+	 * @param string $fqn A fully qualified name.
+	 * @return string A shortened version of the name.
+	 */
+	public static function shorten_fqn( $fqn ) {
+		return preg_replace_callback( '#\\\\[a-zA-Z0-9_\\\\]{4,}\\\\#', function( array $matches ) {
+			preg_match_all( '#\\\\([a-zA-Z0-9_])#', $matches[0], $m );
+			return '\\' . implode( '\\', $m[1] ) . '\\';
+		}, $fqn );
+	}
+
+	public static function sort( array &$array, $field ) {
+		self::$sort_field = $field;
+		usort( $array, array( __CLASS__, '_sort' ) );
+	}
+
+	public static function rsort( array &$array, $field ) {
+		self::$sort_field = $field;
+		usort( $array, array( __CLASS__, '_rsort' ) );
+	}
+
+	private static function _rsort( $a, $b ) {
+		$field = self::$sort_field;
+
+		if ( $a[ $field ] === $b[ $field ] ) {
+			return 0;
+		} else {
+			return ( $a[ $field ] > $b[ $field ] ) ? -1 : 1;
+		}
+	}
+
+	private static function _sort( $a, $b ) {
+		$field = self::$sort_field;
+
+		if ( $a[ $field ] === $b[ $field ] ) {
+			return 0;
+		} else {
+			return ( $a[ $field ] > $b[ $field ] ) ? 1 : -1;
+		}
+	}
+
+}
+}

--- a/query-monitor/classes/debug_bar.php
+++ b/query-monitor/classes/debug_bar.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Mock 'Debug Bar' plugin class.
+ *
+ * @package query-monitor
+ */
+
+class Debug_Bar {
+	public $panels = array();
+
+	public function __construct() {
+		add_action( 'wp_head', array( $this, 'ensure_ajaxurl' ), 1 );
+
+		$this->enqueue();
+		$this->init_panels();
+	}
+
+	public function enqueue() {
+		wp_register_style( 'debug-bar', false, array(
+			'query-monitor',
+		) );
+		wp_register_script( 'debug-bar', false, array(
+			'query-monitor',
+		) );
+
+		do_action( 'debug_bar_enqueue_scripts' );
+	}
+
+	public function init_panels() {
+		require_once 'debug_bar_panel.php';
+
+		$this->panels = apply_filters( 'debug_bar_panels', array() );
+	}
+
+	public function ensure_ajaxurl() {
+		?>
+		<script type="text/javascript">
+		var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
+		</script>
+		<?php
+	}
+
+	public function Debug_Bar() {
+		Debug_Bar::__construct();
+	}
+
+}

--- a/query-monitor/classes/debug_bar_panel.php
+++ b/query-monitor/classes/debug_bar_panel.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Mock 'Debug Bar' panel class.
+ *
+ * @package query-monitor
+ */
+
+abstract class Debug_Bar_Panel {
+
+	public $_title = '';
+	public $_visible = true;
+
+	public function __construct( $title = '' ) {
+		$this->title( $title );
+
+		if ( $this->init() === false ) {
+			$this->set_visible( false );
+			return;
+		}
+
+		# @TODO convert to QM classes
+		add_filter( 'debug_bar_classes', array( $this, 'debug_bar_classes' ) );
+	}
+
+	/**
+	 * Initializes the panel.
+	 */
+	public function init() {}
+
+	public function prerender() {}
+
+	/**
+	 * Renders the panel.
+	 */
+	public function render() {}
+
+	public function is_visible() {
+		return $this->_visible;
+	}
+
+	public function set_visible( $visible ) {
+		$this->_visible = $visible;
+	}
+
+	public function title( $title = null ) {
+		if ( ! isset( $title ) ) {
+			return $this->_title;
+		}
+		$this->_title = $title;
+	}
+
+	public function debug_bar_classes( $classes ) {
+		return $classes;
+	}
+
+	public function Debug_Bar_Panel( $title = '' ) {
+		Debug_Bar_Panel::__construct( $title );
+	}
+
+}

--- a/query-monitor/collectors/admin.php
+++ b/query-monitor/collectors/admin.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Admin screen collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Admin extends QM_Collector {
+
+	public $id = 'response';
+
+	public function name() {
+		return __( 'Admin Screen', 'query-monitor' );
+	}
+
+	public function process() {
+
+		global $pagenow, $wp_list_table;
+
+		$current_screen = get_current_screen();
+
+		if ( isset( $_GET['page'] ) && null !== $current_screen ) { // @codingStandardsIgnoreLine
+			$this->data['base'] = $current_screen->base;
+		} else {
+			$this->data['base'] = $pagenow;
+		}
+
+		$this->data['pagenow'] = $pagenow;
+		$this->data['current_screen'] = ( $current_screen ) ? get_object_vars( $current_screen ) : null;
+
+		$screens = array(
+			'edit'            => true,
+			'edit-comments'   => true,
+			'edit-tags'       => true,
+			'link-manager'    => true,
+			'plugins'         => true,
+			'plugins-network' => true,
+			'sites-network'   => true,
+			'themes-network'  => true,
+			'upload'          => true,
+			'users'           => true,
+			'users-network'   => true,
+		);
+
+		if ( ! empty( $this->data['current_screen'] ) and isset( $screens[ $this->data['current_screen']['base'] ] ) ) {
+
+			$list_table = array();
+
+			# And now, WordPress' legendary inconsistency comes into play:
+
+			if ( ! empty( $this->data['current_screen']['taxonomy'] ) ) {
+				$list_table['column'] = $this->data['current_screen']['taxonomy'];
+			} elseif ( ! empty( $this->data['current_screen']['post_type'] ) ) {
+				$list_table['column'] = $this->data['current_screen']['post_type'] . '_posts';
+			} else {
+				$list_table['column'] = $this->data['current_screen']['base'];
+			}
+
+			if ( ! empty( $this->data['current_screen']['post_type'] ) and empty( $this->data['current_screen']['taxonomy'] ) ) {
+				$list_table['columns'] = $this->data['current_screen']['post_type'] . '_posts';
+			} else {
+				$list_table['columns'] = $this->data['current_screen']['id'];
+			}
+
+			if ( 'edit-comments' === $list_table['column'] ) {
+				$list_table['column'] = 'comments';
+			} elseif ( 'upload' === $list_table['column'] ) {
+				$list_table['column'] = 'media';
+			} elseif ( 'link-manager' === $list_table['column'] ) {
+				$list_table['column'] = 'link';
+			}
+
+			$list_table['sortables'] = $this->data['current_screen']['id'];
+
+			$this->data['list_table'] = array(
+				'columns_filter'   => "manage_{$list_table['columns']}_columns",
+				'sortables_filter' => "manage_{$list_table['sortables']}_sortable_columns",
+				'column_action'    => "manage_{$list_table['column']}_custom_column",
+			);
+
+			if ( ! empty( $wp_list_table ) ) {
+				$this->data['list_table']['class_name'] = get_class( $wp_list_table );
+			}
+		}
+
+	}
+
+}
+
+function register_qm_collector_admin( array $collectors, QueryMonitor $qm ) {
+	$collectors['response'] = new QM_Collector_Admin;
+	return $collectors;
+}
+
+if ( is_admin() ) {
+	add_filter( 'qm/collectors', 'register_qm_collector_admin', 10, 2 );
+}

--- a/query-monitor/collectors/assets.php
+++ b/query-monitor/collectors/assets.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Enqueued scripts and styles collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Assets extends QM_Collector {
+
+	public $id = 'assets';
+
+	public function __construct() {
+		parent::__construct();
+		add_action( 'admin_print_footer_scripts', array( $this, 'action_print_footer_scripts' ) );
+		add_action( 'wp_print_footer_scripts',    array( $this, 'action_print_footer_scripts' ) );
+		add_action( 'admin_head',                 array( $this, 'action_head' ), 999 );
+		add_action( 'wp_head',                    array( $this, 'action_head' ), 999 );
+		add_action( 'login_head',                 array( $this, 'action_head' ), 999 );
+		add_action( 'embed_head',                 array( $this, 'action_head' ), 999 );
+	}
+
+	public function action_head() {
+		global $wp_scripts, $wp_styles;
+
+		$this->data['header']['styles'] = $wp_styles->done;
+		$this->data['header']['scripts'] = $wp_scripts->done;
+
+	}
+
+	public function action_print_footer_scripts() {
+		global $wp_scripts, $wp_styles;
+
+		if ( empty( $this->data['header'] ) ) {
+			return;
+		}
+
+		// @TODO remove the need for these raw scripts & styles to be collected
+		$this->data['raw']['scripts'] = $wp_scripts;
+		$this->data['raw']['styles']  = $wp_styles;
+
+		$this->data['footer']['scripts'] = array_diff( $wp_scripts->done, $this->data['header']['scripts'] );
+		$this->data['footer']['styles']  = array_diff( $wp_styles->done, $this->data['header']['styles'] );
+
+	}
+
+	public function process() {
+		if ( ! isset( $this->data['raw'] ) ) {
+			return;
+		}
+
+		foreach ( array( 'scripts', 'styles' ) as $type ) {
+			foreach ( array( 'header', 'footer' ) as $position ) {
+				if ( empty( $this->data[ $position ][ $type ] ) ) {
+					$this->data[ $position ][ $type ] = array();
+				}
+			}
+			$raw = $this->data['raw'][ $type ];
+			$broken = array_values( array_diff( $raw->queue, $raw->done ) );
+			$missing = array_values( array_diff( $raw->queue, array_keys( $raw->registered ) ) );
+
+			if ( ! empty( $broken ) ) {
+				foreach ( $broken as $key => $handle ) {
+					if ( $item = $raw->query( $handle ) ) {
+						$broken = array_merge( $broken, self::get_broken_dependencies( $item, $raw ) );
+					} else {
+						unset( $broken[ $key ] );
+						$missing[] = $handle;
+					}
+				}
+
+				if ( ! empty( $broken ) ) {
+					$this->data['broken'][ $type ] = array_unique( $broken );
+				}
+			}
+
+			if ( ! empty( $missing ) ) {
+				$this->data['missing'][ $type ] = array_unique( $missing );
+				foreach ( $this->data['missing'][ $type ] as $handle ) {
+					$raw->add( $handle, false );
+					if ( false !== ( $key = array_search( $handle, $raw->done, true ) ) ) {
+						unset( $raw->done[ $key ] );
+					}
+				}
+			}
+		}
+	}
+
+	protected static function get_broken_dependencies( _WP_Dependency $item, WP_Dependencies $dependencies ) {
+		$broken = array();
+
+		foreach ( $item->deps as $handle ) {
+			if ( $dep = $dependencies->query( $handle ) ) {
+				$broken = array_merge( $broken, self::get_broken_dependencies( $dep, $dependencies ) );
+			} else {
+				$broken[] = $item->handle;
+			}
+		}
+
+		return $broken;
+	}
+
+	public function get_dependents( _WP_Dependency $dependency, WP_Dependencies $dependencies ) {
+		$dependents = array();
+		$handles    = array_unique( array_merge( $dependencies->queue, $dependencies->done ) );
+
+		foreach ( $handles as $handle ) {
+			if ( $item = $dependencies->query( $handle ) ) {
+				if ( in_array( $dependency->handle, $item->deps, true ) ) {
+					$dependents[] = $handle;
+				}
+			}
+		}
+
+		sort( $dependents );
+
+		return $dependents;
+	}
+
+	public function name() {
+		return __( 'Scripts & Styles', 'query-monitor' );
+	}
+
+}
+
+function register_qm_collector_assets( array $collectors, QueryMonitor $qm ) {
+	$collectors['assets'] = new QM_Collector_Assets;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_assets', 10, 2 );

--- a/query-monitor/collectors/cache.php
+++ b/query-monitor/collectors/cache.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Object cache collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Cache extends QM_Collector {
+
+	public $id = 'cache';
+
+	public function name() {
+		return __( 'Cache', 'query-monitor' );
+	}
+
+	public function process() {
+		global $wp_object_cache;
+
+		$this->data['ext_object_cache'] = (bool) wp_using_ext_object_cache();
+		$this->data['cache_hit_percentage'] = 0;
+
+		if ( is_object( $wp_object_cache ) ) {
+			if ( property_exists( $wp_object_cache, 'cache_hits' ) ) {
+				$this->data['stats']['cache_hits'] = (int) $wp_object_cache->cache_hits;
+			}
+
+			if ( property_exists( $wp_object_cache, 'cache_misses' ) ) {
+				$this->data['stats']['cache_misses'] = (int) $wp_object_cache->cache_misses;
+			}
+
+			if ( method_exists( $wp_object_cache, 'getStats' ) ) {
+				$stats = $wp_object_cache->getStats();
+			} elseif ( property_exists( $wp_object_cache, 'stats' ) && is_array( $wp_object_cache->stats ) ) {
+				$stats = $wp_object_cache->stats;
+			} elseif ( function_exists( 'wp_cache_get_stats' ) ) {
+				$stats = wp_cache_get_stats();
+			}
+
+			if ( ! empty( $stats ) ) {
+				if ( is_array( $stats ) && ! isset( $stats['get_hits'] ) && 1 === count( $stats ) ) {
+					$first_server = reset( $stats );
+					if ( isset( $first_server['get_hits'] ) ) {
+						$stats = $first_server;
+					}
+				}
+
+				foreach ( $stats as $key => $value ) {
+					if ( ! is_scalar( $value ) ) {
+						continue;
+					}
+					$this->data['stats'][ $key ] = $value;
+				}
+			}
+
+			if ( ! isset( $this->data['stats']['cache_hits'] ) ) {
+				if ( isset( $this->data['stats']['get_hits'] ) ) {
+					$this->data['stats']['cache_hits'] = (int) $this->data['stats']['get_hits'];
+				}
+			}
+
+			if ( ! isset( $this->data['stats']['cache_misses'] ) ) {
+				if ( isset( $this->data['stats']['get_misses'] ) ) {
+					$this->data['stats']['cache_misses'] = (int) $this->data['stats']['get_misses'];
+				}
+			}
+		}
+
+		if ( isset( $this->data['stats']['cache_hits'] ) && isset( $this->data['stats']['cache_misses'] ) ) {
+			$total = $this->data['stats']['cache_misses'] + $this->data['stats']['cache_hits'];
+			$this->data['cache_hit_percentage'] = ( 100 / $total ) * $this->data['stats']['cache_hits'];
+		}
+
+		$this->data['display_hit_rate_warning'] = ( 100 === $this->data['cache_hit_percentage'] );
+
+		if ( function_exists( 'extension_loaded' ) ) {
+			$this->data['extensions'] = array_map( 'extension_loaded', array(
+				'APC'          => 'APC',
+				'APCu'         => 'APCu',
+				'Memcache'     => 'Memcache',
+				'Memcached'    => 'Memcached',
+				'Redis'        => 'Redis',
+				'Zend OPcache' => 'Zend OPcache',
+			) );
+		} else {
+			$this->data['extensions'] = array();
+		}
+	}
+
+}
+
+function register_qm_collector_cache( array $collectors, QueryMonitor $qm ) {
+	$collectors['cache'] = new QM_Collector_Cache;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_cache', 20, 2 );

--- a/query-monitor/collectors/caps.php
+++ b/query-monitor/collectors/caps.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * User capability check collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Caps extends QM_Collector {
+
+	public $id = 'caps';
+
+	public function name() {
+		return __( 'Capability Checks', 'query-monitor' );
+	}
+
+	public function __construct() {
+		parent::__construct();
+		if ( ! defined( 'QM_ENABLE_CAPS_PANEL' ) || ! QM_ENABLE_CAPS_PANEL ) {
+			return;
+		}
+		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), 9999, 3 );
+		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 9999, 4 );
+	}
+
+	public function tear_down() {
+		remove_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), 9999 );
+		remove_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 9999 );
+	}
+
+	/**
+	 * Logs user capability checks.
+	 *
+	 * This does not get called for Super Admins. See filter_map_meta_cap() below.
+	 *
+	 * @param bool[]   $user_caps     Concerned user's capabilities.
+	 * @param string[] $required_caps Required primitive capabilities for the requested capability.
+	 * @param array    $args {
+	 *     Arguments that accompany the requested capability check.
+	 *
+	 *     @type string    $0 Requested capability.
+	 *     @type int       $1 Concerned user ID.
+	 *     @type mixed  ...$2 Optional second and further parameters.
+	 * }
+	 * @return bool[] Concerned user's capabilities.
+	 */
+	public function filter_user_has_cap( array $user_caps, array $caps, array $args ) {
+		$trace  = new QM_Backtrace;
+		$result = true;
+
+		foreach ( $caps as $cap ) {
+			if ( empty( $user_caps[ $cap ] ) ) {
+				$result = false;
+				break;
+			}
+		}
+
+		$this->data['caps'][] = array(
+			'args'   => $args,
+			'trace'  => $trace,
+			'result' => $result,
+		);
+
+		return $user_caps;
+	}
+
+	/**
+	 * Logs user capability checks for Super Admins on Multisite.
+	 *
+	 * This is needed because the `user_has_cap` filter doesn't fire for Super Admins.
+	 *
+	 * @param string[] $required_caps Required primitive capabilities for the requested capability.
+	 * @param string   $cap           Capability or meta capability being checked.
+	 * @param int      $user_id       Concerned user ID.
+	 * @param array    $args {
+	 *     Arguments that accompany the requested capability check.
+	 *
+	 *     @type mixed ...$0 Optional second and further parameters.
+	 * }
+	 * @return string[] Required capabilities for the requested action.
+	 */
+	public function filter_map_meta_cap( array $required_caps, $cap, $user_id, array $args ) {
+		if ( ! is_multisite() ) {
+			return $required_caps;
+		}
+
+		if ( ! is_super_admin( $user_id ) ) {
+			return $required_caps;
+		}
+
+		$trace  = new QM_Backtrace;
+		$result = ( ! in_array( 'do_not_allow', $required_caps, true ) );
+
+		array_unshift( $args, $user_id );
+		array_unshift( $args, $cap );
+
+		$this->data['caps'][] = array(
+			'args'   => $args,
+			'trace'  => $trace,
+			'result' => $result,
+		);
+
+		return $required_caps;
+	}
+
+	public function process() {
+		if ( empty( $this->data['caps'] ) ) {
+			return;
+		}
+
+		$all_parts = array();
+		$all_users = array();
+		$components = array();
+
+		$this->data['caps'] = array_filter( $this->data['caps'], array( $this, 'filter_remove_noise' ) );
+
+		if ( self::hide_qm() ) {
+			$this->data['caps'] = array_filter( $this->data['caps'], array( $this, 'filter_remove_qm' ) );
+		}
+
+		foreach ( $this->data['caps'] as $i => $cap ) {
+			$name = $cap['args'][0];
+
+			if ( ! is_string( $name ) ) {
+				$name = '';
+			}
+
+			$parts = array_filter( preg_split( '#[_/-]#', $name ) );
+			$this->data['caps'][ $i ]['parts'] = $parts;
+			$this->data['caps'][ $i ]['name']  = $name;
+			$this->data['caps'][ $i ]['user']  = $cap['args'][1];
+			$this->data['caps'][ $i ]['args']  = array_slice( $cap['args'], 2 );
+			$all_parts = array_merge( $all_parts, $parts );
+			$all_users[] = $cap['args'][1];
+			$component = $cap['trace']->get_component();
+			$components[ $component->name ] = $component->name;
+		}
+
+		$this->data['parts'] = array_unique( array_filter( $all_parts ) );
+		$this->data['users'] = array_unique( array_filter( $all_users ) );
+		$this->data['components'] = $components;
+	}
+
+	public function filter_remove_noise( array $cap ) {
+		$trace = $cap['trace']->get_trace();
+
+		$exclude_files = array(
+			ABSPATH . 'wp-admin/menu.php',
+			ABSPATH . 'wp-admin/includes/menu.php',
+		);
+		$exclude_functions = array(
+			'_wp_menu_output',
+			'wp_admin_bar_render',
+		);
+
+		foreach ( $trace as $item ) {
+			if ( isset( $item['file'] ) && in_array( $item['file'], $exclude_files, true ) ) {
+				return false;
+			}
+			if ( isset( $item['function'] ) && in_array( $item['function'], $exclude_functions, true ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+}
+
+function register_qm_collector_caps( array $collectors, QueryMonitor $qm ) {
+	$collectors['caps'] = new QM_Collector_Caps;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_caps', 20, 2 );

--- a/query-monitor/collectors/conditionals.php
+++ b/query-monitor/collectors/conditionals.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Template conditionals collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Conditionals extends QM_Collector {
+
+	public $id = 'conditionals';
+
+	public function name() {
+		return __( 'Conditionals', 'query-monitor' );
+	}
+
+	public function process() {
+
+		$conds = apply_filters( 'qm/collect/conditionals', array(
+			'is_404',
+			'is_admin',
+			'is_archive',
+			'is_attachment',
+			'is_author',
+			'is_blog_admin',
+			'is_category',
+			'is_comment_feed',
+			'is_customize_preview',
+			'is_date',
+			'is_day',
+			'is_embed',
+			'is_feed',
+			'is_front_page',
+			'is_home',
+			'is_main_network',
+			'is_main_site',
+			'is_month',
+			'is_network_admin',
+			'is_page',
+			'is_page_template',
+			'is_paged',
+			'is_post_type_archive',
+			'is_preview',
+			'is_robots',
+			'is_rtl',
+			'is_search',
+			'is_single',
+			'is_singular',
+			'is_ssl',
+			'is_sticky',
+			'is_tag',
+			'is_tax',
+			'is_time',
+			'is_trackback',
+			'is_user_admin',
+			'is_year',
+		) );
+		$conds = apply_filters( 'query_monitor_conditionals', $conds );
+
+		$true = $false = $na = array();
+
+		foreach ( $conds as $cond ) {
+			if ( function_exists( $cond ) ) {
+				if ( ( 'is_sticky' === $cond ) and ! get_post( $id = null ) ) {
+					# Special case for is_sticky to prevent PHP notices
+					$false[] = $cond;
+				} elseif ( ! is_multisite() && in_array( $cond, array( 'is_main_network', 'is_main_site' ), true ) ) {
+					# Special case for multisite conditionals to prevent them from being annoying on single site installs
+					$na[] = $cond;
+				} else {
+					if ( call_user_func( $cond ) ) {
+						$true[] = $cond;
+					} else {
+						$false[] = $cond;
+					}
+				}
+			} else {
+				$na[] = $cond;
+			}
+		}
+		$this->data['conds'] = compact( 'true', 'false', 'na' );
+
+	}
+
+}
+
+function register_qm_collector_conditionals( array $collectors, QueryMonitor $qm ) {
+	$collectors['conditionals'] = new QM_Collector_Conditionals;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_conditionals', 10, 2 );

--- a/query-monitor/collectors/db_callers.php
+++ b/query-monitor/collectors/db_callers.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Database query calling function collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_DB_Callers extends QM_Collector {
+
+	public $id = 'db_callers';
+
+	public function name() {
+		return __( 'Queries by Caller', 'query-monitor' );
+	}
+
+	public function process() {
+
+		if ( $dbq = QM_Collectors::get( 'db_queries' ) ) {
+			if ( isset( $dbq->data['times'] ) ) {
+				$this->data['times'] = $dbq->data['times'];
+				QM_Util::rsort( $this->data['times'], 'ltime' );
+			}
+			if ( isset( $dbq->data['types'] ) ) {
+				$this->data['types'] = $dbq->data['types'];
+			}
+		}
+
+	}
+
+}
+
+function register_qm_collector_db_callers( array $collectors, QueryMonitor $qm ) {
+	$collectors['db_callers'] = new QM_Collector_DB_Callers;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_db_callers', 20, 2 );

--- a/query-monitor/collectors/db_components.php
+++ b/query-monitor/collectors/db_components.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Database query calling component collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_DB_Components extends QM_Collector {
+
+	public $id = 'db_components';
+
+	public function name() {
+		return __( 'Queries by Component', 'query-monitor' );
+	}
+
+	public function process() {
+
+		if ( $dbq = QM_Collectors::get( 'db_queries' ) ) {
+			if ( isset( $dbq->data['component_times'] ) ) {
+				$this->data['times'] = $dbq->data['component_times'];
+				QM_Util::rsort( $this->data['times'], 'ltime' );
+			}
+			if ( isset( $dbq->data['types'] ) ) {
+				$this->data['types'] = $dbq->data['types'];
+			}
+		}
+
+	}
+
+}
+
+function register_qm_collector_db_components( array $collectors, QueryMonitor $qm ) {
+	$collectors['db_components'] = new QM_Collector_DB_Components;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_db_components', 20, 2 );

--- a/query-monitor/collectors/db_dupes.php
+++ b/query-monitor/collectors/db_dupes.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Duplicate database query collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_DB_Dupes extends QM_Collector {
+
+	public $id = 'db_dupes';
+
+	public function name() {
+		return __( 'Duplicate Queries', 'query-monitor' );
+	}
+
+	public function process() {
+
+		if ( ! $dbq = QM_Collectors::get( 'db_queries' ) ) {
+			return;
+		}
+		if ( ! isset( $dbq->data['dupes'] ) ) {
+			return;
+		}
+
+		// Filter out SQL queries that do not have dupes
+		$this->data['dupes'] = array_filter( $dbq->data['dupes'], array( $this, '_filter_dupe_queries' ) );
+
+		// Ignore dupes from `WP_Query->set_found_posts()`
+		unset( $this->data['dupes']['SELECT FOUND_ROWS()'] );
+
+		$stacks     = array();
+		$tops       = array();
+		$callers    = array();
+		$components = array();
+
+		// Loop over all SQL queries that have dupes
+		foreach ( $this->data['dupes'] as $sql => $query_ids ) {
+
+			// Loop over each query
+			foreach ( $query_ids as $query_id ) {
+
+				if ( isset( $dbq->data['dbs']['$wpdb']->rows[ $query_id ]['trace'] ) ) {
+					$trace     = $dbq->data['dbs']['$wpdb']->rows[ $query_id ]['trace'];
+					$stack     = wp_list_pluck( $trace->get_filtered_trace(), 'id' );
+					$component = $trace->get_component();
+
+					// Populate the component counts for this query
+					if ( isset( $components[ $sql ][ $component->name ] ) ) {
+						$components[ $sql ][ $component->name ]++;
+					} else {
+						$components[ $sql ][ $component->name ] = 1;
+					}
+				} else {
+					$stack = array_reverse( explode( ', ', $dbq->data['dbs']['$wpdb']->rows[ $query_id ]['stack'] ) );
+				}
+
+				// Populate the caller counts for this query
+				if ( isset( $callers[ $sql ][ $stack[0] ] ) ) {
+					$callers[ $sql ][ $stack[0] ]++;
+				} else {
+					$callers[ $sql ][ $stack[0] ] = 1;
+				}
+
+				// Populate the stack for this query
+				$stacks[ $sql ][] = $stack;
+
+			}
+
+			// Get the callers which are common to all stacks for this query
+			$common = call_user_func_array( 'array_intersect', $stacks[ $sql ] );
+
+			// Remove callers which are common to all stacks for this query
+			foreach ( $stacks[ $sql ] as $i => $stack ) {
+				$stacks[ $sql ][ $i ] = array_values( array_diff( $stack, $common ) );
+
+				// No uncommon callers within the stack? Just use the topmost caller.
+				if ( empty( $stacks[ $sql ][ $i ] ) ) {
+					$stacks[ $sql ][ $i ] = array_keys( $callers[ $sql ] );
+				}
+			}
+
+			// Wave a magic wand
+			$sources[ $sql ] = array_count_values( wp_list_pluck( $stacks[ $sql ], 0 ) );
+
+		}
+
+		if ( ! empty( $sources ) ) {
+			$this->data['dupe_sources']    = $sources;
+			$this->data['dupe_callers']    = $callers;
+			$this->data['dupe_components'] = $components;
+		}
+
+	}
+
+	public function _filter_dupe_queries( $queries ) {
+		return ( count( $queries ) > 1 );
+	}
+
+}
+
+function register_qm_collector_db_dupes( array $collectors, QueryMonitor $qm ) {
+	$collectors['db_dupes'] = new QM_Collector_DB_Dupes;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_db_dupes', 25, 2 );

--- a/query-monitor/collectors/db_queries.php
+++ b/query-monitor/collectors/db_queries.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Database query collector.
+ *
+ * @package query-monitor
+ */
+
+if ( ! defined( 'SAVEQUERIES' ) ) {
+	define( 'SAVEQUERIES', true );
+}
+if ( ! defined( 'QM_DB_EXPENSIVE' ) ) {
+	define( 'QM_DB_EXPENSIVE', 0.05 );
+}
+
+if ( SAVEQUERIES && property_exists( $GLOBALS['wpdb'], 'save_queries' ) ) {
+	$GLOBALS['wpdb']->save_queries = true;
+}
+
+class QM_Collector_DB_Queries extends QM_Collector {
+
+	public $id = 'db_queries';
+	public $db_objects = array();
+
+	public function name() {
+		return __( 'Database Queries', 'query-monitor' );
+	}
+
+	public function get_errors() {
+		if ( ! empty( $this->data['errors'] ) ) {
+			return $this->data['errors'];
+		}
+		return false;
+	}
+
+	public function get_expensive() {
+		if ( ! empty( $this->data['expensive'] ) ) {
+			return $this->data['expensive'];
+		}
+		return false;
+	}
+
+	public static function is_expensive( array $row ) {
+		return $row['ltime'] > QM_DB_EXPENSIVE;
+	}
+
+	public function process() {
+
+		if ( ! SAVEQUERIES ) {
+			return;
+		}
+
+		$this->data['total_qs']   = 0;
+		$this->data['total_time'] = 0;
+		$this->data['errors']     = array();
+
+		$this->db_objects = apply_filters( 'qm/collect/db_objects', array(
+			'$wpdb' => $GLOBALS['wpdb'],
+		) );
+
+		foreach ( $this->db_objects as $name => $db ) {
+			if ( is_a( $db, 'wpdb' ) ) {
+				$this->process_db_object( $name, $db );
+			} else {
+				unset( $this->db_objects[ $name ] );
+			}
+		}
+
+	}
+
+	protected function log_caller( $caller, $ltime, $type ) {
+
+		if ( ! isset( $this->data['times'][ $caller ] ) ) {
+			$this->data['times'][ $caller ] = array(
+				'caller' => $caller,
+				'ltime' => 0,
+				'types' => array(),
+			);
+		}
+
+		$this->data['times'][ $caller ]['ltime'] += $ltime;
+
+		if ( isset( $this->data['times'][ $caller ]['types'][ $type ] ) ) {
+			$this->data['times'][ $caller ]['types'][ $type ]++;
+		} else {
+			$this->data['times'][ $caller ]['types'][ $type ] = 1;
+		}
+
+	}
+
+	public function process_db_object( $id, wpdb $db ) {
+		global $EZSQL_ERROR, $wp_the_query;
+
+		$rows       = array();
+		$types      = array();
+		$total_time = 0;
+		$has_result = false;
+		$has_trace  = false;
+		$i          = 0;
+		$request    = trim( $wp_the_query->request );
+
+		if ( method_exists( $db, 'remove_placeholder_escape' ) ) {
+			$request = $db->remove_placeholder_escape( $request );
+		}
+
+		foreach ( (array) $db->queries as $query ) {
+
+			# @TODO: decide what I want to do with this:
+			if ( false !== strpos( $query[2], 'wp_admin_bar' ) and !isset( $_REQUEST['qm_display_admin_bar'] ) ) { // @codingStandardsIgnoreLine
+				continue;
+			}
+
+			$sql           = $query[0];
+			$ltime         = $query[1];
+			$stack         = $query[2];
+			$has_start     = isset( $query[3] );
+			$has_trace     = isset( $query['trace'] );
+			$has_result    = isset( $query['result'] );
+
+			if ( $has_result ) {
+				$result = $query['result'];
+			} else {
+				$result = null;
+			}
+
+			$total_time += $ltime;
+
+			if ( $has_trace ) {
+
+				$trace       = $query['trace'];
+				$component   = $query['trace']->get_component();
+				$caller      = $query['trace']->get_caller();
+				$caller_name = $caller['display'];
+				$caller      = $caller['display'];
+
+			} else {
+
+				$trace     = null;
+				$component = null;
+				$callers   = explode( ',', $stack );
+				$caller    = trim( end( $callers ) );
+
+				if ( false !== strpos( $caller, '(' ) ) {
+					$caller_name = substr( $caller, 0, strpos( $caller, '(' ) ) . '()';
+				} else {
+					$caller_name = $caller;
+				}
+			}
+
+			$sql  = trim( $sql );
+			$type = QM_Util::get_query_type( $sql );
+
+			$this->log_type( $type );
+			$this->log_caller( $caller_name, $ltime, $type );
+
+			$this->maybe_log_dupe( $sql, $i );
+
+			if ( $component ) {
+				$this->log_component( $component, $ltime, $type );
+			}
+
+			if ( ! isset( $types[ $type ]['total'] ) ) {
+				$types[ $type ]['total'] = 1;
+			} else {
+				$types[ $type ]['total']++;
+			}
+
+			if ( ! isset( $types[ $type ]['callers'][ $caller ] ) ) {
+				$types[ $type ]['callers'][ $caller ] = 1;
+			} else {
+				$types[ $type ]['callers'][ $caller ]++;
+			}
+
+			$is_main_query = ( $request === $sql && ( false !== strpos( $stack, ' WP->main,' ) ) );
+
+			$row = compact( 'caller', 'caller_name', 'sql', 'ltime', 'result', 'type', 'component', 'trace', 'is_main_query' );
+
+			if ( ! isset( $trace ) ) {
+				$row['stack'] = $stack;
+			}
+
+			if ( is_wp_error( $result ) ) {
+				$this->data['errors'][] = $row;
+			}
+
+			if ( self::is_expensive( $row ) ) {
+				$this->data['expensive'][] = $row;
+			}
+
+			$rows[ $i ] = $row;
+			$i++;
+
+		}
+
+		if ( '$wpdb' === $id && ! $has_result && ! empty( $EZSQL_ERROR ) && is_array( $EZSQL_ERROR ) ) {
+			// Fallback for displaying database errors when wp-content/db.php isn't in place
+			foreach ( $EZSQL_ERROR as $error ) {
+				$row = array(
+					'caller'      => __( 'Unknown', 'query-monitor' ),
+					'caller_name' => __( 'Unknown', 'query-monitor' ),
+					'stack'       => '',
+					'sql'         => $error['query'],
+					'ltime'       => 0,
+					'result'      => new WP_Error( 'qmdb', $error['error_str'] ),
+					'type'        => '',
+					'component'   => false,
+					'trace'       => null,
+					'is_main_query' => false,
+				);
+				$this->data['errors'][] = $row;
+			}
+		}
+
+		$total_qs = count( $rows );
+
+		$this->data['total_qs'] += $total_qs;
+		$this->data['total_time'] += $total_time;
+
+		$has_main_query = wp_list_filter( $rows, array(
+			'is_main_query' => true,
+		) );
+
+		# @TODO put errors in here too:
+		# @TODO proper class instead of (object)
+		$this->data['dbs'][ $id ] = (object) compact( 'rows', 'types', 'has_result', 'has_trace', 'total_time', 'total_qs', 'has_main_query' );
+
+	}
+
+}
+
+function register_qm_collector_db_queries( array $collectors, QueryMonitor $qm ) {
+	$collectors['db_queries'] = new QM_Collector_DB_Queries;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_db_queries', 10, 2 );

--- a/query-monitor/collectors/debug_bar.php
+++ b/query-monitor/collectors/debug_bar.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Mock 'Debug Bar' data collector.
+ *
+ * @package query-monitor
+ */
+
+final class QM_Collector_Debug_Bar extends QM_Collector {
+
+	public $id     = 'debug_bar';
+	private $panel = null;
+
+	public function __construct() {
+		parent::__construct();
+	}
+
+	public function name() {
+		$title = $this->get_panel()->title();
+		return sprintf(
+			/* translators: Debug Bar add-on name */
+			__( 'Debug Bar: %s', 'query-monitor' ),
+			$title
+		);
+	}
+
+	public function set_panel( Debug_Bar_Panel $panel ) {
+		$this->panel = $panel;
+	}
+
+	public function get_panel() {
+		return $this->panel;
+	}
+
+	public function process() {
+		$this->get_panel()->prerender();
+	}
+
+	public function is_visible() {
+		return $this->get_panel()->is_visible();
+	}
+
+	public function render() {
+		return $this->get_panel()->render();
+	}
+
+}
+
+function register_qm_collectors_debug_bar() {
+
+	global $debug_bar;
+
+	if ( class_exists( 'Debug_Bar' ) || qm_debug_bar_being_activated() ) {
+		return;
+	}
+
+	$collectors = QM_Collectors::init();
+	$qm = QueryMonitor::init();
+
+	require_once $qm->plugin_path( 'classes/debug_bar.php' );
+
+	$debug_bar = new Debug_Bar;
+	$redundant = array(
+		'debug_bar_actions_addon_panel', // Debug Bar Actions and Filters Addon
+		'debug_bar_remote_requests_panel', // Debug Bar Remote Requests
+		'debug_bar_screen_info_panel', // Debug Bar Screen Info
+		'ps_listdeps_debug_bar_panel', // Debug Bar List Script & Style Dependencies
+	);
+
+	foreach ( $debug_bar->panels as $panel ) {
+		$panel_id = strtolower( sanitize_html_class( get_class( $panel ) ) );
+
+		if ( in_array( $panel_id, $redundant, true ) ) {
+			continue;
+		}
+
+		$collector = new QM_Collector_Debug_Bar;
+		$collector->set_id( "debug_bar_{$panel_id}" );
+		$collector->set_panel( $panel );
+
+		$collectors->add( $collector );
+	}
+
+}
+
+function qm_debug_bar_being_activated() {
+	// @codingStandardsIgnoreStart
+
+	if ( ! is_admin() ) {
+		return false;
+	}
+
+	if ( ! isset( $_REQUEST['action'] ) ) {
+		return false;
+	}
+
+	if ( isset( $_GET['action'] ) ) {
+
+		if ( ! isset( $_GET['plugin'] ) || ! isset( $_GET['_wpnonce'] ) ) {
+			return false;
+		}
+
+		if ( 'activate' === $_GET['action'] && false !== strpos( wp_unslash( $_GET['plugin'] ), 'debug-bar.php' ) ) {
+			return true;
+		}
+
+	} elseif ( isset( $_POST['action'] ) ) {
+
+		if ( ! isset( $_POST['checked'] ) || ! is_array( $_POST['checked'] ) || ! isset( $_POST['_wpnonce'] ) ) {
+			return false;
+		}
+
+		if ( 'activate-selected' === wp_unslash( $_POST['action'] ) && in_array( 'debug-bar/debug-bar.php', wp_unslash( $_POST['checked'] ), true ) ) {
+			return true;
+		}
+
+	}
+
+	return false;
+	// @codingStandardsIgnoreEnd
+}
+
+add_action( 'init', 'register_qm_collectors_debug_bar' );

--- a/query-monitor/collectors/environment.php
+++ b/query-monitor/collectors/environment.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Environment data collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Environment extends QM_Collector {
+
+	public $id = 'environment';
+	protected $php_vars = array(
+		'max_execution_time',
+		'memory_limit',
+		'upload_max_filesize',
+		'post_max_size',
+		'display_errors',
+		'log_errors',
+	);
+
+	public function name() {
+		return __( 'Environment', 'query-monitor' );
+	}
+
+	public function __construct() {
+
+		global $wpdb;
+
+		parent::__construct();
+
+		# If QM_DB is in place then we'll use the values which were
+		# caught early before any plugins had a chance to alter them
+
+		foreach ( $this->php_vars as $setting ) {
+			if ( isset( $wpdb->qm_php_vars ) and isset( $wpdb->qm_php_vars[ $setting ] ) ) {
+				$val = $wpdb->qm_php_vars[ $setting ];
+			} else {
+				$val = ini_get( $setting );
+			}
+			$this->data['php']['variables'][ $setting ]['before'] = $val;
+		}
+
+	}
+
+	protected static function get_error_levels( $error_reporting ) {
+		$levels = array(
+			'E_ERROR'             => false,
+			'E_WARNING'           => false,
+			'E_PARSE'             => false,
+			'E_NOTICE'            => false,
+			'E_CORE_ERROR'        => false,
+			'E_CORE_WARNING'      => false,
+			'E_COMPILE_ERROR'     => false,
+			'E_COMPILE_WARNING'   => false,
+			'E_USER_ERROR'        => false,
+			'E_USER_WARNING'      => false,
+			'E_USER_NOTICE'       => false,
+			'E_STRICT'            => false,
+			'E_RECOVERABLE_ERROR' => false,
+			'E_DEPRECATED'        => false,
+			'E_USER_DEPRECATED'   => false,
+			'E_ALL'               => false,
+		);
+
+		foreach ( $levels as $level => $reported ) {
+			if ( defined( $level ) ) {
+				$c = constant( $level );
+				if ( $error_reporting & $c ) {
+					$levels[ $level ] = true;
+				}
+			}
+		}
+
+		return $levels;
+	}
+
+	public function process() {
+
+		global $wp_version;
+
+		$mysql_vars = array(
+			'key_buffer_size'    => true,  # Key cache size limit
+			'max_allowed_packet' => false, # Individual query size limit
+			'max_connections'    => false, # Max number of client connections
+			'query_cache_limit'  => true,  # Individual query cache size limit
+			'query_cache_size'   => true,  # Total cache size limit
+			'query_cache_type'   => 'ON',  # Query cache on or off
+		);
+
+		if ( $dbq = QM_Collectors::get( 'db_queries' ) ) {
+
+			foreach ( $dbq->db_objects as $id => $db ) {
+
+				if ( method_exists( $db, 'db_version' ) ) {
+					$server = $db->db_version();
+					// query_cache_* deprecated since MySQL 5.7.20
+					if ( version_compare( $server, '5.7.20', '>=' ) ) {
+						unset( $mysql_vars['query_cache_limit'], $mysql_vars['query_cache_size'], $mysql_vars['query_cache_type'] );
+					}
+				} else {
+					$server = null;
+				}
+
+				$variables = $db->get_results( "
+					SHOW VARIABLES
+					WHERE Variable_name IN ( '" . implode( "', '", array_keys( $mysql_vars ) ) . "' )
+				" );
+
+				if ( is_resource( $db->dbh ) ) {
+					# Old mysql extension
+					$extension = 'mysql';
+				} elseif ( is_object( $db->dbh ) ) {
+					# mysqli or PDO
+					$extension = get_class( $db->dbh );
+				} else {
+					# Who knows?
+					$extension = null;
+				}
+
+				if ( isset( $db->use_mysqli ) && $db->use_mysqli ) {
+					$client = mysqli_get_client_version();
+					$info   = mysqli_get_server_info( $db->dbh );
+				} else {
+					if ( preg_match( '|[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}|', mysql_get_client_info(), $matches ) ) {
+						$client = $matches[0];
+					} else {
+						$client = null;
+					}
+					$info = mysql_get_server_info( $db->dbh );
+				}
+
+				if ( false !== strpos( $info, 'MariaDB' ) ) {
+					$rdbms = 'MariaDB';
+				} else {
+					$rdbms = 'MySQL';
+				}
+
+				if ( $client ) {
+					$client_version = implode( '.', QM_Util::get_client_version( $client ) );
+					$client_version = sprintf( '%s (%s)', $client, $client_version );
+				} else {
+					$client_version = null;
+				}
+
+				$info = array(
+					'rdbms'          => $rdbms,
+					'server-version' => $server,
+					'extension'      => $extension,
+					'client-version' => $client_version,
+					'user'           => $db->dbuser,
+					'host'           => $db->dbhost,
+					'database'       => $db->dbname,
+				);
+
+				$this->data['db'][ $id ] = array(
+					'info'      => $info,
+					'vars'      => $mysql_vars,
+					'variables' => $variables,
+				);
+
+			}
+		}
+
+		$this->data['php']['version'] = phpversion();
+		$this->data['php']['sapi']    = php_sapi_name();
+		$this->data['php']['user']    = self::get_current_user();
+		$this->data['php']['old']     = version_compare( $this->data['php']['version'], 7, '<' );
+
+		foreach ( $this->php_vars as $setting ) {
+			$this->data['php']['variables'][ $setting ]['after'] = ini_get( $setting );
+		}
+
+		if ( defined( 'SORT_FLAG_CASE' ) ) {
+			// phpcs:ignore PHPCompatibility.PHP.NewConstants
+			$sort_flags = SORT_STRING | SORT_FLAG_CASE;
+		} else {
+			$sort_flags = SORT_STRING;
+		}
+
+		if ( is_callable( 'get_loaded_extensions' ) ) {
+			$extensions = get_loaded_extensions();
+			sort( $extensions, $sort_flags );
+			$this->data['php']['extensions'] = array_combine( $extensions, array_map( array( $this, 'get_extension_version' ), $extensions ) );
+		} else {
+			$this->data['php']['extensions'] = array();
+		}
+
+		$this->data['php']['error_reporting'] = error_reporting();
+		$this->data['php']['error_levels']    = self::get_error_levels( $this->data['php']['error_reporting'] );
+
+		$this->data['wp']['version']   = $wp_version;
+		$this->data['wp']['constants'] = array(
+			'WP_DEBUG'            => self::format_bool_constant( 'WP_DEBUG' ),
+			'WP_DEBUG_DISPLAY'    => self::format_bool_constant( 'WP_DEBUG_DISPLAY' ),
+			'WP_DEBUG_LOG'        => self::format_bool_constant( 'WP_DEBUG_LOG' ),
+			'SCRIPT_DEBUG'        => self::format_bool_constant( 'SCRIPT_DEBUG' ),
+			'WP_CACHE'            => self::format_bool_constant( 'WP_CACHE' ),
+			'CONCATENATE_SCRIPTS' => self::format_bool_constant( 'CONCATENATE_SCRIPTS' ),
+			'COMPRESS_SCRIPTS'    => self::format_bool_constant( 'COMPRESS_SCRIPTS' ),
+			'COMPRESS_CSS'        => self::format_bool_constant( 'COMPRESS_CSS' ),
+			'WP_LOCAL_DEV'        => self::format_bool_constant( 'WP_LOCAL_DEV' ),
+		);
+
+		if ( is_multisite() ) {
+			$this->data['wp']['constants']['SUNRISE'] = self::format_bool_constant( 'SUNRISE' );
+		}
+
+		if ( isset( $_SERVER['SERVER_SOFTWARE'] ) ) { // WPCS: input var ok
+			$server = explode( ' ', wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ); // WPCS: sanitization ok, input var ok
+			$server = explode( '/', reset( $server ) );
+		} else {
+			$server = array( '' );
+		}
+
+		if ( isset( $server[1] ) ) {
+			$server_version = $server[1];
+		} else {
+			$server_version = null;
+		}
+
+		if ( isset( $_SERVER['SERVER_ADDR'] ) ) { // WPCS: input var ok
+			$address = wp_unslash( $_SERVER['SERVER_ADDR'] ); // WPCS: sanitization ok, input var ok
+		} else {
+			$address = null;
+		}
+
+		$this->data['server'] = array(
+			'name'    => $server[0],
+			'version' => $server_version,
+			'address' => $address,
+			'host'    => null,
+			'OS'      => null,
+		);
+
+		if ( function_exists( 'php_uname' ) ) {
+			$this->data['server']['host'] = php_uname( 'n' );
+			$this->data['server']['OS']   = php_uname( 's' ) . ' ' . php_uname( 'r' );
+		}
+
+	}
+
+	public function get_extension_version( $extension ) {
+		// Nothing is simple in PHP. The exif and mysqlnd extensions (and probably others) add a bunch of
+		// crap to their version number, so we need to pluck out the first numeric value in the string.
+		$version = phpversion( $extension );
+
+		if ( ! $version ) {
+			return $version;
+		}
+
+		$parts = explode( ' ', $version );
+
+		foreach ( $parts as $part ) {
+			if ( is_numeric( $part[0] ) ) {
+				$version = $part;
+				break;
+			}
+		}
+
+		return $version;
+	}
+
+	protected static function get_current_user() {
+
+		$php_u = null;
+
+		if ( function_exists( 'posix_getpwuid' ) ) {
+			$u = posix_getpwuid( posix_getuid() );
+			$g = posix_getgrgid( $u['gid'] );
+			$php_u = $u['name'] . ':' . $g['name'];
+		}
+
+		if ( empty( $php_u ) and isset( $_ENV['APACHE_RUN_USER'] ) ) {
+			$php_u = $_ENV['APACHE_RUN_USER'];
+			if ( isset( $_ENV['APACHE_RUN_GROUP'] ) ) {
+				$php_u .= ':' . $_ENV['APACHE_RUN_GROUP'];
+			}
+		}
+
+		if ( empty( $php_u ) and isset( $_SERVER['USER'] ) ) { // WPCS: input var ok
+			$php_u = wp_unslash( $_SERVER['USER'] ); // WPCS: sanitization ok, input var ok
+		}
+
+		if ( empty( $php_u ) and function_exists( 'exec' ) ) {
+			$php_u = exec( 'whoami' ); // @codingStandardsIgnoreLine
+		}
+
+		if ( empty( $php_u ) and function_exists( 'getenv' ) ) {
+			$php_u = getenv( 'USERNAME' );
+		}
+
+		return $php_u;
+
+	}
+
+}
+
+function register_qm_collector_environment( array $collectors, QueryMonitor $qm ) {
+	$collectors['environment'] = new QM_Collector_Environment;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_environment', 20, 2 );

--- a/query-monitor/collectors/hooks.php
+++ b/query-monitor/collectors/hooks.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Hooks and actions collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Hooks extends QM_Collector {
+
+	public $id = 'hooks';
+	protected static $hide_core;
+
+	public function name() {
+		return __( 'Hooks & Actions', 'query-monitor' );
+	}
+
+	public function process() {
+
+		global $wp_actions, $wp_filter;
+
+		self::$hide_qm   = self::hide_qm();
+		self::$hide_core = ( defined( 'QM_HIDE_CORE_ACTIONS' ) && QM_HIDE_CORE_ACTIONS );
+
+		$hooks = $all_parts = $components = array();
+
+		if ( has_filter( 'all' ) ) {
+			$hooks['all'] = self::process_action( 'all', $wp_filter, self::$hide_qm, self::$hide_core );
+		}
+
+		if ( defined( 'QM_SHOW_ALL_HOOKS' ) && QM_SHOW_ALL_HOOKS ) {
+			// Show all hooks
+			$hook_names = array_keys( $wp_filter );
+		} else {
+			// Only show action hooks that have been called at least once
+			$hook_names = array_keys( $wp_actions );
+		}
+
+		foreach ( $hook_names as $name ) {
+
+			$hooks[ $name ] = self::process_action( $name, $wp_filter, self::$hide_qm, self::$hide_core );
+
+			$all_parts    = array_merge( $all_parts, $hooks[ $name ]['parts'] );
+			$components   = array_merge( $components, $hooks[ $name ]['components'] );
+
+		}
+
+		$this->data['hooks'] = $hooks;
+		$this->data['parts'] = array_unique( array_filter( $all_parts ) );
+		$this->data['components'] = array_unique( array_filter( $components ) );
+
+	}
+
+	public function post_process() {
+		$admin = QM_Collectors::get( 'response' );
+
+		if ( is_admin() && $admin ) {
+			$this->data['screen'] = $admin->data['base'];
+		} else {
+			$this->data['screen'] = '';
+		}
+	}
+
+	public static function process_action( $name, array $wp_filter, $hide_qm = false, $hide_core = false ) {
+
+		$actions = $components = array();
+
+		if ( isset( $wp_filter[ $name ] ) ) {
+
+			# http://core.trac.wordpress.org/ticket/17817
+			$action = $wp_filter[ $name ];
+
+			foreach ( $action as $priority => $callbacks ) {
+
+				foreach ( $callbacks as $callback ) {
+
+					$callback = QM_Util::populate_callback( $callback );
+
+					if ( isset( $callback['component'] ) ) {
+						if (
+							( $hide_qm && 'query-monitor' === $callback['component']->context )
+							|| ( $hide_core && 'core' === $callback['component']->context )
+						) {
+							continue;
+						}
+
+						$components[ $callback['component']->name ] = $callback['component']->name;
+					}
+
+					// This isn't used and takes up a ton of memory:
+					unset( $callback['function'] );
+
+					$actions[] = array(
+						'priority'  => $priority,
+						'callback'  => $callback,
+					);
+
+				}
+			}
+		}
+
+		$parts = array_filter( preg_split( '#[_/-]#', $name ) );
+
+		return array(
+			'name'       => $name,
+			'actions'    => $actions,
+			'parts'      => $parts,
+			'components' => $components,
+		);
+
+	}
+
+}
+
+# Load early to catch all hooks
+QM_Collectors::add( new QM_Collector_Hooks );

--- a/query-monitor/collectors/http.php
+++ b/query-monitor/collectors/http.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * HTTP API request collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_HTTP extends QM_Collector {
+
+	public $id = 'http';
+	private $transport = null;
+	private $info = null;
+
+	public function name() {
+		return __( 'HTTP API Requests', 'query-monitor' );
+	}
+
+	public function __construct() {
+
+		parent::__construct();
+
+		add_filter( 'http_request_args', array( $this, 'filter_http_request_args' ), 99, 2 );
+		add_filter( 'pre_http_request',  array( $this, 'filter_pre_http_request' ), 99, 3 );
+		add_action( 'http_api_debug',    array( $this, 'action_http_api_debug' ), 99, 5 );
+
+		add_action( 'requests-curl.before_request',      array( $this, 'action_curl_before_request' ), 99 );
+		add_action( 'requests-curl.after_request',       array( $this, 'action_curl_after_request' ), 99, 2 );
+		add_action( 'requests-fsockopen.before_request', array( $this, 'action_fsockopen_before_request' ), 99 );
+		add_action( 'requests-fsockopen.after_request',  array( $this, 'action_fsockopen_after_request' ), 99, 2 );
+
+	}
+
+	/**
+	 * Filter the arguments used in an HTTP request.
+	 *
+	 * Used to log the request, and to add the logging key to the arguments array.
+	 *
+	 * @param  array  $args HTTP request arguments.
+	 * @param  string $url  The request URL.
+	 * @return array        HTTP request arguments.
+	 */
+	public function filter_http_request_args( array $args, $url ) {
+		$trace = new QM_Backtrace;
+		if ( isset( $args['_qm_key'] ) ) {
+			// Something has triggered another HTTP request from within the `pre_http_request` filter
+			// (eg. WordPress Beta Tester does this). This allows for one level of nested queries.
+			$args['_qm_original_key'] = $args['_qm_key'];
+			$start = $this->data['http'][ $args['_qm_key'] ]['start'];
+		} else {
+			$start = microtime( true );
+		}
+		$key = microtime( true ) . $url;
+		$this->data['http'][ $key ] = array(
+			'url'   => $url,
+			'args'  => $args,
+			'start' => $start,
+			'trace' => $trace,
+		);
+		$args['_qm_key'] = $key;
+		return $args;
+	}
+
+	/**
+	 * Log the HTTP request's response if it's being short-circuited by another plugin.
+	 * This is necessary due to https://core.trac.wordpress.org/ticket/25747
+	 *
+	 * $response should be one of boolean false, an array, or a `WP_Error`, but be aware that plugins
+	 * which short-circuit the request using this filter may (incorrectly) return data of another type.
+	 *
+	 * @param bool|array|WP_Error $response The preemptive HTTP response. Default false.
+	 * @param array               $args     HTTP request arguments.
+	 * @param string              $url      The request URL.
+	 * @return bool|array|WP_Error          The preemptive HTTP response.
+	 */
+	public function filter_pre_http_request( $response, array $args, $url ) {
+
+		// All is well:
+		if ( false === $response ) {
+			return $response;
+		}
+
+		// Something's filtering the response, so we'll log it
+		$this->log_http_response( $response, $args, $url );
+
+		return $response;
+	}
+
+	/**
+	 * Debugging action for the HTTP API.
+	 *
+	 * @param mixed  $response A parameter which varies depending on $action.
+	 * @param string $action   The debug action. Currently one of 'response' or 'transports_list'.
+	 * @param string $class    The HTTP transport class name.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 */
+	public function action_http_api_debug( $response, $action, $class, $args, $url ) {
+
+		switch ( $action ) {
+
+			case 'response':
+				if ( ! empty( $class ) ) {
+					$this->data['http'][ $args['_qm_key'] ]['transport'] = str_replace( 'wp_http_', '', strtolower( $class ) );
+				} else {
+					$this->data['http'][ $args['_qm_key'] ]['transport'] = null;
+				}
+
+				$this->log_http_response( $response, $args, $url );
+
+				break;
+
+			case 'transports_list':
+				# Nothing
+				break;
+
+		}
+
+	}
+
+	public function action_curl_before_request() {
+		$this->transport = 'curl';
+	}
+
+	public function action_curl_after_request( $headers, array $info = null ) {
+		$this->info = $info;
+	}
+
+	public function action_fsockopen_before_request() {
+		$this->transport = 'fsockopen';
+	}
+
+	public function action_fsockopen_after_request( $headers, array $info = null ) {
+		$this->info = $info;
+	}
+
+	/**
+	 * Log an HTTP response.
+	 *
+	 * @param array|WP_Error $response The HTTP response.
+	 * @param array          $args     HTTP request arguments.
+	 * @param string         $url      The request URL.
+	 */
+	public function log_http_response( $response, array $args, $url ) {
+		$this->data['http'][ $args['_qm_key'] ]['end']      = microtime( true );
+		$this->data['http'][ $args['_qm_key'] ]['response'] = $response;
+		$this->data['http'][ $args['_qm_key'] ]['args']     = $args;
+		if ( isset( $args['_qm_original_key'] ) ) {
+			$this->data['http'][ $args['_qm_original_key'] ]['end']      = $this->data['http'][ $args['_qm_original_key'] ]['start'];
+			$this->data['http'][ $args['_qm_original_key'] ]['response'] = new WP_Error( 'http_request_not_executed', sprintf(
+				/* translators: %s: Hook name */
+				__( 'Request not executed due to a filter on %s', 'query-monitor' ),
+				'pre_http_request'
+			) );
+		}
+
+		$this->data['http'][ $args['_qm_key'] ]['info']      = $this->info;
+		$this->data['http'][ $args['_qm_key'] ]['transport'] = $this->transport;
+		$this->info = null;
+		$this->transport = null;
+	}
+
+	public function process() {
+
+		foreach ( array(
+			'WP_PROXY_HOST',
+			'WP_PROXY_PORT',
+			'WP_PROXY_USERNAME',
+			'WP_PROXY_PASSWORD',
+			'WP_PROXY_BYPASS_HOSTS',
+			'WP_HTTP_BLOCK_EXTERNAL',
+			'WP_ACCESSIBLE_HOSTS',
+		) as $var ) {
+			if ( defined( $var ) and constant( $var ) ) {
+				$val = constant( $var );
+				if ( true === $val ) {
+					# @TODO this transformation should happen in the output, not the collector
+					$val = 'true';
+				}
+				$this->data['vars'][ $var ] = $val;
+			}
+		}
+
+		$this->data['ltime'] = 0;
+
+		if ( ! isset( $this->data['http'] ) ) {
+			return;
+		}
+
+		$silent = apply_filters( 'qm/collect/silent_http_errors', array(
+			'http_request_not_executed',
+			'airplane_mode_enabled',
+		) );
+
+		foreach ( $this->data['http'] as $key => & $http ) {
+
+			if ( ! isset( $http['response'] ) ) {
+				// Timed out
+				$http['response'] = new WP_Error( 'http_request_timed_out', __( 'Request timed out', 'query-monitor' ) );
+				$http['end']      = floatval( $http['start'] + $http['args']['timeout'] );
+			}
+
+			if ( is_wp_error( $http['response'] ) ) {
+				if ( ! in_array( $http['response']->get_error_code(), $silent, true ) ) {
+					$this->data['errors']['alert'][] = $key;
+				}
+				$http['type'] = __( 'Error', 'query-monitor' );
+			} elseif ( ! $http['args']['blocking'] ) {
+				/* translators: A non-blocking HTTP API request */
+				$http['type'] = __( 'Non-blocking', 'query-monitor' );
+			} else {
+				$http['type'] = intval( wp_remote_retrieve_response_code( $http['response'] ) );
+				if ( $http['type'] >= 400 ) {
+					$this->data['errors']['warning'][] = $key;
+				}
+			}
+
+			$http['ltime'] = ( $http['end'] - $http['start'] );
+
+			if ( isset( $http['info'] ) ) {
+				if ( isset( $http['info']['total_time'] ) ) {
+					$http['ltime'] = $http['info']['total_time'];
+				}
+
+				if ( ! empty( $http['info']['url'] ) ) {
+					if ( rtrim( $http['url'], '/' ) !== rtrim( $http['info']['url'], '/' ) ) {
+						$http['redirected_to'] = $http['info']['url'];
+					}
+				}
+			}
+
+			$this->data['ltime'] += $http['ltime'];
+
+			$http['component'] = $http['trace']->get_component();
+
+			$this->log_type( $http['type'] );
+			$this->log_component( $http['component'], $http['ltime'], $http['type'] );
+
+		}
+
+	}
+
+}
+
+# Load early in case a plugin is doing an HTTP request when it initialises instead of after the `plugins_loaded` hook
+QM_Collectors::add( new QM_Collector_HTTP );

--- a/query-monitor/collectors/languages.php
+++ b/query-monitor/collectors/languages.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Language and locale collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Languages extends QM_Collector {
+
+	public $id = 'languages';
+
+	public function name() {
+		return __( 'Languages', 'query-monitor' );
+	}
+
+	public function __construct() {
+
+		parent::__construct();
+
+		add_filter( 'override_load_textdomain', array( $this, 'log_file_load' ), 99, 3 );
+
+	}
+
+	public function process() {
+		$this->data['locale'] = get_locale();
+		ksort( $this->data['languages'] );
+	}
+
+	/**
+	 * Store log data.
+	 *
+	 * @param bool   $override Whether to override the text domain. Default false.
+	 * @param string $domain   Text domain. Unique identifier for retrieving translated strings.
+	 * @param string $mofile   Path to the MO file.
+	 * @return bool
+	 */
+	public function log_file_load( $override, $domain, $mofile ) {
+
+		if ( 'query-monitor' === $domain && self::hide_qm() ) {
+			return $override;
+		}
+
+		$trace    = new QM_Backtrace;
+		$filtered = $trace->get_filtered_trace();
+		$caller   = array();
+
+		foreach ( $filtered as $i => $item ) {
+
+			if ( in_array( $item['function'], array(
+				'load_muplugin_textdomain',
+				'load_plugin_textdomain',
+				'load_theme_textdomain',
+				'load_child_theme_textdomain',
+				'load_default_textdomain',
+			), true ) ) {
+				$caller = $item;
+				$display = $i + 1;
+				if ( isset( $filtered[ $display ] ) ) {
+					$caller['display'] = $filtered[ $display ]['display'];
+				}
+				break;
+			}
+		}
+
+		if ( empty( $caller ) ) {
+			if ( isset( $filtered[1] ) ) {
+				$caller = $filtered[1];
+			} else {
+				$caller = $filtered[0];
+			}
+		}
+
+		if ( ! isset( $caller['file'] ) && isset( $filtered[0]['file'] ) && isset( $filtered[0]['line'] ) ) {
+			$caller['file'] = $filtered[0]['file'];
+			$caller['line'] = $filtered[0]['line'];
+		}
+
+		$this->data['languages'][ $domain ][] = array(
+			'caller' => $caller,
+			'domain' => $domain,
+			'mofile' => $mofile,
+			'found'  => file_exists( $mofile ) ? filesize( $mofile ) : false,
+		);
+
+		return $override;
+
+	}
+
+}
+
+# Load early to catch early errors
+QM_Collectors::add( new QM_Collector_Languages );

--- a/query-monitor/collectors/logger.php
+++ b/query-monitor/collectors/logger.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * PSR-3 compatible logging collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Logger extends QM_Collector {
+
+	public $id = 'logger';
+
+	const EMERGENCY = 'emergency';
+	const ALERT     = 'alert';
+	const CRITICAL  = 'critical';
+	const ERROR     = 'error';
+	const WARNING   = 'warning';
+	const NOTICE    = 'notice';
+	const INFO      = 'info';
+	const DEBUG     = 'debug';
+
+	public function name() {
+		return __( 'Logger', 'query-monitor' );
+	}
+
+	public function __construct() {
+		parent::__construct();
+		foreach ( $this->get_levels() as $level ) {
+			add_action( "qm/{$level}", array( $this, $level ), 10, 2 );
+		}
+
+		add_action( 'qm/log', array( $this, 'log' ), 10, 3 );
+	}
+
+	public function emergency( $message, array $context = array() ) {
+		$this->store( 'emergency', $message, $context );
+	}
+
+	public function alert( $message, array $context = array() ) {
+		$this->store( 'alert', $message, $context );
+	}
+
+	public function critical( $message, array $context = array() ) {
+		$this->store( 'critical', $message, $context );
+	}
+
+	public function error( $message, array $context = array() ) {
+		$this->store( 'error', $message, $context );
+	}
+
+	public function warning( $message, array $context = array() ) {
+		$this->store( 'warning', $message, $context );
+	}
+
+	public function notice( $message, array $context = array() ) {
+		$this->store( 'notice', $message, $context );
+	}
+
+	public function info( $message, array $context = array() ) {
+		$this->store( 'info', $message, $context );
+	}
+
+	public function debug( $message, array $context = array() ) {
+		$this->store( 'debug', $message, $context );
+	}
+
+	public function log( $level, $message, array $context = array() ) {
+		if ( ! in_array( $level, $this->get_levels(), true ) ) {
+			throw new InvalidArgumentException( __( 'Unsupported log level', 'query-monitor' ) );
+		}
+
+		$this->store( $level, $message, $context );
+	}
+
+	protected function store( $level, $message, array $context = array() ) {
+		$trace = new QM_Backtrace( array(
+			'ignore_frames' => 2,
+		) );
+
+		if ( is_wp_error( $message ) ) {
+			$message = sprintf(
+				'%s (%s)',
+				$message->get_error_message(),
+				$message->get_error_code()
+			);
+		}
+
+		if ( $message instanceof Exception ) {
+			$message = $message->getMessage();
+		}
+
+		$this->data['logs'][] = array(
+			'message' => $this->interpolate( $message, $context ),
+			'context' => $context,
+			'trace'   => $trace,
+			'level'   => $level,
+		);
+	}
+
+	protected function interpolate( $message, array $context = array() ) {
+		// build a replacement array with braces around the context keys
+		$replace = array();
+
+		foreach ( $context as $key => $val ) {
+			// check that the value can be casted to string
+			if ( is_scalar( $val ) || ( is_object( $val ) && method_exists( $val, '__toString' ) ) ) {
+				$replace[ "{{$key}}" ] = $val;
+			}
+		}
+
+		// interpolate replacement values into the message and return
+		return strtr( $message, $replace );
+	}
+
+	public function process() {
+		if ( empty( $this->data['logs'] ) ) {
+			return;
+		}
+
+		$components = array();
+
+		foreach ( $this->data['logs'] as $row ) {
+			$component = $row['trace']->get_component();
+			$components[ $component->name ] = $component->name;
+		}
+
+		$this->data['components'] = $components;
+	}
+
+	public function get_levels() {
+		return array(
+			self::EMERGENCY,
+			self::ALERT,
+			self::CRITICAL,
+			self::ERROR,
+			self::WARNING,
+			self::NOTICE,
+			self::INFO,
+			self::DEBUG,
+		);
+	}
+
+	public function get_warning_levels() {
+		return array(
+			self::EMERGENCY,
+			self::ALERT,
+			self::CRITICAL,
+			self::ERROR,
+			self::WARNING,
+		);
+	}
+
+}
+
+# Load early in case a plugin wants to log a message early in the bootstrap process
+QM_Collectors::add( new QM_Collector_Logger );

--- a/query-monitor/collectors/overview.php
+++ b/query-monitor/collectors/overview.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * General overview collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Overview extends QM_Collector {
+
+	public $id = 'overview';
+
+	public function name() {
+		return __( 'Overview', 'query-monitor' );
+	}
+
+	public function process() {
+
+		$this->data['time_taken'] = self::timer_stop_float();
+		$this->data['time_limit'] = ini_get( 'max_execution_time' );
+		$this->data['time_start'] = $GLOBALS['timestart'];
+
+		if ( ! empty( $this->data['time_limit'] ) ) {
+			$this->data['time_usage'] = ( 100 / $this->data['time_limit'] ) * $this->data['time_taken'];
+		} else {
+			$this->data['time_usage'] = 0;
+		}
+
+		if ( function_exists( 'memory_get_peak_usage' ) ) {
+			$this->data['memory'] = memory_get_peak_usage();
+		} elseif ( function_exists( 'memory_get_usage' ) ) {
+			$this->data['memory'] = memory_get_usage();
+		} else {
+			$this->data['memory'] = 0;
+		}
+
+		if ( is_user_logged_in() ) {
+			$this->data['current_user'] = self::format_user( wp_get_current_user() );
+		} else {
+			$this->data['current_user'] = false;
+		}
+
+		if ( function_exists( 'current_user_switched' ) && current_user_switched() ) {
+			$this->data['switched_user'] = self::format_user( current_user_switched() );
+		} else {
+			$this->data['switched_user'] = false;
+		}
+
+		$this->data['memory_limit'] = QM_Util::convert_hr_to_bytes( ini_get( 'memory_limit' ) );
+
+		if ( $this->data['memory_limit'] > 0 ) {
+			$this->data['memory_usage'] = ( 100 / $this->data['memory_limit'] ) * $this->data['memory'];
+		} else {
+			$this->data['memory_usage'] = 0;
+		}
+
+		$this->data['display_time_usage_warning']   = ( $this->data['time_usage'] >= 75 );
+		$this->data['display_memory_usage_warning'] = ( $this->data['memory_usage'] >= 75 );
+
+		$this->data['is_admin'] = is_admin();
+	}
+
+}
+
+function register_qm_collector_overview( array $collectors, QueryMonitor $qm ) {
+	$collectors['overview'] = new QM_Collector_Overview;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_overview', 1, 2 );

--- a/query-monitor/collectors/php_errors.php
+++ b/query-monitor/collectors/php_errors.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * PHP error collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_PHP_Errors extends QM_Collector {
+
+	public $id = 'php_errors';
+	public $types = array();
+	private $error_reporting = null;
+	private $display_errors = null;
+	private static $unexpected_error;
+	private static $wordpress_couldnt;
+
+	public function name() {
+		return __( 'PHP Errors', 'query-monitor' );
+	}
+
+	public function __construct() {
+		if ( defined( 'QM_DISABLE_ERROR_HANDLER' ) and QM_DISABLE_ERROR_HANDLER ) {
+			return;
+		}
+
+		parent::__construct();
+		set_error_handler( array( $this, 'error_handler' ) );
+		register_shutdown_function( array( $this, 'shutdown_handler' ) );
+
+		$this->error_reporting = error_reporting();
+		$this->display_errors = ini_get( 'display_errors' );
+		ini_set( 'display_errors', 0 );
+
+	}
+
+	public function error_handler( $errno, $message, $file = null, $line = null, $context = null ) {
+
+		do_action( 'qm/collect/new_php_error', $errno, $message, $file, $line, $context );
+
+		switch ( $errno ) {
+
+			case E_WARNING:
+			case E_USER_WARNING:
+				$type = 'warning';
+				break;
+
+			case E_NOTICE:
+			case E_USER_NOTICE:
+				$type = 'notice';
+				break;
+
+			case E_STRICT:
+				$type = 'strict';
+				break;
+
+			case E_DEPRECATED:
+			case E_USER_DEPRECATED:
+				$type = 'deprecated';
+				break;
+
+			default:
+				return false;
+				break;
+
+		}
+
+		if ( ! class_exists( 'QM_Backtrace' ) ) {
+			return false;
+		}
+
+		$error_group = 'errors';
+
+		if ( 0 === error_reporting() && 0 !== $this->error_reporting ) {
+			// This is most likely an @-suppressed error
+			$error_group = 'suppressed';
+		}
+
+		if ( ! isset( self::$unexpected_error ) ) {
+			// These strings are from core. They're passed through `__()` as variables so they get translated at runtime
+			// but do not get seen by GlotPress when it populates its database of translatable strings for QM.
+			$unexpected_error  = 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/">support forums</a>.';
+			$wordpress_couldnt = '(WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)';
+			self::$unexpected_error  = call_user_func( '__', $unexpected_error );
+			self::$wordpress_couldnt = call_user_func( '__', $wordpress_couldnt );
+		}
+
+		// Intentionally skip reporting these core warnings. They're a distraction when developing offline.
+		// The failed HTTP request will still appear in QM's output so it's not a big problem hiding these warnings.
+		if ( self::$unexpected_error === $message ) {
+			return false;
+		}
+		if ( self::$unexpected_error . ' ' . self::$wordpress_couldnt === $message ) {
+			return false;
+		}
+
+		$trace  = new QM_Backtrace( array(
+			'ignore_current_filter' => false,
+		) );
+		$caller = $trace->get_caller();
+		$key    = md5( $message . $file . $line . $caller['id'] );
+
+		if ( isset( $this->data[ $error_group ][ $type ][ $key ] ) ) {
+			$this->data[ $error_group ][ $type ][ $key ]['calls']++;
+		} else {
+			$this->data[ $error_group ][ $type ][ $key ] = array(
+				'errno'    => $errno,
+				'type'     => $type,
+				'message'  => wp_strip_all_tags( $message ),
+				'file'     => $file,
+				'filename' => QM_Util::standard_dir( $file, '' ),
+				'line'     => $line,
+				'trace'    => $trace,
+				'calls'    => 1,
+			);
+		}
+
+		return apply_filters( 'qm/collect/php_errors_return_value', false );
+
+	}
+
+	public function shutdown_handler() {
+
+		$e = error_get_last();
+
+		if ( empty( $this->display_errors ) ) {
+			return;
+		}
+
+		if ( empty( $e ) or ! ( $e['type'] & ( E_ERROR | E_PARSE | E_COMPILE_ERROR | E_COMPILE_WARNING | E_USER_ERROR | E_RECOVERABLE_ERROR ) ) ) {
+			return;
+		}
+
+		if ( $e['type'] & E_RECOVERABLE_ERROR ) {
+			$error = 'Catchable fatal error';
+		} elseif ( $e['type'] & E_COMPILE_WARNING ) {
+			$error = 'Warning';
+		} else {
+			$error = 'Fatal error';
+		}
+
+		if ( function_exists( 'xdebug_print_function_stack' ) ) {
+
+			xdebug_print_function_stack( sprintf( '%1$s: %2$s in %3$s on line %4$d. Output triggered ',
+				$error,
+				$e['message'],
+				$e['file'],
+				$e['line']
+			) );
+
+		} else {
+
+			printf( // WPCS: XSS ok.
+				'<br /><b>%1$s</b>: %2$s in <b>%3$s</b> on line <b>%4$d</b><br />',
+				htmlentities( $error ),
+				htmlentities( $e['message'] ),
+				htmlentities( $e['file'] ),
+				intval( $e['line'] )
+			);
+
+		}
+
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		ini_set( 'display_errors', $this->display_errors );
+		restore_error_handler();
+	}
+
+	/**
+	 * Runs post-processing on the collected errors and updates the
+	 * errors collected in the data->errors property.
+	 *
+	 * Any unreportable errors are placed in the data->filtered_errors
+	 * property.
+	 */
+	public function process() {
+		$this->types = array(
+			'errors' => array(
+				'warning'    => _x( 'Warning', 'PHP error level', 'query-monitor' ),
+				'notice'     => _x( 'Notice', 'PHP error level', 'query-monitor' ),
+				'strict'     => _x( 'Strict', 'PHP error level', 'query-monitor' ),
+				'deprecated' => _x( 'Deprecated', 'PHP error level', 'query-monitor' ),
+			),
+			'suppressed' => array(
+				'warning'    => _x( 'Warning (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
+				'notice'     => _x( 'Notice (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
+				'strict'     => _x( 'Strict (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
+				'deprecated' => _x( 'Deprecated (Suppressed)', 'Suppressed PHP error level', 'query-monitor' ),
+			),
+			'silenced' => array(
+				'warning'    => _x( 'Warning (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
+				'notice'     => _x( 'Notice (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
+				'strict'     => _x( 'Strict (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
+				'deprecated' => _x( 'Deprecated (Silenced)', 'Silenced PHP error level', 'query-monitor' ),
+			),
+		);
+		$components = array();
+
+		if ( ! empty( $this->data ) && ! empty( $this->data['errors'] ) ) {
+			/**
+			 * Filters the levels used for reported PHP errors on a per-component basis.
+			 *
+			 * Error levels can be specified in order to silence certain error levels from
+			 * plugins or the current theme. Most commonly, you may wish to use this filter
+			 * in order to silence annoying notices from third party plugins that you do not
+			 * have control over.
+			 *
+			 * Silenced errors will still appear in Query Monitor's output, but will not
+			 * cause highlighting to appear in the top level admin toolbar.
+			 *
+			 * For example, to show all errors in the 'foo' plugin except PHP notices use:
+			 *
+			 *     add_filter( 'qm/collect/php_error_levels', function( array $levels ) {
+			 *         $levels['plugin']['foo'] = ( E_ALL & ~E_NOTICE );
+			 *         return $levels;
+			 *     } );
+			 *
+			 * Errors from themes, WordPress core, and other components can also be filtered:
+			 *
+			 *     add_filter( 'qm/collect/php_error_levels', function( array $levels ) {
+			 *         $levels['theme']['stylesheet'] = ( E_WARNING & E_USER_WARNING );
+			 *         $levels['theme']['template']   = ( E_WARNING & E_USER_WARNING );
+			 *         $levels['core']['core']        = ( 0 );
+			 *         return $levels;
+			 *     } );
+			 *
+			 * Any component which doesn't have an error level specified via this filter is
+			 * assumed to have the default level of `E_ALL`, which shows all errors.
+			 *
+			 * Valid PHP error level bitmasks are supported for each component, including `0`
+			 * to silence all errors from a component. See the PHP documentation on error
+			 * reporting for more info: http://php.net/manual/en/function.error-reporting.php
+			 *
+			 * @param int[] $levels The error levels used for each component.
+			 */
+			$levels = apply_filters( 'qm/collect/php_error_levels', array() );
+
+			/**
+			 * Controls whether silenced PHP errors are hidden entirely by Query Monitor.
+			 *
+			 * To hide silenced errors, use:
+			 *
+			 *     add_filter( 'qm/collect/hide_silenced_php_errors', '__return_true' );
+			 *
+			 * @param bool $hide Whether to hide silenced PHP errors. Default false.
+			 */
+			$this->hide_silenced_php_errors = apply_filters( 'qm/collect/hide_silenced_php_errors', false );
+
+			array_map( array( $this, 'filter_reportable_errors' ), $levels, array_keys( $levels ) );
+
+			foreach ( $this->types as $error_group => $error_types ) {
+				foreach ( $error_types as $type => $title ) {
+					if ( isset( $this->data[ $error_group ][ $type ] ) ) {
+						foreach ( $this->data[ $error_group ][ $type ] as $error ) {
+							$component = $error['trace']->get_component();
+							$components[ $component->name ] = $component->name;
+						}
+					}
+				}
+			}
+		}
+
+		$this->data['components'] = $components;
+	}
+
+	/**
+	 * Filters the reportable PHP errors using the table specified. Users can customize the levels
+	 * using the `qm/collect/php_error_levels` filter.
+	 *
+	 * @param int[]  $components     The error levels keyed by component name.
+	 * @param string $component_type The component type, for example 'plugin' or 'theme'.
+	 */
+	public function filter_reportable_errors( array $components, $component_type ) {
+		$all_errors = $this->data['errors'];
+
+		foreach ( $components as $component_context => $allowed_level ) {
+			foreach ( $all_errors as $error_level => $errors ) {
+				foreach ( $errors as $error_id => $error ) {
+					if ( $this->is_reportable_error( $error['errno'], $allowed_level ) ) {
+						continue;
+					}
+					if ( ! $this->is_affected_component( $error['trace']->get_component(), $component_type, $component_context ) ) {
+						continue;
+					}
+
+					unset( $this->data['errors'][ $error_level ][ $error_id ] );
+
+					if ( $this->hide_silenced_php_errors ) {
+						continue;
+					}
+
+					$this->data['silenced'][ $error_level ][ $error_id ] = $error;
+				}
+			}
+		}
+
+		$this->data['errors'] = array_filter( $this->data['errors'] );
+	}
+
+	/**
+	 * Checks if the file path is within the specified plugin. This is
+	 * used to scope an error's file path to a plugin.
+	 *
+	 * @param string $plugin_name The name of the plugin
+	 * @param string $file_path The full path to the file
+	 * @return bool
+	 */
+	public function is_affected_component( $component, $component_type, $component_context ) {
+		if ( empty( $component ) ) {
+			return false;
+		}
+		return ( $component->type === $component_type && $component->context === $component_context );
+	}
+
+	/**
+	 * Checks if the error number specified is viewable based on the
+	 * flags specified.
+	 *
+	 * @param int $error_no The errno from PHP
+	 * @param int $flags The config flags specified by users
+	 * @return int Truthy int value if reportable else 0.
+	 *
+	 * Eg:- If a plugin had the config flags,
+	 *
+	 * E_ALL & ~E_NOTICE
+	 *
+	 * then,
+	 *
+	 * is_reportable_error( E_NOTICE, E_ALL & ~E_NOTICE ) is false
+	 * is_reportable_error( E_WARNING, E_ALL & ~E_NOTICE ) is true
+	 *
+	 * If the $flag is null, all errors are assumed to be
+	 * reportable by default.
+	 */
+	public function is_reportable_error( $error_no, $flags ) {
+		if ( ! is_null( $flags ) ) {
+			$result = $error_no & $flags;
+		} else {
+			$result = 1;
+		}
+
+		return (bool) $result;
+	}
+
+	/**
+	 * For testing purposes only. Sets the errors property manually.
+	 * Needed to test the filter since the data property is protected.
+	 *
+	 * @param array $errors The list of errors
+	 */
+	public function set_php_errors( $errors ) {
+		$this->data['errors'] = $errors;
+	}
+}
+
+# Load early to catch early errors
+QM_Collectors::add( new QM_Collector_PHP_Errors );

--- a/query-monitor/collectors/redirects.php
+++ b/query-monitor/collectors/redirects.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * HTTP redirect collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Redirects extends QM_Collector {
+
+	public $id = 'redirects';
+
+	public function name() {
+		return __( 'Redirects', 'query-monitor' );
+	}
+
+	public function __construct() {
+		parent::__construct();
+		add_filter( 'wp_redirect', array( $this, 'filter_wp_redirect' ), 999, 2 );
+	}
+
+	public function filter_wp_redirect( $location, $status ) {
+
+		if ( ! $location ) {
+			return $location;
+		}
+
+		$trace = new QM_Backtrace;
+
+		$this->data['trace']    = $trace;
+		$this->data['location'] = $location;
+		$this->data['status']   = $status;
+
+		return $location;
+
+	}
+
+}
+
+# Load early in case a plugin is doing a redirect when it initialises instead of after the `plugins_loaded` hook
+QM_Collectors::add( new QM_Collector_Redirects );

--- a/query-monitor/collectors/request.php
+++ b/query-monitor/collectors/request.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Request collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Request extends QM_Collector {
+
+	public $id = 'request';
+
+	public function name() {
+		return __( 'Request', 'query-monitor' );
+	}
+
+	public function process() {
+
+		global $wp, $wp_query, $current_blog, $current_site, $wp_rewrite;
+
+		$qo = get_queried_object();
+		$user = wp_get_current_user();
+
+		if ( $user->exists() ) {
+			$user_title = sprintf(
+				/* translators: %d: User ID */
+				__( 'Current User: #%d', 'query-monitor' ),
+				$user->ID
+			);
+		} else {
+			/* translators: No user */
+			$user_title = _x( 'None', 'user', 'query-monitor' );
+		}
+
+		$this->data['user'] = array(
+			'title' => $user_title,
+			'data'  => ( $user->exists() ? $user : false ),
+		);
+
+		if ( is_multisite() ) {
+			$this->data['multisite']['current_site'] = array(
+				'title' => sprintf(
+					/* translators: %d: Multisite site ID */
+					__( 'Current Site: #%d', 'query-monitor' ),
+					$current_blog->blog_id
+				),
+				'data'  => $current_blog,
+			);
+		}
+
+		if ( QM_Util::is_multi_network() ) {
+			$this->data['multisite']['current_network'] = array(
+				'title' => sprintf(
+					/* translators: %d: Multisite network ID */
+					__( 'Current Network: #%d', 'query-monitor' ),
+					$current_site->id
+				),
+				'data'  => $current_site,
+			);
+		}
+
+		if ( is_admin() ) {
+			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+				$home_path = trim( parse_url( home_url(), PHP_URL_PATH ), '/' );
+				$request   = wp_unslash( $_SERVER['REQUEST_URI'] ); // @codingStandardsIgnoreLine
+
+				$this->data['request']['request'] = str_replace( "/{$home_path}/", '', $request );
+			} else {
+				$this->data['request']['request'] = '';
+			}
+			foreach ( array( 'query_string' ) as $item ) {
+				$this->data['request'][ $item ] = $wp->$item;
+			}
+		} else {
+			foreach ( array( 'request', 'matched_rule', 'matched_query', 'query_string' ) as $item ) {
+				$this->data['request'][ $item ] = $wp->$item;
+			}
+		}
+
+		$plugin_qvars = array_flip( apply_filters( 'query_vars', array() ) );
+		$qvars        = $wp_query->query_vars;
+		$query_vars   = array();
+
+		foreach ( $qvars as $k => $v ) {
+			if ( isset( $plugin_qvars[ $k ] ) ) {
+				if ( '' !== $v ) {
+					$query_vars[ $k ] = $v;
+				}
+			} else {
+				if ( ! empty( $v ) ) {
+					$query_vars[ $k ] = $v;
+				}
+			}
+		}
+
+		ksort( $query_vars );
+
+		# First add plugin vars to $this->data['qvars']:
+		foreach ( $query_vars as $k => $v ) {
+			if ( isset( $plugin_qvars[ $k ] ) ) {
+				$this->data['qvars'][ $k ] = $v;
+				$this->data['plugin_qvars'][ $k ] = $v;
+			}
+		}
+
+		# Now add all other vars to $this->data['qvars']:
+		foreach ( $query_vars as $k => $v ) {
+			if ( ! isset( $plugin_qvars[ $k ] ) ) {
+				$this->data['qvars'][ $k ] = $v;
+			}
+		}
+
+		switch ( true ) {
+
+			case ! is_object( $qo ):
+				// Nada
+				break;
+
+			case is_a( $qo, 'WP_Post' ):
+				// Single post
+				$this->data['queried_object']['title'] = sprintf(
+					/* translators: 1: Post type name, 2: Post ID */
+					__( 'Single %1$s: #%2$d', 'query-monitor' ),
+					get_post_type_object( $qo->post_type )->labels->singular_name,
+					$qo->ID
+				);
+				break;
+
+			case is_a( $qo, 'WP_User' ):
+				// Author archive
+				$this->data['queried_object']['title'] = sprintf(
+					/* translators: %s: Author name */
+					__( 'Author archive: %s', 'query-monitor' ),
+					$qo->user_nicename
+				);
+				break;
+
+			case is_a( $qo, 'WP_Term' ):
+			case property_exists( $qo, 'term_id' ):
+				// Term archive
+				$this->data['queried_object']['title'] = sprintf(
+					/* translators: %s: Taxonomy term name */
+					__( 'Term archive: %s', 'query-monitor' ),
+					$qo->slug
+				);
+				break;
+
+			case is_a( $qo, 'WP_Post_Type' ):
+			case property_exists( $qo, 'has_archive' ):
+				// Post type archive
+				$this->data['queried_object']['title'] = sprintf(
+					/* translators: %s: Post type name */
+					__( 'Post type archive: %s', 'query-monitor' ),
+					$qo->name
+				);
+				break;
+
+			default:
+				// Unknown, but we have a queried object
+				$this->data['queried_object']['title'] = __( 'Unknown queried object', 'query-monitor' );
+				break;
+
+		}
+
+		if ( $qo ) {
+			$this->data['queried_object']['data'] = $qo;
+		}
+
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) ) {
+			$this->data['request_method'] = strtoupper( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ); // @codingStandardsIgnoreLine
+		} else {
+			$this->data['request_method'] = '';
+		}
+
+		if ( is_admin() || QM_Util::is_async() || empty( $wp_rewrite->rules ) ) {
+			return;
+		}
+
+		$matching = array();
+
+		foreach ( $wp_rewrite->rules as $match => $query ) {
+			if ( preg_match( "#^{$match}#", $this->data['request']['request'] ) ) {
+				$matching[ $match ] = $query;
+			}
+		}
+
+		$this->data['matching_rewrites'] = $matching;
+	}
+
+}
+
+function register_qm_collector_request( array $collectors, QueryMonitor $qm ) {
+	$collectors['request'] = new QM_Collector_Request;
+	return $collectors;
+}
+
+add_filter( 'qm/collectors', 'register_qm_collector_request', 10, 2 );

--- a/query-monitor/collectors/theme.php
+++ b/query-monitor/collectors/theme.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Template and theme collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Theme extends QM_Collector {
+
+	public $id = 'response';
+	protected $got_theme_compat = false;
+
+	public function name() {
+		return __( 'Theme', 'query-monitor' );
+	}
+
+	public function __construct() {
+		parent::__construct();
+		add_filter( 'body_class',       array( $this, 'filter_body_class' ), 999 );
+		add_filter( 'template_include', array( $this, 'filter_template_include' ), 999 );
+		add_filter( 'timber/output',    array( $this, 'filter_timber_output' ), 999, 3 );
+		add_action( 'template_redirect', array( $this, 'action_template_redirect' ) );
+	}
+
+	public static function get_query_template_names() {
+		return array(
+			'embed'             => 'is_embed',
+			'404'               => 'is_404',
+			'search'            => 'is_search',
+			'front_page'        => 'is_front_page',
+			'home'              => 'is_home',
+			'post_type_archive' => 'is_post_type_archive',
+			'taxonomy'          => 'is_tax',
+			'attachment'        => 'is_attachment',
+			'single'            => 'is_single',
+			'page'              => 'is_page',
+			'singular'          => 'is_singular',
+			'category'          => 'is_category',
+			'tag'               => 'is_tag',
+			'author'            => 'is_author',
+			'date'              => 'is_date',
+			'archive'           => 'is_archive',
+			'index'             => '__return_true',
+		);
+	}
+
+	// https://core.trac.wordpress.org/ticket/14310
+	public function action_template_redirect() {
+
+		foreach ( self::get_query_template_names() as $template => $conditional ) {
+
+			// If a matching theme-compat file is found, further conditional checks won't occur in template-loader.php
+			if ( $this->got_theme_compat ) {
+				break;
+			}
+
+			$get_template = "get_{$template}_template";
+
+			if ( function_exists( $conditional ) && function_exists( $get_template ) && call_user_func( $conditional ) ) {
+				$filter = str_replace( '_', '', $template );
+				add_filter( "{$filter}_template_hierarchy", array( $this, 'filter_template_hierarchy' ), 999 );
+				call_user_func( $get_template );
+				remove_filter( "{$filter}_template_hierarchy", array( $this, 'filter_template_hierarchy' ), 999 );
+			}
+		}
+
+	}
+
+	public function filter_template_hierarchy( array $templates ) {
+		if ( ! isset( $this->data['template_hierarchy'] ) ) {
+			$this->data['template_hierarchy'] = array();
+		}
+
+		foreach ( $templates as $template_name ) {
+			if ( file_exists( ABSPATH . WPINC . '/theme-compat/' . $template_name ) ) {
+				$this->got_theme_compat = true;
+				break;
+			}
+		}
+
+		$this->data['template_hierarchy'] = array_merge( $this->data['template_hierarchy'], $templates );
+
+		return $templates;
+	}
+
+	public function filter_body_class( array $class ) {
+		$this->data['body_class'] = $class;
+		return $class;
+	}
+
+	public function filter_template_include( $template_path ) {
+		$this->data['template_path'] = $template_path;
+		return $template_path;
+	}
+
+	public function filter_timber_output( $output, $data = null, $file = null ) {
+		if ( $file ) {
+			$this->data['timber_files'][] = $file;
+		}
+
+		return $output;
+	}
+
+	public function process() {
+
+		if ( ! empty( $this->data['template_path'] ) ) {
+
+			$template_path        = QM_Util::standard_dir( $this->data['template_path'] );
+			$stylesheet_directory = QM_Util::standard_dir( get_stylesheet_directory() );
+			$template_directory   = QM_Util::standard_dir( get_template_directory() );
+			$theme_directory      = QM_Util::standard_dir( get_theme_root() );
+
+			$template_file       = str_replace( array( $stylesheet_directory, $template_directory, ABSPATH ), '', $template_path );
+			$template_file       = ltrim( $template_file, '/' );
+			$theme_template_file = str_replace( array( $theme_directory, ABSPATH ), '', $template_path );
+			$theme_template_file = ltrim( $theme_template_file, '/' );
+
+			$this->data['template_path']       = $template_path;
+			$this->data['template_file']       = $template_file;
+			$this->data['theme_template_file'] = $theme_template_file;
+			$this->data['template_hierarchy']   = array_unique( $this->data['template_hierarchy'] );
+
+			foreach ( get_included_files() as $file ) {
+				$file = QM_Util::standard_dir( $file );
+				$filename = str_replace( array(
+					$stylesheet_directory,
+					$template_directory,
+				), '', $file );
+				if ( $filename !== $file ) {
+					$slug          = trim( str_replace( '.php', '', $filename ), '/' );
+					$display       = trim( $filename, '/' );
+					$theme_display = trim( str_replace( $theme_directory, '', $file ), '/' );
+					if ( did_action( "get_template_part_{$slug}" ) ) {
+						$this->data['template_parts'][ $file ]       = $display;
+						$this->data['theme_template_parts'][ $file ] = $theme_display;
+					} else {
+						$slug = trim( preg_replace( '|\-[^\-]+$|', '', $slug ), '/' );
+						if ( did_action( "get_template_part_{$slug}" ) ) {
+							$this->data['template_parts'][ $file ]       = $display;
+							$this->data['theme_template_parts'][ $file ] = $theme_display;
+						}
+					}
+				}
+			}
+		}
+
+		$this->data['stylesheet']         = get_stylesheet();
+		$this->data['template']           = get_template();
+		$this->data['is_child_theme']     = ( $this->data['stylesheet'] !== $this->data['template'] );
+
+		if ( isset( $this->data['body_class'] ) ) {
+			asort( $this->data['body_class'] );
+		}
+
+	}
+
+}
+
+function register_qm_collector_theme( array $collectors, QueryMonitor $qm ) {
+	$collectors['response'] = new QM_Collector_Theme;
+	return $collectors;
+}
+
+if ( ! is_admin() ) {
+	add_filter( 'qm/collectors', 'register_qm_collector_theme', 10, 2 );
+}

--- a/query-monitor/collectors/timing.php
+++ b/query-monitor/collectors/timing.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Timing and profiling collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Timing extends QM_Collector {
+
+	public $id = 'timing';
+	private $track_timer = array();
+	private $start = array();
+	private $stop = array();
+	private $laps = array();
+
+	public function name() {
+		return __( 'Timing', 'query-monitor' );
+	}
+
+	public function __construct() {
+		parent::__construct();
+		add_action( 'qm/start', array( $this, 'action_function_time_start' ), 10, 1 );
+		add_action( 'qm/stop',  array( $this, 'action_function_time_stop' ), 10, 1 );
+		add_action( 'qm/lap',   array( $this, 'action_function_time_lap' ), 10, 2 );
+	}
+
+	public function action_function_time_start( $function ) {
+		$this->track_timer[ $function ] = new QM_Timer;
+		$this->start[ $function ] = $this->track_timer[ $function ]->start();
+	}
+
+	public function action_function_time_stop( $function ) {
+		if ( ! isset( $this->track_timer[ $function ] ) ) {
+			$trace = new QM_Backtrace;
+			$this->data['warning'][] = array(
+				'function'  => $function,
+				'message'   => __( 'Timer not started', 'query-monitor' ),
+				'trace'     => $trace,
+			);
+			return;
+		}
+		$this->stop[ $function ] = $this->track_timer[ $function ]->stop();
+		$this->calculate_time( $function );
+	}
+
+	public function action_function_time_lap( $function, $name = null ) {
+		if ( ! isset( $this->track_timer[ $function ] ) ) {
+			$trace = new QM_Backtrace;
+			$this->data['warning'][] = array(
+				'function'  => $function,
+				'message'   => __( 'Timer not started', 'query-monitor' ),
+				'trace'     => $trace,
+			);
+			return;
+		}
+		$this->track_timer[ $function ]->lap( array(), $name );
+	}
+
+	public function calculate_time( $function ) {
+		$trace           = $this->track_timer[ $function ]->get_trace();
+		$function_time   = $this->track_timer[ $function ]->get_time();
+		$function_memory = $this->track_timer[ $function ]->get_memory();
+		$function_laps   = $this->track_timer[ $function ]->get_laps();
+
+		$this->data['timing'][] = array(
+			'function'        => $function,
+			'function_time'   => $function_time,
+			'function_memory' => $function_memory,
+			'laps'            => $function_laps,
+			'trace'           => $trace,
+		);
+	}
+
+	public function process() {
+		foreach ( $this->start as $function => $value ) {
+			if ( ! isset( $this->stop[ $function ] ) ) {
+				$trace = $this->track_timer[ $function ]->get_trace();
+				$this->data['warning'][] = array(
+					'function'  => $function,
+					'message'   => __( 'Timer not stopped', 'query-monitor' ),
+					'trace'     => $trace,
+				);
+			}
+		}
+	}
+
+}
+
+# Load early in case a plugin is setting the function to be checked when it initialises instead of after the `plugins_loaded` hook
+QM_Collectors::add( new QM_Collector_Timing );

--- a/query-monitor/collectors/transients.php
+++ b/query-monitor/collectors/transients.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Transient storage collector.
+ *
+ * @package query-monitor
+ */
+
+class QM_Collector_Transients extends QM_Collector {
+
+	public $id = 'transients';
+
+	public function name() {
+		return __( 'Transients', 'query-monitor' );
+	}
+
+	public function __construct() {
+		parent::__construct();
+		add_action( 'setted_site_transient', array( $this, 'action_setted_site_transient' ), 10, 3 );
+		add_action( 'setted_transient',      array( $this, 'action_setted_blog_transient' ), 10, 3 );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		remove_action( 'setted_site_transient', array( $this, 'action_setted_site_transient' ), 10 );
+		remove_action( 'setted_transient',      array( $this, 'action_setted_blog_transient' ), 10 );
+	}
+
+	public function action_setted_site_transient( $transient, $value, $expiration ) {
+		$this->setted_transient( $transient, 'site', $value, $expiration );
+	}
+
+	public function action_setted_blog_transient( $transient, $value, $expiration ) {
+		$this->setted_transient( $transient, 'blog', $value, $expiration );
+	}
+
+	public function setted_transient( $transient, $type, $value, $expiration ) {
+		$trace = new QM_Backtrace( array(
+			'ignore_frames' => 1, # Ignore the action_setted_(site|blog)_transient method
+		) );
+		$this->data['trans'][] = array(
+			'transient'  => $transient,
+			'trace'      => $trace,
+			'type'       => $type,
+			'value'      => $value,
+			'expiration' => $expiration,
+			'size'       => strlen( maybe_serialize( $value ) ),
+		);
+	}
+
+}
+
+# Load early in case a plugin is setting transients when it initialises instead of after the `plugins_loaded` hook
+QM_Collectors::add( new QM_Collector_Transients );

--- a/query-monitor/composer.json
+++ b/query-monitor/composer.json
@@ -1,0 +1,47 @@
+{
+	"name"       : "johnbillion/query-monitor",
+	"description": "The Developer Tools panel for WordPress.",
+	"homepage"   : "https://github.com/johnbillion/query-monitor/",
+	"type"       : "wordpress-plugin",
+	"license"    : "GPL-2.0-or-later",
+	"authors"    : [
+		{
+			"name"    : "John Blackbourn",
+			"homepage": "https://johnblackbourn.com/"
+		}
+	],
+	"support": {
+		"issues": "https://github.com/johnbillion/query-monitor/issues",
+		"forum": "https://wordpress.org/support/plugin/query-monitor",
+		"source": "https://github.com/johnbillion/query-monitor"
+	},
+	"repositories": [
+		{
+			"type": "package",
+			"package": {
+			  "name": "danieltj27/dark-mode",
+			  "version": "3.1.1",
+			  "source": {
+				"type" : "git",
+				"url" : "git://github.com/danieltj27/Dark-Mode.git",
+				"reference" : "3.1.1"
+			  },
+			  "dist": {
+				"url": "https://github.com/danieltj27/Dark-Mode/archive/90236dc3d60c559c3a29209c0057aabcfb95a8d1.zip",
+				"type": "zip"
+			  }
+			}
+		  }
+	],
+	"require": {
+		"php": ">=5.3",
+		"composer/installers": "~1.0"
+	},
+	"require-dev" : {
+		"squizlabs/php_codesniffer": "^3.2",
+		"phpcompatibility/php-compatibility": "~8.2",
+		"danieltj27/dark-mode": "3.1.1",
+		"wp-coding-standards/wpcs": "0.13",
+		"phpunit/phpunit": "^5"
+	}
+}

--- a/query-monitor/dispatchers/AJAX.php
+++ b/query-monitor/dispatchers/AJAX.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Ajax request dispatcher.
+ *
+ * @package query-monitor
+ */
+
+class QM_Dispatcher_AJAX extends QM_Dispatcher {
+
+	public $id = 'ajax';
+
+	public function __construct( QM_Plugin $qm ) {
+		parent::__construct( $qm );
+
+		add_action( 'shutdown', array( $this, 'dispatch' ), 0 );
+
+	}
+
+	public function init() {
+
+		if ( ! $this->user_can_view() ) {
+			return;
+		}
+
+		if ( QM_Util::is_ajax() ) {
+			ob_start();
+		}
+
+	}
+
+	public function dispatch() {
+
+		if ( ! $this->should_dispatch() ) {
+			return;
+		}
+
+		$this->before_output();
+
+		/* @var QM_Output_Headers[] */
+		foreach ( $this->get_outputters( 'headers' ) as $id => $output ) {
+			$output->output();
+		}
+
+		$this->after_output();
+
+	}
+
+	protected function before_output() {
+
+		require_once $this->qm->plugin_path( 'output/Headers.php' );
+
+		foreach ( glob( $this->qm->plugin_path( 'output/headers/*.php' ) ) as $file ) {
+			require_once $file;
+		}
+	}
+
+	protected function after_output() {
+
+		# flush once, because we're nice
+		if ( ob_get_length() ) {
+			ob_flush();
+		}
+
+	}
+
+	public function is_active() {
+
+		if ( ! QM_Util::is_ajax() ) {
+			return false;
+		}
+
+		if ( ! $this->user_can_view() ) {
+			return false;
+		}
+
+		# If the headers have already been sent then we can't do anything about it
+		if ( headers_sent() ) {
+			return false;
+		}
+
+		# Don't process if the minimum required actions haven't fired:
+		if ( is_admin() ) {
+			if ( ! did_action( 'admin_init' ) ) {
+				return false;
+			}
+		} else {
+			if ( ! did_action( 'wp' ) ) {
+				return false;
+			}
+		}
+
+		return true;
+
+	}
+
+}
+
+function register_qm_dispatcher_ajax( array $dispatchers, QM_Plugin $qm ) {
+	$dispatchers['ajax'] = new QM_Dispatcher_AJAX( $qm );
+	return $dispatchers;
+}
+
+add_filter( 'qm/dispatchers', 'register_qm_dispatcher_ajax', 10, 2 );

--- a/query-monitor/dispatchers/Html.php
+++ b/query-monitor/dispatchers/Html.php
@@ -1,0 +1,539 @@
+<?php
+/**
+ * General HTML request dispatcher.
+ *
+ * @package query-monitor
+ */
+
+class QM_Dispatcher_Html extends QM_Dispatcher {
+
+	public $id = 'html';
+	public $did_footer = false;
+
+	protected $outputters     = array();
+	protected $admin_bar_menu = array();
+	protected $panel_menu     = array();
+
+	public function __construct( QM_Plugin $qm ) {
+
+		add_action( 'admin_bar_menu',             array( $this, 'action_admin_bar_menu' ), 999 );
+		add_action( 'wp_ajax_qm_auth_on',         array( $this, 'ajax_on' ) );
+		add_action( 'wp_ajax_qm_auth_off',        array( $this, 'ajax_off' ) );
+		add_action( 'wp_ajax_nopriv_qm_auth_off', array( $this, 'ajax_off' ) );
+
+		add_action( 'shutdown',                   array( $this, 'dispatch' ), 0 );
+
+		add_action( 'wp_footer',                  array( $this, 'action_footer' ) );
+		add_action( 'admin_footer',               array( $this, 'action_footer' ) );
+		add_action( 'login_footer',               array( $this, 'action_footer' ) );
+		add_action( 'embed_footer',               array( $this, 'action_footer' ) );
+		add_action( 'gp_footer',                  array( $this, 'action_footer' ) );
+
+		parent::__construct( $qm );
+
+	}
+
+	public function action_footer() {
+		$this->did_footer = true;
+	}
+
+	/**
+	 * Helper function. Should the authentication cookie be secure?
+	 *
+	 * @return bool Should the authentication cookie be secure?
+	 */
+	public static function secure_cookie() {
+		return ( is_ssl() and ( 'https' === parse_url( home_url(), PHP_URL_SCHEME ) ) );
+	}
+
+	public function ajax_on() {
+
+		if ( ! current_user_can( 'view_query_monitor' ) or ! check_ajax_referer( 'qm-auth-on', 'nonce', false ) ) {
+			wp_send_json_error();
+		}
+
+		$expiration = time() + ( 2 * DAY_IN_SECONDS );
+		$secure     = self::secure_cookie();
+		$cookie     = wp_generate_auth_cookie( get_current_user_id(), $expiration, 'logged_in' );
+
+		setcookie( QM_COOKIE, $cookie, $expiration, COOKIEPATH, COOKIE_DOMAIN, $secure, false );
+
+		wp_send_json_success();
+
+	}
+
+	public function ajax_off() {
+
+		if ( ! self::user_verified() or ! check_ajax_referer( 'qm-auth-off', 'nonce', false ) ) {
+			wp_send_json_error();
+		}
+
+		$expiration = time() - 31536000;
+
+		setcookie( QM_COOKIE, ' ', $expiration, COOKIEPATH, COOKIE_DOMAIN );
+
+		wp_send_json_success();
+
+	}
+
+	public function action_admin_bar_menu( WP_Admin_Bar $wp_admin_bar ) {
+
+		if ( ! $this->user_can_view() ) {
+			return;
+		}
+
+		$title = __( 'Query Monitor', 'query-monitor' );
+
+		$wp_admin_bar->add_menu( array(
+			'id'    => 'query-monitor',
+			'title' => esc_html( $title ),
+			'href'  => '#qm-overview',
+		) );
+
+		$wp_admin_bar->add_menu( array(
+			'parent' => 'query-monitor',
+			'id'     => 'query-monitor-placeholder',
+			'title'  => esc_html( $title ),
+			'href'   => '#qm-overview',
+		) );
+
+	}
+
+	public function init() {
+
+		if ( ! $this->user_can_view() ) {
+			return;
+		}
+
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', 1 );
+		}
+
+		add_action( 'wp_enqueue_scripts',    array( $this, 'enqueue_assets' ), -999 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ), -999 );
+		add_action( 'login_enqueue_scripts', array( $this, 'enqueue_assets' ), -999 );
+		add_action( 'enqueue_embed_scripts', array( $this, 'enqueue_assets' ), -999 );
+		add_action( 'send_headers',          'nocache_headers' );
+
+		add_action( 'gp_head',                array( $this, 'manually_print_assets' ), 11 );
+
+	}
+
+	public function manually_print_assets() {
+		wp_print_scripts( array(
+			'query-monitor',
+		) );
+		wp_print_styles( array(
+			'query-monitor',
+		) );
+	}
+
+	public function enqueue_assets() {
+		global $wp_locale, $wp_version;
+
+		$deps = array(
+			'jquery',
+		);
+
+		if ( defined( 'QM_NO_JQUERY' ) && QM_NO_JQUERY ) {
+			$deps = array();
+		}
+
+		$css = 'query-monitor';
+
+		if ( method_exists( 'Dark_Mode', 'is_using_dark_mode' ) && is_user_logged_in() ) {
+			if ( Dark_Mode::is_using_dark_mode() ) {
+				$css .= '-dark';
+			}
+		}
+
+		wp_enqueue_style(
+			'query-monitor',
+			$this->qm->plugin_url( "assets/{$css}.css" ),
+			array( 'dashicons' ),
+			$this->qm->plugin_ver( "assets/{$css}.css" )
+		);
+		wp_enqueue_script(
+			'query-monitor',
+			$this->qm->plugin_url( 'assets/query-monitor.js' ),
+			$deps,
+			$this->qm->plugin_ver( 'assets/query-monitor.js' ),
+			false
+		);
+		wp_localize_script(
+			'query-monitor',
+			'qm_number_format',
+			$wp_locale->number_format
+		);
+		wp_localize_script(
+			'query-monitor',
+			'qm_l10n',
+			array(
+				'ajax_error' => __( 'PHP Errors in Ajax Response', 'query-monitor' ),
+				'ajaxurl'    => admin_url( 'admin-ajax.php' ),
+				'auth_nonce' => array(
+					'on'  => wp_create_nonce( 'qm-auth-on' ),
+					'off' => wp_create_nonce( 'qm-auth-off' ),
+				),
+			)
+		);
+	}
+
+	public function dispatch() {
+
+		if ( ! $this->should_dispatch() ) {
+			return;
+		}
+
+		$switched_locale = function_exists( 'switch_to_locale' ) && switch_to_locale( get_user_locale() );
+
+		$this->before_output();
+
+		/* @var QM_Output_Html[] */
+		foreach ( $this->outputters as $id => $output ) {
+			$timer = new QM_Timer;
+			$timer->start();
+
+			printf(
+				"\n" . '<!-- Begin %s output -->' . "\n",
+				esc_html( $id )
+			);
+			$output->output();
+			printf(
+				"\n" . '<!-- End %s output -->' . "\n",
+				esc_html( $id )
+			);
+
+			$output->set_timer( $timer->stop() );
+		}
+
+		$this->after_output();
+
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+
+	}
+
+	protected function before_output() {
+
+		require_once $this->qm->plugin_path( 'output/Html.php' );
+
+		foreach ( glob( $this->qm->plugin_path( 'output/html/*.php' ) ) as $file ) {
+			require_once $file;
+		}
+
+		$this->outputters     = $this->get_outputters( 'html' );
+		$this->admin_bar_menu = apply_filters( 'qm/output/menus', array() );
+		$this->panel_menu     = apply_filters( 'qm/output/panel_menus', $this->admin_bar_menu );
+
+		$class = array(
+			'qm-no-js',
+		);
+
+		if ( did_action( 'wp_head' ) ) {
+			$class[] = sprintf( 'qm-theme-%s', get_template() );
+			$class[] = sprintf( 'qm-theme-%s', get_stylesheet() );
+		}
+
+		if ( ! is_admin_bar_showing() ) {
+			$class[] = 'qm-peek';
+		}
+
+		if ( wp_is_mobile() ) {
+			$class[] = 'qm-touch';
+		}
+
+		$json = array(
+			'menu'        => $this->js_admin_bar_menu(),
+			'ajax_errors' => array(), # @TODO move this into the php_errors collector
+		);
+
+		echo '<script type="text/javascript">' . "\n\n";
+		echo 'var qm = ' . json_encode( $json ) . ';' . "\n\n";
+		echo '</script>' . "\n\n";
+
+		echo '<div id="query-monitor" class="' . implode( ' ', array_map( 'esc_attr', $class ) ) . '" dir="ltr">';
+		echo '<div id="qm-title">';
+		echo '<h1 class="qm-title-heading">' . esc_html__( 'Query Monitor', 'query-monitor' ) . '</h1>';
+		echo '<div class="qm-title-heading">';
+		echo '<select>';
+
+		printf(
+			'<option value="%1$s">%2$s</option>',
+			'#qm-overview',
+			esc_html__( 'Overview', 'query-monitor' )
+		);
+
+		foreach ( $this->panel_menu as $menu ) {
+			printf(
+				'<option value="%1$s">%2$s</option>',
+				esc_attr( $menu['href'] ),
+				esc_html( $menu['title'] )
+			);
+		}
+		echo '</select>';
+
+		echo '</div>';
+		echo '<div class="qm-title-button"><button class="qm-button-container-settings"><span class="screen-reader-text">' . esc_html__( 'Settings', 'query-monitor' ) . '</span><span class="dashicons dashicons-admin-generic" aria-hidden="true"></span></button></div>';
+		echo '<div class="qm-title-button"><button class="qm-button-container-pin"><span class="screen-reader-text">' . esc_html__( 'Pin Panel Open', 'query-monitor' ) . '</span><span class="dashicons dashicons-admin-post" aria-hidden="true"></span></button></div>';
+		echo '<div class="qm-title-button"><button class="qm-button-container-close"><span class="screen-reader-text">' . esc_html__( 'Close Panel', 'query-monitor' ) . '</span><span class="dashicons dashicons-no-alt" aria-hidden="true"></span></button></div>';
+		echo '</div>'; // #qm-title
+
+		echo '<div id="qm-wrapper">';
+		echo '<div id="qm-panel-menu" role="navigation" aria-labelledby="qm-panel-menu-caption">';
+		echo '<h2 class="qm-screen-reader-text" id="qm-panel-menu-caption">' . esc_html__( 'Query Monitor Menu', 'query-monitor' ) . '</h2>';
+		echo '<ul>';
+
+		printf(
+			'<li><button data-qm-href="%1$s">%2$s</button></li>',
+			'#qm-overview',
+			esc_html__( 'Overview', 'query-monitor' )
+		);
+
+		foreach ( $this->panel_menu as $menu ) {
+			printf(
+				'<li><button data-qm-href="%1$s">%2$s</button></li>',
+				esc_attr( $menu['href'] ),
+				esc_html( $menu['title'] )
+			);
+		}
+
+		echo '</ul>';
+		echo '</div>'; // #qm-panel-menu
+
+		echo '<div id="qm-panels">';
+
+	}
+
+	protected function after_output() {
+
+		$state = self::user_verified() ? 'on' : 'off';
+		$text  = array(
+			'on'  => __( 'Clear authentication cookie', 'query-monitor' ),
+			'off' => __( 'Set authentication cookie', 'query-monitor' ),
+		);
+
+		echo '<div class="qm qm-non-tabular" id="qm-settings" data-qm-state="' . esc_attr( $state ) . '">';
+		echo '<h2 class="qm-screen-reader-text">' . esc_html__( 'Settings', 'query-monitor' ) . '</h2>';
+
+		echo '<div class="qm-boxed">';
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Authentication', 'query-monitor' ) . '</h3>';
+
+		echo '<p>' . esc_html__( 'You can set an authentication cookie which allows you to view Query Monitor output when you&rsquo;re not logged in, or when you&rsquo;re logged in as a different user.', 'query-monitor' ) . '</p>';
+
+		echo '<p data-qm-state-visibility="on"><span class="dashicons dashicons-yes qm-dashicons-yes"></span> ' . esc_html__( 'Authentication cookie is set', 'query-monitor' ) . '</p>';
+
+		echo '<p><button class="qm-auth qm-button" data-qm-text-on="' . esc_attr( $text['on'] ) . '" data-qm-text-off="' . esc_attr( $text['off'] ) . '">' . esc_html( $text[ $state ] ) . '</button></p>';
+		echo '</div>';
+
+		$constants = array(
+			'QM_DB_EXPENSIVE' => array(
+				/* translators: %s: The default value for a PHP constant */
+				'label'   => __( 'If an individual database query takes longer than this time to execute, it\'s considered "slow" and triggers a warning. Default value: %s.', 'query-monitor' ),
+				'default' => 0.05,
+			),
+			'QM_DISABLED' => array(
+				'label'   => __( 'Disable Query Monitor entirely.', 'query-monitor' ),
+				'default' => false,
+			),
+			'QM_DISABLE_ERROR_HANDLER' => array(
+				'label'   => __( 'Disable the handling of PHP errors.', 'query-monitor' ),
+				'default' => false,
+			),
+			'QM_ENABLE_CAPS_PANEL' => array(
+				'label'   => __( 'Enable the Capability Checks panel.', 'query-monitor' ),
+				'default' => false,
+			),
+			'QM_HIDE_CORE_ACTIONS' => array(
+				'label'   => __( 'Hide WordPress core on the Hooks & Actions panel.', 'query-monitor' ),
+				'default' => false,
+			),
+			'QM_HIDE_SELF' => array(
+				'label'   => __( 'Hide Query Monitor itself from various panels.', 'query-monitor' ),
+				'default' => false,
+			),
+			'QM_NO_JQUERY' => array(
+				'label'   => __( 'Don\'t specify jQuery as a dependency of Query Monitor. If jQuery isn\'t enqueued then Query Monitor will still operate, but with some reduced functionality.', 'query-monitor' ),
+				'default' => false,
+			),
+			'QM_SHOW_ALL_HOOKS' => array(
+				'label'   => __( 'In the Hooks & Actions panel, show every hook that has an action or filter attached (instead of every action hook that fired during the request).', 'query-monitor' ),
+				'default' => false,
+			),
+		);
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Configuration', 'query-monitor' ) . '</h3>';
+		echo '<p>';
+		printf(
+			/* translators: %s: Name of the config file */
+			esc_html__( 'The following PHP constants can be defined in your %s file in order to control the behavior of Query Monitor:', 'query-monitor' ),
+			'<code>wp-config.php</code>'
+		);
+		echo '</p>';
+
+		echo '<dl>';
+
+		foreach ( $constants as $name => $constant ) {
+			echo '<dt><code>' . esc_html( $name ) . '</code></dt>';
+			echo '<dd>';
+			printf(
+				esc_html( $constant['label'] ),
+				'<code>' . esc_html( $constant['default'] ) . '</code>'
+			);
+
+			if ( defined( $name ) ) {
+				$current_value = constant( $name );
+				if ( is_bool( $current_value ) ) {
+					$current_value = QM_Collector::format_bool_constant( $name );
+				}
+			}
+
+			if ( defined( $name ) && ( constant( $name ) !== $constant['default'] ) ) {
+				echo '<br><span class="qm-info">';
+				printf(
+					/* translators: %s: Current value for a PHP constant */
+					esc_html__( 'Current value: %s', 'query-monitor' ),
+					'<code>' . esc_html( $current_value ) . '</code>'
+				);
+				echo '</span>';
+			}
+			echo '</dd>';
+		}
+
+		echo '</dl>';
+		echo '</div>';
+
+		echo '</div>';
+
+		echo '</div>'; // #qm-settings
+
+		do_action( 'qm/output/after', $this, $this->outputters );
+
+		echo '</div>'; // #qm-panels
+		echo '</div>'; // #qm-wrapper
+		echo '</div>'; // #qm
+
+		echo '<script type="text/javascript">' . "\n\n";
+		?>
+		window.addEventListener('load', function() {
+			if ( ( 'undefined' === typeof QM_i18n ) || ( 'undefined' === typeof jQuery ) || ! window.jQuery ) {
+				/* Fallback for worst case scenario */
+				document.getElementById( 'query-monitor' ).className += ' qm-broken';
+				console.error( document.getElementById( 'qm-broken' ).textContent );
+
+				if ( 'undefined' === typeof QM_i18n ) {
+					console.error( 'QM error from page: undefined QM_i18n' );
+				}
+
+				if ( 'undefined' === typeof jQuery ) {
+					console.error( 'QM error from page: undefined jQuery' );
+				}
+
+				if ( ! window.jQuery ) {
+					console.error( 'QM error from page: no jQuery' );
+				}
+
+				var menu_item = document.getElementById( 'wp-admin-bar-query-monitor' );
+				if ( menu_item ) {
+					menu_item.addEventListener( 'click', function() {
+						document.getElementById( 'query-monitor' ).className += ' qm-show';
+					} );
+				}
+			} else if ( ! document.getElementById( 'wpadminbar' ) ) {
+				document.getElementById( 'query-monitor' ).className += ' qm-peek';
+			}
+		} );
+		<?php
+		echo '</script>' . "\n\n";
+		echo '<!-- End of Query Monitor output -->' . "\n\n";
+
+	}
+
+	public static function size( $var ) {
+		$start_memory = memory_get_usage();
+
+		try {
+			$var = unserialize( serialize( $var ) ); // @codingStandardsIgnoreLine
+		} catch ( Exception $e ) {
+			return $e;
+		}
+
+		return memory_get_usage() - $start_memory - ( PHP_INT_SIZE * 8 );
+	}
+
+	public function js_admin_bar_menu() {
+
+		$class = implode( ' ', apply_filters( 'qm/output/menu_class', array() ) );
+
+		if ( false === strpos( $class, 'qm-' ) ) {
+			$class .= ' qm-all-clear';
+		}
+
+		$title = implode( '&nbsp;&nbsp;&nbsp;', apply_filters( 'qm/output/title', array() ) );
+
+		if ( empty( $title ) ) {
+			$title = esc_html__( 'Query Monitor', 'query-monitor' );
+		}
+
+		$admin_bar_menu = array(
+			'top' => array(
+				'title'     => sprintf( '<span class="ab-icon">QM</span><span class="ab-label">%s</span>', $title ),
+				'classname' => $class,
+			),
+			'sub' => array(),
+		);
+
+		foreach ( $this->admin_bar_menu as $menu ) {
+			$admin_bar_menu['sub'][ $menu['id'] ] = $menu;
+		}
+
+		return $admin_bar_menu;
+
+	}
+
+	public function is_active() {
+
+		if ( ! $this->user_can_view() ) {
+			return false;
+		}
+
+		if ( ! $this->did_footer ) {
+			return false;
+		}
+
+		// If this is an async request and not a customizer preview:
+		if ( QM_Util::is_async() && ( ! function_exists( 'is_customize_preview' ) || ! is_customize_preview() ) ) {
+			return false;
+		}
+
+		# Don't process if the minimum required actions haven't fired:
+		if ( is_admin() ) {
+			if ( ! did_action( 'admin_init' ) ) {
+				return false;
+			}
+		} else {
+			if ( ! ( did_action( 'wp' ) || did_action( 'login_init' ) || did_action( 'gp_head' ) ) ) {
+				return false;
+			}
+		}
+
+		# Back-compat filter. Please use `qm/dispatch/html` instead
+		if ( ! apply_filters( 'qm/process', true, is_admin_bar_showing() ) ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+}
+
+function register_qm_dispatcher_html( array $dispatchers, QM_Plugin $qm ) {
+	$dispatchers['html'] = new QM_Dispatcher_Html( $qm );
+	return $dispatchers;
+}
+
+add_filter( 'qm/dispatchers', 'register_qm_dispatcher_html', 10, 2 );

--- a/query-monitor/dispatchers/REST.php
+++ b/query-monitor/dispatchers/REST.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * REST API request dispatcher.
+ *
+ * @package query-monitor
+ */
+
+class QM_Dispatcher_REST extends QM_Dispatcher {
+
+	public $id = 'rest';
+
+	public function __construct( QM_Plugin $qm ) {
+		parent::__construct( $qm );
+
+		add_filter( 'rest_post_dispatch', array( $this, 'filter_rest_post_dispatch' ), 1, 3 );
+
+	}
+
+	/**
+	 * Filters a REST API response in order to add QM's headers.
+	 *
+	 * @param WP_HTTP_Response $result  Result to send to the client. Usually a WP_REST_Response.
+	 * @param WP_REST_Server   $server  Server instance.
+	 * @param WP_REST_Request  $request Request used to generate the response.
+	 * @return WP_HTTP_Response Result to send to the client.
+	 */
+	public function filter_rest_post_dispatch( WP_HTTP_Response $result, WP_REST_Server $server, WP_REST_Request $request ) {
+
+		if ( ! $this->should_dispatch() ) {
+			return $result;
+		}
+
+		$this->before_output();
+
+		/* @var QM_Output_Headers[] */
+		foreach ( $this->get_outputters( 'headers' ) as $id => $output ) {
+			$output->output();
+		}
+
+		$this->after_output();
+
+		return $result;
+
+	}
+
+	protected function before_output() {
+
+		require_once $this->qm->plugin_path( 'output/Headers.php' );
+
+		foreach ( glob( $this->qm->plugin_path( 'output/headers/*.php' ) ) as $file ) {
+			include_once $file;
+		}
+	}
+
+	public function is_active() {
+
+		# If the headers have already been sent then we can't do anything about it
+		if ( headers_sent() ) {
+			return false;
+		}
+
+		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+			return false;
+		}
+
+		if ( ! $this->user_can_view() ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+}
+
+function register_qm_dispatcher_rest( array $dispatchers, QM_Plugin $qm ) {
+	$dispatchers['rest'] = new QM_Dispatcher_REST( $qm );
+	return $dispatchers;
+}
+
+add_filter( 'qm/dispatchers', 'register_qm_dispatcher_rest', 10, 2 );

--- a/query-monitor/dispatchers/Redirect.php
+++ b/query-monitor/dispatchers/Redirect.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * HTTP redirect dispatcher.
+ *
+ * @package query-monitor
+ */
+
+class QM_Dispatcher_Redirect extends QM_Dispatcher {
+
+	public $id = 'redirect';
+
+	public function __construct( QM_Plugin $qm ) {
+		parent::__construct( $qm );
+
+		add_filter( 'wp_redirect', array( $this, 'filter_wp_redirect' ), 999, 2 );
+
+	}
+
+	/**
+	 * Filters a redirect location in order to output QM's headers.
+	 *
+	 * @param string $location The path to redirect to.
+	 * @param int    $status   Status code to use.
+	 */
+	public function filter_wp_redirect( $location, $status ) {
+
+		if ( ! $this->should_dispatch() ) {
+			return $location;
+		}
+
+		$this->before_output();
+
+		/* @var QM_Output_Headers[] */
+		foreach ( $this->get_outputters( 'headers' ) as $id => $output ) {
+			$output->output();
+		}
+
+		$this->after_output();
+
+		return $location;
+
+	}
+
+	protected function before_output() {
+
+		require_once $this->qm->plugin_path( 'output/Headers.php' );
+
+		foreach ( glob( $this->qm->plugin_path( 'output/headers/*.php' ) ) as $file ) {
+			require_once $file;
+		}
+	}
+
+	public function is_active() {
+
+		if ( ! $this->user_can_view() ) {
+			return false;
+		}
+
+		# If the headers have already been sent then we can't do anything about it
+		if ( headers_sent() ) {
+			return false;
+		}
+
+		# Don't process if the minimum required actions haven't fired:
+		if ( is_admin() ) {
+			if ( ! did_action( 'admin_init' ) ) {
+				return false;
+			}
+		} else {
+			if ( ! ( did_action( 'wp' ) || did_action( 'login_init' ) ) ) {
+				return false;
+			}
+		}
+
+		return true;
+
+	}
+
+}
+
+function register_qm_dispatcher_redirect( array $dispatchers, QM_Plugin $qm ) {
+	$dispatchers['redirect'] = new QM_Dispatcher_Redirect( $qm );
+	return $dispatchers;
+}
+
+add_filter( 'qm/dispatchers', 'register_qm_dispatcher_redirect', 10, 2 );

--- a/query-monitor/query-monitor.php
+++ b/query-monitor/query-monitor.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Query Monitor plugin for WordPress
+ *
+ * @package   query-monitor
+ * @link      https://github.com/johnbillion/query-monitor
+ * @author    John Blackbourn <john@johnblackbourn.com>
+ * @copyright 2009-2018 John Blackbourn
+ * @license   GPL v2 or later
+ *
+ * Plugin Name:  Query Monitor
+ * Description:  The Developer Tools Panel for WordPress.
+ * Version:      3.1.1
+ * Plugin URI:   https://querymonitor.com/
+ * Author:       John Blackbourn & contributors
+ * Author URI:   https://querymonitor.com/
+ * Text Domain:  query-monitor
+ * Domain Path:  /languages/
+ * Requires PHP: 5.3.6
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+defined( 'ABSPATH' ) or die();
+
+$qm_dir = dirname( __FILE__ );
+
+require_once "{$qm_dir}/classes/Plugin.php";
+
+# No autoloaders for us. See https://github.com/johnbillion/query-monitor/issues/7
+foreach ( array( 'Activation', 'Util', 'QM' ) as $qm_class ) {
+	require_once "{$qm_dir}/classes/{$qm_class}.php";
+}
+
+QM_Activation::init( __FILE__ );
+
+if ( ! QM_Plugin::php_version_met() ) {
+	return;
+}
+
+if ( defined( 'QM_DISABLED' ) and QM_DISABLED ) {
+	return;
+}
+
+if ( 'cli' === php_sapi_name() && ! defined( 'QM_TESTS' ) ) {
+	# For the time being, let's not load QM when using the CLI because we've no persistent storage and no means of
+	# outputting collected data on the CLI. This will hopefully change in a future version of QM.
+	return;
+}
+
+if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+	# Let's not load QM during cron events for the same reason as above.
+	return;
+}
+
+foreach ( array( 'QueryMonitor', 'Backtrace', 'Collectors', 'Collector', 'Dispatchers', 'Dispatcher', 'Output', 'Timer' ) as $qm_class ) {
+	require_once "{$qm_dir}/classes/{$qm_class}.php";
+}
+
+QueryMonitor::init( __FILE__ );

--- a/query-monitor/readme.txt
+++ b/query-monitor/readme.txt
@@ -1,0 +1,155 @@
+=== Query Monitor ===
+Contributors: johnbillion
+Tags: debug, debug-bar, debugging, development, developer, performance, profiler, queries, query monitor, rest-api
+Requires at least: 3.7
+Tested up to: 4.9
+Stable tag: 3.1.1
+License: GPLv2 or later
+Requires PHP: 5.3
+
+Query Monitor is the developer tools panel for WordPress.
+
+== Description ==
+
+Query Monitor is the developer tools panel for WordPress. It includes some advanced features such as Ajax and REST API debugging, and the ability to narrow down its output by plugin or theme.
+
+Query Monitor focuses heavily on presenting its information in a useful manner. For example, aggregate database query information is made available, allowing you to quickly determine poorly performing plugins, themes, or functions. It adds an admin toolbar menu showing an overview of the current page, with complete data shown in a panel once you select a menu item.
+
+For complete information, please see [the Query Monitor website](https://querymonitor.com/).
+
+Here's an overview of some of what's shown:
+
+= Database Queries =
+
+ * Shows all database queries performed on the current request
+ * Shows notifications for slow queries, duplicate queries, and queries with errors
+ * Filter queries by query type (`SELECT`, `UPDATE`, `DELETE`, etc)
+ * Filter queries by component (WordPress core, Plugin X, Plugin Y, theme)
+ * Filter queries by calling function
+ * View aggregate query information grouped by component, calling function, and type
+ * Super advanced: Supports multiple instances of wpdb on one page (more info in the FAQ)
+
+Filtering queries by component or calling function makes it easy to see which plugins, themes, or functions are making the most (or the slowest) database queries.
+
+= Hooks =
+
+ * Shows all hooks fired on the current request, along with hooked actions, their priorities, and their components
+ * Filter actions by component (WordPress core, Plugin X, Plugin Y, theme)
+
+= Theme =
+
+ * Shows the template filename for the current request
+ * Shows the complete template hierarchy for the current request (WordPress 4.7+)
+ * Shows all template parts used on the current request
+
+= PHP Errors =
+
+ * PHP errors (warnings, notices, stricts, and deprecated) are presented nicely along with their component and call stack
+ * Shows an easily visible warning in the admin toolbar
+
+= Request =
+
+ * Shows query vars for the current request, and highlights custom query vars
+ * Shows all matched rewrite rules and associated query strings
+
+= Scripts & Styles =
+
+ * Shows all enqueued scripts and styles on the current request, along with their URL and version
+ * Shows their dependencies and dependents, and displays an alert for any broken dependencies
+
+= Languages =
+
+ * Shows language settings and text domains
+ * Shows the MO files for each text domain and which ones were loaded or not
+
+= HTTP Requests =
+
+ * Shows all HTTP requests performed on the current request (as long as they use WordPress' HTTP API)
+ * Shows the response code, call stack, component, timeout, and time taken
+ * Highlights erroneous responses, such as failed requests and anything without a `200` response code
+
+= User Capability Checks =
+
+ * Shows every user capability check that is performed on the page, along with the result and any parameters passed along with the capability check.
+
+= Redirects =
+
+ * Whenever a redirect occurs, Query Monitor adds an `X-QM-Redirect` HTTP header containing the call stack, so you can use your favourite HTTP inspector or browser developer tools to easily trace where a redirect has come from
+
+= Ajax =
+
+The response from any jQuery Ajax request on the page will contain various debugging information in its headers. Any errors also get output to the developer console. No hooking required.
+
+Currently this includes PHP errors and some overview information such as memory usage, but this will be built upon in future versions.
+
+= REST API =
+
+The response from an authenticated WordPress REST API (v2 or later) request will contain various debugging information in its headers, as long as the authenticated user has permission to view Query Monitor's output.
+
+Currently this includes PHP errors and some overview information such as memory usage, but this will be built upon in future versions.
+
+= Authentication =
+
+By default, Query Monitor's output is only shown to Administrators on single-site installs, and Super Admins on Multisite installs.
+
+In addition to this, you can set an authentication cookie which allows you to view Query Monitor output when you're not logged in (or if you're logged in as a non-administrator). See the bottom of Query Monitor's output for details.
+
+= Privacy Statement =
+
+Query Monitor does not persistently store any of the data that it collects. It does not send data to any third party, nor does it include any third party resources.
+
+[Query Monitor's full privacy statement can be found here](https://github.com/johnbillion/query-monitor/wiki/Privacy-Statement).
+
+== Screenshots ==
+
+1. The admin toolbar menu showing an overview
+2. Aggregate database queries by component
+3. User capability checks with an active filter
+4. Database queries complete with filter controls
+5. Hooks and actions
+6. HTTP requests (showing an HTTP error)
+7. Aggregate database queries grouped by calling function
+
+== Frequently Asked Questions ==
+
+= Who can see Query Monitor's output? =
+
+By default, Query Monitor's output is only shown to Administrators on single-site installs, and Super Admins on Multisite installs.
+
+In addition to this, you can set an authentication cookie which allows you to view Query Monitor output when you're not logged in (or if you're logged in as a non-administrator). See the bottom of Query Monitor's output for details.
+
+= Does Query Monitor itself impact the page generation time or memory usage? =
+
+Short answer: Yes, but only a little.
+
+Long answer: Query Monitor has a small impact on page generation time because it hooks into WordPress in the same way that other plugins do. The impact is low; typically between 10ms and 100ms depending on the complexity of your site.
+
+Query Monitor's memory usage typically accounts for around 10% of the total memory used to generate the page.
+
+= Are there any add-on plugins for Query Monitor? =
+
+[A list of add-on plugins for Query Monitor can be found here.](https://github.com/johnbillion/query-monitor/wiki/Query-Monitor-Add-on-Plugins)
+
+In addition, Query Monitor transparently supports add-ons for the Debug Bar plugin. If you have any Debug Bar add-ons installed, just deactivate Debug Bar and the add-ons will show up in Query Monitor's menu.
+
+= Where can I suggest a new feature or report a bug? =
+
+Please use [the issue tracker on Query Monitor's GitHub repo](https://github.com/johnbillion/query-monitor/issues) as it's easier to keep track of issues there, rather than on the wordpress.org support forums.
+
+= Is Query Monitor available on WordPress.com VIP Go? =
+
+Yep! You just need to add `define( 'WPCOM_VIP_QM_ENABLE', true );` to your `vip-config/vip-config.php` file.
+
+(It's not available on standard WordPress.com VIP though.)
+
+= I'm using multiple instances of `wpdb`. How do I get my additional instances to show up in Query Monitor? =
+
+You'll need to hook into the `qm/collect/db_objects` filter and add an item to the array with your connection name as the key and the `wpdb` instance as the value. Your `wpdb` instance will then show up as a separate panel, and the query time and query count will show up separately in the admin toolbar menu. Aggregate information (queries by caller and component) will not be separated.
+
+= Do you accept donations? =
+
+No, I do not accept donations. If you like the plugin, I'd love for you to [leave a review](https://wordpress.org/support/view/plugin-reviews/query-monitor). Tell all your friends about the plugin too!
+
+== Changelog ==
+
+For Query Monitor's changelog, please see [the Releases page on GitHub](https://github.com/johnbillion/query-monitor/releases).

--- a/query-monitor/wp-content/db.php
+++ b/query-monitor/wp-content/db.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Plugin Name: Query Monitor Database Class
+ *
+ * *********************************************************************
+ *
+ * Ensure this file is symlinked to your wp-content directory to provide
+ * additional database query information in Query Monitor's output.
+ *
+ * *********************************************************************
+ *
+ * @package query-monitor
+ */
+
+defined( 'ABSPATH' ) or die();
+
+if ( defined( 'QM_DISABLED' ) and QM_DISABLED ) {
+	return;
+}
+
+if ( 'cli' === php_sapi_name() && ! defined( 'QM_TESTS' ) ) {
+	# For the time being, let's not load QM when using the CLI because we've no persistent storage and no means of
+	# outputting collected data on the CLI. This will hopefully change in a future version of QM.
+	return;
+}
+
+if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+	# Let's not load QM during cron events for the same reason as above.
+	return;
+}
+
+# No autoloaders for us. See https://github.com/johnbillion/query-monitor/issues/7
+$qm_dir = dirname( dirname( __FILE__ ) );
+$plugin = "{$qm_dir}/classes/Plugin.php";
+
+if ( ! is_readable( $plugin ) ) {
+	return;
+}
+require_once $plugin;
+
+if ( ! QM_Plugin::php_version_met() ) {
+	return;
+}
+
+$backtrace = "{$qm_dir}/classes/Backtrace.php";
+if ( ! is_readable( $backtrace ) ) {
+	return;
+}
+require_once $backtrace;
+
+if ( ! defined( 'SAVEQUERIES' ) ) {
+	define( 'SAVEQUERIES', true );
+}
+
+class QM_DB extends wpdb {
+
+	public $qm_php_vars = array(
+		'max_execution_time'  => null,
+		'memory_limit'        => null,
+		'upload_max_filesize' => null,
+		'post_max_size'       => null,
+		'display_errors'      => null,
+		'log_errors'          => null,
+	);
+
+	/**
+	 * Class constructor
+	 */
+	function __construct( $dbuser, $dbpassword, $dbname, $dbhost ) {
+
+		foreach ( $this->qm_php_vars as $setting => &$val ) {
+			$val = ini_get( $setting );
+		}
+
+		parent::__construct( $dbuser, $dbpassword, $dbname, $dbhost );
+
+	}
+
+	/**
+	 * Perform a MySQL database query, using current database connection.
+	 *
+	 * @see wpdb::query()
+	 *
+	 * @param string $query Database query
+	 * @return int|false Number of rows affected/selected or false on error
+	 */
+	function query( $query ) {
+		if ( ! $this->ready ) {
+			if ( isset( $this->check_current_query ) ) {
+				// This property was introduced in WP 4.2
+				$this->check_current_query = true;
+			}
+			return false;
+		}
+
+		if ( $this->show_errors ) {
+			$this->hide_errors();
+		}
+
+		$result = parent::query( $query );
+
+		if ( ! SAVEQUERIES ) {
+			return $result;
+		}
+
+		$i = $this->num_queries - 1;
+		$this->queries[ $i ]['trace'] = new QM_Backtrace( array(
+			'ignore_frames' => 1,
+		) );
+
+		if ( ! isset( $this->queries[ $i ][3] ) ) {
+			$this->queries[ $i ][3] = $this->time_start;
+		}
+
+		if ( $this->last_error ) {
+			$code = 'qmdb';
+			if ( $this->use_mysqli ) {
+				if ( $this->dbh instanceof mysqli ) {
+					$code = mysqli_errno( $this->dbh );
+				}
+			} else {
+				if ( is_resource( $this->dbh ) ) {
+					$code = mysql_errno( $this->dbh );
+				}
+			}
+			$this->queries[ $i ]['result'] = new WP_Error( $code, $this->last_error );
+		} else {
+			$this->queries[ $i ]['result'] = $result;
+		}
+
+		return $result;
+	}
+
+}
+
+$wpdb = new QM_DB( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );


### PR DESCRIPTION
And replace it with a raw implementation from the .org directory. We're generally trending towards not relying too much on submodules and this will help simplify the process of updating the version of QM moving forward.

No deploy should be necessary since there's no functional changes (we're continuing to use 3.1.1).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Make sure site doesn't explode with and without QM active.