### PR TITLE
QM: Re-add previously ignored output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ phpdoc
 # Composer
 /vendor/
 output
+# Allow the QM output directory, as it's needed.
+!query-monitor/output
 
 # npm
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,7 @@ phpdoc
 
 # Composer
 /vendor/
-output
-# Allow the QM output directory, as it's needed.
-!query-monitor/output
+/output/
 
 # npm
 node_modules

--- a/query-monitor/output/Headers.php
+++ b/query-monitor/output/Headers.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Abstract output class for HTTP headers.
+ *
+ * @package query-monitor
+ */
+
+abstract class QM_Output_Headers extends QM_Output {
+
+	public function output() {
+
+		$id = $this->collector->id;
+
+		foreach ( $this->get_output() as $key => $value ) {
+			if ( is_scalar( $value ) ) {
+				header( sprintf( 'X-QM-%s-%s: %s', $id, $key, $value ) );
+			} else {
+				header( sprintf( 'X-QM-%s-%s: %s', $id, $key, json_encode( $value ) ) );
+			}
+		}
+
+	}
+
+}

--- a/query-monitor/output/Html.php
+++ b/query-monitor/output/Html.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * Abstract output class for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+abstract class QM_Output_Html extends QM_Output {
+
+	protected static $file_link_format = null;
+
+	public function admin_menu( array $menu ) {
+
+		$menu[] = $this->menu( array(
+			'title' => esc_html( $this->collector->name() ),
+		) );
+		return $menu;
+
+	}
+
+	public function get_output() {
+		ob_start();
+		// compat until I convert all the existing outputters to use `get_output()`
+		$this->output();
+		$out = ob_get_clean();
+		return $out;
+	}
+
+	protected function before_tabular_output( $id = null, $name = null ) {
+		if ( null === $id ) {
+			$id = $this->collector->id();
+		}
+		if ( null === $name ) {
+			$name = $this->collector->name();
+		}
+
+		printf(
+			'<div class="qm" id="%1$s" role="group" aria-labelledby="%1$s-caption" tabindex="-1">',
+			esc_attr( $id )
+		);
+
+		echo '<table class="qm-sortable">';
+
+		printf(
+			'<caption class="qm-screen-reader-text"><h2 id="%1$s-caption">%2$s</h2></caption>',
+			esc_attr( $id ),
+			esc_html( $name )
+		);
+	}
+
+	protected function after_tabular_output() {
+		echo '</table>';
+		echo '</div>';
+	}
+
+	protected function before_non_tabular_output( $id = null, $name = null ) {
+		if ( null === $id ) {
+			$id = $this->collector->id();
+		}
+		if ( null === $name ) {
+			$name = $this->collector->name();
+		}
+
+		printf(
+			'<div class="qm qm-non-tabular" id="%1$s" role="group" aria-labelledby="%1$s-caption" tabindex="-1">',
+			esc_attr( $id )
+		);
+
+		echo '<div class="qm-boxed">';
+
+		printf(
+			'<h2 class="qm-screen-reader-text" id="%1$s-caption">%2$s</h2>',
+			esc_attr( $id ),
+			esc_html( $name )
+		);
+	}
+
+	protected function after_non_tabular_output() {
+		echo '</div>';
+		echo '</div>';
+	}
+
+	protected function before_debug_bar_output( $id = null, $name = null ) {
+		if ( null === $id ) {
+			$id = $this->collector->id();
+		}
+		if ( null === $name ) {
+			$name = $this->collector->name();
+		}
+
+		printf(
+			'<div class="qm qm-debug-bar" id="%1$s" role="group" aria-labelledby="%1$s-caption" tabindex="-1">',
+			esc_attr( $id )
+		);
+
+		printf(
+			'<h2 class="qm-screen-reader-text" id="%1$s-caption">%2$s</h2>',
+			esc_attr( $id ),
+			esc_html( $name )
+		);
+	}
+
+	protected function after_debug_bar_output() {
+		echo '</div>';
+	}
+
+	protected function build_notice( $notice ) {
+		$return = '<div class="qm-section">';
+		$return .= '<div class="qm-notice">';
+		$return .= '<p>';
+		$return .= $notice;
+		$return .= '</p>';
+		$return .= '</div>';
+		$return .= '</div>';
+
+		return $return;
+	}
+
+	public static function output_inner( $vars ) {
+
+		echo '<table class="qm-inner">';
+
+		foreach ( $vars as $key => $value ) {
+			echo '<tr>';
+			echo '<td>' . esc_html( $key ) . '</td>';
+			if ( is_array( $value ) ) {
+				echo '<td class="qm-has-inner">';
+				self::output_inner( $value );
+				echo '</td>';
+			} elseif ( is_object( $value ) ) {
+				echo '<td class="qm-has-inner">';
+				self::output_inner( get_object_vars( $value ) );
+				echo '</td>';
+			} elseif ( is_bool( $value ) ) {
+				if ( $value ) {
+					echo '<td class="qm-true">true</td>';
+				} else {
+					echo '<td class="qm-false">false</td>';
+				}
+			} else {
+				echo '<td>';
+				echo nl2br( esc_html( $value ) );
+				echo '</td>';
+			}
+			echo '</td>';
+			echo '</tr>';
+		}
+		echo '</table>';
+
+	}
+
+	/**
+	 * Returns the table filter controls. Safe for output.
+	 *
+	 * @param  string   $name   The name for the `data-` attributes that get filtered by this control.
+	 * @param  string[] $values Option values for this control.
+	 * @param  string   $label  Label text for the filter control.
+	 * @param  array    $args {
+	 *     @type string $highlihgt The name for the `data-` attributes that get highlighted by this control.
+	 *     @type array  $prepend   Associative array of options to prepend to the list of values.
+	 * }
+	 * @return string Markup for the table filter controls.
+	 */
+	protected function build_filter( $name, array $values, $label, $args = array() ) {
+
+		if ( empty( $values ) ) {
+			return esc_html( $label ); // Return label text, without being marked up as a label element.
+		}
+
+		if ( ! is_array( $args ) ) {
+			$args = array(
+				'highlight' => $args,
+			);
+		}
+
+		$args = array_merge( array(
+			'highlight' => '',
+			'prepend'   => array(),
+		), $args );
+
+		$core = __( 'Core', 'query-monitor' );
+
+		if ( 'component' === $name && count( $values ) > 1 && in_array( $core, $values, true ) ) {
+			$args['prepend']['non-core'] = __( 'Non-Core', 'query-monitor' );
+		}
+
+		$filter_id = 'qm-filter-' . $this->collector->id . '-' . $name;
+
+		$out = '<div class="qm-filter-container">';
+		$out .= '<label for="' . esc_attr( $filter_id ) . '">' . esc_html( $label ) . '</label>';
+		$out .= '<select id="' . esc_attr( $filter_id ) . '" class="qm-filter" data-filter="' . esc_attr( $name ) . '" data-highlight="' . esc_attr( $args['highlight'] ) . '">';
+		$out .= '<option value="">' . esc_html_x( 'All', '"All" option for filters', 'query-monitor' ) . '</option>';
+
+		if ( ! empty( $args['prepend'] ) ) {
+			foreach ( $args['prepend'] as $value => $label ) {
+				$out .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $label ) . '</option>';
+			}
+		}
+
+		foreach ( $values as $value ) {
+			$out .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $value ) . '</option>';
+		}
+
+		$out .= '</select>';
+		$out .= '</div>';
+
+		return $out;
+
+	}
+
+	/**
+	 * Returns the column sorter controls. Safe for output.
+	 *
+	 * @param string $heading Heading text for the column. Optional.
+	 * @return string Markup for the column sorter controls.
+	 */
+	protected function build_sorter( $heading = '' ) {
+		$out = '';
+		$out .= '<label class="qm-th">';
+		$out .= '<span class="qm-sort-heading">';
+
+		if ( '#' === $heading ) {
+			$out .= '<span class="qm-screen-reader-text">' . esc_html__( 'Sequence', 'query-monitor' ) . '</span>';
+		} elseif ( $heading ) {
+			$out .= esc_html( $heading );
+		}
+
+		$out .= '</span>';
+		$out .= '<button class="qm-sort-controls">';
+		$out .= '<span class="qm-sort-arrow" aria-hidden="true"></span>';
+		$out .= '</button>';
+		$out .= '</label>';
+		return $out;
+	}
+
+	/**
+	 * Returns a toggle control. Safe for output.
+	 *
+	 * @return string Markup for the column sorter controls.
+	 */
+	protected static function build_toggler() {
+		$out = '<button class="qm-toggle" data-on="+" data-off="-" aria-expanded="false"><span aria-hidden="true">+</span><span class="screen-reader-text">' . esc_html__( ' Toggle button', 'query-monitor' ) . '</span></button>';
+		return $out;
+	}
+
+	protected function menu( array $args ) {
+
+		return array_merge( array(
+			'id'   => esc_attr( "query-monitor-{$this->collector->id}" ),
+			'href' => esc_attr( '#' . $this->collector->id() ),
+		), $args );
+
+	}
+
+	/**
+	 * Returns the given SQL string in a nicely presented format. Safe for output.
+	 *
+	 * @param  string $sql An SQL query string.
+	 * @return string      The SQL formatted with markup.
+	 */
+	public static function format_sql( $sql ) {
+
+		$sql = str_replace( array( "\r\n", "\r", "\n", "\t" ), ' ', $sql );
+		$sql = esc_html( $sql );
+		$sql = trim( $sql );
+
+		$regex = 'ADD|AFTER|ALTER|AND|BEGIN|COMMIT|CREATE|DELETE|DESCRIBE|DO|DROP|ELSE|END|EXCEPT|EXPLAIN|FROM|GROUP|HAVING|INNER|INSERT|INTERSECT|LEFT|LIMIT|ON|OR|ORDER|OUTER|RENAME|REPLACE|RIGHT|ROLLBACK|SELECT|SET|SHOW|START|THEN|TRUNCATE|UNION|UPDATE|USE|USING|VALUES|WHEN|WHERE|XOR';
+		$sql = preg_replace( '# (' . $regex . ') #', '<br> $1 ', $sql );
+
+		$keywords = '\b(?:ACTION|ADD|AFTER|ALTER|AND|ASC|AS|AUTO_INCREMENT|BEGIN|BETWEEN|BIGINT|BINARY|BIT|BLOB|BOOLEAN|BOOL|BREAK|BY|CASE|COLLATE|COLUMNS?|COMMIT|CONTINUE|CREATE|DATA(?:BASES?)?|DATE(?:TIME)?|DECIMAL|DECLARE|DEC|DEFAULT|DELAYED|DELETE|DESCRIBE|DESC|DISTINCT|DOUBLE|DO|DROP|DUPLICATE|ELSE|END|ENUM|EXCEPT|EXISTS|EXPLAIN|FIELDS|FLOAT|FOREIGN|FOR|FROM|FULL|FUNCTION|GROUP|HAVING|IF|IGNORE|INDEX|INNER|INSERT|INTEGER|INTERSECT|INTERVAL|INTO|INT|IN|IS|JOIN|KEYS?|LEFT|LIKE|LIMIT|LONG(?:BLOB|TEXT)|MEDIUM(?:BLOB|INT|TEXT)|MERGE|MIDDLEINT|NOT|NO|NULLIF|ON|ORDER|OR|OUTER|PRIMARY|PROC(?:EDURE)?|REGEXP|RENAME|REPLACE|RIGHT|RLIKE|ROLLBACK|SCHEMA|SELECT|SET|SHOW|SMALLINT|START|TABLES?|TEXT(?:SIZE)?|THEN|TIME(?:STAMP)?|TINY(?:BLOB|INT|TEXT)|TRUNCATE|UNION|UNIQUE|UNSIGNED|UPDATE|USE|USING|VALUES?|VAR(?:BINARY|CHAR)|WHEN|WHERE|WHILE|XOR)\b';
+		$sql = preg_replace( '#' . $keywords . '#', '<b>$0</b>', $sql );
+
+		return '<code>' . $sql . '</code>';
+
+	}
+
+	/**
+	 * Returns the given URL in a nicely presented format. Safe for output.
+	 *
+	 * @param  string $url A URL.
+	 * @return string      The URL formatted with markup.
+	 */
+	public static function format_url( $url ) {
+		return str_replace( array( '?', '&amp;' ), array( '<br>?', '<br>&amp;' ), esc_html( $url ) );
+	}
+
+	/**
+	 * Returns a file path, name, and line number. Safe for output.
+	 *
+	 * If clickable file links are enabled via the `xdebug.file_link_format` setting in the PHP configuration,
+	 * a link such as this is returned:
+	 *
+	 *     <a href="subl://open/?line={line}&url={file}">{text}</a>
+	 *
+	 * Otherwise, the display text and file details such as this is returned:
+	 *
+	 *     {text}<br>{file}:{line}
+	 *
+	 * Further information on clickable stack traces for your editor:
+	 *
+	 * PhpStorm: (support is built in)
+	 * `phpstorm://open?file=%f&line=%l`
+	 *
+	 * Visual Studio Code: (support is built in)
+	 * `vscode://file/%f:%l`
+	 *
+	 * Sublime Text: https://github.com/corysimmons/subl-handler
+	 * `subl://open/?url=file://%f&line=%l`
+	 *
+	 * Atom: https://github.com/WizardOfOgz/atom-handler
+	 * `atm://open/?url=file://%f&line=%l`
+	 *
+	 * Netbeans: http://simonwheatley.co.uk/2012/08/clickable-stack-traces-with-netbeans/
+	 * `nbopen://%f:%l`
+	 *
+	 * @param  string $text        The display text, such as a function name or file name.
+	 * @param  string $file        The full file path and name.
+	 * @param  int    $line        Optional. A line number, if appropriate.
+	 * @param  bool   $is_filename Optional. Is the text a plain file name? Default false.
+	 * @return string The fully formatted file link or file name, safe for output.
+	 */
+	public static function output_filename( $text, $file, $line = 0, $is_filename = false ) {
+
+		if ( empty( $file ) ) {
+			if ( $is_filename ) {
+				return esc_html( $text );
+			} else {
+				return '<code>' . esc_html( $text ) . '</code>';
+			}
+		}
+
+		$link_line = ( $line ) ? $line : 1;
+
+		if ( ! self::has_clickable_links() ) {
+			$fallback = QM_Util::standard_dir( $file, '' );
+			if ( $line ) {
+				$fallback .= ':' . $line;
+			}
+			if ( $is_filename ) {
+				$return = esc_html( $text );
+			} else {
+				$return = '<code>' . esc_html( $text ) . '</code>';
+			}
+			if ( $fallback !== $text ) {
+				$return .= '<br><span class="qm-info qm-supplemental">' . esc_html( $fallback ) . '</span>';
+			}
+			return $return;
+		}
+
+		$map = self::get_file_path_map();
+
+		if ( ! empty( $map ) ) {
+			foreach ( $map as $from => $to ) {
+				$file = str_replace( $from, $to, $file );
+			}
+		}
+
+		$link = sprintf( self::get_file_link_format(), rawurlencode( $file ), intval( $link_line ) );
+
+		if ( $is_filename ) {
+			$format = '<a href="%s" class="qm-edit-link">%s</a>';
+		} else {
+			$format = '<a href="%s" class="qm-edit-link"><code>%s</code></a>';
+		}
+
+		return sprintf(
+			$format,
+			esc_attr( $link ),
+			esc_html( $text )
+		);
+	}
+
+	public static function get_file_link_format() {
+		if ( ! isset( self::$file_link_format ) ) {
+			$format = ini_get( 'xdebug.file_link_format' );
+			$format = apply_filters( 'qm/output/file_link_format', $format );
+			if ( empty( $format ) ) {
+				self::$file_link_format = false;
+			} else {
+				self::$file_link_format = str_replace( array( '%f', '%l' ), array( '%1$s', '%2$d' ), $format );
+			}
+		}
+
+		return self::$file_link_format;
+	}
+
+	public static function get_file_path_map() {
+		// @TODO document this!
+		return apply_filters( 'qm/output/file_path_map', array() );
+	}
+
+	public static function has_clickable_links() {
+		return ( false !== self::get_file_link_format() );
+	}
+
+}

--- a/query-monitor/output/headers/overview.php
+++ b/query-monitor/output/headers/overview.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * General overview output for HTTP headers.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Headers_Overview extends QM_Output_Headers {
+
+	public function get_output() {
+
+		$data = $this->collector->get_data();
+		$headers = array();
+
+		$headers['time_taken'] = number_format_i18n( $data['time_taken'], 4 );
+		$headers['time_usage'] = sprintf(
+			/* translators: 1: Percentage of time limit used, 2: Time limit in seconds */
+			__( '%1$s%% of %2$ss limit', 'query-monitor' ),
+			number_format_i18n( $data['time_usage'], 1 ),
+			number_format_i18n( $data['time_limit'] )
+		);
+
+		if ( ! empty( $data['memory'] ) ) {
+			$headers['memory'] = sprintf(
+				/* translators: %s: Memory used in kilobytes */
+				__( '%s kB', 'query-monitor' ),
+				number_format_i18n( $data['memory'] / 1024 )
+			);
+			$headers['memory_usage'] = sprintf(
+				/* translators: 1: Percentage of memory limit used, 2: Memory limit in kilobytes */
+				__( '%1$s%% of %2$s kB limit', 'query-monitor' ),
+				number_format_i18n( $data['memory_usage'], 1 ),
+				number_format_i18n( $data['memory_limit'] / 1024 )
+			);
+		}
+
+		return $headers;
+
+	}
+
+}
+
+function register_qm_output_headers_overview( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'overview' ) ) {
+		$output['overview'] = new QM_Output_Headers_Overview( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/headers', 'register_qm_output_headers_overview', 10, 2 );

--- a/query-monitor/output/headers/php_errors.php
+++ b/query-monitor/output/headers/php_errors.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * PHP error output for HTTP headers.
+ *
+ * @package query-monitor
+ */
+class QM_Output_Headers_PHP_Errors extends QM_Output_Headers {
+
+	public function get_output() {
+
+		$data = $this->collector->get_data();
+		$headers = array();
+
+		if ( empty( $data['errors'] ) ) {
+			return array();
+		}
+
+		$count = 0;
+
+		foreach ( $data['errors'] as $type => $errors ) {
+
+			foreach ( $errors as $key => $error ) {
+
+				$count++;
+
+				# @TODO we should calculate the component during process() so we don't need to do it
+				# separately in each output.
+				$component = $error['trace']->get_component();
+				$output_error = array(
+					'type'      => $error['type'],
+					'message'   => $error['message'],
+					'file'      => QM_Util::standard_dir( $error['file'], '' ),
+					'line'      => $error['line'],
+					'stack'     => $error['trace']->get_stack(),
+					'component' => $component->name,
+				);
+
+				$key = sprintf( 'error-%d', $count );
+				$headers[ $key ] = json_encode( $output_error );
+
+			}
+		}
+
+		return array_merge( array(
+			'error-count' => $count,
+		), $headers );
+
+	}
+
+}
+
+function register_qm_output_headers_php_errors( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'php_errors' ) ) {
+		$output['php_errors'] = new QM_Output_Headers_PHP_Errors( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/headers', 'register_qm_output_headers_php_errors', 110, 2 );

--- a/query-monitor/output/headers/redirects.php
+++ b/query-monitor/output/headers/redirects.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * HTTP redirects output for HTTP headers.
+ *
+ * @package query-monitor
+ */
+class QM_Output_Headers_Redirects extends QM_Output_Headers {
+
+	public function get_output() {
+
+		$data = $this->collector->get_data();
+		$headers = array();
+
+		if ( empty( $data['trace'] ) ) {
+			return array();
+		}
+
+		$headers['Redirect-Trace'] = implode( ', ', $data['trace']->get_stack() );
+		return $headers;
+
+	}
+
+}
+
+function register_qm_output_headers_redirects( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'redirects' ) ) {
+		$output['redirects'] = new QM_Output_Headers_Redirects( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/headers', 'register_qm_output_headers_redirects', 140, 2 );

--- a/query-monitor/output/html/admin.php
+++ b/query-monitor/output/html/admin.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Admin screen output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Admin extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 60 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['current_screen'] ) ) {
+			return;
+		}
+
+		$this->before_non_tabular_output();
+
+		echo '<div class="qm-section">';
+		echo '<h3>get_current_screen()</h3>';
+
+		echo '<table>';
+		echo '<thead class="qm-screen-reader-text">';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Property', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Value', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+		echo '<tbody>';
+
+		foreach ( $data['current_screen'] as $key => $value ) {
+			echo '<tr>';
+			echo '<th scope="row">' . esc_html( $key ) . '</th>';
+			echo '<td>' . esc_html( $value ) . '</td>';
+			echo '</tr>';
+		}
+
+		echo '</tbody>';
+		echo '</table>';
+		echo '</div>';
+
+		echo '<div class="qm-section">';
+		echo '<h3>$pagenow</h3>';
+		echo '<p>' . esc_html( $data['pagenow'] ) . '</p>';
+		echo '</div>';
+
+		if ( ! empty( $data['list_table'] ) ) {
+
+			echo '<div class="qm-section">';
+			echo '<h3>' . esc_html__( 'List Table', 'query-monitor' ) . '</h3>';
+
+			if ( ! empty( $data['list_table']['class_name'] ) ) {
+				echo '<h4>' . esc_html__( 'Class:', 'query-monitor' ) . '</h4>';
+				echo '<p><code>' . esc_html( $data['list_table']['class_name'] ) . '</code></p>';
+			}
+
+			echo '<h4>' . esc_html__( 'Column Filters:', 'query-monitor' ) . '</h4>';
+			echo '<p><code>' . esc_html( $data['list_table']['columns_filter'] ) . '</code></p>';
+			echo '<p><code>' . esc_html( $data['list_table']['sortables_filter'] ) . '</code></p>';
+			echo '<h4>' . esc_html__( 'Column Action:', 'query-monitor' ) . '</h4>';
+			echo '<p><code>' . esc_html( $data['list_table']['column_action'] ) . '</code></p>';
+			echo '</div>';
+
+		}
+
+		$this->after_non_tabular_output();
+	}
+
+}
+
+function register_qm_output_html_admin( array $output, QM_Collectors $collectors ) {
+	if ( is_admin() && $collector = QM_Collectors::get( 'response' ) ) {
+		$output['response'] = new QM_Output_Html_Admin( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_admin', 70, 2 );

--- a/query-monitor/output/html/assets.php
+++ b/query-monitor/output/html/assets.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Scripts and styles output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Assets extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus',      array( $this, 'admin_menu' ), 70 );
+		add_filter( 'qm/output/menu_class', array( $this, 'admin_class' ) );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['raw'] ) ) {
+			return;
+		}
+
+		$position_labels = array(
+			'missing' => __( 'Missing', 'query-monitor' ),
+			'broken'  => __( 'Missing Dependencies', 'query-monitor' ),
+			'header'  => __( 'Header', 'query-monitor' ),
+			'footer'  => __( 'Footer', 'query-monitor' ),
+		);
+
+		$type_labels = array(
+			'scripts' => array(
+				/* translators: %s: Total number of enqueued scripts */
+				'total'    => _x( 'Total: %s', 'Enqueued scripts', 'query-monitor' ),
+				'plural'   => __( 'Scripts', 'query-monitor' ),
+			),
+			'styles' => array(
+				/* translators: %s: Total number of enqueued styles */
+				'total'    => _x( 'Total: %s', 'Enqueued styles', 'query-monitor' ),
+				'plural'   => __( 'Styles', 'query-monitor' ),
+			),
+		);
+
+		foreach ( $type_labels as $type => $type_label ) {
+
+			$types = array();
+
+			foreach ( $position_labels as $position => $label ) {
+				if ( ! empty( $data[ $position ][ $type ] ) ) {
+					$types[ $position ] = $label;
+				}
+			}
+
+			$hosts = array(
+				__( 'Other', 'query-monitor' ),
+			);
+
+			$panel_id = sprintf(
+				'%s-%s',
+				$this->collector->id(),
+				$type
+			);
+
+			$this->before_tabular_output( $panel_id, $type_label['plural'] );
+
+			echo '<thead>';
+			echo '<tr>';
+			echo '<th scope="col">' . esc_html__( 'Position', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Handle', 'query-monitor' ) . '</th>';
+			echo '<th scope="col" class="qm-filterable-column">';
+			$args = array(
+				'prepend' => array(
+					// phpcs:ignore WordPress.VIP.ValidatedSanitizedInput
+					'local' => wp_unslash( $_SERVER['HTTP_HOST'] ),
+				),
+			);
+			echo $this->build_filter( $type . '-host', $hosts, __( 'Host', 'query-monitor' ), $args ); // WPCS: XSS ok.
+			echo '</th>';
+			echo '<th scope="col">' . esc_html__( 'Source', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Dependencies', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Dependents', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Version', 'query-monitor' ) . '</th>';
+			echo '</tr>';
+			echo '</thead>';
+
+			echo '<tbody>';
+
+			$total = 0;
+
+			foreach ( $position_labels as $position => $label ) {
+				if ( ! empty( $data[ $position ][ $type ] ) ) {
+					$this->dependency_rows( $data[ $position ][ $type ], $data['raw'][ $type ], $label, $type );
+					$total += count( $data[ $position ][ $type ] );
+				}
+			}
+
+			echo '</tbody>';
+
+			echo '<tfoot>';
+
+			echo '<tr>';
+			printf(
+				'<td colspan="7">%1$s</td>',
+				sprintf(
+					esc_html( $type_label['total'] ),
+					'<span class="qm-items-number">' . esc_html( number_format_i18n( $total ) ) . '</span>'
+				)
+			);
+			echo '</tr>';
+			echo '</tfoot>';
+
+			$this->after_tabular_output();
+		}
+
+	}
+
+	protected function dependency_rows( array $handles, WP_Dependencies $dependencies, $label, $type ) {
+		foreach ( $handles as $handle ) {
+
+			$dependency = $dependencies->query( $handle );
+
+			list( $src, $host, $source, $local ) = $this->get_dependency_data( $dependency, $dependencies, $type );
+
+			$qm_host = ( $local ) ? 'local' : __( 'Other', 'query-monitor' );
+
+			if ( in_array( $handle, $dependencies->done, true ) ) {
+				echo '<tr data-qm-subject="' . esc_attr( $type . '-' . $handle ) . '" data-qm-' . esc_attr( $type ) . '-host="' . esc_attr( $qm_host ) . '">';
+				echo '<td class="qm-nowrap">' . esc_html( $label ) . '</td>';
+			} else {
+				echo '<tr data-qm-subject="' . esc_attr( $type . '-' . $handle ) . '" data-qm-' . esc_attr( $type ) . '-host="' . esc_attr( $qm_host ) . '" class="qm-warn">';
+				echo '<td class="qm-nowrap"><span class="dashicons dashicons-warning" aria-hidden="true"></span>' . esc_html( $label ) . '</td>';
+			}
+
+			$this->dependency_row( $dependency, $dependencies, $type );
+
+			echo '</tr>';
+		}
+	}
+
+	protected function get_dependency_data( _WP_Dependency $dependency, WP_Dependencies $dependencies, $type ) {
+		$loader = rtrim( $type, 's' );
+
+		/**
+		 * Filter the asset loader source.
+		 *
+		 * The variable {$loader} can be either 'script' or 'style'.
+		 *
+		 * @param string $src    Script or style loader source path.
+		 * @param string $handle Script or style handle.
+		 */
+		$source = apply_filters( "{$loader}_loader_src", $dependency->src, $dependency->handle );
+
+		$host = (string) wp_parse_url( $source, PHP_URL_HOST );
+		// phpcs:ignore WordPress.VIP.ValidatedSanitizedInput
+		$http_host = wp_unslash( $_SERVER['HTTP_HOST'] );
+
+		if ( empty( $host ) && ! empty( $http_host ) ) {
+			$host = $http_host;
+		}
+
+		if ( is_wp_error( $source ) ) {
+			$src = $source->get_error_message();
+			if ( ( $error_data = $source->get_error_data() ) && isset( $error_data['src'] ) ) {
+				$src .= ' (' . $error_data['src'] . ')';
+				$host = (string) wp_parse_url( $error_data['src'], PHP_URL_HOST );
+			}
+		} elseif ( empty( $source ) ) {
+			$src = '';
+			$host = '';
+		} else {
+			$src = $source;
+		}
+
+		$local = ( $http_host === $host );
+
+		return array( $src, $host, $source, $local );
+	}
+
+	protected function dependency_row( _WP_Dependency $dependency, WP_Dependencies $dependencies, $type ) {
+
+		if ( empty( $dependency->ver ) ) {
+			$ver = '';
+		} else {
+			$ver = $dependency->ver;
+		}
+
+		list( $src, $host, $source, $local ) = $this->get_dependency_data( $dependency, $dependencies, $type );
+
+		$dependents = $this->collector->get_dependents( $dependency, $dependencies );
+		$deps = $dependency->deps;
+		sort( $deps );
+
+		foreach ( $deps as & $dep ) {
+			if ( ! $dependencies->query( $dep ) ) {
+				/* translators: %s: Script or style dependency name */
+				$dep = sprintf( __( '%s (missing)', 'query-monitor' ), $dep );
+			}
+		}
+
+		$this->type = $type;
+
+		$highlight_deps       = array_map( array( $this, '_prefix_type' ), $deps );
+		$highlight_dependents = array_map( array( $this, '_prefix_type' ), $dependents );
+
+		echo '<td class="qm-nowrap qm-ltr">' . esc_html( $dependency->handle ) . '</td>';
+		echo '<td class="qm-nowrap qm-ltr">' . esc_html( $host ) . '</td>';
+		echo '<td class="qm-ltr">';
+		if ( is_wp_error( $source ) ) {
+			printf(
+				 '<span class="qm-warn">%s</span>',
+				esc_html( $src )
+			);
+		} elseif ( ! empty( $src ) ) {
+			printf(
+				'<a href="%s" class="qm-link">%s</a>',
+				esc_attr( $src ),
+				esc_html( $src )
+			);
+		}
+		echo '</td>';
+		echo '<td class="qm-ltr qm-highlighter" data-qm-highlight="' . esc_attr( implode( ' ', $highlight_deps ) ) . '">' . implode( ', ', array_map( 'esc_html', $deps ) ) . '</td>';
+		echo '<td class="qm-ltr qm-highlighter" data-qm-highlight="' . esc_attr( implode( ' ', $highlight_dependents ) ) . '">' . implode( ', ', array_map( 'esc_html', $dependents ) ) . '</td>';
+		echo '<td class="qm-ltr">' . esc_html( $ver ) . '</td>';
+
+	}
+
+	public function _prefix_type( $val ) {
+		return $this->type . '-' . $val;
+	}
+
+	public function admin_class( array $class ) {
+
+		$data = $this->collector->get_data();
+
+		if ( ! empty( $data['broken'] ) or ! empty( $data['missing'] ) ) {
+			$class[] = 'qm-error';
+		}
+
+		return $class;
+
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+		$labels = array(
+			'scripts' => __( 'Scripts', 'query-monitor' ),
+			'styles'  => __( 'Styles', 'query-monitor' ),
+		);
+
+		foreach ( $labels as $type => $label ) {
+			$args = array(
+				'title' => esc_html( $label ),
+				'id'    => esc_attr( "query-monitor-{$this->collector->id}-{$type}" ),
+				'href'  => esc_attr( '#' . $this->collector->id() . '-' . $type ),
+			);
+
+			if ( ! empty( $data['broken'][ $type ] ) or ! empty( $data['missing'][ $type ] ) ) {
+				$args['meta']['classname'] = 'qm-error';
+			}
+
+			$menu[] = $this->menu( $args );
+		}
+
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_assets( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'assets' ) ) {
+		$output['assets'] = new QM_Output_Html_Assets( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_assets', 80, 2 );

--- a/query-monitor/output/html/caps.php
+++ b/query-monitor/output/html/caps.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * User capability checks output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Caps extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 105 );
+	}
+
+	public function output() {
+		if ( ! defined( 'QM_ENABLE_CAPS_PANEL' ) || ! QM_ENABLE_CAPS_PANEL ) {
+			$this->before_non_tabular_output();
+
+			echo '<div class="qm-section">';
+			echo '<div class="qm-notice">';
+			echo '<p>';
+			printf(
+				/* translators: %s: Configuration file name. */
+				esc_html__( 'For performance reasons, this panel is not enabled by default. To enable it, add the following code to your %s file:', 'query-monitor' ),
+				'<code>wp-config.php</code>'
+			);
+			echo '</p>';
+			echo "<p><code>define( 'QM_ENABLE_CAPS_PANEL', true );</code></p>";
+			echo '</div>';
+			echo '</div>';
+
+			$this->after_non_tabular_output();
+
+			return;
+		}
+
+		$data = $this->collector->get_data();
+
+		if ( ! empty( $data['caps'] ) ) {
+			$this->before_tabular_output();
+
+			$results = array(
+				'true',
+				'false',
+			);
+			$show_user  = ( count( $data['users'] ) > 1 );
+			$parts      = $data['parts'];
+			$components = $data['components'];
+
+			usort( $parts, 'strcasecmp' );
+			usort( $components, 'strcasecmp' );
+
+			echo '<thead>';
+			echo '<tr>';
+			echo '<th scope="col" class="qm-filterable-column">';
+			echo $this->build_filter( 'name', $parts, __( 'Capability Check', 'query-monitor' ) ); // WPCS: XSS ok;
+			echo '</th>';
+
+			if ( $show_user ) {
+				$users = $data['users'];
+
+				usort( $users, 'strcasecmp' );
+
+				echo '<th scope="col" class="qm-filterable-column qm-num">';
+				echo $this->build_filter( 'user', $users, __( 'User', 'query-monitor' ) ); // WPCS: XSS ok;
+				echo '</th>';
+			}
+
+			echo '<th scope="col" class="qm-filterable-column">';
+			echo $this->build_filter( 'result', $results, __( 'Result', 'query-monitor' ) ); // WPCS: XSS ok;
+			echo '</th>';
+			echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+			echo '<th scope="col" class="qm-filterable-column">';
+			echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+			echo '</th>';
+			echo '</tr>';
+			echo '</thead>';
+
+			echo '<tbody>';
+
+			foreach ( $data['caps'] as $row ) {
+				$component = $row['trace']->get_component();
+
+				$row_attr = array();
+				$row_attr['data-qm-name']      = implode( ' ', $row['parts'] );
+				$row_attr['data-qm-user']      = $row['user'];
+				$row_attr['data-qm-component'] = $component->name;
+				$row_attr['data-qm-result']    = ( $row['result'] ) ? 'true' : 'false';
+
+				if ( 'core' !== $component->context ) {
+					$row_attr['data-qm-component'] .= ' non-core';
+				}
+
+				if ( '' === $row['name'] ) {
+					$row_attr['class'] = 'qm-warn';
+				}
+
+				$attr = '';
+
+				foreach ( $row_attr as $a => $v ) {
+					$attr .= ' ' . $a . '="' . esc_attr( $v ) . '"';
+				}
+
+				printf( // WPCS: XSS ok.
+					'<tr %s>',
+					$attr
+				);
+
+				$name = esc_html( $row['name'] );
+
+				if ( ! empty( $row['args'] ) ) {
+					foreach ( $row['args'] as $arg ) {
+						$name .= ',&nbsp;' . esc_html( QM_Util::display_variable( $arg ) );
+					}
+				}
+
+				printf( // WPCS: XSS ok.
+					'<td class="qm-ltr qm-nowrap"><code>%s</code></td>',
+					$name
+				);
+
+				if ( $show_user ) {
+					printf(
+						'<td class="qm-num">%s</td>',
+						esc_html( $row['user'] )
+					);
+				}
+
+				$result = ( $row['result'] ) ? '<span class="qm-true">true&nbsp;&#x2713;</span>' : 'false';
+				printf( // WPCS: XSS ok.
+					'<td class="qm-ltr qm-nowrap">%s</td>',
+					$result
+				);
+
+				$stack          = array();
+				$trace          = $row['trace']->get_trace();
+				$filtered_trace = $row['trace']->get_display_trace();
+
+				$last = end( $filtered_trace );
+				if ( isset( $last['function'] ) && 'map_meta_cap' === $last['function'] ) {
+					array_pop( $filtered_trace ); // remove the map_meta_cap() call
+				}
+
+				array_pop( $filtered_trace ); // remove the WP_User->has_cap() call
+				array_pop( $filtered_trace ); // remove the *_user_can() call
+
+				if ( ! count( $filtered_trace ) ) {
+					$responsible_name = QM_Util::standard_dir( $trace[1]['file'], '' ) . ':' . $trace[1]['line'];
+
+					$responsible_item = $trace[1];
+					$responsible_item['display'] = $responsible_name;
+					$responsible_item['calling_file'] = $trace[1]['file'];
+					$responsible_item['calling_line'] = $trace[1]['line'];
+					array_unshift( $filtered_trace, $responsible_item );
+				}
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = self::output_filename( $item['display'], $item['calling_file'], $item['calling_line'] );
+				}
+
+				echo '<td class="qm-has-toggle qm-nowrap qm-ltr"><ol class="qm-toggler qm-numbered">';
+
+				$caller = array_pop( $stack );
+
+				if ( ! empty( $stack ) ) {
+					echo self::build_toggler(); // WPCS: XSS ok;
+					echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>'; // WPCS: XSS ok.
+				}
+
+				echo "<li>{$caller}</li>"; // WPCS: XSS ok.
+				echo '</ol></td>';
+
+				printf(
+					'<td class="qm-nowrap">%s</td>',
+					esc_html( $component->name )
+				);
+
+				echo '</tr>';
+
+			}
+
+			echo '</tbody>';
+
+			echo '<tfoot>';
+
+			$colspan = ( $show_user ) ? 5 : 4;
+
+			echo '<tr>';
+			echo '<td colspan="' . absint( $colspan ) . '">';
+			printf(
+				/* translators: %s: Number of user capability checks */
+				esc_html_x( 'Total: %s', 'User capability checks', 'query-monitor' ),
+				'<span class="qm-items-number">' . esc_html( number_format_i18n( count( $data['caps'] ) ) ) . '</span>'
+			);
+			echo '</td>';
+			echo '</tr>';
+			echo '</tfoot>';
+
+			$this->after_tabular_output();
+		} else {
+			$this->before_non_tabular_output();
+
+			$notice = __( 'No capability checks were recorded.', 'query-monitor' );
+			echo $this->build_notice( $notice ); // WPCS: XSS ok.
+
+			$this->after_non_tabular_output();
+		}
+	}
+
+	public function admin_menu( array $menu ) {
+		$menu[] = $this->menu( array(
+			'title' => $this->collector->name(),
+		) );
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_caps( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'caps' ) ) {
+		$output['caps'] = new QM_Output_Html_Caps( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_caps', 105, 2 );

--- a/query-monitor/output/html/conditionals.php
+++ b/query-monitor/output/html/conditionals.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Template conditionals output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Conditionals extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 1000 );
+		add_filter( 'qm/output/panel_menus', array( $this, 'panel_menu' ), 1000 );
+	}
+
+	public function output() {
+		$data = $this->collector->get_data();
+
+		$this->before_non_tabular_output();
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'True Conditionals', 'query-monitor' ) . '</h3>';
+
+		foreach ( $data['conds']['true'] as $cond ) {
+			echo '<p class="qm-item qm-ltr qm-true"><code>' . esc_html( $cond ) . '()</code></p>';
+		}
+
+		echo '</div>';
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'False Conditionals', 'query-monitor' ) . '</h3>';
+
+		foreach ( $data['conds']['false'] as $cond ) {
+			echo '<p class="qm-item qm-ltr qm-false"><code>' . esc_html( $cond ) . '()</code></p>';
+		}
+
+		echo '</div>';
+
+		$this->after_non_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+
+		foreach ( $data['conds']['true'] as $cond ) {
+			$menu[ "conditionals-{$cond}" ] = $this->menu( array(
+				'title' => esc_html( $cond . '()' ),
+				'id'    => 'query-monitor-conditionals-' . esc_attr( $cond ),
+				'meta'  => array(
+					'classname' => 'qm-true qm-ltr',
+				),
+			) );
+		}
+
+		return $menu;
+
+	}
+
+	public function panel_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+
+		foreach ( $data['conds']['true'] as $cond ) {
+			unset( $menu[ "conditionals-{$cond}" ] );
+		}
+
+		$menu['conditionals'] = $this->menu( array(
+			'title' => esc_html__( 'Conditionals', 'query-monitor' ),
+			'id'    => 'query-monitor-conditionals',
+		) );
+
+		return $menu;
+
+	}
+
+
+}
+
+function register_qm_output_html_conditionals( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'conditionals' ) ) {
+		$output['conditionals'] = new QM_Output_Html_Conditionals( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_conditionals', 50, 2 );

--- a/query-monitor/output/html/db_callers.php
+++ b/query-monitor/output/html/db_callers.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Database query calling function output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_DB_Callers extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 30 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['types'] ) ) {
+			return;
+		}
+
+		$total_time  = 0;
+
+		if ( ! empty( $data['times'] ) ) {
+			$this->before_tabular_output();
+
+			echo '<thead>';
+			echo '<tr>';
+			echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+
+			foreach ( $data['types'] as $type_name => $type_count ) {
+				echo '<th scope="col" class="qm-num qm-ltr qm-sortable-column" role="columnheader" aria-sort="none">';
+				echo $this->build_sorter( $type_name ); // WPCS: XSS ok;
+				echo '</th>';
+			}
+
+			echo '<th scope="col" class="qm-num qm-sorted-desc qm-sortable-column" role="columnheader" aria-sort="descending">';
+			echo $this->build_sorter( __( 'Time', 'query-monitor' ) ); // WPCS: XSS ok;
+			echo '</th>';
+			echo '</tr>';
+			echo '</thead>';
+
+			echo '<tbody>';
+
+			foreach ( $data['times'] as $row ) {
+				$total_time  += $row['ltime'];
+				$stime = number_format_i18n( $row['ltime'], 4 );
+
+				echo '<tr>';
+				echo '<td class="qm-ltr"><a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="caller" data-qm-value="' . esc_attr( $row['caller'] ) . '"><code>' . esc_html( $row['caller'] ) . '</code></a></td>';
+
+				foreach ( $data['types'] as $type_name => $type_count ) {
+					if ( isset( $row['types'][ $type_name ] ) ) {
+						echo "<td class='qm-num'>" . esc_html( number_format_i18n( $row['types'][ $type_name ] ) ) . '</td>';
+					} else {
+						echo "<td class='qm-num'>&nbsp;</td>";
+					}
+				}
+
+				echo '<td class="qm-num" data-qm-sort-weight="' . esc_attr( $row['ltime'] ) . '">' . esc_html( $stime ) . '</td>';
+				echo '</tr>';
+
+			}
+
+			echo '</tbody>';
+			echo '<tfoot>';
+
+			$total_stime = number_format_i18n( $total_time, 4 );
+
+			echo '<tr>';
+			echo '<td>&nbsp;</td>';
+
+			foreach ( $data['types'] as $type_name => $type_count ) {
+				echo '<td class="qm-num">' . esc_html( number_format_i18n( $type_count ) ) . '</td>';
+			}
+
+			echo '<td class="qm-num">' . esc_html( $total_stime ) . '</td>';
+			echo '</tr>';
+
+			echo '</tfoot>';
+
+			$this->after_tabular_output();
+		} else {
+			$this->before_non_tabular_output();
+
+			echo '<div class="qm-none">';
+			echo '<p>' . esc_html__( 'None', 'query-monitor' ) . '</p>';
+			echo '</div>';
+
+			$this->after_non_tabular_output();
+		}
+	}
+
+	public function admin_menu( array $menu ) {
+
+		if ( $dbq = QM_Collectors::get( 'db_queries' ) ) {
+			$dbq_data = $dbq->get_data();
+			if ( isset( $dbq_data['times'] ) ) {
+				$menu[] = $this->menu( array(
+					'title' => esc_html__( 'Queries by Caller', 'query-monitor' ),
+				) );
+			}
+		}
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_db_callers( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'db_callers' ) ) {
+		$output['db_callers'] = new QM_Output_Html_DB_Callers( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_db_callers', 30, 2 );

--- a/query-monitor/output/html/db_components.php
+++ b/query-monitor/output/html/db_components.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Database query calling component output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_DB_Components extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 40 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['types'] ) || empty( $data['times'] ) ) {
+			return;
+		}
+
+		$total_time  = 0;
+		$span = count( $data['types'] ) + 2;
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+
+		foreach ( $data['types'] as $type_name => $type_count ) {
+			echo '<th scope="col" class="qm-num qm-sortable-column" role="columnheader" aria-sort="none">';
+			echo $this->build_sorter( $type_name ); // WPCS: XSS ok;
+			echo '</th>';
+		}
+
+		echo '<th scope="col" class="qm-num qm-sorted-desc qm-sortable-column" role="columnheader" aria-sort="descending">';
+		echo $this->build_sorter( __( 'Time', 'query-monitor' ) ); // WPCS: XSS ok;
+		echo '</th>';
+		echo '</tr>';
+
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		foreach ( $data['times'] as $row ) {
+			$total_time  += $row['ltime'];
+
+			echo '<tr>';
+			echo '<td class="qm-row-component"><a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="component" data-qm-value="' . esc_attr( $row['component'] ) . '">' . esc_html( $row['component'] ) . '</a></td>';
+
+			foreach ( $data['types'] as $type_name => $type_count ) {
+				if ( isset( $row['types'][ $type_name ] ) ) {
+					echo '<td class="qm-num">' . esc_html( number_format_i18n( $row['types'][ $type_name ] ) ) . '</td>';
+				} else {
+					echo '<td class="qm-num">&nbsp;</td>';
+				}
+			}
+
+			echo '<td class="qm-num" data-qm-sort-weight="' . esc_attr( $row['ltime'] ) . '">' . esc_html( number_format_i18n( $row['ltime'], 4 ) ) . '</td>';
+			echo '</tr>';
+
+		}
+
+		echo '</tbody>';
+		echo '<tfoot>';
+
+		$total_stime = number_format_i18n( $total_time, 4 );
+
+		echo '<tr>';
+		echo '<td>&nbsp;</td>';
+
+		foreach ( $data['types'] as $type_name => $type_count ) {
+			echo '<td class="qm-num">' . esc_html( number_format_i18n( $type_count ) ) . '</td>';
+		}
+
+		echo '<td class="qm-num">' . esc_html( $total_stime ) . '</td>';
+		echo '</tr>';
+		echo '</tfoot>';
+
+		$this->after_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['types'] ) || empty( $data['times'] ) ) {
+			return $menu;
+		}
+
+		if ( $dbq = QM_Collectors::get( 'db_queries' ) ) {
+			$dbq_data = $dbq->get_data();
+			if ( isset( $dbq_data['component_times'] ) ) {
+				$menu[] = $this->menu( array(
+					'title' => esc_html__( 'Queries by Component', 'query-monitor' ),
+				) );
+			}
+		}
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_db_components( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'db_components' ) ) {
+		$output['db_components'] = new QM_Output_Html_DB_Components( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_db_components', 40, 2 );

--- a/query-monitor/output/html/db_dupes.php
+++ b/query-monitor/output/html/db_dupes.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Duplicate database query output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_DB_Dupes extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 45 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['dupes'] ) ) {
+			return;
+		}
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-num">' . esc_html__( 'Count', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Callers', 'query-monitor' ) . '</th>';
+		if ( ! empty( $data['dupe_components'] ) ) {
+			echo '<th scope="col">' . esc_html__( 'Components', 'query-monitor' ) . '</th>';
+		}
+		echo '<th scope="col">' . esc_html__( 'Potential Troublemakers', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		/* translators: %s: Number of calls to a PHP function */
+		$call_text = _n_noop( '%s call', '%s calls', 'query-monitor' );
+
+		foreach ( $data['dupes'] as $sql => $queries ) {
+
+			// This should probably happen in the collector's processor
+			$type    = QM_Util::get_query_type( $sql );
+			$sql_out = self::format_sql( $sql );
+
+			if ( 'SELECT' !== $type ) {
+				$sql_out = "<span class='qm-nonselectsql'>{$sql_out}</span>";
+			}
+
+			echo '<tr>';
+			echo '<td class="qm-row-sql qm-ltr qm-wrap">';
+			echo $sql_out; // WPCS: XSS ok;
+			echo '</td>';
+			echo '<td class="qm-num">';
+			echo esc_html( number_format_i18n( count( $queries ), 0 ) );
+			echo '</td>';
+			echo '<td class="qm-row-caller qm-nowrap qm-ltr">';
+			foreach ( $data['dupe_callers'][ $sql ] as $caller => $calls ) {
+				printf(
+					'<a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="caller" data-qm-value="%s"><code>%s</code></a><br><span class="qm-info qm-supplemental">%s</span><br>',
+					esc_attr( $caller ),
+					esc_html( $caller ),
+					esc_html( sprintf(
+						translate_nooped_plural( $call_text, $calls, 'query-monitor' ),
+						number_format_i18n( $calls )
+					) )
+				);
+			}
+			echo '</td>';
+			if ( isset( $data['dupe_components'][ $sql ] ) ) {
+				echo '<td class="qm-row-component qm-nowrap">';
+				foreach ( $data['dupe_components'][ $sql ] as $component => $calls ) {
+					printf(
+						'%s<br><span class="qm-info qm-supplemental">%s</span><br>',
+						esc_html( $component ),
+						esc_html( sprintf(
+							translate_nooped_plural( $call_text, $calls, 'query-monitor' ),
+							number_format_i18n( $calls )
+						) )
+					);
+				}
+				echo '</td>';
+			}
+			echo '<td class="qm-row-caller qm-nowrap qm-ltr">';
+			foreach ( $data['dupe_sources'][ $sql ] as $source => $calls ) {
+				printf(
+					'<code>%s</code><br><span class="qm-info qm-supplemental">%s</span><br>',
+					esc_html( $source ),
+					esc_html( sprintf(
+						translate_nooped_plural( $call_text, $calls, 'query-monitor' ),
+						number_format_i18n( $calls )
+					) )
+				);
+			}
+			echo '</td>';
+			echo '</tr>';
+		}
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+
+		if ( $dbq = QM_Collectors::get( 'db_dupes' ) ) {
+			$dbq_data = $dbq->get_data();
+			if ( isset( $dbq_data['dupes'] ) && count( $dbq_data['dupes'] ) ) {
+				$menu[] = $this->menu( array(
+					'title' => esc_html( sprintf(
+						/* translators: %s: Number of duplicate database queries */
+						__( 'Duplicate Queries (%s)', 'query-monitor' ),
+						count( $dbq_data['dupes'] )
+					) ),
+				) );
+			}
+		}
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_db_dupes( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'db_dupes' ) ) {
+		$output['db_dupes'] = new QM_Output_Html_DB_Dupes( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_db_dupes', 45, 2 );

--- a/query-monitor/output/html/db_queries.php
+++ b/query-monitor/output/html/db_queries.php
@@ -1,0 +1,527 @@
+<?php
+/**
+ * Database query output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_DB_Queries extends QM_Output_Html {
+
+	public $query_row = 0;
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 20 );
+		add_filter( 'qm/output/title', array( $this, 'admin_title' ), 20 );
+		add_filter( 'qm/output/menu_class', array( $this, 'admin_class' ) );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['dbs'] ) ) {
+			$this->output_empty_queries();
+			return;
+		}
+
+		if ( ! empty( $data['errors'] ) ) {
+			$this->output_error_queries( $data['errors'] );
+		}
+
+		if ( ! empty( $data['expensive'] ) ) {
+			$this->output_expensive_queries( $data['expensive'] );
+		}
+
+		foreach ( $data['dbs'] as $name => $db ) {
+			$this->output_queries( $name, $db, $data );
+		}
+
+	}
+
+	protected function output_empty_queries() {
+		$id = sprintf(
+			'%s-wpdb',
+			$this->collector->id()
+		);
+		$this->before_non_tabular_output( $id );
+
+		if ( ! SAVEQUERIES ) {
+			$notice = sprintf(
+				/* translators: 1: Name of PHP constant, 2: Value of PHP constant */
+				esc_html__( 'No database queries were logged because the %1$s constant is set to %2$s.', 'query-monitor' ),
+				'<code>SAVEQUERIES</code>',
+				'<code>false</code>'
+			);
+		} else {
+			$notice = __( 'No database queries were logged.', 'query-monitor' );
+		}
+
+		echo $this->build_notice( $notice ); // WPCS: XSS ok.
+		$this->after_non_tabular_output();
+	}
+
+	protected function output_error_queries( array $errors ) {
+		$this->before_tabular_output( 'qm-query-errors', __( 'Database Errors', 'query-monitor' ) );
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Error Message', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Error Code', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+		echo '<tbody>';
+
+		foreach ( $errors as $row ) {
+			$this->output_query_row( $row, array( 'sql', 'caller', 'component', 'errno', 'result' ) );
+		}
+
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	protected function output_expensive_queries( array $expensive ) {
+		$dp = strlen( substr( strrchr( QM_DB_EXPENSIVE, '.' ), 1 ) );
+
+		$panel_name = sprintf(
+			/* translators: %s: Database query time in seconds */
+			esc_html__( 'Slow Database Queries (above %ss)', 'query-monitor' ),
+			'<span class="qm-warn">' . esc_html( number_format_i18n( QM_DB_EXPENSIVE, $dp ) ) . '</span>'
+		);
+		$this->before_tabular_output( 'qm-query-expensive', $panel_name );
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Query', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+
+		if ( isset( $expensive[0]['component'] ) ) {
+			echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+		}
+
+		if ( isset( $expensive[0]['result'] ) ) {
+			echo '<th scope="col" class="qm-num">' . esc_html__( 'Rows', 'query-monitor' ) . '</th>';
+		}
+
+		echo '<th scope="col" class="qm-num">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+		echo '<tbody>';
+
+		foreach ( $expensive as $row ) {
+			$this->output_query_row( $row, array( 'sql', 'caller', 'component', 'result', 'time' ) );
+		}
+
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	protected function output_queries( $name, stdClass $db, array $data ) {
+		$this->query_row = 0;
+		$span = 4;
+
+		if ( $db->has_result ) {
+			$span++;
+		}
+		if ( $db->has_trace ) {
+			$span++;
+		}
+
+		$panel_id = sprintf(
+			'%s-%s',
+			$this->collector->id(),
+			sanitize_title_with_dashes( $name )
+		);
+		$panel_name = sprintf(
+			/* translators: %s: Name of database controller */
+			__( '%s Queries', 'query-monitor' ),
+			$name
+		);
+
+		if ( ! empty( $db->rows ) ) {
+			$this->before_tabular_output( $panel_id, $panel_name );
+
+			echo '<thead>';
+
+			/**
+			 * Filter whether to show the QM extended query information prompt.
+			 *
+			 * By default QM shows a prompt to install the QM db.php drop-in,
+			 * this filter allows a dev to choose not to show the prompt.
+			 *
+			 * @param bool $show_prompt Whether to show the prompt.
+			 */
+			if ( apply_filters( 'qm/show_extended_query_prompt', true ) && ! $db->has_trace && ( '$wpdb' === $name ) ) {
+				echo '<tr>';
+				echo '<th colspan="' . absint( $span ) . '" class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+				if ( file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
+					/* translators: 1: Symlink file name, 2: URL to wiki page */
+					$message = __( 'Extended query information such as the component and affected rows is not available. A conflicting %1$s file is present. <a href="%2$s" target="_blank" class="qm-external-link">See this wiki page for more information.</a>', 'query-monitor' );
+				} else {
+					/* translators: 1: Symlink file name, 2: URL to wiki page */
+					$message = __( 'Extended query information such as the component and affected rows is not available. Query Monitor was unable to symlink its %1$s file into place. <a href="%2$s" target="_blank" class="qm-external-link">See this wiki page for more information.</a>', 'query-monitor' );
+				}
+				echo wp_kses( sprintf(
+					$message,
+					'<code>db.php</code>',
+					'https://github.com/johnbillion/query-monitor/wiki/db.php-Symlink'
+				), array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+						'class'  => array(),
+					),
+				) );
+				echo '</th>';
+				echo '</tr>';
+			}
+
+			$types      = array_keys( $db->types );
+			$prepend    = array();
+			$callers    = wp_list_pluck( $data['times'], 'caller' );
+
+			sort( $types );
+			usort( $callers, 'strcasecmp' );
+
+			if ( count( $types ) > 1 ) {
+				$prepend['non-select'] = __( 'Non-SELECT', 'query-monitor' );
+			}
+
+			$args = array(
+				'prepend' => $prepend,
+			);
+
+			echo '<tr>';
+			echo '<th scope="col" class="qm-sorted-asc qm-sortable-column" role="columnheader" aria-sort="ascending">';
+			echo $this->build_sorter( '#' ); // WPCS: XSS ok;
+			echo '</th>';
+			echo '<th scope="col" class="qm-filterable-column">';
+			echo $this->build_filter( 'type', $types, __( 'Query', 'query-monitor' ), $args ); // WPCS: XSS ok;
+			echo '</th>';
+			echo '<th scope="col" class="qm-filterable-column">';
+
+			$prepend = array();
+
+			if ( $db->has_main_query ) {
+				$prepend['qm-main-query'] = __( 'Main Query', 'query-monitor' );
+			}
+
+			$args = array(
+				'prepend' => $prepend,
+			);
+			echo $this->build_filter( 'caller', $callers, __( 'Caller', 'query-monitor' ), $args ); // WPCS: XSS ok.
+			echo '</th>';
+
+			if ( $db->has_trace ) {
+				$components = wp_list_pluck( $data['component_times'], 'component' );
+
+				usort( $components, 'strcasecmp' );
+
+				echo '<th scope="col" class="qm-filterable-column">';
+				echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+				echo '</th>';
+			}
+
+			if ( $db->has_result ) {
+				if ( empty( $data['errors'] ) ) {
+					$class = 'qm-num';
+				} else {
+					$class = '';
+				}
+				echo '<th scope="col" class="' . esc_attr( $class ) . ' qm-sortable-column" role="columnheader" aria-sort="none">';
+				echo $this->build_sorter( __( 'Rows', 'query-monitor' ) ); // WPCS: XSS ok.
+				echo '</th>';
+			}
+
+			echo '<th scope="col" class="qm-num qm-sortable-column" role="columnheader" aria-sort="none">';
+			echo $this->build_sorter( __( 'Time', 'query-monitor' ) ); // WPCS: XSS ok.
+			echo '</th>';
+			echo '</tr>';
+			echo '</thead>';
+
+			echo '<tbody>';
+
+			foreach ( $db->rows as $row ) {
+				$this->output_query_row( $row, array( 'row', 'sql', 'caller', 'component', 'result', 'time' ) );
+			}
+
+			echo '</tbody>';
+			echo '<tfoot>';
+
+			$total_stime = number_format_i18n( $db->total_time, 4 );
+
+			echo '<tr>';
+			echo '<td colspan="' . absint( $span - 1 ) . '">';
+			printf(
+				/* translators: %s: Number of database queries */
+				esc_html_x( 'Total: %s', 'Database queries', 'query-monitor' ),
+				'<span class="qm-items-number">' . esc_html( number_format_i18n( $db->total_qs ) ) . '</span>'
+			);
+			echo '</td>';
+			echo '<td class="qm-num qm-items-time">' . esc_html( $total_stime ) . '</td>';
+			echo '</tr>';
+			echo '</tfoot>';
+
+			$this->after_tabular_output();
+		} else {
+			$this->before_non_tabular_output( $panel_id, $panel_name );
+
+			$notice = __( 'No queries! Nice work.', 'query-monitor' );
+			echo $this->build_notice( $notice ); // WPCS: XSS ok.
+
+			$this->after_non_tabular_output();
+		}
+	}
+
+	protected function output_query_row( array $row, array $cols ) {
+
+		$cols = array_flip( $cols );
+
+		if ( ! isset( $row['component'] ) ) {
+			unset( $cols['component'] );
+		}
+		if ( ! isset( $row['result'] ) ) {
+			unset( $cols['result'], $cols['errno'] );
+		}
+
+		$stime = number_format_i18n( $row['ltime'], 4 );
+		$td = $this->collector->is_expensive( $row ) ? ' qm-warn' : '';
+
+		$sql = self::format_sql( $row['sql'] );
+
+		if ( 'SELECT' !== $row['type'] ) {
+			$sql = "<span class='qm-nonselectsql'>{$sql}</span>";
+		}
+
+		if ( isset( $row['trace'] ) ) {
+
+			$caller         = $row['trace']->get_caller();
+			$caller_name    = self::output_filename( $row['caller'], $caller['calling_file'], $caller['calling_line'] );
+			$stack          = array();
+			$filtered_trace = $row['trace']->get_display_trace();
+			array_pop( $filtered_trace );
+
+			foreach ( $filtered_trace as $item ) {
+				$stack[] = self::output_filename( $item['display'], $item['calling_file'], $item['calling_line'] );
+			}
+		} else {
+
+			$caller_name = '<code>' . esc_html( $row['caller'] ) . '</code>';
+			$stack       = explode( ', ', $row['stack'] );
+			$stack       = array_reverse( $stack );
+			array_shift( $stack );
+			$stack       = array_map( function( $item ) {
+				return '<code>' . esc_html( $item ) . '</code>';
+			}, $stack );
+
+		}
+
+		$row_attr = array();
+
+		if ( is_wp_error( $row['result'] ) ) {
+			$row_attr['class'] = 'qm-warn';
+		}
+		if ( isset( $cols['sql'] ) ) {
+			$row_attr['data-qm-type'] = $row['type'];
+			if ( 'SELECT' !== $row['type'] ) {
+				$row_attr['data-qm-type'] .= ' non-select';
+			}
+		}
+		if ( isset( $cols['component'] ) && $row['component'] ) {
+			$row_attr['data-qm-component'] = $row['component']->name;
+
+			if ( 'core' !== $row['component']->context ) {
+				$row_attr['data-qm-component'] .= ' non-core';
+			}
+		}
+		if ( isset( $cols['caller'] ) ) {
+			$row_attr['data-qm-caller'] = $row['caller_name'];
+
+			if ( $row['is_main_query'] ) {
+				$row_attr['data-qm-caller'] .= ' qm-main-query';
+			}
+		}
+		if ( isset( $cols['time'] ) ) {
+			$row_attr['data-qm-time'] = $row['ltime'];
+		}
+
+		$attr = '';
+
+		foreach ( $row_attr as $a => $v ) {
+			$attr .= ' ' . $a . '="' . esc_attr( $v ) . '"';
+		}
+
+		echo "<tr{$attr}>"; // WPCS: XSS ok.
+
+		if ( isset( $cols['row'] ) ) {
+			echo '<th scope="row" class="qm-row-num qm-num">' . absint( ++$this->query_row ) . '</th>';
+		}
+
+		if ( isset( $cols['sql'] ) ) {
+			printf( // WPCS: XSS ok.
+				'<td class="qm-row-sql qm-ltr qm-wrap">%s</td>',
+				$sql
+			);
+		}
+
+		if ( isset( $cols['caller'] ) ) {
+			echo "<td class='qm-row-caller qm-ltr qm-has-toggle qm-nowrap'><ol class='qm-toggler qm-numbered'>";
+			echo self::build_toggler(); // WPCS: XSS ok;
+
+			if ( ! empty( $stack ) ) {
+				echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>'; // WPCS: XSS ok.
+			}
+
+			echo "<li>{$caller_name}</li>"; // WPCS: XSS ok.
+
+			echo '</ol>';
+			if ( $row['is_main_query'] ) {
+				printf(
+					'<p>%s</p>',
+					esc_html__( 'Main Query', 'query-monitor' )
+				);
+			}
+			echo '</td>';
+		}
+
+		if ( isset( $cols['stack'] ) ) {
+			echo '<td class="qm-row-caller qm-row-stack qm-nowrap qm-ltr"><ol class="qm-numbered">';
+			if ( ! empty( $stack ) ) {
+				echo '<li>' . implode( '</li><li>', $stack ) . '</li>'; // WPCS: XSS ok.
+			}
+			echo "<li>{$caller_name}</li>"; // WPCS: XSS ok.
+			echo '</ol></td>';
+		}
+
+		if ( isset( $cols['component'] ) ) {
+			if ( $row['component'] ) {
+			echo "<td class='qm-row-component qm-nowrap'>" . esc_html( $row['component']->name ) . "</td>\n";
+			} else {
+				echo "<td class='qm-row-component qm-nowrap'>" . esc_html__( 'Unknown', 'query-monitor' ) . "</td>\n";
+			}
+		}
+
+		if ( isset( $cols['result'] ) ) {
+			if ( is_wp_error( $row['result'] ) ) {
+				echo "<td class='qm-row-result qm-row-error'><span class='dashicons dashicons-warning' aria-hidden='true'></span>" . esc_html( $row['result']->get_error_message() ) . "</td>\n";
+			} else {
+				echo "<td class='qm-row-result qm-num'>" . esc_html( $row['result'] ) . "</td>\n";
+			}
+		}
+
+		if ( isset( $cols['errno'] ) && is_wp_error( $row['result'] ) ) {
+			echo "<td class='qm-row-result qm-row-error'>" . esc_html( $row['result']->get_error_code() ) . "</td>\n";
+		}
+
+		if ( isset( $cols['time'] ) ) {
+			echo '<td class="qm-num qm-row-time' . esc_attr( $td ) . '" data-qm-sort-weight="' . esc_attr( $row['ltime'] ) . '">' . esc_html( $stime ) . "</td>\n";
+		}
+
+		echo '</tr>';
+
+	}
+
+	public function admin_title( array $title ) {
+
+		$data = $this->collector->get_data();
+
+		if ( isset( $data['dbs'] ) ) {
+			foreach ( $data['dbs'] as $key => $db ) {
+				$title[] = sprintf(
+					/* translators: %s: Database query time in seconds */
+					'%s' . esc_html_x( '%s S', 'Query time', 'query-monitor' ),
+					( count( $data['dbs'] ) > 1 ? '&bull;&nbsp;&nbsp;&nbsp;' : '' ),
+					number_format_i18n( $db->total_time, 4 )
+				);
+				$title[] = sprintf(
+					/* translators: %s: Number of database queries */
+					esc_html_x( '%s Q', 'Query count', 'query-monitor' ),
+					number_format_i18n( $db->total_qs )
+				);
+			}
+		}
+
+		foreach ( $title as &$t ) {
+			$t = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', $t );
+		}
+
+		return $title;
+	}
+
+	public function admin_class( array $class ) {
+
+		if ( $this->collector->get_errors() ) {
+			$class[] = 'qm-error';
+		}
+		if ( $this->collector->get_expensive() ) {
+			$class[] = 'qm-expensive';
+		}
+		return $class;
+
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+
+		if ( $errors = $this->collector->get_errors() ) {
+			$menu[] = $this->menu( array(
+				'id'    => 'query-monitor-errors',
+				'href'  => '#qm-query-errors',
+				'title' => esc_html( sprintf(
+					/* translators: %s: Number of database errors */
+					__( 'Database Errors (%s)', 'query-monitor' ),
+					number_format_i18n( count( $errors ) )
+				) ),
+			) );
+		}
+		if ( $expensive = $this->collector->get_expensive() ) {
+			$menu[] = $this->menu( array(
+				'id'    => 'query-monitor-expensive',
+				'href'  => '#qm-query-expensive',
+				'title' => esc_html( sprintf(
+					/* translators: %s: Number of slow database queries */
+					__( 'Slow Queries (%s)', 'query-monitor' ),
+					number_format_i18n( count( $expensive ) )
+				) ),
+			) );
+		}
+
+		if ( isset( $data['dbs'] ) and count( $data['dbs'] ) > 1 ) {
+			foreach ( $data['dbs'] as $name => $db ) {
+				$menu[] = $this->menu( array(
+					'id'    => esc_attr( sprintf( 'query-monitor-%s-db-%s', $this->collector->id(), sanitize_title_with_dashes( $name ) ) ),
+					'title' => esc_html( sprintf(
+						/* translators: %s: Name of database controller */
+						__( 'Queries: %s', 'query-monitor' ),
+						$name
+					) ),
+					'href'  => esc_attr( sprintf( '#%s-%s', $this->collector->id(), sanitize_title_with_dashes( $name ) ) ),
+				) );
+			}
+		} else {
+			$menu[] = $this->menu( array(
+				'title' => esc_html__( 'Queries', 'query-monitor' ),
+				'href'  => esc_attr( sprintf( '#%s-wpdb', $this->collector->id() ) ),
+			) );
+		}
+
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_db_queries( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'db_queries' ) ) {
+		$output['db_queries'] = new QM_Output_Html_DB_Queries( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_db_queries', 20, 2 );

--- a/query-monitor/output/html/debug_bar.php
+++ b/query-monitor/output/html/debug_bar.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * 'Debug Bar' output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Debug_Bar extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 200 );
+	}
+
+	public function output() {
+		$target = sanitize_html_class( get_class( $this->collector->get_panel() ) );
+
+		$this->before_debug_bar_output();
+
+		echo '<div id="debug-menu-target-' . esc_attr( $target ) . '" class="debug-menu-target qm-debug-bar-output">';
+
+		ob_start();
+		$this->collector->render();
+		$panel = ob_get_clean();
+
+		$panel = str_replace( array(
+			'<h4',
+			'<h3',
+			'<h2',
+			'<h1',
+			'</h4>',
+			'</h3>',
+			'</h2>',
+			'</h1>',
+		), array(
+			'<h5',
+			'<h4',
+			'<h3',
+			'<h2',
+			'</h5>',
+			'</h4>',
+			'</h3>',
+			'</h2>',
+		), $panel );
+
+		echo $panel; // @codingStandardsIgnoreLine
+
+		echo '</div>';
+
+		$this->after_debug_bar_output();
+	}
+
+}
+
+function register_qm_output_html_debug_bar( array $output, QM_Collectors $collectors ) {
+	global $debug_bar;
+
+	if ( empty( $debug_bar ) ) {
+		return $output;
+	}
+
+	foreach ( $debug_bar->panels as $panel ) {
+		$panel_id  = strtolower( sanitize_html_class( get_class( $panel ) ) );
+		$collector = QM_Collectors::get( "debug_bar_{$panel_id}" );
+
+		if ( $collector and $collector->is_visible() ) {
+			$output[ "debug_bar_{$panel_id}" ] = new QM_Output_Html_Debug_Bar( $collector );
+		}
+	}
+
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_debug_bar', 200, 2 );

--- a/query-monitor/output/html/environment.php
+++ b/query-monitor/output/html/environment.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Environment data output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Environment extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 110 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		$this->before_non_tabular_output();
+
+		echo '<div class="qm-section">';
+		echo '<h3>PHP</h3>';
+
+		echo '<table>';
+		echo '<tbody>';
+
+		$append      = '';
+		$class       = '';
+		$php_warning = $data['php']['old'];
+
+		if ( $php_warning ) {
+			$append .= sprintf(
+				'&nbsp;<span class="qm-info">(<a href="%s" target="_blank" class="qm-external-link">%s</a>)</span>',
+				'https://wordpress.org/support/upgrade-php/',
+				esc_html__( 'Help', 'query-monitor' )
+			);
+			$class = 'qm-warn';
+		}
+
+		echo '<tr class="' . esc_attr( $class ) . '">';
+		echo '<th scope="row">' . esc_html__( 'Version', 'query-monitor' ) . '</th>';
+		echo '<td>';
+		echo esc_html( $data['php']['version'] );
+		echo $append; // WPCS: XSS ok.
+		echo '</td>';
+		echo '</tr>';
+
+		echo '<tr>';
+		echo '<th scope="row">SAPI</th>';
+		echo '<td>' . esc_html( $data['php']['sapi'] ) . '</td>';
+		echo '</tr>';
+
+		echo '<tr>';
+		echo '<th scope="row">' . esc_html__( 'User', 'query-monitor' ) . '</th>';
+		if ( ! empty( $data['php']['user'] ) ) {
+			echo '<td>' . esc_html( $data['php']['user'] ) . '</td>';
+		} else {
+			echo '<td><em>' . esc_html__( 'Unknown', 'query-monitor' ) . '</em></td>';
+		}
+		echo '</tr>';
+
+		foreach ( $data['php']['variables'] as $key => $val ) {
+
+			echo '<tr>';
+			echo '<th scope="row">' . esc_html( $key ) . '</th>';
+			echo '<td>';
+			echo esc_html( $val['after'] );
+
+			if ( $val['after'] !== $val['before'] ) {
+				printf(
+					'<br><span class="qm-info qm-supplemental">%s</span>',
+					esc_html( sprintf(
+						/* translators: %s: Original value of a variable */
+						__( 'Overridden at runtime from %s', 'query-monitor' ),
+						$val['before']
+					) )
+				);
+			}
+
+			echo '</td>';
+			echo '</tr>';
+		}
+
+		$out = array();
+
+		foreach ( $data['php']['error_levels'] as $level => $reported ) {
+			if ( $reported ) {
+				$out[] = esc_html( $level ) . '&nbsp;&#x2713;';
+			} else {
+				$out[] = '<span class="qm-false">' . esc_html( $level ) . '</span>';
+			}
+		}
+
+		$error_levels = implode( '</li><li>', $out );
+
+		echo '<tr>';
+		echo '<th scope="row">' . esc_html__( 'Error Reporting', 'query-monitor' ) . '</th>';
+		echo '<td class="qm-has-toggle qm-ltr"><div class="qm-toggler">';
+
+		echo esc_html( $data['php']['error_reporting'] );
+		echo self::build_toggler(); // WPCS: XSS ok;
+
+		echo '<div class="qm-toggled">';
+		echo "<ul class='qm-supplemental'><li>{$error_levels}</li></ul>"; // WPCS: XSS ok.
+		echo '</div>';
+
+		echo '</div></td>';
+		echo '</tr>';
+
+		if ( ! empty( $data['php']['extensions'] ) ) {
+			echo '<tr>';
+			echo '<th scope="row">' . esc_html__( 'Extensions', 'query-monitor' ) . '</th>';
+			echo '<td class="qm-has-inner qm-has-toggle qm-ltr"><div class="qm-toggler">';
+
+			printf( // WPCS: XSS ok.
+				'<div class="qm-inner-toggle">%1$s %2$s</div>',
+				esc_html( number_format_i18n( count( $data['php']['extensions'] ) ) ),
+				self::build_toggler()
+			);
+
+			echo '<div class="qm-toggled">';
+			self::output_inner( $data['php']['extensions'] );
+			echo '</div>';
+
+			echo '</div></td>';
+			echo '</tr>';
+		}
+
+		echo '</tbody>';
+		echo '</table>';
+
+		echo '</div>';
+
+		if ( isset( $data['db'] ) ) {
+
+			foreach ( $data['db'] as $id => $db ) {
+
+				if ( 1 === count( $data['db'] ) ) {
+					$name = __( 'Database', 'query-monitor' );
+				} else {
+					/* translators: %s: Name of database controller */
+					$name = sprintf( __( 'Database: %s', 'query-monitor' ), $id );
+				}
+
+				echo '<div class="qm-section">';
+				echo '<h3>' . esc_html( $name ) . '</h3>';
+
+				echo '<table>';
+				echo '<tbody>';
+
+				$info = array(
+					'rdbms'          => __( 'RDBMS', 'query-monitor' ),
+					'server-version' => __( 'Server Version', 'query-monitor' ),
+					'extension'      => __( 'Extension', 'query-monitor' ),
+					'client-version' => __( 'Client Version', 'query-monitor' ),
+					'user'           => __( 'User', 'query-monitor' ),
+					'host'           => __( 'Host', 'query-monitor' ),
+					'database'       => __( 'Database', 'query-monitor' ),
+				);
+
+				foreach ( $info as $field => $label ) {
+
+					echo '<tr>';
+					echo '<th scope="row">' . esc_html( $label ) . '</th>';
+
+					if ( ! isset( $db['info'][ $field ] ) ) {
+						echo '<td><span class="qm-warn">' . esc_html__( 'Unknown', 'query-monitor' ) . '</span></td>';
+					} else {
+						echo '<td>' . esc_html( $db['info'][ $field ] ) . '</td>';
+					}
+
+					echo '</tr>';
+
+				}
+
+				echo '<tr>';
+
+				$first  = true;
+				$search = 'https://www.google.com/search?q=mysql+performance+%s';
+
+				foreach ( $db['variables'] as $setting ) {
+
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+					$key = $setting->Variable_name;
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+					$val = $setting->Value;
+
+					$append = '';
+					$show_warning = false;
+
+					if ( ( true === $db['vars'][ $key ] ) and empty( $val ) ) {
+						$show_warning = true;
+					} elseif ( is_string( $db['vars'][ $key ] ) and ( $val !== $db['vars'][ $key ] ) ) {
+						$show_warning = true;
+					}
+
+					if ( $show_warning ) {
+						$append .= sprintf(
+							'&nbsp;<span class="qm-info">(<a href="%s" target="_blank" class="qm-external-link">%s</a>)</span>',
+							esc_url( sprintf( $search, rawurlencode( $key ) ) ),
+							esc_html__( 'Help', 'query-monitor' )
+						);
+					}
+
+					if ( is_numeric( $val ) and ( $val >= ( 1024 * 1024 ) ) ) {
+						$append .= sprintf(
+							'&nbsp;<span class="qm-info">(~%s)</span>',
+							esc_html( size_format( $val ) )
+						);
+					}
+
+					$class = ( $show_warning ) ? 'qm-warn' : '';
+
+					if ( ! $first ) {
+						echo '<tr class="' . esc_attr( $class ) . '">';
+					}
+
+					echo '<th scope="row">' . esc_html( $key ) . '</th>';
+					echo '<td>';
+					echo esc_html( $val );
+					echo $append; // WPCS: XSS ok.
+					echo '</td>';
+
+					echo '</tr>';
+
+					$first = false;
+
+				}
+
+				echo '</tbody>';
+				echo '</table>';
+
+				echo '</div>';
+
+			}
+		}
+
+		echo '<div class="qm-section">';
+		echo '<h3>WordPress</h3>';
+
+		echo '<table>';
+		echo '<tbody>';
+
+		echo '<tr>';
+		echo '<th scope="row">' . esc_html__( 'Version', 'query-monitor' ) . '</th>';
+		echo '<td>' . esc_html( $data['wp']['version'] ) . '</td>';
+		echo '</tr>';
+
+		foreach ( $data['wp']['constants'] as $key => $val ) {
+
+			echo '<tr>';
+			echo '<th scope="row">' . esc_html( $key ) . '</th>';
+			echo '<td>' . esc_html( $val ) . '</td>';
+			echo '</tr>';
+
+		}
+
+		echo '</tbody>';
+		echo '</table>';
+
+		echo '</div>';
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Server', 'query-monitor' ) . '</h3>';
+
+		$server = array(
+			'name'    => __( 'Software', 'query-monitor' ),
+			'version' => __( 'Version', 'query-monitor' ),
+			'address' => __( 'Address', 'query-monitor' ),
+			'host'    => __( 'Host', 'query-monitor' ),
+			'OS'      => __( 'OS', 'query-monitor' ),
+		);
+
+		echo '<table>';
+		echo '<tbody>';
+
+		foreach ( $server as $field => $label ) {
+			echo '<tr>';
+			echo '<th scope="row">' . esc_html( $label ) . '</th>';
+			if ( ! empty( $data['server'][ $field ] ) ) {
+				echo '<td>' . esc_html( $data['server'][ $field ] ) . '</td>';
+			} else {
+				echo '<td><em>' . esc_html__( 'Unknown', 'query-monitor' ) . '</em></td>';
+			}
+			echo '</tr>';
+		}
+
+		echo '</tbody>';
+		echo '</table>';
+		echo '</div>';
+
+		$this->after_non_tabular_output();
+	}
+
+}
+
+function register_qm_output_html_environment( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'environment' ) ) {
+		$output['environment'] = new QM_Output_Html_Environment( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_environment', 120, 2 );

--- a/query-monitor/output/html/hooks.php
+++ b/query-monitor/output/html/hooks.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Hooks and actions output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Hooks extends QM_Output_Html {
+
+	public $id = 'hooks';
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 80 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['hooks'] ) ) {
+			return;
+		}
+
+		if ( is_multisite() and is_network_admin() ) {
+			$screen = preg_replace( '|-network$|', '', $data['screen'] );
+		} else {
+			$screen = $data['screen'];
+		}
+
+		$parts = $data['parts'];
+		$components = $data['components'];
+
+		usort( $parts, 'strcasecmp' );
+		usort( $components, 'strcasecmp' );
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'name', $parts, __( 'Hook', 'query-monitor' ) ); // WPCS: XSS ok.
+		echo '</th>';
+		echo '<th scope="col">' . esc_html__( 'Priority', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Action', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ), 'subject' ); // WPCS: XSS ok.
+		echo '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+		self::output_hook_table( $data['hooks'], $screen );
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	public static function output_hook_table( array $hooks, $screen = '' ) {
+		foreach ( $hooks as $hook ) {
+
+			if ( ! empty( $screen ) ) {
+
+				if ( false !== strpos( $hook['name'], $screen . '.php' ) ) {
+					$hook_name = str_replace( '-' . $screen . '.php', '-<span class="qm-current">' . $screen . '.php</span>', esc_html( $hook['name'] ) );
+				} else {
+					$hook_name = str_replace( '-' . $screen, '-<span class="qm-current">' . $screen . '</span>', esc_html( $hook['name'] ) );
+				}
+			} else {
+				$hook_name = esc_html( $hook['name'] );
+			}
+
+			$row_attr = array();
+			$row_attr['data-qm-name']      = implode( ' ', $hook['parts'] );
+			$row_attr['data-qm-component'] = implode( ' ', $hook['components'] );
+
+			if ( ! empty( $row_attr['data-qm-component'] ) && 'Core' !== $row_attr['data-qm-component'] ) {
+				$row_attr['data-qm-component'] .= ' non-core';
+			}
+
+			$attr = '';
+
+			if ( ! empty( $hook['actions'] ) ) {
+				$rowspan = count( $hook['actions'] );
+			} else {
+				$rowspan = 1;
+			}
+
+			foreach ( $row_attr as $a => $v ) {
+				$attr .= ' ' . $a . '="' . esc_attr( $v ) . '"';
+			}
+
+			if ( ! empty( $hook['actions'] ) ) {
+
+				$first = true;
+
+				foreach ( $hook['actions'] as $action ) {
+
+					if ( isset( $action['callback']['component'] ) ) {
+						$component = $action['callback']['component']->name;
+					} else {
+						$component = '';
+					}
+
+					printf( // WPCS: XSS ok.
+						'<tr data-qm-subject="%s" %s>',
+						esc_attr( $component ),
+						$attr
+					);
+
+					if ( $first ) {
+
+						echo '<th scope="row" rowspan="' . absint( $rowspan ) . '" class="qm-nowrap qm-ltr"><span class="qm-sticky">';
+						echo '<code>' . $hook_name . '</code>'; // WPCS: XSS ok.
+						if ( 'all' === $hook['name'] ) {
+							echo '<br><span class="qm-warn">';
+							printf(
+								/* translators: %s: Action name */
+								esc_html__( 'Warning: The %s action is extremely resource intensive. Try to avoid using it.', 'query-monitor' ),
+								'<code>all</code>'
+							);
+							echo '<span>';
+						}
+						echo '</span></th>';
+
+					}
+
+					if ( isset( $action['callback']['error'] ) ) {
+						$class = ' qm-warn';
+					} else {
+						$class = '';
+					}
+
+					echo '<td class="qm-num' . esc_attr( $class ) . '">' . intval( $action['priority'] ) . '</td>';
+
+					if ( isset( $action['callback']['file'] ) ) {
+						if ( self::has_clickable_links() ) {
+							echo '<td class="qm-nowrap qm-ltr' . esc_attr( $class ) . '">';
+							echo self::output_filename( $action['callback']['name'], $action['callback']['file'], $action['callback']['line'] ); // WPCS: XSS ok.
+							echo '</td>';
+						} else {
+							echo '<td class="qm-nowrap qm-ltr qm-has-toggle' . esc_attr( $class ) . '"><ol class="qm-toggler">';
+							echo self::build_toggler(); // WPCS: XSS ok;
+							echo '<li>';
+							echo self::output_filename( $action['callback']['name'], $action['callback']['file'], $action['callback']['line'] ); // WPCS: XSS ok.
+							echo '</li>';
+							echo '</ol></td>';
+						}
+					} else {
+						echo '<td class="qm-ltr qm-nowrap' . esc_attr( $class ) . '">';
+						echo '<code>' . esc_html( $action['callback']['name'] ) . '</code>';
+					}
+
+					if ( isset( $action['callback']['error'] ) ) {
+						echo '<br>';
+						echo esc_html( sprintf(
+							/* translators: %s: Error message text */
+							__( 'Error: %s', 'query-monitor' ),
+							$action['callback']['error']->get_error_message()
+						) );
+					}
+
+					echo '</td>';
+					echo '<td class="qm-nowrap' . esc_attr( $class ) . '">';
+					echo esc_html( $component );
+					echo '</td>';
+					echo '</tr>';
+					$first = false;
+				}
+			} else {
+				echo "<tr{$attr}>"; // WPCS: XSS ok.
+				echo '<th scope="row" class="qm-ltr"><span class="qm-sticky">';
+				echo '<code>' . $hook_name . '</code>'; // WPCS: XSS ok.
+				echo '</span></th>';
+				echo '<td>&nbsp;</td>';
+				echo '<td>&nbsp;</td>';
+				echo '<td>&nbsp;</td>';
+				echo '</tr>';
+			}
+		}
+
+	}
+
+}
+
+function register_qm_output_html_hooks( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'hooks' ) ) {
+		$output['hooks'] = new QM_Output_Html_Hooks( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_hooks', 80, 2 );

--- a/query-monitor/output/html/http.php
+++ b/query-monitor/output/html/http.php
@@ -1,0 +1,375 @@
+<?php
+/**
+ * HTTP API request output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_HTTP extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 90 );
+		add_filter( 'qm/output/menu_class', array( $this, 'admin_class' ) );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		$total_time = 0;
+
+		$vars = array();
+
+		if ( ! empty( $data['vars'] ) ) {
+			foreach ( $data['vars'] as $key => $value ) {
+				$vars[] = $key . ': ' . $value;
+			}
+		}
+
+		if ( ! empty( $data['http'] ) ) {
+			$statuses   = array_keys( $data['types'] );
+			$components = wp_list_pluck( $data['component_times'], 'component' );
+
+			usort( $statuses, 'strcasecmp' );
+			usort( $components, 'strcasecmp' );
+
+			$this->before_tabular_output();
+
+			echo '<thead>';
+			echo '<tr>';
+			echo '<th scope="col">' . esc_html__( 'Method', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'URL', 'query-monitor' ) . '</th>';
+			echo '<th scope="col" class="qm-filterable-column">';
+			echo $this->build_filter( 'type', $statuses, __( 'Status', 'query-monitor' ) ); // WPCS: XSS ok.
+			echo '</th>';
+			echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+			echo '<th scope="col" class="qm-filterable-column">';
+			echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+			echo '</th>';
+			echo '<th scope="col" class="qm-num">' . esc_html__( 'Timeout', 'query-monitor' ) . '</th>';
+			echo '<th scope="col" class="qm-num">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
+			echo '</tr>';
+			echo '</thead>';
+
+			echo '<tbody>';
+			$i = 0;
+
+			foreach ( $data['http'] as $key => $row ) {
+				$ltime = $row['ltime'];
+				$i++;
+				$is_error = false;
+				$row_attr = array();
+				$css      = '';
+
+				if ( is_wp_error( $row['response'] ) ) {
+					$response = $row['response']->get_error_message();
+					$is_error = true;
+				} elseif ( ! $row['args']['blocking'] ) {
+					/* translators: A non-blocking HTTP API request */
+					$response = __( 'Non-blocking', 'query-monitor' );
+				} else {
+					$code     = wp_remote_retrieve_response_code( $row['response'] );
+					$msg      = wp_remote_retrieve_response_message( $row['response'] );
+
+					if ( intval( $code ) >= 400 ) {
+						$is_error = true;
+					}
+
+					$response = $code . ' ' . $msg;
+
+				}
+
+				if ( $is_error ) {
+					$css = 'qm-warn';
+				}
+
+				$url = self::format_url( $row['url'] );
+				$info = '';
+
+				if ( 'https' === parse_url( $row['url'], PHP_URL_SCHEME ) ) {
+					if ( empty( $row['args']['sslverify'] ) && empty( $row['args']['local'] ) ) {
+						$info .= '<span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>' . esc_html( sprintf(
+							/* translators: An HTTP API request has disabled certificate verification. 1: Relevant argument name */
+							__( 'Certificate verification disabled (%s)', 'query-monitor' ),
+							'sslverify=false'
+						) ) . '</span><br>';
+						$url = preg_replace( '|^https:|', '<span class="qm-warn">https</span>:', $url );
+					} elseif ( ! $is_error && $row['args']['blocking'] ) {
+						$url = preg_replace( '|^https:|', '<span class="qm-true">https</span>:', $url );
+					}
+				}
+
+				$component = $row['component'];
+
+				$stack          = array();
+				$filtered_trace = $row['trace']->get_display_trace();
+
+				$filtered_trace = array_filter( $filtered_trace, function( $item ) {
+					// @TODO This should happen during collection.
+					if ( isset( $item['class'] ) ) {
+						return ! in_array( $item['class'], array(
+							'WP_Http',
+						), true );
+					}
+
+					if ( isset( $item['function'] ) ) {
+						return ! in_array( $item['function'], array(
+							'wp_safe_remote_request',
+							'wp_safe_remote_get',
+							'wp_safe_remote_post',
+							'wp_safe_remote_head',
+							'wp_remote_request',
+							'wp_remote_get',
+							'wp_remote_post',
+							'wp_remote_head',
+							'wp_remote_fopen',
+							'download_url',
+							'vip_safe_wp_remote_get',
+							'wpcom_vip_file_get_contents',
+						), true );
+					}
+
+					return true;
+				} );
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = self::output_filename( $item['display'], $item['calling_file'], $item['calling_line'] );
+				}
+
+				$row_attr['data-qm-component'] = $component->name;
+				$row_attr['data-qm-type']      = $row['type'];
+				$row_attr['data-qm-time']      = $row['ltime'];
+
+				if ( 'core' !== $component->context ) {
+					$row_attr['data-qm-component'] .= ' non-core';
+				}
+
+				$attr = '';
+				foreach ( $row_attr as $a => $v ) {
+					$attr .= ' ' . $a . '="' . esc_attr( $v ) . '"';
+				}
+
+				printf( // WPCS: XSS ok.
+					'<tr %s class="%s">',
+					$attr,
+					esc_attr( $css )
+				);
+				printf(
+					'<td>%s</td>',
+					esc_html( $row['args']['method'] )
+				);
+
+				if ( ! empty( $row['redirected_to'] ) ) {
+					$url .= sprintf(
+						'<br><span class="qm-warn">%1$s</span><br>%2$s',
+						/* translators: An HTTP API request redirected to another URL */
+						__( 'Redirected to:', 'query-monitor' ),
+						self::format_url( $row['redirected_to'] )
+					);
+				}
+
+				printf( // WPCS: XSS ok.
+					'<td class="qm-url qm-ltr qm-wrap">%s%s</td>',
+					$info,
+					$url
+				);
+
+				$show_toggle = ( ! empty( $row['transport'] ) && ! empty( $row['info'] ) );
+
+				echo '<td class="qm-has-toggle qm-col-status"><div class="qm-toggler">';
+				if ( $is_error ) {
+					echo '<span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+				}
+				echo esc_html( $response );
+
+				if ( $show_toggle ) {
+					echo self::build_toggler(); // WPCS: XSS ok;
+					echo '<ul class="qm-toggled">';
+				}
+
+				if ( ! empty( $row['transport'] ) ) {
+					$transport = sprintf(
+						/* translators: %s HTTP API transport name */
+						__( 'HTTP API Transport: %s', 'query-monitor' ),
+						$row['transport']
+					);
+					printf(
+						'<li><span class="qm-info qm-supplemental">%s</span></li>',
+						esc_html( $transport )
+					);
+				}
+
+				if ( ! empty( $row['info'] ) ) {
+					$time_fields = array(
+						'namelookup_time'    => __( 'DNS Resolution Time', 'query-monitor' ),
+						'connect_time'       => __( 'Connection Time', 'query-monitor' ),
+						'starttransfer_time' => __( 'Transfer Start Time (TTFB)', 'query-monitor' ),
+					);
+					foreach ( $time_fields as $key => $value ) {
+						if ( ! isset( $row['info'][ $key ] ) ) {
+							continue;
+						}
+						printf(
+							'<li><span class="qm-info qm-supplemental">%1$s: %2$s</span></li>',
+							esc_html( $value ),
+							esc_html( number_format_i18n( $row['info'][ $key ], 4 ) )
+						);
+					}
+
+					$size_fields = array(
+						'size_download' => __( 'Response Size', 'query-monitor' ),
+					);
+					foreach ( $size_fields as $key => $value ) {
+						if ( ! isset( $row['info'][ $key ] ) ) {
+							continue;
+						}
+						printf(
+							'<li><span class="qm-info qm-supplemental">%1$s: %2$s</span></li>',
+							esc_html( $value ),
+							esc_html( size_format( $row['info'][ $key ] ) )
+						);
+					}
+
+					$other_fields = array(
+						'content_type' => __( 'Response Content Type', 'query-monitor' ),
+						'primary_ip'   => __( 'IP Address', 'query-monitor' ),
+					);
+					foreach ( $other_fields as $key => $value ) {
+						if ( ! isset( $row['info'][ $key ] ) ) {
+							continue;
+						}
+						printf(
+							'<li><span class="qm-info qm-supplemental">%1$s: %2$s</span></li>',
+							esc_html( $value ),
+							esc_html( $row['info'][ $key ] )
+						);
+					}
+				}
+
+				if ( $show_toggle ) {
+					echo '</ul>';
+				}
+
+				echo '</td>';
+
+				echo '<td class="qm-has-toggle qm-nowrap qm-ltr"><ol class="qm-toggler qm-numbered">';
+
+				$caller = array_pop( $stack );
+
+				if ( ! empty( $stack ) ) {
+					echo self::build_toggler(); // WPCS: XSS ok;
+					echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>'; // WPCS: XSS ok.
+				}
+
+				echo "<li>{$caller}</li>"; // WPCS: XSS ok.
+				echo '</ol></td>';
+
+				printf(
+					'<td class="qm-nowrap">%s</td>',
+					esc_html( $component->name )
+				);
+				printf(
+					'<td class="qm-num">%s</td>',
+					esc_html( $row['args']['timeout'] )
+				);
+
+				if ( empty( $ltime ) ) {
+					$stime = '';
+				} else {
+					$stime = number_format_i18n( $ltime, 4 );
+				}
+
+				printf(
+					'<td class="qm-num">%s</td>',
+					esc_html( $stime )
+				);
+				echo '</tr>';
+			}
+
+			echo '</tbody>';
+			echo '<tfoot>';
+
+			$total_stime = number_format_i18n( $data['ltime'], 4 );
+
+			echo '<tr>';
+			printf(
+				'<td colspan="6">%1$s<br>%2$s</td>',
+				sprintf(
+					/* translators: %s: Number of HTTP API requests */
+					esc_html_x( 'Total: %s', 'HTTP API calls', 'query-monitor' ),
+					'<span class="qm-items-number">' . esc_html( number_format_i18n( count( $data['http'] ) ) ) . '</span>'
+				),
+				implode( '<br>', array_map( 'esc_html', $vars ) )
+			);
+			echo '<td class="qm-num qm-items-time">' . esc_html( $total_stime ) . '</td>';
+			echo '</tr>';
+			echo '</tfoot>';
+
+			$this->after_tabular_output();
+		} else {
+			$this->before_non_tabular_output();
+
+			$notice = __( 'No HTTP API calls.', 'query-monitor' );
+			echo $this->build_notice( $notice ); // WPCS: XSS ok.
+
+			$this->after_non_tabular_output();
+		}
+	}
+
+	public function admin_class( array $class ) {
+
+		$data = $this->collector->get_data();
+
+		if ( isset( $data['errors']['alert'] ) ) {
+			$class[] = 'qm-alert';
+		}
+		if ( isset( $data['errors']['warning'] ) ) {
+			$class[] = 'qm-warning';
+		}
+
+		return $class;
+
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+
+		$count = isset( $data['http'] ) ? count( $data['http'] ) : 0;
+
+		$title = ( empty( $count ) )
+			? __( 'HTTP API Calls', 'query-monitor' )
+			/* translators: %s: Number of calls to the HTTP API */
+			: __( 'HTTP API Calls (%s)', 'query-monitor' );
+
+		$args = array(
+			'title' => esc_html( sprintf(
+				$title,
+				number_format_i18n( $count )
+			) ),
+		);
+
+		if ( isset( $data['errors']['alert'] ) ) {
+			$args['meta']['classname'] = 'qm-alert';
+		}
+		if ( isset( $data['errors']['warning'] ) ) {
+			$args['meta']['classname'] = 'qm-warning';
+		}
+
+		$menu[] = $this->menu( $args );
+
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_http( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'http' ) ) {
+		$output['http'] = new QM_Output_Html_HTTP( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_http', 90, 2 );

--- a/query-monitor/output/html/languages.php
+++ b/query-monitor/output/html/languages.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Language and locale output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Languages extends QM_Output_Html {
+
+	public $id = 'languages';
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 80 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['languages'] ) ) {
+			return;
+		}
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Text Domain', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'MO File', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Size', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		$not_found_class = ( substr( $data['locale'], 0, 3 ) === 'en_' ) ? '' : 'qm-warn';
+
+		echo '<tbody>';
+
+		foreach ( $data['languages'] as $textdomain => $mofiles ) {
+			foreach ( $mofiles as $mofile ) {
+				echo '<tr>';
+
+				echo '<td class="qm-ltr">' . esc_html( $mofile['domain'] ) . '</td>';
+
+				if ( self::has_clickable_links() ) {
+					echo '<td class="qm-nowrap qm-ltr">';
+					echo self::output_filename( $mofile['caller']['display'], $mofile['caller']['file'], $mofile['caller']['line'] ); // WPCS: XSS ok.
+					echo '</td>';
+				} else {
+					echo '<td class="qm-nowrap qm-ltr qm-has-toggle"><ol class="qm-toggler">';
+					echo self::build_toggler(); // WPCS: XSS ok;
+					echo '<li>';
+					echo self::output_filename( $mofile['caller']['display'], $mofile['caller']['file'], $mofile['caller']['line'] ); // WPCS: XSS ok.
+					echo '</li>';
+					echo '</ol></td>';
+				}
+
+				echo '<td class="qm-ltr">';
+				echo esc_html( QM_Util::standard_dir( $mofile['mofile'], '' ) );
+				echo '</td>';
+
+				if ( $mofile['found'] ) {
+					echo '<td class="qm-nowrap">';
+					echo esc_html( size_format( $mofile['found'] ) );
+					echo '</td>';
+				} else {
+					echo '<td class="' . esc_attr( $not_found_class ) . '">';
+					echo esc_html__( 'Not Found', 'query-monitor' );
+					echo '</td>';
+				}
+
+				echo '</tr>';
+				$first = false;
+			}
+		}
+
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+		$args = array(
+			'title' => esc_html( $this->collector->name() ),
+		);
+
+		$menu[] = $this->menu( $args );
+
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_languages( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'languages' ) ) {
+		$output['languages'] = new QM_Output_Html_Languages( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_languages', 81, 2 );

--- a/query-monitor/output/html/logger.php
+++ b/query-monitor/output/html/logger.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * PSR-3 compatible logging output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Logger extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 12 );
+		add_filter( 'qm/output/menu_class', array( $this, 'admin_class' ) );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['logs'] ) ) {
+			return;
+		}
+
+		$levels = array_map( 'ucfirst', $this->collector->get_levels() );
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'type', $levels, __( 'Level', 'query-monitor' ) ); // WPCS: XSS ok.
+		echo '</th>';
+		echo '<th scope="col" class="qm-col-message">' . esc_html__( 'Message', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'component', $data['components'], __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+		echo '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		foreach ( $data['logs'] as $row ) {
+			$component = $row['trace']->get_component();
+
+			$row_attr  = array();
+			$row_attr['data-qm-component'] = $component->name;
+			$row_attr['data-qm-type']      = ucfirst( $row['level'] );
+
+			$attr = '';
+
+			foreach ( $row_attr as $a => $v ) {
+				$attr .= ' ' . $a . '="' . esc_attr( $v ) . '"';
+			}
+
+			$is_warning = in_array( $row['level'], $this->collector->get_warning_levels(), true );
+
+			if ( $is_warning ) {
+				$class = 'qm-warn';
+			} else {
+				$class = '';
+			}
+
+			echo '<tr ' . $attr . 'class="' . esc_attr( $class ) . '">'; // WPCS: XSS ok.
+
+			echo '<td scope="row" class="qm-nowrap">';
+
+			if ( $is_warning ) {
+				echo '<span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+			} else {
+				echo '<span class="dashicons" aria-hidden="true"></span>';
+			}
+
+			echo esc_html( ucfirst( $row['level'] ) );
+			echo '</td>';
+
+			printf(
+				'<td>%s</td>',
+				esc_html( $row['message'] )
+			);
+
+			$stack          = array();
+			$filtered_trace = $row['trace']->get_display_trace();
+
+			foreach ( $filtered_trace as $item ) {
+				$stack[] = self::output_filename( $item['display'], $item['calling_file'], $item['calling_line'] );
+			}
+
+			echo '<td class="qm-has-toggle qm-nowrap qm-ltr"><ol class="qm-toggler qm-numbered">';
+
+			$caller = array_pop( $stack );
+
+			if ( ! empty( $stack ) ) {
+				echo self::build_toggler(); // WPCS: XSS ok;
+				echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>'; // WPCS: XSS ok.
+			}
+
+			echo "<li>{$caller}</li>"; // WPCS: XSS ok.
+			echo '</ol></td>';
+
+			printf(
+				'<td class="qm-nowrap">%s</td>',
+				esc_html( $component->name )
+			);
+
+			echo '</tr>';
+
+		}
+
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	public function admin_class( array $class ) {
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['logs'] ) ) {
+			return $class;
+		}
+
+		foreach ( $data['logs'] as $log ) {
+			if ( in_array( $log['level'], $this->collector->get_warning_levels(), true ) ) {
+				$class[] = 'qm-warning';
+				break;
+			}
+		}
+
+		return $class;
+	}
+
+	public function admin_menu( array $menu ) {
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['logs'] ) ) {
+			return $menu;
+		}
+
+		$key = 'log';
+
+		foreach ( $data['logs'] as $log ) {
+			if ( in_array( $log['level'], $this->collector->get_warning_levels(), true ) ) {
+				$key = 'warning';
+				break;
+			}
+		}
+
+		$menu[] = $this->menu( array(
+			'id'    => "query-monitor-logger-{$key}",
+			'title' => esc_html__( 'Logs', 'query-monitor' ),
+		) );
+
+		return $menu;
+	}
+
+}
+
+function register_qm_output_html_logger( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'logger' ) ) {
+		$output['logger'] = new QM_Output_Html_Logger( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_logger', 12, 2 );

--- a/query-monitor/output/html/overview.php
+++ b/query-monitor/output/html/overview.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * General overview output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Overview extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/title', array( $this, 'admin_title' ), 10 );
+	}
+
+	public function output() {
+		$data = $this->collector->get_data();
+
+		$db_query_num   = null;
+		$db_query_types = array();
+		$db_queries     = QM_Collectors::get( 'db_queries' );
+
+		if ( $db_queries ) {
+			# @TODO: make this less derpy:
+			$db_queries_data = $db_queries->get_data();
+			if ( isset( $db_queries_data['types'] ) && isset( $db_queries_data['total_time'] ) ) {
+				$db_query_num = $db_queries_data['types'];
+			}
+		}
+
+		$cache = QM_Collectors::get( 'cache' );
+
+		if ( $cache ) {
+			$cache_data = $cache->get_data();
+			if ( isset( $cache_data['stats'] ) && isset( $cache_data['cache_hit_percentage'] ) ) {
+				$cache_hit_percentage = $cache_data['cache_hit_percentage'];
+			}
+		}
+
+		$qm_broken = __( 'A JavaScript problem on the page is preventing Query Monitor from working correctly. jQuery may have been blocked from loading.', 'query-monitor' );
+		$ajax_errors = __( 'PHP errors were triggered during an Ajax request. See your browser developer console for details.', 'query-monitor' );
+
+		$this->before_non_tabular_output();
+
+		echo '<div class="qm-section" id="qm-broken">';
+		echo '<p class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>' . esc_html( $qm_broken ) . '</p>';
+		echo '</div>';
+
+		echo '<div class="qm-section" id="qm-ajax-errors">';
+		echo '<p class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>' . esc_html( $ajax_errors ) . '</p>';
+		echo '</div>';
+
+		echo '</div>';
+		echo '<div class="qm-boxed">';
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Page Generation Time', 'query-monitor' ) . '</h3>';
+		echo '<p class="qm-item">';
+		echo esc_html( number_format_i18n( $data['time_taken'], 4 ) );
+
+		if ( $data['time_limit'] > 0 ) {
+			if ( $data['display_time_usage_warning'] ) {
+				echo '<br><span class="qm-warn">';
+			} else {
+				echo '<br><span class="qm-info">';
+			}
+			echo esc_html( sprintf(
+				/* translators: 1: Percentage of time limit used, 2: Time limit in seconds */
+				__( '%1$s%% of %2$ss limit', 'query-monitor' ),
+				number_format_i18n( $data['time_usage'], 1 ),
+				number_format_i18n( $data['time_limit'] )
+			) );
+			echo '</span>';
+		} else {
+			echo '<br><span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+			esc_html_e( 'No execution time limit', 'query-monitor' );
+			echo '</span>';
+		}
+		echo '</p>';
+		echo '</div>';
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Peak Memory Usage', 'query-monitor' ) . '</h3>';
+		echo '<p class="qm-item">';
+
+		if ( empty( $data['memory'] ) ) {
+			esc_html_e( 'Unknown', 'query-monitor' );
+		} else {
+			echo esc_html( sprintf(
+				/* translators: %s: Memory used in kilobytes */
+				__( '%s kB', 'query-monitor' ),
+				number_format_i18n( $data['memory'] / 1024 )
+			) );
+
+			if ( $data['memory_limit'] > 0 ) {
+				if ( $data['display_memory_usage_warning'] ) {
+					echo '<br><span class="qm-warn">';
+				} else {
+					echo '<br><span class="qm-info">';
+				}
+				echo esc_html( sprintf(
+					/* translators: 1: Percentage of memory limit used, 2: Memory limit in kilobytes */
+					__( '%1$s%% of %2$s kB limit', 'query-monitor' ),
+					number_format_i18n( $data['memory_usage'], 1 ),
+					number_format_i18n( $data['memory_limit'] / 1024 )
+				) );
+				echo '</span>';
+			} else {
+				echo '<br><span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+				esc_html_e( 'No memory limit', 'query-monitor' );
+				echo '</span>';
+			}
+		}
+
+		echo '</p>';
+		echo '</div>';
+
+		if ( isset( $db_query_num ) ) {
+			echo '<div class="qm-section">';
+			echo '<h3>' . esc_html__( 'Database Query Time', 'query-monitor' ) . '</h3>';
+			echo '<p class="qm-item">';
+			echo esc_html( number_format_i18n( $db_queries_data['total_time'], 4 ) );
+			echo '</p>';
+			echo '</div>';
+
+			echo '<div class="qm-section">';
+			echo '<h3>' . esc_html__( 'Database Queries', 'query-monitor' ) . '</h3>';
+			echo '<p class="qm-item">';
+
+			if ( ! isset( $db_query_num['SELECT'] ) || count( $db_query_num ) > 1 ) {
+				foreach ( $db_query_num as $type_name => $type_count ) {
+					printf(
+						'<a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="type" data-qm-value="%1$s">%2$s: %3$s</a><br>',
+						esc_attr( $type_name ),
+						esc_html( $type_name ),
+						esc_html( number_format_i18n( $type_count ) )
+					);
+				}
+			}
+
+			echo esc_html__( 'Total', 'query-monitor' ) . ': ' . esc_html( number_format_i18n( $db_queries_data['total_qs'] ) );
+
+			echo '</p>';
+			echo '</div>';
+		}
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Object Cache', 'query-monitor' ) . '</h3>';
+		echo '<p class="qm-item">';
+
+		if ( isset( $cache_hit_percentage ) ) {
+			echo esc_html( sprintf(
+				/* translators: 1: Cache hit rate percentage, 2: number of cache hits, 3: number of cache misses */
+				__( '%1$s%% hit rate (%2$s hits, %3$s misses)', 'query-monitor' ),
+				number_format_i18n( $cache_hit_percentage, 1 ),
+				number_format_i18n( $cache_data['stats']['cache_hits'], 0 ),
+				number_format_i18n( $cache_data['stats']['cache_misses'], 0 )
+			) );
+			if ( $cache_data['display_hit_rate_warning'] ) {
+				printf(
+					'<br><a href="%s" class="qm-external-link">%s</a>',
+					'https://github.com/johnbillion/query-monitor/wiki/Cache-Hit-Rate',
+					esc_html__( 'Why is this value 100%?', 'query-monitor' )
+				);
+			}
+			if ( $cache_data['ext_object_cache'] ) {
+				echo '<br><span class="qm-info">';
+				printf(
+					'<a href="%s" class="qm-link">%s</a>',
+					esc_url( network_admin_url( 'plugins.php?plugin_status=dropins' ) ),
+					esc_html__( 'External object cache in use', 'query-monitor' )
+				);
+				echo '</span>';
+			} else {
+				echo '<br><span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+				echo esc_html__( 'External object cache not in use', 'query-monitor' );
+				echo '</span>';
+
+				$potentials = array_filter( $cache_data['extensions'] );
+
+				if ( ! empty( $potentials ) ) {
+					echo '<ul>';
+					foreach ( $potentials as $name => $value ) {
+						echo '<li class="qm-warn">';
+						echo esc_html( sprintf(
+							/* translators: %s: PHP extension name */
+							__( 'The %s extension for PHP is installed but is not in use by WordPress', 'query-monitor' ),
+							$name
+						) );
+						echo '</li>';
+					}
+					echo '</ul>';
+				}
+			}
+		} else {
+			echo '<span class="qm-info">';
+			echo esc_html__( 'Object cache information is not available', 'query-monitor' );
+			echo '</span>';
+		}
+
+		echo '</p>';
+		echo '</div>';
+
+		$this->after_non_tabular_output();
+	}
+
+	public function admin_title( array $title ) {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['memory'] ) ) {
+			$memory = '??';
+		} else {
+			$memory = number_format_i18n( ( $data['memory'] / 1024 ), 0 );
+		}
+
+		$title[] = sprintf(
+			/* translators: %s: Page load time in seconds */
+			esc_html_x( '%s S', 'Page load time', 'query-monitor' ),
+			number_format_i18n( $data['time_taken'], 2 )
+		);
+		$title[] = sprintf(
+			/* translators: %s: Memory usage in kilobytes */
+			esc_html_x( '%s kB', 'Memory usage', 'query-monitor' ),
+			$memory
+		);
+
+		foreach ( $title as &$t ) {
+			$t = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', $t );
+		}
+
+		return $title;
+	}
+
+}
+
+function register_qm_output_html_overview( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'overview' ) ) {
+		$output['overview'] = new QM_Output_Html_Overview( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_overview', 10, 2 );

--- a/query-monitor/output/html/php_errors.php
+++ b/query-monitor/output/html/php_errors.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * PHP error output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_PHP_Errors extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 10 );
+		add_filter( 'qm/output/panel_menus', array( $this, 'panel_menu' ), 10 );
+		add_filter( 'qm/output/menu_class', array( $this, 'admin_class' ) );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['errors'] ) && empty( $data['silenced'] ) && empty( $data['suppressed'] ) ) {
+			return;
+		}
+
+		$levels = array(
+			'Warning',
+			'Notice',
+			'Strict',
+			'Deprecated',
+		);
+		$components = $data['components'];
+
+		usort( $components, 'strcasecmp' );
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'type', $levels, __( 'Level', 'query-monitor' ) ); // WPCS: XSS ok.
+		echo '</th>';
+		echo '<th scope="col" class="qm-col-message">' . esc_html__( 'Message', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-num">' . esc_html__( 'Count', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Location', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'component', $components, __( 'Component', 'query-monitor' ) ); // WPCS: XSS ok.
+		echo '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		foreach ( $this->collector->types as $error_group => $error_types ) {
+			foreach ( $error_types as $type => $title ) {
+
+				if ( ! isset( $data[ $error_group ][ $type ] ) ) {
+					continue;
+				}
+
+				foreach ( $data[ $error_group ][ $type ] as $error ) {
+
+					$component = $error['trace']->get_component();
+					$row_attr  = array();
+					$row_attr['data-qm-component'] = $component->name;
+					$row_attr['data-qm-type']      = ucfirst( $type );
+
+					if ( 'core' !== $component->context ) {
+						$row_attr['data-qm-component'] .= ' non-core';
+					}
+
+					$attr = '';
+
+					foreach ( $row_attr as $a => $v ) {
+						$attr .= ' ' . $a . '="' . esc_attr( $v ) . '"';
+					}
+
+					$is_warning = ( 'errors' === $error_group && 'warning' === $type );
+
+					if ( $is_warning ) {
+						$class = 'qm-warn';
+					} else {
+						$class = '';
+					}
+
+					echo '<tr ' . $attr . 'class="' . esc_attr( $class ) . '">'; // WPCS: XSS ok.
+					echo '<td scope="row" class="qm-nowrap">';
+
+					if ( $is_warning ) {
+						echo '<span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+					} else {
+						echo '<span class="dashicons" aria-hidden="true"></span>';
+					}
+
+					echo esc_html( $title );
+					echo '</td>';
+
+					echo '<td class="qm-ltr">' . esc_html( $error['message'] ) . '</td>';
+					echo '<td class="qm-num">' . esc_html( number_format_i18n( $error['calls'] ) ) . '</td>';
+
+					$stack          = array();
+					$filtered_trace = $error['trace']->get_display_trace();
+
+					// debug_backtrace() (used within QM_Backtrace) doesn't like being used within an error handler so
+					// we need to handle its somewhat unreliable stack trace items.
+					// https://bugs.php.net/bug.php?id=39070
+					// https://bugs.php.net/bug.php?id=64987
+					foreach ( $filtered_trace as $i => $item ) {
+						if ( isset( $item['file'] ) && isset( $item['line'] ) ) {
+							$stack[] = self::output_filename( $item['display'], $item['file'], $item['line'] );
+						} elseif ( 0 === $i ) {
+							$stack[] = self::output_filename( $item['display'], $error['file'], $error['line'] );
+						} else {
+							$stack[] = $item['display'] . '<br><span class="qm-info qm-supplemental"><em>' . __( 'Unknown location', 'query-monitor' ) . '</em></span>';
+						}
+					}
+
+					echo '<td class="qm-row-caller qm-row-stack qm-nowrap qm-ltr qm-has-toggle"><ol class="qm-toggler qm-numbered">';
+
+					echo self::build_toggler(); // WPCS: XSS ok;
+					if ( ! empty( $stack ) ) {
+						echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>'; // WPCS: XSS ok.
+					}
+
+					echo '<li>';
+					echo self::output_filename( $error['filename'] . ':' . $error['line'], $error['file'], $error['line'], true ); // WPCS: XSS ok.
+					echo '</li>';
+
+					echo '</ol></td>';
+
+					if ( $component ) {
+						echo '<td class="qm-nowrap">' . esc_html( $component->name ) . '</td>';
+					} else {
+						echo '<td><em>' . esc_html__( 'Unknown', 'query-monitor' ) . '</em></td>';
+					}
+
+					echo '</tr>';
+				}
+			}
+		}
+
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	public function admin_class( array $class ) {
+
+		$data = $this->collector->get_data();
+
+		if ( ! empty( $data['errors'] ) ) {
+			foreach ( $data['errors'] as $type => $errors ) {
+				$class[] = 'qm-' . $type;
+			}
+		}
+
+		return $class;
+
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+		$menu_label = array();
+
+		$types = array(
+			/* translators: %s: Number of deprecated PHP errors */
+			'deprecated' => _nx_noop( '%s Deprecated', '%s Deprecated', 'PHP error level', 'query-monitor' ),
+			/* translators: %s: Number of strict PHP errors */
+			'strict'     => _nx_noop( '%s Strict', '%s Stricts', 'PHP error level', 'query-monitor' ),
+			/* translators: %s: Number of PHP notices */
+			'notice'     => _nx_noop( '%s Notice', '%s Notices', 'PHP error level', 'query-monitor' ),
+			/* translators: %s: Number of PHP warnings */
+			'warning'    => _nx_noop( '%s Warning', '%s Warnings', 'PHP error level', 'query-monitor' ),
+		);
+
+		$key = 'quiet';
+		$generic = false;
+
+		foreach ( $types as $type => $label ) {
+
+			$count = 0;
+			$has_errors = false;
+
+			if ( isset( $data['suppressed'][ $type ] ) ) {
+				$has_errors = true;
+				$generic = true;
+			}
+			if ( isset( $data['silenced'][ $type ] ) ) {
+				$has_errors = true;
+				$generic = true;
+			}
+			if ( isset( $data['errors'][ $type ] ) ) {
+				$has_errors = true;
+				$key   = $type;
+				$count += array_sum( wp_list_pluck( $data['errors'][ $type ], 'calls' ) );
+			}
+
+			if ( ! $has_errors ) {
+				continue;
+			}
+
+			if ( $count ) {
+				$label = sprintf(
+					translate_nooped_plural(
+						$label,
+						$count,
+						'query-monitor'
+					),
+					number_format_i18n( $count )
+				);
+				$menu_label[] = $label;
+			}
+		}
+
+		if ( empty( $menu_label ) && ! $generic ) {
+			return $menu;
+		}
+
+		/* translators: %s: Number of PHP errors */
+		$title = __( 'PHP Errors (%s)', 'query-monitor' );
+
+		/* translators: used between list items, there is a space after the comma */
+		$sep = __( ', ', 'query-monitor' );
+
+		if ( count( $menu_label ) ) {
+			$title = sprintf(
+				$title,
+				implode( $sep, array_reverse( $menu_label ) )
+			);
+		} else {
+			$title = __( 'PHP Errors', 'query-monitor' );
+		}
+
+		$menu['php_errors'] = $this->menu( array(
+			'id'    => "query-monitor-{$key}s",
+			'title' => $title,
+		) );
+		return $menu;
+
+	}
+
+	public function panel_menu( array $menu ) {
+		if ( isset( $menu['php_errors'] ) ) {
+			$menu['php_errors']['title'] = __( 'PHP Errors', 'query-monitor' );
+		}
+
+		return $menu;
+	}
+
+}
+
+function register_qm_output_html_php_errors( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'php_errors' ) ) {
+		$output['php_errors'] = new QM_Output_Html_PHP_Errors( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_php_errors', 110, 2 );

--- a/query-monitor/output/html/request.php
+++ b/query-monitor/output/html/request.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Request data output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Request extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 50 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		$db_queries = QM_Collectors::get( 'db_queries' );
+
+		$this->before_non_tabular_output();
+
+		foreach ( array(
+			'request'       => __( 'Request', 'query-monitor' ),
+			'matched_rule'  => __( 'Matched Rule', 'query-monitor' ),
+			'matched_query' => __( 'Matched Query', 'query-monitor' ),
+			'query_string'  => __( 'Query String', 'query-monitor' ),
+		) as $item => $name ) {
+			if ( is_admin() && ! isset( $data['request'][ $item ] ) ) {
+				continue;
+			}
+
+			if ( ! empty( $data['request'][ $item ] ) ) {
+				if ( in_array( $item, array( 'request', 'matched_query', 'query_string' ), true ) ) {
+					$value = self::format_url( $data['request'][ $item ] );
+				} else {
+					$value = esc_html( $data['request'][ $item ] );
+				}
+			} else {
+				$value = '<em>' . esc_html__( 'none', 'query-monitor' ) . '</em>';
+			}
+
+			echo '<div class="qm-section">';
+			echo '<h3>' . esc_html( $name ) . '</h3>';
+			echo '<p class="qm-ltr"><code>' . $value . '</code></p>'; // WPCS: XSS ok.
+			echo '</div>';
+		}
+
+		echo '</div>';
+
+		echo '<div class="qm-boxed qm-boxed-wrap">';
+
+		if ( ! empty( $data['matching_rewrites'] ) ) {
+			echo '<div class="qm-section">';
+			echo '<h3>' . esc_html__( 'All Matching Rewrite Rules', 'query-monitor' ) . '</h3>';
+			echo '<table>';
+
+			foreach ( $data['matching_rewrites'] as $rule => $query ) {
+				$query = str_replace( 'index.php?', '', $query );
+
+				echo '<tr>';
+				echo '<td class="qm-ltr"><code>' . esc_html( $rule ) . '</code></td>';
+				echo '<td class="qm-ltr"><code>';
+				echo self::format_url( $query ); // WPCS: XSS ok.
+				echo '</code></td>';
+				echo '</tr>';
+			}
+
+			echo '</table>';
+			echo '</div>';
+		}
+
+		echo '<div class="qm-section">';
+		echo '<h3>';
+		esc_html_e( 'Query Vars', 'query-monitor' );
+		echo '</h3>';
+
+		if ( $db_queries ) {
+			$db_queries_data = $db_queries->get_data();
+			if ( ! empty( $db_queries_data['dbs']['$wpdb']->has_main_query ) ) {
+				printf(
+					'<p><a href="#" class="qm-filter-trigger" data-qm-target="db_queries-wpdb" data-qm-filter="caller" data-qm-value="qm-main-query">%s</a></p>',
+					esc_html__( 'View Main Query', 'query-monitor' )
+				);
+			}
+		}
+
+		if ( ! empty( $data['qvars'] ) ) {
+
+			echo '<table>';
+
+			foreach ( $data['qvars'] as $var => $value ) {
+
+				echo '<tr>';
+
+				if ( isset( $data['plugin_qvars'][ $var ] ) ) {
+					echo '<th scope="row" class="qm-ltr"><span class="qm-current">' . esc_html( $var ) . '</span></td>';
+				} else {
+					echo '<th scope="row" class="qm-ltr">' . esc_html( $var ) . '</td>';
+				}
+
+				if ( is_array( $value ) or is_object( $value ) ) {
+					echo '<td class="qm-ltr"><pre>';
+					echo esc_html( print_r( $value, true ) );
+					echo '</pre></td>';
+				} else {
+					echo '<td class="qm-ltr qm-wrap">' . esc_html( $value ) . '</td>';
+				}
+
+				echo '</tr>';
+
+			}
+			echo '</table>';
+
+		} else {
+
+			echo '<p><em>' . esc_html__( 'none', 'query-monitor' ) . '</em></p>';
+
+		}
+
+		echo '</div>';
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Queried Object', 'query-monitor' ) . '</h3>';
+
+		if ( ! empty( $data['queried_object'] ) ) {
+			printf( // WPCS: XSS ok.
+				'<p>%1$s (%2$s)</p>',
+				esc_html( $data['queried_object']['title'] ),
+				esc_html( get_class( $data['queried_object']['data'] ) )
+			);
+		} else {
+			echo '<p><em>' . esc_html__( 'none', 'query-monitor' ) . '</em></p>';
+		}
+
+		echo '</div>';
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Current User', 'query-monitor' ) . '</h3>';
+
+		if ( ! empty( $data['user']['data'] ) ) {
+			printf( // WPCS: XSS ok.
+				'<p>%1$s</p>',
+				esc_html( $data['user']['title'] )
+			);
+		} else {
+			echo '<p><em>' . esc_html__( 'none', 'query-monitor' ) . '</em></p>';
+		}
+
+		echo '</div>';
+
+		if ( ! empty( $data['multisite'] ) ) {
+			echo '<div class="qm-section">';
+			echo '<h3>' . esc_html__( 'Multisite', 'query-monitor' ) . '</h3>';
+
+			foreach ( $data['multisite'] as $var => $value ) {
+				printf( // WPCS: XSS ok.
+					'<p>%1$s</p>',
+					esc_html( $value['title'] )
+				);
+			}
+
+			echo '</div>';
+		}
+
+		$this->after_non_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data  = $this->collector->get_data();
+		$count = isset( $data['plugin_qvars'] ) ? count( $data['plugin_qvars'] ) : 0;
+
+		$title = ( empty( $count ) )
+			? __( 'Request', 'query-monitor' )
+			/* translators: %s: Number of additional query variables */
+			: __( 'Request (+%s)', 'query-monitor' );
+
+		$menu[] = $this->menu( array(
+			'title' => esc_html( sprintf(
+				$title,
+				number_format_i18n( $count )
+			) ),
+		) );
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_request( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'request' ) ) {
+		$output['request'] = new QM_Output_Html_Request( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_request', 60, 2 );

--- a/query-monitor/output/html/theme.php
+++ b/query-monitor/output/html/theme.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Template and theme output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Theme extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 60 );
+		add_filter( 'qm/output/panel_menus', array( $this, 'panel_menu' ), 60 );
+	}
+
+	public function output() {
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['stylesheet'] ) ) {
+			return;
+		}
+
+		$this->before_non_tabular_output();
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Template File', 'query-monitor' ) . '</h3>';
+
+		if ( ! empty( $data['template_path'] ) ) {
+			if ( $data['is_child_theme'] ) {
+				echo '<p class="qm-ltr">' . self::output_filename( $data['theme_template_file'], $data['template_path'], 0, true ) . '</p>'; // WPCS: XSS ok.
+			} else {
+				echo '<p class="qm-ltr">' . self::output_filename( $data['template_file'], $data['template_path'], 0, true ) . '</p>'; // WPCS: XSS ok.
+			}
+		} else {
+			echo '<p><em>' . esc_html__( 'Unknown', 'query-monitor' ) . '</em></p>';
+		}
+
+		echo '</div>';
+
+		if ( ! empty( $data['template_hierarchy'] ) ) {
+			echo '<div class="qm-section">';
+			echo '<h3>' . esc_html__( 'Template Hierarchy', 'query-monitor' ) . '</h3>';
+			echo '<ol class="qm-ltr qm-numbered"><li>' . implode( '</li><li>', array_map( 'esc_html', $data['template_hierarchy'] ) ) . '</li></ol>';
+			echo '</div>';
+		}
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Template Parts', 'query-monitor' ) . '</h3>';
+
+		if ( ! empty( $data['template_parts'] ) ) {
+
+			if ( $data['is_child_theme'] ) {
+				$parts = $data['theme_template_parts'];
+			} else {
+				$parts = $data['template_parts'];
+			}
+
+			echo '<ul class="qm-ltr">';
+
+			foreach ( $parts as $filename => $display ) {
+				echo '<li>' . self::output_filename( $display, $filename, 0, true ) . '</li>'; // WPCS: XSS ok.
+			}
+
+			echo '</ul>';
+
+		} else {
+			echo '<p><em>' . esc_html__( 'None', 'query-monitor' ) . '</em></p>';
+		}
+
+		echo '</div>';
+
+		if ( ! empty( $data['timber_files'] ) ) {
+			echo '<div class="qm-section">';
+			echo '<h3>' . esc_html__( 'Timber Files', 'query-monitor' ) . '</h3>';
+			echo '<ul class="qm-ltr">';
+
+			foreach ( $data['timber_files'] as $filename ) {
+				echo '<li>' . esc_html( $filename ) . '</li>';
+			}
+
+			echo '</ul>';
+			echo '</div>';
+		}
+
+		echo '<div class="qm-section">';
+		echo '<h3>' . esc_html__( 'Theme', 'query-monitor' ) . '</h3>';
+		echo '<p>' . esc_html( $data['stylesheet'] ) . '</p>';
+
+		if ( $data['is_child_theme'] ) {
+			echo '<h3>' . esc_html__( 'Parent Theme:', 'query-monitor' ) . '</h3>';
+			echo '<p>' . esc_html( $data['template'] ) . '</p>';
+		}
+
+		echo '</div>';
+
+		if ( ! empty( $data['body_class'] ) ) {
+			echo '<div class="qm-section">';
+
+			echo '<h3>' . esc_html__( 'Body Classes', 'query-monitor' ) . '</h3>';
+			echo '<ul class="qm-ltr">';
+
+			foreach ( $data['body_class'] as $class ) {
+				echo '<li>' . esc_html( $class ) . '</li>';
+			}
+
+			echo '</ul>';
+			echo '</div>';
+		}
+
+		$this->after_non_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data = $this->collector->get_data();
+
+		if ( isset( $data['template_file'] ) ) {
+			$menu['theme'] = $this->menu( array(
+				'title' => esc_html( sprintf(
+					/* translators: %s: Template file name */
+					__( 'Template: %s', 'query-monitor' ),
+					( $data['is_child_theme'] ? $data['theme_template_file'] : $data['template_file'] )
+				) ),
+			) );
+		}
+		return $menu;
+
+	}
+
+	public function panel_menu( array $menu ) {
+		if ( isset( $menu['theme'] ) ) {
+			$menu['theme']['title'] = __( 'Template', 'query-monitor' );
+		}
+
+		return $menu;
+	}
+
+}
+
+function register_qm_output_html_theme( array $output, QM_Collectors $collectors ) {
+	if ( ! is_admin() && $collector = QM_Collectors::get( 'response' ) ) {
+		$output['response'] = new QM_Output_Html_Theme( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_theme', 70, 2 );

--- a/query-monitor/output/html/timing.php
+++ b/query-monitor/output/html/timing.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Timing and profiling output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Timing extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 15 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( empty( $data['timing'] ) && empty( $data['warning'] ) ) {
+			return;
+		}
+
+		$this->before_tabular_output();
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Tracked Function', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-num">' . esc_html__( 'Time', 'query-monitor' ) . '</th>';
+		echo '<th scope="col" class="qm-num">' . esc_html__( 'Memory', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+		if ( ! empty( $data['timing'] ) ) {
+			foreach ( $data['timing'] as $row ) {
+
+				$component = $row['trace']->get_component();
+				$trace     = $row['trace']->get_filtered_trace();
+				$file      = self::output_filename( $row['function'], $trace[0]['file'], $trace[0]['line'] );
+
+				echo '<tr>';
+
+				if ( self::has_clickable_links() ) {
+					echo '<td class="qm-ltr">';
+					echo $file; // WPCS: XSS ok.
+					echo '</td>';
+				} else {
+					echo '<td class="qm-ltr qm-has-toggle"><ol class="qm-toggler">';
+					echo self::build_toggler(); // WPCS: XSS ok;
+					echo '<li>';
+					echo $file; // WPCS: XSS ok.
+					echo '</li>';
+					echo '</ol></td>';
+				}
+
+				printf(
+					'<td class="qm-num">%s</td>',
+					esc_html( number_format_i18n( $row['function_time'], 4 ) )
+				);
+
+				$mem = sprintf(
+					/* translators: %s: Approximate memory used in kilobytes */
+					__( '~%s kB', 'query-monitor' ),
+					number_format_i18n( $row['function_memory'] / 1024 )
+				);
+				printf(
+					'<td class="qm-num">%s</td>',
+					esc_html( $mem )
+				);
+				printf(
+					'<td class="qm-nowrap">%s</td>',
+					esc_html( $component->name )
+				);
+
+				echo '</tr>';
+
+				if ( ! empty( $row['laps'] ) ) {
+					foreach ( $row['laps'] as $lap_id => $lap ) {
+						echo '<tr>';
+
+						echo '<td class="qm-ltr"><code>&mdash;&nbsp;';
+						echo esc_html( $row['function'] . ': ' . $lap_id );
+						echo '</code></td>';
+
+						printf(
+							'<td class="qm-num">%s</td>',
+							esc_html( number_format_i18n( $lap['time_used'], 4 ) )
+						);
+
+						$mem = sprintf(
+							/* translators: %s: Approximate memory used in kilobytes */
+							__( '~%s kB', 'query-monitor' ),
+							number_format_i18n( $lap['memory_used'] / 1024 )
+						);
+						printf(
+							'<td class="qm-num">%s</td>',
+							esc_html( $mem )
+						);
+						echo '<td class="qm-nowrap"></td>';
+
+						echo '</tr>';
+					}
+				}
+			}
+		}
+		if ( ! empty( $data['warning'] ) ) {
+			foreach ( $data['warning'] as $row ) {
+				$component = $row['trace']->get_component();
+				$trace     = $row['trace']->get_filtered_trace();
+				$file      = self::output_filename( $row['function'], $trace[0]['file'], $trace[0]['line'] );
+
+				echo '<tr class="qm-warn">';
+				if ( self::has_clickable_links() ) {
+					echo '<td class="qm-ltr">';
+					echo $file; // WPCS: XSS ok.
+					echo '</td>';
+				} else {
+					echo '<td class="qm-ltr qm-has-toggle"><ol class="qm-toggler">';
+					echo self::build_toggler(); // WPCS: XSS ok;
+					echo '<li>';
+					echo $file; // WPCS: XSS ok.
+					echo '</li>';
+					echo '</ol></td>';
+				}
+
+				printf(
+					'<td colspan="2">%s</td>',
+					esc_html( $row['message'] )
+				);
+
+				printf(
+					'<td class="qm-nowrap">%s</td>',
+					esc_html( $component->name )
+				);
+			}
+		}
+
+		echo '</tbody>';
+
+		$this->after_tabular_output();
+	}
+
+	public function admin_menu( array $menu ) {
+		$data = $this->collector->get_data();
+
+		if ( ! empty( $data['timing'] ) || ! empty( $data['warning'] ) ) {
+			$count = 0;
+			if ( ! empty( $data['timing'] ) ) {
+				$count += count( $data['timing'] );
+			}
+			if ( ! empty( $data['warning'] ) ) {
+				$count += count( $data['warning'] );
+			}
+			/* translators: %s: Number of function timing results that are available */
+			$label = _n( 'Timings (%s)', 'Timings (%s)', $count, 'query-monitor' );
+			$menu[] = $this->menu( array(
+				'title' => esc_html( sprintf(
+					$label,
+					number_format_i18n( $count )
+				) ),
+			) );
+		}
+
+		return $menu;
+	}
+
+}
+
+function register_qm_output_html_timing( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'timing' ) ) {
+		$output['timing'] = new QM_Output_Html_Timing( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_timing', 15, 2 );

--- a/query-monitor/output/html/transients.php
+++ b/query-monitor/output/html/transients.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Transient storage output for HTML pages.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Html_Transients extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 100 );
+	}
+
+	public function output() {
+
+		$data = $this->collector->get_data();
+
+		if ( ! empty( $data['trans'] ) ) {
+
+			$this->before_tabular_output();
+
+			echo '<thead>';
+			echo '<tr>';
+			echo '<th scope="col">' . esc_html__( 'Updated Transient', 'query-monitor' ) . '</th>';
+			if ( is_multisite() ) {
+				echo '<th scope="col">' . esc_html_x( 'Type', 'transient type', 'query-monitor' ) . '</th>';
+			}
+			echo '<th scope="col">' . esc_html__( 'Expiration', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html_x( 'Size', 'size of transient value', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Caller', 'query-monitor' ) . '</th>';
+			echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor' ) . '</th>';
+			echo '</tr>';
+			echo '</thead>';
+
+			echo '<tbody>';
+
+			foreach ( $data['trans'] as $row ) {
+				$transient = str_replace( array(
+					'_site_transient_',
+					'_transient_',
+				), '', $row['transient'] );
+
+				$component = $row['trace']->get_component();
+
+				echo '<tr>';
+				printf(
+					'<td class="qm-ltr"><code>%s</code></td>',
+					esc_html( $transient )
+				);
+				if ( is_multisite() ) {
+					printf(
+						'<td class="qm-ltr qm-nowrap">%s</td>',
+						esc_html( $row['type'] )
+					);
+				}
+
+				if ( 0 === $row['expiration'] ) {
+					printf(
+						'<td class="qm-nowrap"><em>%s</em></td>',
+						esc_html__( 'none', 'query-monitor' )
+					);
+				} else {
+					printf(
+						'<td class="qm-nowrap">%s <span class="qm-info">(~%s)</span></td>',
+						esc_html( $row['expiration'] ),
+						esc_html( human_time_diff( 0, $row['expiration'] ) )
+					);
+				}
+
+				printf(
+					'<td class="qm-nowrap">~%s</td>',
+					esc_html( size_format( $row['size'] ) )
+				);
+
+				$stack          = array();
+				$filtered_trace = $row['trace']->get_display_trace();
+				array_pop( $filtered_trace ); // remove do_action('setted_(site_)?transient')
+				array_pop( $filtered_trace ); // remove set_(site_)?transient()
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = self::output_filename( $item['display'], $item['calling_file'], $item['calling_line'] );
+				}
+
+				echo '<td class="qm-has-toggle qm-nowrap qm-ltr"><ol class="qm-toggler qm-numbered">';
+
+				$caller = array_pop( $stack );
+
+				if ( ! empty( $stack ) ) {
+					echo self::build_toggler(); // WPCS: XSS ok;
+					echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>'; // WPCS: XSS ok.
+				}
+
+				echo "<li>{$caller}</li>"; // WPCS: XSS ok.
+				echo '</ol></td>';
+
+				printf(
+					'<td class="qm-nowrap">%s</td>',
+					esc_html( $component->name )
+				);
+
+				echo '</tr>';
+
+			}
+
+			$this->after_tabular_output();
+		} else {
+			$this->before_non_tabular_output();
+
+			$notice = __( 'No transients set.', 'query-monitor' );
+			echo $this->build_notice( $notice ); // WPCS: XSS ok.
+
+			$this->after_non_tabular_output();
+		}
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$data  = $this->collector->get_data();
+		$count = isset( $data['trans'] ) ? count( $data['trans'] ) : 0;
+
+		$title = ( empty( $count ) )
+			? __( 'Transient Updates', 'query-monitor' )
+			/* translators: %s: Number of transient values that were updated */
+			: __( 'Transient Updates (%s)', 'query-monitor' );
+
+		$menu[] = $this->menu( array(
+			'title' => esc_html( sprintf(
+				$title,
+				number_format_i18n( $count )
+			) ),
+		) );
+		return $menu;
+
+	}
+
+}
+
+function register_qm_output_html_transients( array $output, QM_Collectors $collectors ) {
+	if ( $collector = QM_Collectors::get( 'transients' ) ) {
+		$output['transients'] = new QM_Output_Html_Transients( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/html', 'register_qm_output_html_transients', 100, 2 );


### PR DESCRIPTION
## Description

In #1683, the Query Monitor plugin was changed from being a git submodule to a standard set of files. The version of the plugin was not changed.

However, the `output` directory was missing from #1683, due to a rule in the `.gitignore` file.

This PR adds an exception to that rule for the `query-monitor/output` directory, and adds the missing directory itself.

Without this fix, the original report (#1683) says that "Query Monitor has no output ( admin ) or a critical error is thrown ( front-end )."

This didn't show-up at the time of the merge three days ago, as (fortunately) there was [no deploy](https://github.com/Automattic/vip-go-mu-plugins/pull/1683#issuecomment-663731121).

Fixes #1684.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Compare https://github.com/Automattic/vip-go-mu-plugins/tree/master@%7B2020-07-27T19:00:06Z%7D/query-monitor to the download of [QM 3.1.1 from wp.org](https://wordpress.org/plugins/query-monitor/advanced/)
1. Note the missing `output` directory.
