### PR TITLE
Add permission_callback to test-cache-ttl-manager-rest.php

### DIFF
--- a/tests/test-cache-ttl-manager-rest.php
+++ b/tests/test-cache-ttl-manager-rest.php
@@ -13,6 +13,7 @@ class TTL_Manager__REST_API__Test extends \WP_Test_REST_TestCase {
 		register_rest_route( 'tests/v1', '/endpoint', [
 			'methods' => [ 'GET', 'HEAD', 'POST', 'PUT', 'DELETE' ],
 			'callback' => '__return_null',
+			'permission_callback' => '__return_true',
 		] );
 	}
 


### PR DESCRIPTION
## Description

WP 5.5 adds a `_doing_it_wrong()` warning when `permission_callback` is missing from `register_rest_route()`.

See https://make.wordpress.org/core/2020/07/22/rest-api-changes-in-wordpress-5-5/.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

1. Run tests using WP nightly, with WP_DEBUG enabled. See an error triggered.
2. Pull the fix, and re-run tests.