### PR TITLE
Look for all line ending types in mail test for checking tracking

### DIFF
--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -55,6 +55,6 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 		$mailer = tests_retrieve_phpmailer_instance();
 		$header = $mailer->get_sent()->header;
 
-		$this->assertRegExp( '/X-Automattic-Tracking: 1:\d+:.+:\d+:\d+:\d+\n/', $header );
+		$this->assertRegExp( '/X-Automattic-Tracking: 1:\d+:.+:\d+:\d+:\d+(\\r\\n|\\r|\\n)/', $header );
 	}
 }


### PR DESCRIPTION
## Description

This test was breaking against the WordPress nightly build. Just updated the regex test to handle more line ending types.