### PR TITLE
Add nightly builds for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,3 +90,22 @@ jobs:
     docker:
       - image: circleci/php:7.4-node
       - image: *db_image
+
+  php73-build-multisite-nightly:
+    <<: *php_job
+    environment:
+      - RUN_EXTRA: "1"
+      - WP_MULTISITE: "1"
+      - WP_VERSION: "nightly"
+    docker:
+      - image: circleci/php:7.3-node
+      - image: *db_image
+
+  php73-build-singlesite-nightly:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE: "0"
+      - WP_VERSION: "nightly"
+    docker:
+      - image: circleci/php:7.3-node
+      - image: *db_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ workflows:
       - php73-build-singlesite
       - php74-build-multisite
       - php74-build-singlesite
+      - php73-build-multisite-nightly
+      - php73-build-singlesite-nightly
 
 version: 2
 

--- a/bin/download-wp-tests.sh
+++ b/bin/download-wp-tests.sh
@@ -20,7 +20,10 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+
+if [[ $WP_VERSION == 'nightly' ]]; then
+	WP_TESTS_TAG="trunk"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
 	WP_TESTS_TAG="tags/$WP_VERSION"
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
@@ -60,9 +63,18 @@ install_wp() {
 		local ARCHIVE_NAME="wordpress-$WP_VERSION"
 	fi
 
-	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR_ACTUAL
-
+	if [ $WP_VERSION == 'nightly' ]; then
+		local ARCHIVE_NAME='nightly-builds/wordpress-latest'
+		download https://wordpress.org/${ARCHIVE_NAME}.zip  /tmp/wordpress.zip
+		unzip -qq /tmp/wordpress.zip -d /tmp
+		cd /tmp/wordpress
+		cp -r . $WP_CORE_DIR_ACTUAL
+		rm -rf /tmp/wordpress
+	else
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR_ACTUAL
+	fi
+	
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR_ACTUAL/wp-content/db.php
 }
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -9,7 +9,12 @@ DB_NAME=$1
 DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
-WP_VERSION=${5-latest}
+
+if [[ $5 == 'nightly' ]]; then
+	WP_VERSION='nightly'
+else
+	WP_VERSION=${5-latest}
+fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 $DIR/download-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION"


### PR DESCRIPTION
## Description

We don't currently test against nightly. Probably a good idea to do so though.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Install circleci cli locally
2. Run both of the added jobs via the circleci cli(e.g.: `circleci local execute --job php73-build-singlesite-nightly`)
3. Everything should run normally and all tests should complete successfully.