### PR TITLE
Use full file path for file service caching

### DIFF
--- a/files/class-api-cache.php
+++ b/files/class-api-cache.php
@@ -59,69 +59,55 @@ class API_Cache {
 	}
 
 	public function get_file( $filepath ) {
-		$file_name = basename( $filepath );
-
-		if ( isset( $this->files[ $file_name ] ) ) {
-			return $this->files[ $file_name ];
+		if ( isset( $this->files[ $filepath ] ) ) {
+			return $this->files[ $filepath ];
 		}
 
 		return false;
 	}
 
 	public function get_file_stats( $filepath ) {
-		$file_name = basename( $filepath );
-
-		if ( isset( $this->file_stats[ $file_name ] ) ) {
-			return $this->file_stats[ $file_name ];
+		if ( isset( $this->file_stats[ $filepath ] ) ) {
+			return $this->file_stats[ $filepath ];
 		}
 
 		return false;
 	}
 
 	public function cache_file( $filepath, $local_file ) {
-		$file_name = basename( $filepath );
-
-		$this->files[ $file_name ] = $local_file;
+		$this->files[ $filepath ] = $local_file;
 	}
 
 	public function cache_file_stats( $filepath, $info ) {
-		$file_name = basename( $filepath );
-
 		// This will overwrite existing stats if any
-		$this->file_stats[ $file_name ] = $info;
+		$this->file_stats[ $filepath ] = $info;
 	}
 
 	public function copy_to_cache( $dst, $src ) {
-		$file_name = basename( $dst );
-
-		if ( ! isset( $this->files[ $file_name ] ) ) {
+		if ( ! isset( $this->files[ $dst ] ) ) {
 			// create file with unique filename
 			$tmp_file = $this->create_tmp_file();
 
-			$this->files[ $file_name ] = $tmp_file;
+			$this->files[ $dst ] = $tmp_file;
 		}
 
 		// This will overwrite existing file if any
-		copy( $src, $this->files[ $file_name ] );
+		copy( $src, $this->files[ $dst ] );
 	}
 
 	public function remove_file( $filepath ) {
-		$file_name = basename( $filepath );
-
-		if ( isset( $this->files[ $file_name ] ) ) {
-			unlink( $this->files[ $file_name ] );
-			unset( $this->files[ $file_name ] );
+		if ( isset( $this->files[ $filepath ] ) ) {
+			unlink( $this->files[ $filepath ] );
+			unset( $this->files[ $filepath ] );
 		}
 
 		// Remove cached stats too if any
-		unset( $this->file_stats[ $file_name ] );
+		unset( $this->file_stats[ $filepath ] );
 	}
 
 	public function remove_stats( $filepath ) {
-		$file_name = basename( $filepath );
-
 		// Remove cached stats if any
-		unset( $this->file_stats[ $file_name ] );
+		unset( $this->file_stats[ $filepath ] );
 	}
 
 	public function create_tmp_file() {

--- a/tests/files/test-vip-filesystem-api-cache.php
+++ b/tests/files/test-vip-filesystem-api-cache.php
@@ -87,6 +87,20 @@ class API_Cache_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function test__get_file__invalid__same_file_different_path() {
+		$test_file = tempnam( sys_get_temp_dir(), 'test' );
+		$expected = 'test data';
+
+		file_put_contents( $test_file, $expected );
+
+		$prop = self::get_property( $this->cache, 'files' );
+		$prop->setValue( $this->cache, [ 'test.jpg' => $test_file ] );
+
+		$result = $this->cache->get_file( '/tmp/test.jpg' );
+
+		$this->assertFalse( $result );
+	}
+
 	public function test__get_file_stats() {
 		$expected = [ 'size' => '123', 'mtime' => '123456779' ];
 
@@ -104,16 +118,27 @@ class API_Cache_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function test__get_file_stats__invalid__same_file_different_path() {
+		$expected = [ 'size' => '123', 'mtime' => '123456779' ];
+
+		$prop = self::get_property( $this->cache, 'file_stats' );
+		$prop->setValue( $this->cache, [ 'test.jpg' => $expected ] );
+
+		$result = $this->cache->get_file_stats( '/tmp/test.jpg' );
+
+		$this->assertFalse( $result );
+	}
+
 	public function test__cache_file() {
 		$prop = self::get_property( $this->cache, 'files' );
 
 		$file = tempnam( sys_get_temp_dir(), 'test' );
 
-		$this->cache->cache_file( 'test.txt', $file );
+		$this->cache->cache_file( '/test/path/test.txt', $file );
 
 		$files = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $files[ 'test.txt' ] ) );
+		$this->assertTrue( isset( $files[ '/test/path/test.txt' ] ) );
 	}
 
 	public function test__cache_file__update_cache() {
@@ -122,7 +147,7 @@ class API_Cache_Test extends \WP_UnitTestCase {
 		file_put_contents( $test_file, 'test data' );
 
 		$prop = self::get_property( $this->cache, 'files' );
-		$prop->setValue( $this->cache, [ 'test.jpg' => $test_file ] );
+		$prop->setValue( $this->cache, [ '/test/path/test.jpg' => $test_file ] );
 
 		$expected = 'updated data';
 
@@ -130,49 +155,49 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		file_put_contents( $updated_file, $expected );
 
-		$this->cache->cache_file( 'test.jpg', $updated_file );
+		$this->cache->cache_file( '/test/path/test.jpg', $updated_file );
 
 		$files = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $files[ 'test.jpg' ] ) );
-		$this->assertEquals( $expected, file_get_contents( $files[ 'test.jpg' ] ) );
+		$this->assertTrue( isset( $files[ '/test/path/test.jpg' ] ) );
+		$this->assertEquals( $expected, file_get_contents( $files[ '/test/path/test.jpg' ] ) );
 	}
 
 	public function test__cache_file_stats() {
 		$prop = self::get_property( $this->cache, 'file_stats' );
 		$expected = [ 'size' => '123', 'mtime' => '123456779'];
 
-		$this->cache->cache_file_stats( 'test.txt', $expected );
+		$this->cache->cache_file_stats( '/test/path/test.txt', $expected );
 
 		$stats = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $stats[ 'test.txt' ] ) );
-		$this->assertEquals( $expected, $stats[ 'test.txt' ] );
+		$this->assertTrue( isset( $stats[ '/test/path/test.txt' ] ) );
+		$this->assertEquals( $expected, $stats[ '/test/path/test.txt' ] );
 	}
 
 	public function test__cache_file_stats__update_cache() {
 		$prop = self::get_property( $this->cache, 'file_stats' );
-		$prop->setValue( $this->cache, [ 'test.jpg' => [ 'size' => '234', 'mtime' => '123456779' ] ] );
+		$prop->setValue( $this->cache, [ '/test/path/test.jpg' => [ 'size' => '234', 'mtime' => '123456779' ] ] );
 
 		$expected = [ 'size' => '411', 'mtime' => '123459001'];
 
-		$this->cache->cache_file_stats( 'test.jpg', $expected );
+		$this->cache->cache_file_stats( '/test/path/test.jpg', $expected );
 
 		$stats = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $stats[ 'test.jpg' ] ) );
-		$this->assertEquals( $expected, $stats[ 'test.jpg' ] );
+		$this->assertTrue( isset( $stats[ '/test/path/test.jpg' ] ) );
+		$this->assertEquals( $expected, $stats[ '/test/path/test.jpg' ] );
 	}
 
 	public function test__copy_to_cache() {
 		$file_path = __DIR__ . '/../fixtures/files/upload.jpg';
 		$prop = self::get_property( $this->cache, 'files' );
 
-		$this->cache->copy_to_cache( 'test.txt', $file_path );
+		$this->cache->copy_to_cache( '/test/path/test.txt', $file_path );
 
 		$files = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $files[ 'test.txt' ] ) );
+		$this->assertTrue( isset( $files[ '/test/path/test.txt' ] ) );
 	}
 
 	public function test__copy_to_cache__update_cache() {
@@ -181,7 +206,7 @@ class API_Cache_Test extends \WP_UnitTestCase {
 		file_put_contents( $test_file, 'test data' );
 
 		$prop = self::get_property( $this->cache, 'files' );
-		$prop->setValue( $this->cache, [ 'test.jpg' => $test_file ] );
+		$prop->setValue( $this->cache, [ '/test/path/test.jpg' => $test_file ] );
 
 		$expected = 'updated data';
 
@@ -189,12 +214,12 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		file_put_contents( $test_file2, $expected );
 
-		$this->cache->copy_to_cache( 'test.jpg', $test_file2 );
+		$this->cache->copy_to_cache( '/test/path/test.jpg', $test_file2 );
 
 		$files = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $files[ 'test.jpg' ] ) );
-		$this->assertEquals( $expected, file_get_contents( $files[ 'test.jpg' ] ) );
+		$this->assertTrue( isset( $files[ '/test/path/test.jpg' ] ) );
+		$this->assertEquals( $expected, file_get_contents( $files[ '/test/path/test.jpg' ] ) );
 	}
 
 	public function test__remove_file() {
@@ -203,12 +228,12 @@ class API_Cache_Test extends \WP_UnitTestCase {
 		file_put_contents( $test_file, 'test data' );
 
 		$filesProp = self::get_property( $this->cache, 'files' );
-		$filesProp->setValue( $this->cache, [ 'test.jpg' => $test_file ] );
+		$filesProp->setValue( $this->cache, [ '/test/path/test.jpg' => $test_file ] );
 
 		$statsProp = self::get_property( $this->cache, 'file_stats' );
-		$statsProp->setValue( $this->cache, [ 'test.jpg' => [ 'size' => '24', 'mtime' => '123456779' ] ] );
+		$statsProp->setValue( $this->cache, [ '/test/path/test.jpg' => [ 'size' => '24', 'mtime' => '123456779' ] ] );
 
-		$this->cache->remove_file( 'test.jpg' );
+		$this->cache->remove_file( '/test/path/test.jpg' );
 
 		$files = $filesProp->getValue( $this->cache );
 
@@ -222,12 +247,12 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 	public function test__remove_stats() {
 		$prop = self::get_property( $this->cache, 'file_stats' );
-		$prop->setValue( $this->cache, [ 'test.jpg' => [ 'size' => '234', 'mtime' => '123456779' ] ] );
+		$prop->setValue( $this->cache, [ '/test/path/test.jpg' => [ 'size' => '234', 'mtime' => '123456779' ] ] );
 
-		$this->cache->remove_stats( 'test.jpg' );
+		$this->cache->remove_stats( '/test/path/test.jpg' );
 
 		$stats = $prop->getValue( $this->cache );
 
-		$this->assertFalse( isset( $stats[ 'test.jpg' ] ) );
+		$this->assertFalse( isset( $stats[ '/test/path/test.jpg' ] ) );
 	}
 }

--- a/tests/files/test-vip-filesystem-api-cache.php
+++ b/tests/files/test-vip-filesystem-api-cache.php
@@ -119,7 +119,10 @@ class API_Cache_Test extends \WP_UnitTestCase {
 	}
 
 	public function test__get_file_stats__invalid__same_file_different_path() {
-		$expected = [ 'size' => '123', 'mtime' => '123456779' ];
+		$expected = [
+			'size' => '123',
+			'mtime' => '123456779',
+		];
 
 		$prop = self::get_property( $this->cache, 'file_stats' );
 		$prop->setValue( $this->cache, [ 'test.jpg' => $expected ] );
@@ -138,7 +141,7 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		$files = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $files[ '/test/path/test.txt' ] ) );
+		$this->assertTrue( isset( $files['/test/path/test.txt'] ) );
 	}
 
 	public function test__cache_file__update_cache() {
@@ -159,8 +162,8 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		$files = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $files[ '/test/path/test.jpg' ] ) );
-		$this->assertEquals( $expected, file_get_contents( $files[ '/test/path/test.jpg' ] ) );
+		$this->assertTrue( isset( $files['/test/path/test.jpg'] ) );
+		$this->assertEquals( $expected, file_get_contents( $files['/test/path/test.jpg'] ) );
 	}
 
 	public function test__cache_file_stats() {
@@ -171,22 +174,30 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		$stats = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $stats[ '/test/path/test.txt' ] ) );
-		$this->assertEquals( $expected, $stats[ '/test/path/test.txt' ] );
+		$this->assertTrue( isset( $stats['/test/path/test.txt'] ) );
+		$this->assertEquals( $expected, $stats['/test/path/test.txt'] );
 	}
 
 	public function test__cache_file_stats__update_cache() {
 		$prop = self::get_property( $this->cache, 'file_stats' );
-		$prop->setValue( $this->cache, [ '/test/path/test.jpg' => [ 'size' => '234', 'mtime' => '123456779' ] ] );
+		$prop->setValue( $this->cache, [
+			'/test/path/test.jpg' => [
+				'size' => '234',
+				'mtime' => '123456779',
+			],
+		] );
 
-		$expected = [ 'size' => '411', 'mtime' => '123459001'];
+		$expected = [
+			'size' => '411',
+			'mtime' => '123459001'
+		];
 
 		$this->cache->cache_file_stats( '/test/path/test.jpg', $expected );
 
 		$stats = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $stats[ '/test/path/test.jpg' ] ) );
-		$this->assertEquals( $expected, $stats[ '/test/path/test.jpg' ] );
+		$this->assertTrue( isset( $stats['/test/path/test.jpg'] ) );
+		$this->assertEquals( $expected, $stats['/test/path/test.jpg'] );
 	}
 
 	public function test__copy_to_cache() {
@@ -218,8 +229,8 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		$files = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $files[ '/test/path/test.jpg' ] ) );
-		$this->assertEquals( $expected, file_get_contents( $files[ '/test/path/test.jpg' ] ) );
+		$this->assertTrue( isset( $files['/test/path/test.jpg'] ) );
+		$this->assertEquals( $expected, file_get_contents( $files['/test/path/test.jpg'] ) );
 	}
 
 	public function test__remove_file() {
@@ -227,32 +238,42 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		file_put_contents( $test_file, 'test data' );
 
-		$filesProp = self::get_property( $this->cache, 'files' );
-		$filesProp->setValue( $this->cache, [ '/test/path/test.jpg' => $test_file ] );
+		$files_prop = self::get_property( $this->cache, 'files' );
+		$files_prop->setValue( $this->cache, [ '/test/path/test.jpg' => $test_file ] );
 
-		$statsProp = self::get_property( $this->cache, 'file_stats' );
-		$statsProp->setValue( $this->cache, [ '/test/path/test.jpg' => [ 'size' => '24', 'mtime' => '123456779' ] ] );
+		$stats_prop = self::get_property( $this->cache, 'file_stats' );
+		$stats_prop->setValue( $this->cache, [
+			'/test/path/test.jpg' => [
+				'size' => '24',
+				'mtime' => '123456779',
+			],
+		] );
 
 		$this->cache->remove_file( '/test/path/test.jpg' );
 
-		$files = $filesProp->getValue( $this->cache );
+		$files = $files_prop->getValue( $this->cache );
 
 		$this->assertEmpty( $files );
 		$this->assertFalse( file_exists( $test_file ) );
 
-		$stats = $statsProp->getValue( $this->cache );
+		$stats = $stats_prop->getValue( $this->cache );
 
 		$this->assertEmpty( $stats );
 	}
 
 	public function test__remove_stats() {
 		$prop = self::get_property( $this->cache, 'file_stats' );
-		$prop->setValue( $this->cache, [ '/test/path/test.jpg' => [ 'size' => '234', 'mtime' => '123456779' ] ] );
+		$prop->setValue( $this->cache, [
+			'/test/path/test.jpg' => [
+				'size' => '234',
+				'mtime' => '123456779',
+			],
+		] );
 
 		$this->cache->remove_stats( '/test/path/test.jpg' );
 
 		$stats = $prop->getValue( $this->cache );
 
-		$this->assertFalse( isset( $stats[ '/test/path/test.jpg' ] ) );
+		$this->assertFalse( isset( $stats['/test/path/test.jpg'] ) );
 	}
 }

--- a/tests/files/test-vip-filesystem-api-cache.php
+++ b/tests/files/test-vip-filesystem-api-cache.php
@@ -189,7 +189,7 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		$expected = [
 			'size' => '411',
-			'mtime' => '123459001'
+			'mtime' => '123459001',
 		];
 
 		$this->cache->cache_file_stats( '/test/path/test.jpg', $expected );
@@ -208,7 +208,7 @@ class API_Cache_Test extends \WP_UnitTestCase {
 
 		$files = $prop->getValue( $this->cache );
 
-		$this->assertTrue( isset( $files[ '/test/path/test.txt' ] ) );
+		$this->assertTrue( isset( $files['/test/path/test.txt'] ) );
 	}
 
 	public function test__copy_to_cache__update_cache() {


### PR DESCRIPTION
## Description

The current file service API cache uses the file base name as the cache key but this causes problem when a file is uploaded with the same name but on a different path. Functions like `file_exist` will return `true` even though the file is on a different path.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).

## Steps to Test

1. Check out PR.
1. Upload changes to a sandboxed site
1. `wp --allow-root shell`
1. Upload a new file: `file_put_contents( 'vip://wp-content/uploads/path1/test.txt', 'test' );`
1. `file_exist( 'vip://wp-content/uploads/path2/test.txt' );`
1. Verify that `file_exist` call returns `false`.
