### PR TITLE
Search: Create the new index in ES when a version is registered

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -220,7 +220,26 @@ class Versioning {
 			return $result;
 		}
 
+		// Setup the index + mapping so that it's available for immediate use (as changes will start getting replicated here)
+		$this->create_versioned_index_with_mapping( $indexable, $new_version_number );
+
 		return $new_version;
+	}
+
+	/**
+	 * Create the index in ES and put the mapping
+	 * 
+	 * @param \ElasticPress\Indexable $indexable The Indexable type for which to create the new versioned index
+	 * @param int $version_number The index version number to create
+	 */
+	public function create_versioned_index_with_mapping( $indexable, $version_number ) {
+		$this->set_current_version_number( $indexable, $version_number );
+
+		$result = $indexable->put_mapping();
+
+		$this->reset_current_version_number( $indexable );
+
+		return $result;
 	}
 
 	/**

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -48,7 +48,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			return WP_CLI::error( 'Failed to register the new index version' );
 		}
 
-		WP_CLI::success( sprintf( 'Registered new index version %d. The new index has not yet been created', $new_version['number'] ) );
+		WP_CLI::success( sprintf( 'Registered and created new index version %d', $new_version['number'] ) );
 	}
 
 	/**

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -40,11 +40,11 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		$new_version = $search->versioning->add_version( $indexable );
 
-		if ( is_wp_error( $result ) ) {
+		if ( is_wp_error( $new_version ) ) {
 			return WP_CLI::error( $result->get_error_message() );
 		}
 
-		if ( false === $result ) {
+		if ( false === $new_version ) {
 			return WP_CLI::error( 'Failed to register the new index version' );
 		}
 


### PR DESCRIPTION
## Description

Previously, adding a new index version only registered it with VIP Search - it didn't actually create it in Elasticsearch until you ran the `index` command. This changes that behavior so that the index (with mapping) is created when the new version is registered.

This will simplify things and prevent user error/confusion. It also ensures the index is there so we can start syncing changes to it immediately without causing problems.

A full indexing is still required - content is not automatically indexed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Make sure you are running https://github.com/Automattic/vip-go-mu-dev/pull/34 and have rebuilt the env (`lando rebuild --yes`) to expose ES to your local machine.
1. `curl 127.0.0.1:19200/_aliases?pretty=true` to list all existing indexes in ES
1. `lando wp vip-search index-versions add post` to add a new version
1. `curl 127.0.0.1:19200/_aliases?pretty=true` - the new index version should show up
1. `curl 127.0.0.1:19200/vip-200508-post-1-v3/_mapping?pretty=true` (use appropriate index name) - the mapping should be present and have the right stuff (from the ElasticPress mapping file)
