### PR TITLE
Add unified lint command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,7 @@ job-references:
           name: "Run Tests"
           command: |
             if [[ "$RUN_EXTRA" == "1" ]]; then
-              npm run phplint
-              npm run phpcs:changed:remote
+              npm run lint
             fi
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "phplint": "bin/php-lint.sh",
     "phpcs": "vendor/bin/phpcs",
     "phpcs:changed:remote": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet",
-	"phpcs:changed:local": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet -d index",
-	"lint": "npm run phplint && npm run phpcs:changed:remote",
-	"update-subtrees": "git subtree pull --prefix search/es-wp-query git@github.com:Automattic/es-wp-query master --squash"
+    "phpcs:changed:local": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet -d index",
+    "lint": "npm run phplint && npm run phpcs:changed:remote",
+    "update-subtrees": "git subtree pull --prefix search/es-wp-query git@github.com:Automattic/es-wp-query master --squash"
   },
   "author": "Automattic",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "phpcs": "vendor/bin/phpcs",
     "phpcs:changed:remote": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet",
 	"phpcs:changed:local": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet -d index",
+	"lint": "npm run phplint && npm run phpcs:changed:remote",
 	"update-subtrees": "git subtree pull --prefix search/es-wp-query git@github.com:Automattic/es-wp-query master --squash"
   },
   "author": "Automattic",


### PR DESCRIPTION
## Description

We currently have several lint commands, primarily 1 for checking PHP syntax, and another for checking PHPCS rules for the diff. This combines those into an easier-to-type single command - `npm run lint`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- n/a This change works and has been tested locally (or has an appropriate fallback).
- n/a This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `npm run lint` - should run both `./bin/php-lint.sh` and `npm run phpcs:changed:remote`
