### PR TITLE
Reduce add to queue stat usage

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -514,6 +514,8 @@ class Versioning {
 					\Automattic\VIP\Search\Search::instance()->queue->queue_object( $object_id, $object_type, $options );
 				}
 
+				\Automattic\VIP\Search\Search::instance()->queue->record_added_to_queue_stat( count( $objects_by_version[ $active_version_number ] ), $indexable->slug );
+
 				$this->reset_current_version_number( $indexable );
 			}
 		}

--- a/search/includes/classes/queue/class-cron.php
+++ b/search/includes/classes/queue/class-cron.php
@@ -180,9 +180,7 @@ class Cron {
 		// Iterate pagination
 		while ( $args['paged'] <= $posts->max_num_pages ) {
 			// Queue all posts for page 
-			foreach ( $posts->posts as $post ) {
-				$this->queue->queue_object( $post );
-			}
+			$this->queue->queue_objects( $posts->posts, 'post' );
 
 			// Go to the next page and reset $posts
 			$args['paged'] = intval( $args['paged'] ) + 1;


### PR DESCRIPTION
## Description

Reduce the number of statsd calls by not repeatedly incrementing add to queue stats by 1. Instead, increment by the number added to the queue so it's always only 1 call.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Use https://github.com/Automattic/vip-go-mu-dev
2. Apply PR.
3. `~$ lando logs -f` to see statsd output
4. `~$ lando wp shell`
5. `\Automattic\VIP\Search\Search::instance()->queue->record_added_to_queue_stat(3000, 'post');`
6. Added to queue stat should be add up to 3000 in statsd output.
7. `\Automattic\VIP\Search\Search::instance()->queue->queue_objects( array( 0, 1, 2, 3, 4, 5) );`
8. Added to queue stat should add up to 6.
9. `~$ lando wp vip-search queue stress-test`
10. Added to queue stat should add up to the number outputted(e.g.: `Without index debouncing and rate limiting, would expect 600 index operations` would mean the stat should add up to 600).