### PR TITLE
Search: Add version support to document count validation job and command

### DIFF
--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -120,7 +120,9 @@ class HealthJob {
 		$versions = $search->versioning->get_versions( $post_indexable );
 
 		foreach( $versions as $version ) {
-			$post_results = Health::validate_index_posts_count( $version['number'] );
+			$post_results = Health::validate_index_posts_count( array(
+				'index_version' => $version['number'],
+			) );
 
 			$this->process_results( $post_results );
 		}

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -113,7 +113,7 @@ class HealthJob {
 
 			$users_versions = $search->versioning->get_versions( $users_indexable );
 
-			foreach( $users_versions as $version ) {
+			foreach ( $users_versions as $version ) {
 				$user_results = Health::validate_index_users_count( array(
 					'index_version' => $version['number'],
 				) );
@@ -126,7 +126,7 @@ class HealthJob {
 
 		$posts_versions = $search->versioning->get_versions( $post_indexable );
 
-		foreach( $posts_versions as $version ) {
+		foreach ( $posts_versions as $version ) {
 			$post_results = Health::validate_index_posts_count( array(
 				'index_version' => $version['number'],
 			) );

--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -104,22 +104,29 @@ class HealthJob {
 			return;
 		}
 
+		$search = \Automattic\VIP\Search\Search::instance();
+
 		$users_feature = \ElasticPress\Features::factory()->get_registered_feature( 'users' );
 
 		if ( $users_feature instanceof \ElasticPress\Feature && $users_feature->is_active() ) {
-			$user_results = Health::validate_index_users_count();
+			$users_indexable = \ElasticPress\Indexables::factory()->get( 'user' );
 
-			$this->process_results( $user_results );
+			$users_versions = $search->versioning->get_versions( $users_indexable );
+
+			foreach( $users_versions as $version ) {
+				$user_results = Health::validate_index_users_count( array(
+					'index_version' => $version['number'],
+				) );
+
+				$this->process_results( $user_results );
+			}
 		}
-
-		// Check all versions
-		$search = \Automattic\VIP\Search\Search::instance();
 
 		$post_indexable = \ElasticPress\Indexables::factory()->get( 'post' );
 
-		$versions = $search->versioning->get_versions( $post_indexable );
+		$posts_versions = $search->versioning->get_versions( $post_indexable );
 
-		foreach( $versions as $version ) {
+		foreach( $posts_versions as $version ) {
 			$post_results = Health::validate_index_posts_count( array(
 				'index_version' => $version['number'],
 			) );

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -169,8 +169,6 @@ class Health {
 
 			$result = self::validate_index_entity_count( $query_args, $posts );
 
-			$result['index_version'] = $index_version;
-
 			// In case of error skip to the next post type
 			// Not returning an error, otherwise there is no visibility on other post types
 			if ( is_wp_error( $result ) ) {
@@ -181,6 +179,8 @@ class Health {
 					'index_version' => $index_version,
 				];
 			}
+
+			$result['index_version'] = $index_version;
 
 			$results[] = $result;
 

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -121,7 +121,7 @@ class Health {
 		// Indexables::factory()->get() returns boolean|array
 		// False is returned in case of error
 		if ( ! $posts ) {
-			return new WP_Error( 'es_users_query_error', 'failure retrieving post documents from ES #vip-search' );
+			return new WP_Error( 'es_users_query_error', 'failure retrieving post indexable from ES #vip-search' );
 		}
 
 		$post_types = $posts->get_indexable_post_types();

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -90,22 +90,41 @@ class Health {
 	 *
 	 * @return array Array containing entity (post/user), type (N/A), error, ES count, DB count, difference
 	 */
-	public static function validate_index_users_count() {
+	public static function validate_index_users_count( $options = array() ) {
 		$users = Indexables::factory()->get( 'user' );
+
 		// Indexables::factory()->get() returns boolean|array
 		// False is returned in case of error
 		if ( ! $users ) {
-			return new WP_Error( 'es_users_query_error', 'failure retrieving user documents from ES #vip-search' );
+			return new WP_Error( 'es_users_query_error', 'failure retrieving user indexable from ES #vip-search' );
 		}
+
+		$search = \Automattic\VIP\Search\Search::instance();
+
+		if ( $options['index_version'] ) {
+			$version_result = $search->versioning->set_current_version_number( $users, $options['index_version'] );
+
+			if ( is_wp_error( $version_result ) ) {
+				return $version_result;
+			}
+		}
+
+		$index_version = $search->versioning->get_current_version_number( $users );
 
 		$query_args = [
 			'order' => 'asc',
 		];
 
 		$result = self::validate_index_entity_count( $query_args, $users );
+
 		if ( is_wp_error( $result ) ) {
 			return new WP_Error( 'es_users_query_error', sprintf( 'failure retrieving users from ES: %s #vip-search', $result->get_error_message() ) );
 		}
+
+		$result['index_version'] = $index_version;
+	
+		$search->versioning->reset_current_version_number( $users );
+
 		return array( $result );
 	}
 

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -70,7 +70,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 			$versions = wp_list_pluck( $version_objects, 'number' );
 		}
 
-		foreach( $versions as $version_number ) {
+		foreach ( $versions as $version_number ) {
 			$users_results = \Automattic\VIP\Search\Health::validate_index_users_count( array(
 				'index_version' => $version_number,
 			) );
@@ -113,7 +113,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 			$versions = wp_list_pluck( $version_objects, 'number' );
 		}
 
-		foreach( $versions as $version_number ) {
+		foreach ( $versions as $version_number ) {
 			$posts_results = \Automattic\VIP\Search\Health::validate_index_posts_count( array(
 				'index_version' => $version_number,
 			) );

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -90,9 +90,9 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 			$versions = wp_list_pluck( $version_objects, 'number' );
 		}
 
-		foreach( $versions as $version ) {
+		foreach( $versions as $version_number ) {
 			$posts_results = \Automattic\VIP\Search\Health::validate_index_posts_count( array(
-				'index_version' => $version,
+				'index_version' => $version_number,
 			) );
 
 			if ( is_wp_error( $posts_results ) ) {

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -72,6 +72,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 				'type' => 'post',
 				'db_total' => 1000,
 				'es_total' => 900,
+				'index_version' => 111,
 				'diff' => -100,
 			),
 			array(
@@ -79,6 +80,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 				'type' => 'custom_type',
 				'db_total' => 100,
 				'es_total' => 200,
+				'index_version' => 222,
 				'diff' => 100,
 			),
 			array(
@@ -86,6 +88,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 				'type' => 'N/A',
 				'db_total' => 100,
 				'es_total' => 100,
+				'index_version' => 333,
 				'diff' => 0,
 			),
 			array(
@@ -108,10 +111,11 @@ class HealthJob_Test extends \WP_UnitTestCase {
 				array(
 					'#vip-go-es-alerts',
 					sprintf(
-						'Index inconsistencies found for %s: (entity: %s, type: %s, DB count: %s, ES count: %s, Diff: %s)',
+						'Index inconsistencies found for %s: (entity: %s, type: %s, index_version: %d, DB count: %s, ES count: %s, Diff: %s)',
 						home_url(),
 						$results[0]['entity'],
 						$results[0]['type'],
+						$results[0]['index_version'],
 						$results[0]['db_total'],
 						$results[0]['es_total'],
 						$results[0]['diff']
@@ -122,10 +126,11 @@ class HealthJob_Test extends \WP_UnitTestCase {
 				array(
 					'#vip-go-es-alerts',
 					sprintf(
-						'Index inconsistencies found for %s: (entity: %s, type: %s, DB count: %s, ES count: %s, Diff: %s)',
+						'Index inconsistencies found for %s: (entity: %s, type: %s, index_version: %d, DB count: %s, ES count: %s, Diff: %s)',
 						home_url(),
 						$results[1]['entity'],
 						$results[1]['type'],
+						$results[1]['index_version'],
 						$results[1]['db_total'],
 						$results[1]['es_total'],
 						$results[1]['diff']

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -3,6 +3,13 @@
 namespace Automattic\VIP\Search;
 
 class HealthJob_Test extends \WP_UnitTestCase {
+	/**
+	 * Make tests run in separate processes since we're testing state
+	 * related to plugin init, including various constants.
+	 */
+	protected $preserveGlobalState = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+	protected $runTestInSeparateProcess = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
 	public static function setUpBeforeClass() {
 		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array( 'https://elasticsearch:9200' ) );
 

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -3,8 +3,21 @@
 namespace Automattic\VIP\Search;
 
 class HealthJob_Test extends \WP_UnitTestCase {
-	public function setUp() {
+	public static function setUpBeforeClass() {
+		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array( 'https://elasticsearch:9200' ) );
+
 		require_once __DIR__ . '/../../../../search/search.php';
+
+		\Automattic\VIP\Search\Search::instance();
+
+		// Required so that EP registers the Indexables
+		do_action( 'plugins_loaded' );
+
+		// Users indexable doesn't get registered by default, but we have tests that queue user objects
+		\ElasticPress\Indexables::factory()->register( new \ElasticPress\Indexable\User\User() );
+	}
+
+	public function setUp() {
 		require_once __DIR__ . '/../../../../search/includes/classes/class-health-job.php';
 	}
 


### PR DESCRIPTION
## Description

Now that index versioning is supported, we need to monitor the consistency of the various versions. This PR adds version support to `wp vip-search health validate-counts` and the cron job that monitors counts.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR
1. Make sure you have at least an additional index version (`lando wp vip-search index-versions list post`)
1. Run `lando wp vip-search health validate-counts` - if there are no inconsistencies, there is no difference
1. Introduce an inconsistency by adding a new version (but not running the index command for it) - `lando wp vip-search index-versions add post`
1. `lando wp vip-search health validate-counts` again - should get inconsistencies as the new index is not built. Like:

```
❌  inconsistencies found when counting entity: post, type: post, index_version: 5 - (DB: 1001, ES: 1, Diff: -1000)
❌  inconsistencies found when counting entity: post, type: page, index_version: 5 - (DB: 51, ES: 1, Diff: -50)
```

1. Test the cron job - not sure this is worth doing manually, I did it myself, but basically you have to add an error_log() to `wpcom_vip_irc()`, edit the `HealthJob::is_enabled()` function to always return true, visit a page so that the cron job is registered, manually run cron with `wp cron event run --due-now`, then check the `wp-content/wp-debug.log` file to see if the message went through.
1. Test users - steps TBD (not sure this works at all)
