### PR TITLE
Search: Improve memory management for validate_contents

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -240,9 +240,7 @@ class Health {
 			}
 
 			// Cleanup WordPress object cache to keep memory usage under control
-			global $wp_object_cache;
-			$wp_object_cache->flush();
-			$wp_object_cache->group_ops = array();
+			wpcom_vip_flush_object_cache();
 
 			if ( $is_cli && ! $silent ) {
 				echo sprintf( "...%s\n", empty( $result ) ? '✅' : '❌' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -240,7 +240,7 @@ class Health {
 			}
 
 			// Cleanup WordPress object cache to keep memory usage under control
-			wpcom_vip_flush_object_cache();
+			vip_reset_local_object_cache();
 
 			if ( $is_cli && ! $silent ) {
 				echo sprintf( "...%s\n", empty( $result ) ? '✅' : '❌' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -239,6 +239,11 @@ class Health {
 				$last_post_id = self::get_last_post_id();
 			}
 
+			// Cleanup WordPress object cache to keep memory usage under control
+			global $wp_object_cache;
+			$wp_object_cache->flush();
+			$wp_object_cache->group_ops = array();
+
 			if ( $is_cli && ! $silent ) {
 				echo sprintf( "...%s\n", empty( $result ) ? '✅' : '❌' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -147,6 +147,14 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * @subcommand validate-contents
 	 */
 	public function validate_contents( $args, $assoc_args ) {
+		// Disable DB and ES query logs to keep memory usage under control
+		if ( ! defined( 'SAVEQUERIES' ) ) {
+			define( 'SAVEQUERIES', false );
+		}
+		if ( ! defined( 'EP_QUERY_LOG' ) ) {
+			define( 'EP_QUERY_LOG', false );
+		}
+
 		$results = \Automattic\VIP\Search\Health::validate_index_posts_content( $assoc_args['start_post_id'], $assoc_args['last_post_id'], $assoc_args['batch_size'], $assoc_args['max_diff_size'], isset( $assoc_args['silent'] ), isset( $assoc_args['inspect'] ) );
 
 		if ( is_wp_error( $results ) ) {

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -742,15 +742,17 @@ function wpcom_vip_enable_maybe_skip_old_slug_redirect() {
 function wpcom_vip_flush_object_cache() {
 	global $wp_object_cache;
 
-	if ( !is_object( $wp_object_cache ) )
+	if ( ! is_object( $wp_object_cache ) ) {
 		return;
+	}
 
 	$wp_object_cache->group_ops = array();
 	$wp_object_cache->memcache_debug = array();
 	$wp_object_cache->cache = array();
 
-	if ( is_callable( $wp_object_cache, '__remoteset' ) )
+	if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
 		$wp_object_cache->__remoteset(); // important
+	}
 }
 
 /**

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -735,11 +735,12 @@ function wpcom_vip_enable_maybe_skip_old_slug_redirect() {
 }
 
 /**
- * Flush WordPress object cache
+ * Reset the local WordPress object cache
  *
- * Some of these are also done by wp_cache_flush(), but this is more complete
+ * This only cleans the local cache in WP_Object_Cache, without
+ * affecting memcache
  */
-function wpcom_vip_flush_object_cache() {
+function vip_reset_local_object_cache() {
 	global $wp_object_cache;
 
 	if ( ! is_object( $wp_object_cache ) ) {
@@ -756,9 +757,9 @@ function wpcom_vip_flush_object_cache() {
 }
 
 /**
- * Flush WP DB query log
+ * Reset the WordPress DB query log
  */
-function wpcom_vip_flush_db_query_log() {
+function vip_reset_db_query_log() {
 	global $wpdb;
 
 	$wpdb->queries = array();

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -735,6 +735,34 @@ function wpcom_vip_enable_maybe_skip_old_slug_redirect() {
 }
 
 /**
+ * Flush WordPress object cache
+ *
+ * Some of these are also done by wp_cache_flush(), but this is more complete
+ */
+function wpcom_vip_flush_object_cache() {
+	global $wp_object_cache;
+
+	if ( !is_object( $wp_object_cache ) )
+		return;
+
+	$wp_object_cache->group_ops = array();
+	$wp_object_cache->memcache_debug = array();
+	$wp_object_cache->cache = array();
+
+	if ( is_callable( $wp_object_cache, '__remoteset' ) )
+		$wp_object_cache->__remoteset(); // important
+}
+
+/**
+ * Flush WP DB query log
+ */
+function wpcom_vip_flush_db_query_log() {
+	global $wpdb;
+
+	$wpdb->queries = array();
+}
+
+/**
 * Enables object caching for the response sent by Instagram when querying for Instagram image HTML.
 *
 * This cannot be included inside Jetpack because it ships with caching disabled by default.

--- a/vip-helpers/vip-wp-cli.php
+++ b/vip-helpers/vip-wp-cli.php
@@ -6,8 +6,8 @@ class WPCOM_VIP_CLI_Command extends WP_CLI_Command {
 	 *  Clear all of the caches for memory management
 	 */
 	protected function stop_the_insanity() {
-		wpcom_vip_flush_db_query_log();
-		wpcom_vip_flush_object_cache();
+		vip_reset_db_query_log();
+		vip_reset_local_object_cache();
 	}
 
 	/**

--- a/vip-helpers/vip-wp-cli.php
+++ b/vip-helpers/vip-wp-cli.php
@@ -2,23 +2,12 @@
 
 class WPCOM_VIP_CLI_Command extends WP_CLI_Command {
 
-	/*
+	/**
 	 *  Clear all of the caches for memory management
 	 */
 	protected function stop_the_insanity() {
-		global $wpdb, $wp_object_cache;
-
-		$wpdb->queries = array(); // or define( 'WP_IMPORTING', true );
-
-		if ( !is_object( $wp_object_cache ) )
-			return;
-
-		$wp_object_cache->group_ops = array();
-		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache = array();
-
-		if ( is_callable( $wp_object_cache, '__remoteset' ) )
-			$wp_object_cache->__remoteset(); // important
+		wpcom_vip_flush_db_query_log();
+		wpcom_vip_flush_object_cache();
 	}
 
 	/**


### PR DESCRIPTION
## Description

Improve memory management for the command `wp vip-search health validate-contents`.

On very large sites with hundreds of thousands of documents, this command would take increasingly amounts of memory (e.g, around 4 GB for 100k documents). This is mostly due to non-flushing cache and logs, so this PR tackles them:

- Disable Elasticpress query log
- Disable WP DB query log
- Flush WP object cache after every validation block

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
n/a This change has relevant unit tests (if applicable).
n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out this PR
1. Check out the required PR for ElasticPress submodule: https://github.com/Automattic/ElasticPress/pull/48
1. Run `wp vip-search health validate-contents` for a large site and check that memory usage doesn't increase (or increases slowly)