### PR TITLE
Fix undeclared variable

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -23,6 +23,8 @@ class CoreCommand extends \ElasticPress\Command {
 				return WP_CLI::error( 'The --indexables argument is required when specifying --version, as each indexable has separate versioning' );
 			}
 
+			$search = \Automattic\VIP\Search\Search::instance();
+
 			// Additionally, --version is not compatible with --network-wide in non-network mode, because subsites will also have different versions
 			if ( isset( $assoc_args['network-wide'] ) && ! $search->is_network_mode() ) {
 				return WP_CLI::error( 'The --network-wide argument is not compatible with --version when not using network mode (the `EP_IS_NETWORK` constant), as subsites can have differing index versions' );
@@ -30,8 +32,6 @@ class CoreCommand extends \ElasticPress\Command {
 
 			// For each indexable specified, override the version
 			$indexable_slugs = explode( ',', str_replace( ' ', '', $assoc_args['indexables'] ) );
-
-			$search = \Automattic\VIP\Search\Search::instance();
 
 			foreach ( $indexable_slugs as $slug ) {
 				$indexable = \ElasticPress\Indexables::factory()->get( $slug );


### PR DESCRIPTION
## Description

Fix for an undeclared $search variable which is needed for the EP network mode check.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Execute `wp vip-search index --network-wide --version=2 --indexables=post`, it will fail with a PHP error
1. Check out PR.
1. Execute the same command again, it will show the expected error message
