### PR TITLE
Fix parse_str() missing parameter deprecation

### DIFF
--- a/tests/vip-helpers/test-wpcom-vip-set-image-quality-for-url.php
+++ b/tests/vip-helpers/test-wpcom-vip-set-image-quality-for-url.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Automattic\VIP\Tests;
+
+class WPCOM_VIP_Set_Image_Quality_For_Url_Test extends \WP_UnitTestCase {
+
+	private const ATTACHMENT_URL = 'https://example.com/wp-contents/uploads/2020/08/foo.jpg';
+
+	public function get_data_for_testing_args() {
+		return [
+			'Valid args'                    => [
+				null,
+				80,
+				'info',
+				'?quality=80&strip=info',
+			],
+			'Quality greater than 100'      => [ // How does VIP File Service handle this?
+				null,
+				101,
+				false,
+				'?quality=101',
+			],
+			'Quality is a negative integer' => [
+				null,
+				-20,
+				false,
+				'?quality=20',
+			],
+			'Quality is a string'           => [
+				null,
+				'ninety-nine',
+				false,
+				'?quality=0', // Should there be a better value if the argument isn't valid?
+			],
+			'Quality is boolean true'       => [
+				null,
+				true,
+				false,
+				'?quality=1', // Should there be a better value if the argument isn't valid?
+			],
+			'Quality is boolean false'      => [
+				null,
+				false,
+				false,
+				'?quality=0', // Should there be a better value if the argument isn't valid?
+			],
+			'Strip is boolean true'         => [
+				null,
+				100,
+				true,
+				'?quality=100&strip=all',
+			],
+			'Strip is a positive int'       => [
+				null,
+				100,
+				99,
+				'?quality=100&strip=99', // Should there be a better value if the argument isn't valid?
+			],
+			'Strip is a zero int'           => [
+				null,
+				100,
+				0,
+				'?quality=100',
+			],
+			'Strip is a negative int'       => [
+				null,
+				100,
+				-99,
+				'?quality=100&strip=-99', // Should there be a better value if the argument isn't valid?
+			],
+			'URL is valid, but does not contain a jpg or jpeg' => [
+				'https://example.com/foo.png?foo=bar',
+				100,
+				false,
+				'',
+			],
+			'URL is valid, contains jpg or jpeg in the path but not in an extension' => [
+				'https://example.com/jpgs/foo.png',
+				80,
+				'all',
+				'',
+			],
+			'URL is valid, contains jpg or jpeg in the querystring but not in an extension' => [
+				'https://example.com/foo.png?image-type=jpeg',
+				80,
+				'all',
+				'',
+			],
+			'URL is not a URL string'       => [
+				'not a URL',
+				100,
+				false,
+				'',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_data_for_testing_args
+	 */
+	public function test__args( $attachment_url, $quality, $strip, $expected_qs ) {
+		$attachment_url = $attachment_url ?? self::ATTACHMENT_URL;
+
+		$this->assertEquals(
+			$attachment_url . $expected_qs,
+			wpcom_vip_set_image_quality_for_url( $attachment_url, $quality, $strip )
+		);
+	}
+
+	public function test__default_args() {
+		$this->assertEquals(
+			self::ATTACHMENT_URL . '?quality=100',
+			wpcom_vip_set_image_quality_for_url( self::ATTACHMENT_URL )
+		);
+	}
+}

--- a/vip-helpers/vip-media.php
+++ b/vip-helpers/vip-media.php
@@ -114,7 +114,7 @@ function wpcom_vip_set_image_quality_for_url( $attachment_url, $quality = 100, $
 		return $attachment_url;
 
 	if ( isset( $url['query'] ) )
-		$query = parse_str( $url['query'] );
+		parse_str( $url['query'], $query );
 
 	$query['quality'] = absint( $quality );
 


### PR DESCRIPTION
## Description

PHPCompatibility flagged the original instance of the code as:

> The "result" parameter for function parse_str() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is deprecated since PHP 7.2 (PHPCompatibility.FunctionUse.OptionalToRequiredFunctionParameters.parse_str_resultSoftRequired)

As per the `parse_str()` [documentation](php.net/manual/en/function.parse-str.php), "using this function without the result parameter is highly DISCOURAGED and DEPRECATED as of PHP 7.2."

To ensure that the fix didn't change the behaviour, I wrote a bunch of unit tests before making the change, and then made the change, and the unit tests still passed.

As an aside, the unit tests revealed some non-ideal values being returned, to which I've left comments on the tests, but fixing them is out the scope of this PR.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] ~This change has relevant documentation additions / updates (if applicable).~

## Steps to Test

1. Check out the first commit, https://github.com/Automattic/vip-go-mu-plugins/commit/71b00588712841ff205c491a5168cefcefb07ee7.
1. `lando ssh` then `phpunit tests/vip-helpers/test-wpcom-vip-set-image-quality-for-url.php` to just run this unit test.
1. Confirm tests pass, and give a visual inspection of the suitability.
1. Check out this PR / the second commit (https://github.com/Automattic/vip-go-mu-plugins/commit/76796c561097f11e1f060dcaa51b411d08b6775b).
1. Re-run the unit tests and confirm they still pass.
