### PR TITLE
Override ep prepare meta allowed protected keys

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -212,6 +212,9 @@ class Search {
 	
 		// Check if meta is on allow list. If not, don't re-index
 		add_filter( 'ep_skip_post_meta_sync', array( $this, 'filter__ep_skip_post_meta_sync' ), PHP_INT_MAX, 5 );
+
+		// Override value of ep_prepare_meta_allowed_protected_keys with the value of vip_search_post_meta_allow_list 
+		add_filter( 'ep_prepare_meta_allowed_protected_keys', array( $this, 'filter__ep_prepare_meta_allowed_protected_keys' ), PHP_INT_MAX );
 	}
 
 	protected function load_commands() {
@@ -1358,6 +1361,10 @@ class Search {
 
 		return $post_meta_allow_list;
 	}
+
+	public function filter__ep_prepare_meta_allowed_protected_keys( $keys ) {
+		return \apply_filters( 'vip_search_post_meta_allow_list', $keys );
+	}	
 
 	/*
 	 * Increment the number of queries that have been passed through VIP Search

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1364,7 +1364,7 @@ class Search {
 
 	public function filter__ep_prepare_meta_allowed_protected_keys( $keys ) {
 		return \apply_filters( 'vip_search_post_meta_allow_list', $keys );
-	}	
+	}
 
 	/*
 	 * Increment the number of queries that have been passed through VIP Search

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2053,6 +2053,42 @@ class Search_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__filter__ep_prepare_meta_allowed_protected_keys_should_be_empty_if_post_meta_allow_list_is_empty() {
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array();
+			},
+			PHP_INT_MAX
+		);
+
+		\Automattic\VIP\Search\Search::instance();
+
+		$this->assertEmpty( \apply_filters( 'ep_prepare_meta_allowed_protected_keys', array( 'test', 'keys' ) ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__filter__ep_prepare_meta_allowed_protected_keys_should_equal_post_meta_allow_list() {
+		\add_filter(
+			'vip_search_post_meta_allow_list',
+			function() {
+				return array( 'different', 'stuff' );
+			},
+			PHP_INT_MAX
+		);
+
+		\Automattic\VIP\Search\Search::instance();
+
+		$this->assertEquals( \apply_filters( 'ep_prepare_meta_allowed_protected_keys', array( 'test', 'keys' ) ), array( 'different', 'stuff' ) );
+	}
+
+	/**
 	 * Helper function for accessing protected methods.
 	 */
 	protected static function get_method( $name ) {


### PR DESCRIPTION
## Description

The protected meta allow list from ElasticPress should be overridden to use our post meta allow list for ease-of-use.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Apply PR.
2. `lando test tests/search/test-class-search.php`