### PR TITLE
Move `clearstatcache` call into the client class

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -93,6 +93,11 @@ class API_Client {
 			return new WP_Error( 'upload_file-failed-invalid_path', sprintf( __( 'Failed to upload file `%1$s` to `%2$s`; the file does not exist.' ), $local_path, $upload_path ) );
 		}
 
+		// Clear stat caches for the file.
+		// The various stat-related functions below are cached.
+		// The cached values can then lead to unexpected behavior even after the file has changed (e.g. in Curl_Streamer).
+		clearstatcache( false, $local_path );
+
 		$file_size = filesize( $local_path );
 		$file_name = basename( $local_path );
 		$file_info = wp_check_filetype( $file_name );

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -196,11 +196,6 @@ class VIP_Filesystem_Stream_Wrapper {
 
 				// File doesn't exist on File service so create new file
 				$file = $this->string_to_resource( '', $mode );
-
-				// Clear stat caches for the file.
-				// The upload above calls various stat-related functions which are then cached.
-				// The cached values can then lead to unexpected behavior even after the file has changed (e.g. in Curl_Streamer).
-				clearstatcache( false, $path );
 			} else {
 				$file = fopen( $result, $mode );
 			}


### PR DESCRIPTION
## Description

It was highlighted that there's potential for the files stats to be inaccurate when uploading files due to PHP's built in file stat cache. We had a call to `clearstatcache()` added but that really only affected new files. This ensures that the stat cache is cleared for _every_ upload.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

Not really sure how to effectively test this but I basically sandboxed a site and ensured that files are uploaded properly to the file service.