### PR TITLE
Reenable ep post meta filter override

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -214,7 +214,7 @@ class Search {
 		add_filter( 'ep_skip_post_meta_sync', array( $this, 'filter__ep_skip_post_meta_sync' ), PHP_INT_MAX, 5 );
 
 		// Override value of ep_prepare_meta_allowed_protected_keys with the value of vip_search_post_meta_allow_list 
-		//add_filter( 'ep_prepare_meta_allowed_protected_keys', array( $this, 'filter__ep_prepare_meta_allowed_protected_keys' ), PHP_INT_MAX );
+		add_filter( 'ep_prepare_meta_allowed_protected_keys', array( $this, 'filter__ep_prepare_meta_allowed_protected_keys' ), PHP_INT_MAX, 2 );
 	}
 
 	protected function load_commands() {
@@ -1362,8 +1362,8 @@ class Search {
 		return $post_meta_allow_list;
 	}
 
-	public function filter__ep_prepare_meta_allowed_protected_keys( $keys ) {
-		return \apply_filters( 'vip_search_post_meta_allow_list', $keys );
+	public function filter__ep_prepare_meta_allowed_protected_keys( $keys, $post ) {
+		return \apply_filters( 'vip_search_post_meta_allow_list', $keys, $post );
 	}
 
 	/*

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2057,8 +2057,8 @@ class Search_Test extends \WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__filter__ep_prepare_meta_allowed_protected_keys_should_be_empty_if_post_meta_allow_list_is_empty() {
-		$this->markTestSkipped();
-	
+		$post = $this->factory->post->create_and_get( [ 'post_status' => 'publish' ] );
+
 		\add_filter(
 			'vip_search_post_meta_allow_list',
 			function() {
@@ -2069,7 +2069,7 @@ class Search_Test extends \WP_UnitTestCase {
 
 		\Automattic\VIP\Search\Search::instance();
 
-		$this->assertEmpty( \apply_filters( 'ep_prepare_meta_allowed_protected_keys', array( 'test', 'keys' ) ) );
+		$this->assertEmpty( \apply_filters( 'ep_prepare_meta_allowed_protected_keys', array( 'test', 'keys' ), $post ) );
 	}
 
 	/**
@@ -2077,7 +2077,7 @@ class Search_Test extends \WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__filter__ep_prepare_meta_allowed_protected_keys_should_equal_post_meta_allow_list() {
-		$this->markTestSkipped();
+		$post = $this->factory->post->create_and_get( [ 'post_status' => 'publish' ] );
 
 		\add_filter(
 			'vip_search_post_meta_allow_list',
@@ -2089,7 +2089,7 @@ class Search_Test extends \WP_UnitTestCase {
 
 		\Automattic\VIP\Search\Search::instance();
 
-		$this->assertEquals( \apply_filters( 'ep_prepare_meta_allowed_protected_keys', array( 'test', 'keys' ) ), array( 'different', 'stuff' ) );
+		$this->assertEquals( \apply_filters( 'ep_prepare_meta_allowed_protected_keys', array( 'test', 'keys' ), $post ), array( 'different', 'stuff' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Added post field for compatibility.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Apply PR.
2. Replace `add_filter( 'ep_prepare_meta_allowed_protected_keys', array( $this, 'filter__ep_prepare_meta_allowed_protected_keys' ), PHP_INT_MAX, 2 );` with `add_filter( 'ep_prepare_meta_allowed_protected_keys', array( $this, 'filter__ep_prepare_meta_allowed_protected_keys' ), PHP_INT_MAX );`
3. `lando test lando test tests/search/test-class-search.php`
4. It should error.
5. Reset to PR changes.
6. `lando test lando test tests/search/test-class-search.php`
7. It should not error. 