### PR TITLE
Search: Support --network-wide in validate-counts commands

### DIFF
--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -111,6 +111,8 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 				switch_to_blog( $site['blog_id'] );
 
 				$this->validate_indexable_count_for_site( $indexable_slug, $version );
+				
+				restore_current_blog();
 			}
 		} else {
 			WP_CLI::line( "Validating $indexable_slug count\n" );

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -93,7 +93,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 			$version = null;
 		}
 
-		if ( isset( $assoc_args['network-wide'] ) && is_multisite() && $search->is_network_mode() ) {
+		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
 			if ( isset( $version ) ) {
 				return WP_CLI::error( 'The --network-wide argument is not compatible with --version when not using network mode (the `EP_IS_NETWORK` constant), as subsites  can have differing index versions' );
 			}


### PR DESCRIPTION
## Description

Support `--network-wide` parameter for `vip-search health validate-counts` commands. If the parameter is provided, these commands will show the stats for all sites of the network, instead of only the main site.

This is not compatible with `--version`, as every subsite can have a different index version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR
1. Execute on a multisite site: `wp vip-search health validate-counts --network-side`
1. Ensure stats for all subsites are shown
