### PR TITLE
Enable comment type cron job for percentage

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -250,12 +250,6 @@ add_filter( 'wp_headers', function( $headers ) {
 // https://make.wordpress.org/core/2020/07/22/new-xml-sitemaps-functionality-in-wordpress-5-5/
 add_filter( 'wp_sitemaps_enabled', '__return_false' );
 
-// Decrease the batch size to 10
-add_filter( 'wp_update_comment_type_batch_size', function() {
-	return 10;
-} );
-// Completely disable comment upgrade routine
-
 remove_action( 'admin_init', '_wp_check_for_scheduled_update_comment_type' );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -250,13 +250,16 @@ add_filter( 'wp_headers', function( $headers ) {
 // https://make.wordpress.org/core/2020/07/22/new-xml-sitemaps-functionality-in-wordpress-5-5/
 add_filter( 'wp_sitemaps_enabled', '__return_false' );
 
-remove_action( 'admin_init', '_wp_check_for_scheduled_update_comment_type' );
+// Completely disable comment upgrade routine for a subset of sites
+if ( ! \Automattic\VIP\Feature::is_enabled( 'comment_type_update_cron' ) ) {
+	remove_action( 'admin_init', '_wp_check_for_scheduled_update_comment_type' );
 
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	// @phpcs:ignore PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, PEAR.Functions.FunctionCallSignature.MultipleArguments
-	add_action( 'init', function() {
-		wp_unschedule_hook( 'wp_update_comment_type_batch' );
-	} );
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		// @phpcs:ignore PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, PEAR.Functions.FunctionCallSignature.MultipleArguments
+		add_action( 'init', function() {
+			wp_unschedule_hook( 'wp_update_comment_type_batch' );
+		} );
+	}
 }
 
 do_action( 'vip_loaded' );

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -3,7 +3,9 @@
 namespace Automattic\VIP;
 
 class Feature {
-	public static $feature_percentages = array();
+	public static $feature_percentages = array(
+		'comment_type_update_cron' => 0.10, // Percent of sites that can run the comment type update batch jobs
+	);
 
 	public static $site_id = FILES_CLIENT_SITE_ID;
 


### PR DESCRIPTION
## Description

Enables the comment type batch jobs for 10% of sites. We'll ramp this up over time.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1.  Ensure dev env is on 5.5
1. Edit mu-plugins/lib/feature/class-feature.php to set the `comment_type_update_cron` percentage to 1 (to ensure it runs)
1. `lando wp option delete finished_updating_comment_type` to reset the cron job
1. Visit a wp-admin page
1. `lando wp cron-control events list | grep wp_update_comment_type_batch` - should report that the cron job is scheduled
1. Let that cron job run
1. Edit mu-plugins/lib/feature/class-feature.php to set the `comment_type_update_cron` percentage to - (to ensure it never runs)
1. `lando wp option delete finished_updating_comment_type` to reset the cron job
1. Visit a wp-admin page
1. `lando wp cron-control events list | grep wp_update_comment_type_batch` - should come back empty as the job has been unscheduled (is disabled)

