### PR TITLE
Bump comment type job percentage to 75%

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -4,7 +4,7 @@ namespace Automattic\VIP;
 
 class Feature {
 	public static $feature_percentages = array(
-		'comment_type_update_cron' => 0.50, // Percent of sites that can run the comment type update batch jobs
+		'comment_type_update_cron' => 0.75, // Percent of sites that can run the comment type update batch jobs
 	);
 
 	public static $site_id = FILES_CLIENT_SITE_ID;


### PR DESCRIPTION
## Description

Increases number of sites running the comment type update batch job to 75%

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
