### PR TITLE
Disable above compat admin notice for EP

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -215,6 +215,9 @@ class Search {
 
 		// Override value of ep_prepare_meta_allowed_protected_keys with the value of vip_search_post_meta_allow_list 
 		add_filter( 'ep_prepare_meta_allowed_protected_keys', array( $this, 'filter__ep_prepare_meta_allowed_protected_keys' ), PHP_INT_MAX, 2 );
+
+		// Do not show the above compat notice since VIP Search will support whatever Elasticsearch version we're running
+		add_filter( 'pre_option_ep_hide_es_above_compat_notice', '__return_true' );
 	}
 
 	protected function load_commands() {


### PR DESCRIPTION
## Description

Once we go over Elasticsearch 7.5, admin notices about being over the compatible version will show.

We should hide these since we should never be above the version we support since we control the full stack.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Open wp-admin in Lando. You should see the above compat admin notice.
2. Apply PR.
3. The notice should no longer appear.
