### PR TITLE
Enable comment type update cron job for all sites

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -255,16 +255,4 @@ add_filter( 'wp_headers', function( $headers ) {
 // https://make.wordpress.org/core/2020/07/22/new-xml-sitemaps-functionality-in-wordpress-5-5/
 add_filter( 'wp_sitemaps_enabled', '__return_false' );
 
-// Completely disable comment upgrade routine for a subset of sites
-if ( ! \Automattic\VIP\Feature::is_enabled( 'comment_type_update_cron' ) ) {
-	remove_action( 'admin_init', '_wp_check_for_scheduled_update_comment_type' );
-
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		// @phpcs:ignore PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, PEAR.Functions.FunctionCallSignature.MultipleArguments
-		add_action( 'init', function() {
-			wp_unschedule_hook( 'wp_update_comment_type_batch' );
-		} );
-	}
-}
-
 do_action( 'vip_loaded' );

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -3,9 +3,7 @@
 namespace Automattic\VIP;
 
 class Feature {
-	public static $feature_percentages = array(
-		'comment_type_update_cron' => 0.75, // Percent of sites that can run the comment type update batch jobs
-	);
+	public static $feature_percentages = array();
 
 	public static $site_id = FILES_CLIENT_SITE_ID;
 


### PR DESCRIPTION
## Description

Have ramped up to 75%, so now going to 100% by removing all the disabling code

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Since this just removes the block (ramping up to 100% of sites, from 75%), this has all been tested before, but still should poke around the site to ensure no errors are reported.
