### PR TITLE
Updates VIP GO Privacy Exports for 5.4

### DIFF
--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -179,32 +179,32 @@ function generate_personal_data_export_file( $request_id ) {
 		$archive_pathname = $exports_dir . $archive_filename;
 		$archive_url      = $exports_url . $archive_filename;
 
-			// Remove the deprecated postmeta.
-			delete_post_meta( $request_id, '_export_file_url' );
-			delete_post_meta( $request_id, '_export_file_path' );
-		} elseif ( ! empty( $archive_pathname ) ) {
-			// Check if archive_pathname exists. If not, create the new postmeta and remove the deprecated.
-			$archive_filename = basename( $archive_pathname );
-			$archive_url      = $exports_url . $archive_filename;
+		// Remove the deprecated postmeta.
+		delete_post_meta( $request_id, '_export_file_url' );
+		delete_post_meta( $request_id, '_export_file_path' );
+	} elseif ( ! empty( $archive_pathname ) ) {
+		// Check if archive_pathname exists. If not, create the new postmeta and remove the deprecated.
+		$archive_filename = basename( $archive_pathname );
+		$archive_url      = $exports_url . $archive_filename;
 
-			// Add the new postmeta that is used since version 5.4.
-			update_post_meta( $request_id, '_export_file_name', wp_normalize_path( $archive_filename ) );
+		// Add the new postmeta that is used since version 5.4.
+		update_post_meta( $request_id, '_export_file_name', wp_normalize_path( $archive_filename ) );
 
-			// Remove the deprecated postmeta.
-			delete_post_meta( $request_id, '_export_file_url' );
-			delete_post_meta( $request_id, '_export_file_path' );
-		} else {
-			// If there's no archive_filename or archive_pathname create a new one.
-			$archive_filename = $file_basename . '.zip';
-			$archive_url      = $exports_url . $archive_filename;
-			$archive_pathname = $exports_dir . $archive_filename;
+		// Remove the deprecated postmeta.
+		delete_post_meta( $request_id, '_export_file_url' );
+		delete_post_meta( $request_id, '_export_file_path' );
+	} else {
+		// If there's no archive_filename or archive_pathname create a new one.
+		$archive_filename = $file_basename . '.zip';
+		$archive_url      = $exports_url . $archive_filename;
+		$archive_pathname = $exports_dir . $archive_filename;
 
-			// Add the new postmeta that is used since version 5.4.
-			update_post_meta( $request_id, '_export_file_name', wp_normalize_path( $archive_filename ) );
+		// Add the new postmeta that is used since version 5.4.
+		update_post_meta( $request_id, '_export_file_name', wp_normalize_path( $archive_filename ) );
 
-			// Remove the deprecated postmeta.
-			delete_post_meta( $request_id, '_export_file_url' );
-			delete_post_meta( $request_id, '_export_file_path' );
+		// Remove the deprecated postmeta.
+		delete_post_meta( $request_id, '_export_file_url' );
+		delete_post_meta( $request_id, '_export_file_path' );
 	}
 
 	// Track generated time to simplify deletions.

--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -265,7 +265,7 @@ function generate_personal_data_export_file( $request_id ) {
 	// ZipArchive may not be available across all applications.
 	// Use it if it exists, otherwise fallback to PclZip.
 	if ( class_exists( '\ZipArchive' ) ) {
-		$zip = new \ZipArchive;
+		$zip = new \ZipArchive; // phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
 		if ( true === $zip->open( $local_archive_pathname, \ZipArchive::CREATE ) ) {
 			if ( ! $zip->addFile( $json_report_pathname, 'export.json' ) ) {
 				$error = __( 'Unable to add data to JSON file.' );

--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -72,7 +72,7 @@ function generate_personal_data_export_file( $request_id ) {
 	$stripped_email       = str_replace( '@', '-at-', $email_address );
 	$stripped_email       = sanitize_title( $stripped_email ); // slugify the email address
 	$obscura              = wp_generate_password( 32, false, false );
-	$file_basename        = 'wp-personal-data-file-' . $stripped_email . '-' . $obscura;;
+	$file_basename        = 'wp-personal-data-file-' . $stripped_email . '-' . $obscura;
 	$html_report_filename = wp_unique_filename( $temp_dir, $file_basename . '.html' );
 	$html_report_pathname = wp_normalize_path( $temp_dir . $html_report_filename );
 	$json_report_filename = $file_basename . '.json';


### PR DESCRIPTION
## Description

WordPress 5.4 changed how privacy exports managed the post meta data for generated ZIP files.  This was done in https://core.trac.wordpress.org/changeset/48127 and it broke VIP Go's overrides.

This PR should bring the VIP Go functionality up to date with the changes in the core functionality.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Visit a site's export `/wp-admin/export-personal-data.php` on a WP 5.4 or higher install
1. Try to export data, and see it fails.
1. Patch
1. Try again and see if a ZIP is downloaded.
