### PR TITLE
Hotfix for async scheduler command: don't use wp_schedule_single_event, instead use Cron Control's schedule_event

### DIFF
--- a/wp-cli/class-async-scheduler-command.php
+++ b/wp-cli/class-async-scheduler-command.php
@@ -50,7 +50,7 @@ class Async_Scheduler_Command extends \WPCOM_VIP_CLI_Command {
 
 		if ( ! $scheduled_or_running ) {
 			WP_CLI::line( sprintf( 'Scheduling the command: `%s` (timestamp: %d)', $command, $timestamp ) );
-			wp_schedule_single_event( $timestamp, self::COMMAND_CRON_EVENT_KEY, [ $command ] );
+			\Automattic\WP\Cron_Control\schedule_event( $timestamp, self::COMMAND_CRON_EVENT_KEY, [ 'args' => [ $command ] ] );
 			wp_cache_set( $cache_key, $timestamp, self::COMMAND_TIMESTAMP_CACHE_GROUP );
 		} else {
 			WP_CLI::error( 'This command is already scheduled or running.' );


### PR DESCRIPTION
## Description

This is a follow-up to #1723 

As it turns out, `wp_schedule_single_event` doesn't actually schedule properly with Cron Control on our infrastructure (It does so in local dev). 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Schedule the command `wp vip cmd-scheduler check-status --cmd="my cmd to-run" --when="1598297946"
1. `wp cron-control event list` to make sure it got scheduled.
1. Rejoice.
