### PR TITLE
Search: implement a confirmation prompt before executing destructive CLI commands

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -87,10 +87,10 @@ class Search {
 		 * Load CLI commands
 		 */
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			require_once __DIR__ . '/commands/class-corecommand.php';
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 			require_once __DIR__ . '/commands/class-queuecommand.php';
 			require_once __DIR__ . '/commands/class-versioncommand.php';
-			require_once __DIR__ . '/commands/class-corecommand.php';
 
 			// Remove elasticpress command. Need a better way.
 			//WP_CLI::add_hook( 'before_add_command:elasticpress', [ $this, 'abort_elasticpress_add_command' ] );

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -93,6 +93,21 @@ class CoreCommand extends \ElasticPress\Command {
 	}
 
 	/**
+	 * Delete the index for each indexable. !!Warning!! This removes your elasticsearch index(s)
+	 * for the entire site.
+	 *
+	 * @synopsis [--index-name] [--network-wide] [--skip-confirm]
+	 * @subcommand delete-index
+	 *
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function delete_index( $args, $assoc_args ) {
+		self::confirm_destructive_operation( $assoc_args );
+		parent::delete_index( $args, $assoc_args );
+	}
+
+	/**
 	 * Certain operations might result in data loss (deleting an index version or putting a new mapping).
 	 *
 	 * We need to make sure we get a user's confirmation before proceeding with a destructive operation

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -196,6 +196,9 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 * <version_number>
 	 * : The version number of the index to delete
 	 *
+	 * [--skip-confirm]
+	 * : Skip confirmation
+	 *
 	 * ## EXAMPLES
 	 *     wp vip-search index-versions delete post 2
 	 *
@@ -223,7 +226,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			return WP_CLI::error( sprintf( 'Index version %d is active for type %s and cannot be deleted', $version_number, $type ) );
 		}
 
-		WP_CLI::confirm( sprintf( 'Are you sure you want to delete index version %d for type %s?', $version_number, $type ), $assoc_args );
+		CoreCommand::confirm_destructive_operation( $assoc_args );
 
 		$result = $search->versioning->delete_version( $indexable, $version_number );
 


### PR DESCRIPTION
## Description

Currently, it's too easy to destroy an index inadvertently. E.g. a bad copy-paste with `--setup` flag does not require confirmation. Same with `put-mapping`.

To address that we're introducing `CoreCommand::confirm_destructive_operation()`, which prints a nice prompt for those types of operations.

If `--skip-confirm` is passed, no prompt will be displayed/

<img width="739" alt="Screen Shot 2020-08-25 at 1 23 47 PM" src="https://user-images.githubusercontent.com/459254/91214289-7a747b80-e6d8-11ea-8561-96587c234cd6.png">


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

