### PR TITLE
Search: Add Health::reconcile_diff method to allow for the correction of index inconsistencies.

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -282,7 +282,7 @@ class Health {
 			vip_reset_local_object_cache();
 
 			if ( $is_cli && ! $silent ) {
-				echo sprintf( "...%s %s\n", empty( $result ) ? '✅' : '❌', $do_not_heal || empty( $result ) ? '' : '(attempted to reconcile)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo sprintf( "...%s %s\n", empty( $result ) ? '✓' : '✘', $do_not_heal || empty( $result ) ? '' : '(attempted to reconcile)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		} while ( $start_post_id <= $last_post_id );
 

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -463,16 +463,17 @@ class Health {
 	/**
 	 * Iterate over an array of inconsistencies and address accordingly.
 	 *
-	 * If an object is missing from the index - add it to the queue for the sweep.
+	 * If an object is missing from the index or inconsistent - add it to the queue for the sweep.
 	 *
 	 * If an object is missing from the DB, remove it from the index.
 	 *
-	 * @param array $diff array of inconsistenices in the following shape: [ id => string, type => string (Indexable), issue => <missing_from_index|extra_in_index> ].
+	 * @param array $diff array of inconsistenices in the following shape: [ id => string, type => string (Indexable), issue => <missing_from_index|extra_in_index|inconsistent> ].
 	 */
 	public static function reconcile_diff( array $diff ) {
 		foreach ( $diff as $key => $obj_to_reconcile ) {
 			switch ( $obj_to_reconcile['issue'] ) {
 				case 'missing_from_index':
+				case 'inconsistent':
 					\Automattic\VIP\Search\Search::instance()->queue->queue_object( $obj_to_reconcile['id'], $obj_to_reconcile['type'] );
 					break;
 				case 'extra_in_index':

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -474,10 +474,10 @@ class Health {
 			switch ( $obj_to_reconcile['issue'] ) {
 				case 'missing_from_index':
 					\Automattic\VIP\Search\Search::instance()->queue->queue_object( $obj_to_reconcile['id'], $obj_to_reconcile['type'] );
-				break;
+					break;
 				case 'extra_in_index':
 					\ElasticPress\Indexables::factory()->get( 'post' )->delete( $obj_to_reconcile['id'], false );
-				break;
+					break;
 			}
 		}
 	}

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -460,6 +460,28 @@ class Health {
 		return $diff;
 	}
 
+	/**
+	 * Iterate over an array of inconsistencies and address accordingly.
+	 *
+	 * If an object is missing from the index - add it to the queue for the sweep.
+	 *
+	 * If an object is missing from the DB, remove it from the index.
+	 *
+	 * @param array $diff array of inconsistenices in the following shape: [ id => string, type => string (Indexable), issue => <missing_from_index|extra_in_index> ].
+	 */
+	public static function reconcile_diff( array $diff ) {
+		foreach ( $diff as $key => $obj_to_reconcile ) {
+			switch ( $obj_to_reconcile['issue'] ) {
+				case 'missing_from_index':
+					\Automattic\VIP\Search\Search::instance()->queue->queue_object( $obj_to_reconcile['id'], $obj_to_reconcile['type'] );
+				break;
+				case 'extra_in_index':
+					\ElasticPress\Indexables::factory()->get( 'post' )->delete( $obj_to_reconcile['id'], false );
+				break;
+			}
+		}
+	}
+
 	public static function get_last_post_id() {
 		global $wpdb;
 

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -231,6 +231,9 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * default: csv
 	 * ---
 	 *
+	 * [--heal]
+	 * : Optional try to correct the issue (either index missing or remove extra from an index)
+	 *
 	 * [--silent]
 	 * : Optional silences all non-error output except for the final results
 	 *
@@ -249,12 +252,17 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		}
 
 		$results = \Automattic\VIP\Search\Health::validate_index_posts_content( $assoc_args['start_post_id'], $assoc_args['last_post_id'], $assoc_args['batch_size'], $assoc_args['max_diff_size'], isset( $assoc_args['silent'] ), isset( $assoc_args['inspect'] ) );
-
+		
 		if ( is_wp_error( $results ) ) {
 			$diff = $results->get_error_data( 'diff' );
 
 			if ( ! empty( $diff ) ) {
 				$this->render_contents_diff( $diff, $assoc_args['format'], $assoc_args['max_diff_size'] );
+
+				if ( isset( $assoc_args['heal'] ) && $assoc_args['heal'] ) {
+					WP_CLI::line( 'Reconciling the differences!' );
+					\Automattic\VIP\Search\Health::reconcile_diff( $diff );
+				}
 			}
 
 			WP_CLI::error( $results->get_error_message() );
@@ -272,6 +280,11 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		if ( ! isset( $assoc_args['silent'] ) ) {
 			// Not empty, so inconsistencies were found...
 			WP_CLI::warning( 'Inconsistencies found!' );
+		}
+
+		if ( isset( $assoc_args['heal'] ) && $assoc_args['heal'] ) {
+			WP_CLI::line( 'Reconciling the differences!' );
+			\Automattic\VIP\Search\Health::reconcile_diff( $results );
 		}
 
 		$this->render_contents_diff( $results, $assoc_args['format'], $assoc_args['max_diff_size'], isset( $assoc_args['silent'] ) );


### PR DESCRIPTION
## Description

Currently, the only way to address index inconsistencies is to re-index the content. Re-indexing also doesn't resolve the issue where something is in the indexed, but the object was deleted in a way that our hooks didn't catch.

This PR addresses that by introducing a new static method Health::reconcile_diff which addresses a batch on inconsistencies (either add to the index queue or delete from the index.

By default, try to correct the inconsistencies, but allow to skip that step via `--do-not-heal` flag.

Here's how it looks:

First run:
```
$ wp vip-search health validate-contents
Validating posts 1 - 500...❌
Warning: Inconsistencies found!
Reconciling the differences!
type,id,issue
post,1,extra_in_index
```

Second run:
```
$ wp vip-search health validate-contents 
Validating posts 1 - 500...✅
Success: No inconsistencies found!
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Add or remove a post directly in the DB (i.e. not using any core methods)
1. Run `wp vip-search health validate-contents --heal` and verify that inconsistencies are indeed found
1. Run the queue via `wp cron event run vip_search_queue_processor`
1. Run `wp vip-search health validate-contents --heal` again and verify that there are no inconsistencies anymore.
