### PR TITLE
Features: Use a site_id() function instead of defaulting to FILES_CLIENT_SITE_ID

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -5,7 +5,7 @@ namespace Automattic\VIP;
 class Feature {
 	public static $feature_percentages = array();
 
-	public static $site_id = FILES_CLIENT_SITE_ID;
+	public static $site_id = false;
 
 	public static function is_enabled( $feature ) {
 		return static::is_enabled_by_percentage( $feature );
@@ -20,11 +20,19 @@ class Feature {
 
 		// Which bucket is the site in - 100 possibilites, one for each percentage. We run this through crc32 with
 		// the feature name so that the same sites aren't always the canaries
-		$bucket = crc32( $feature . '-' . static::$site_id ) % 100;
+		$bucket = crc32( $feature . '-' . static::site_id() ) % 100;
 
 		// Is the bucket enabled?
 		$threshold = $percentage * 100; // $percentage is decimal
 
 		return $bucket < $threshold; // If our 0-based bucket is inside our threshold, it's enabled
+	}
+
+	public static function site_id() {
+		if ( static::$site_id ) {
+			return static::$site_id;
+		}
+
+		return defined( 'FILES_CLIENT_SITE_ID' ) ? FILES_CLIENT_SITE_ID : 0;
 	}
 }

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -29,6 +29,7 @@ class Feature {
 	}
 
 	public static function site_id() {
+		// This is used in tests, so the site id can be easily changed
 		if ( static::$site_id ) {
 			return static::$site_id;
 		}

--- a/tests/lib/feature/test-class-feature.php
+++ b/tests/lib/feature/test-class-feature.php
@@ -160,6 +160,20 @@ class Feature_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $expected, $enabled );
 	}
 
+	public function test_is_enabled_by_percentage_using_constant() {
+		Feature::$site_id = false;
+
+		// Feature will use FILES_CLIENT_SITE_ID, which is 123 in tests, when it isn't set on the class
+
+		Feature::$feature_percentages = array(
+			'foo-feature' => 0.75,
+		);
+
+		$enabled = Feature::is_enabled_by_percentage( 'foo-feature' );
+
+		$this->assertEquals( true, $enabled );
+	}
+
 	public function test_is_enabled_by_percentage_with_undefined_feature() {
 		Feature::$site_id = 1;
 


### PR DESCRIPTION
## Description

The `FILES_CLIENT_SITE_ID` constant is not necessarily defined, such as in custom local dev environments, so can't use it directly...needs to be wrapped.

Fixes #1730

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Remove any reference to `define( 'FILES_CLIENT_SITE_ID', ... )` anywhere
1. Run a check in the theme's functions.php - `\Automattic\VIP\Feature::is_enabled( 'foo' )` - this should not throw any undefined constant warnings
