### PR TITLE
Fix file stats cache reset on upload

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -145,8 +145,9 @@ class API_Client {
 		// save to cache
 		$this->cache->copy_to_cache( $response_data->filename, $local_path );
 
-		// reset file stats cache if any
-		$this->cache->remove_stats( $response_data->filename );
+		// Reset file stats cache, if any.
+		// Note: the ltrim is because we store the path without the leading slash but the API returns the path with it.
+		$this->cache->remove_stats( ltrim( $response_data->filename, '/' ) );
 
 		return $response_data->filename;
 	}

--- a/tests/files/test-api-client.php
+++ b/tests/files/test-api-client.php
@@ -486,9 +486,22 @@ class API_Client_Test extends \WP_UnitTestCase {
 		$file_path = __DIR__ . '/../fixtures/files/upload.jpg';
 		$upload_path = '/wp-content/uploads/file.txt';
 
+		$cache = self::get_property( $this->api_client, 'cache' )->getValue( $this->api_client );
+
+		// To test that upload_file() properly clears the cache, we'll set some data to start
+		$cache->cache_file_stats( 'wp-content/uploads/file.txt', array(
+			'size' => 0,
+			'mtime' => 12345,
+		) );
+
 		$actual_result = $this->api_client->upload_file( $file_path, $upload_path );
 
-		$this->assertEquals( $upload_path, $actual_result );
+		$this->assertEquals( $upload_path, $actual_result, 'Invalid result from upload_file()' );
+
+		$cachedStats = $cache->get_file_stats( 'wp-content/uploads/file.txt' );
+
+		// Should be cleared out of stats cache
+		$this->assertFalse( $cachedStats, 'Expected false from the file stat cache after upload' );
 	}
 
 	public function get_test_data__get_unique_filename() {

--- a/tests/files/test-api-client.php
+++ b/tests/files/test-api-client.php
@@ -498,10 +498,10 @@ class API_Client_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $upload_path, $actual_result, 'Invalid result from upload_file()' );
 
-		$cachedStats = $cache->get_file_stats( 'wp-content/uploads/file.txt' );
+		$cached_stats = $cache->get_file_stats( 'wp-content/uploads/file.txt' );
 
 		// Should be cleared out of stats cache
-		$this->assertFalse( $cachedStats, 'Expected false from the file stat cache after upload' );
+		$this->assertFalse( $cached_stats, 'Expected false from the file stat cache after upload' );
 	}
 
 	public function get_test_data__get_unique_filename() {

--- a/tests/files/test-api-client.php
+++ b/tests/files/test-api-client.php
@@ -65,6 +65,12 @@ class API_Client_Test extends \WP_UnitTestCase {
 		return $method;
 	}
 
+	public static function get_property( $object, $name ) {
+		$property = new \ReflectionProperty( get_class( $object ), $name );
+		$property->setAccessible( true );
+		return $property;
+	}
+
 	public function get_test_data__is_valid_path() {
 		return [
 			'other path' => [


### PR DESCRIPTION
We store the path in the cache without the leading slash but the API returns the path with it. We need to remove the leading slash, otherwise the cache doesn't get cleared and we end up with stale data (e.g. filesize is incorrect).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `wp shell`
1. `file_put_contents( 'vip://wp-content/uploads/yay1.txt', 'hello' )`
1. `filesize( 'vip://wp-content/uploads/yay1.txt' )` <= should return `5`; without the fix, returns `0`.