### PR TITLE
Adjust environment type to the ones allowed in WP 5.5.1

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -201,21 +201,23 @@ if ( ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) || // legac
 	}
 }
 
-// Set WordPress environment type to the VIP Go environment name
+// Set WordPress environment type
+// Map some VIP environments to 'production' and 'development', and use 'staging' for any other
 if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
-	$env = VIP_GO_APP_ENVIRONMENT;
-	if ( 'production' !== $env && 'development' !== $env && 'staging' !== $env ) {
-		if ( ! defined( 'WP_ENVIRONMENT_TYPES' ) ) {
-			define( 'WP_ENVIRONMENT_TYPES', array(
-				'production',
-				'development',
-				'staging',
-				$env,
-			) );
-		}
+	switch ( VIP_GO_APP_ENVIRONMENT ) {
+		case 'production':
+			$environment_type = 'production';
+			break;
+		case 'develop':
+		case 'development':
+			$environment_type = 'development';
+			break;
+		default:
+			$environment_type = 'staging';
+			break;
 	}
 
-	define( 'WP_ENVIRONMENT_TYPE', $env );
+	define( 'WP_ENVIRONMENT_TYPE', $environment_type );
 
 	// VIP sites should not be set as staging in Jetpack
 	// since it breaks SSO and prevents data from being passed to


### PR DESCRIPTION
## Description

WordPress 5.5.1 [won't allow to set custom environment types](https://make.wordpress.org/core/2020/08/27/wordpress-environment-types/), so our previous code to set it matching the VIP environment name won't work.

This PR recovers a previous implementation ( #1703 ) where we map "production" and "develop" VIP environments to "production" and "development" environment types, assigning the "staging" type to any other.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Execute `wp_get_environment_type()` in a wp shell
1. For production sites it should return "production", for develop sites it should return "development", and for the rest "staging"

