### PR TITLE
checkout Cron-Control submodule over https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/Automattic/gutenberg-ramp.git
 [submodule "cron-control-next"]
 	path = cron-control-next
-	url = git@github.com:Automattic/Cron-Control.git
+	url = https://github.com/Automattic/Cron-Control.git
 [submodule "elasticsearch/elasticpress"]
 	path = search/elasticpress
 	url = https://github.com/Automattic/ElasticPress.git


### PR DESCRIPTION
## Description

checkout the `Automattic/Cron-Control` with https instead of ssh.  This is consistent with all other submodules, and has the advantage of checkout without github login.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Tested with `git submodule update --recursive --init --jobs 8` on a newly cloned repo and it successfully checkout all submodules.