### PR TITLE
Package mu-plugins into a container

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,4 +1,5 @@
 .deployignore
+.dockerignore
 
 .ackrc
 .babelrc
@@ -30,6 +31,7 @@ composer.json
 composer.lock
 CONTRIBUTING.md
 dangerfile.js
+Dockerfile
 Gruntfile.js
 gulpfile.babel.js
 install-wp-tests.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.deployignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+#
+# pre-requisite: checkout submodules before building
+#
+FROM debian:buster-slim
+WORKDIR /mu-plugins
+COPY . .
+CMD /bin/sleep infinity

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 #
 # pre-requisite: checkout submodules before building
 #
-FROM debian:buster-slim
+FROM alpine:latest
+RUN apk update && apk add --no-cache rsync
 WORKDIR /mu-plugins
 COPY . .
-CMD /bin/sleep infinity
+ENV MU_PLUGINS_DIR=/host/mu-plugins
+CMD rsync --delete -av /mu-plugins/ "${MU_PLUGINS_DIR}/"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# CI script to build and push the container image
+#
+# requires the following environment variables:
+# REGISTRY: docker registry e.g. hub.docker.com
+#
+set -euo pipefail
+set -x
+
+if [[ -z ${REGISTRY+x} ]]; then
+  echo "REGISTRY must be set to the docker registry url" >&2
+  exit 1
+fi
+
+image_base="${1:-${REGISTRY}/mu-plugins}"
+tag=$(git describe --always --tags HEAD)
+image="${image_base}:${tag}"
+latest="${image_base}:latest"
+
+# prepare repo
+function prepare {
+  # git checkout master
+  # git pull
+  git submodule deinit -f .
+  git submodule update --recursive --init --jobs 8
+}
+
+# build the image
+function build {
+  docker build --pull -t "${image}" -t "${latest}" .
+}
+
+# push the image to the registry
+function push {
+  docker push "${image}"
+  docker push "${latest}"
+}
+
+prepare
+build
+#push

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
 #
-# CI script to build and push the container image
+# Usage: $0 <image-base-name>
+#  e.g. $0 registry.example.com/mu-plugins
 #
-# requires the following environment variables:
-# REGISTRY: docker registry e.g. hub.docker.com
+# build and push the container image
+# - run this from the directory with the Dockerfile
+# - supply image basename as the first argument
+# - image will be tagged with the commit sha and the latest tag
 #
 set -euo pipefail
 set -x
 
-if [[ -z ${REGISTRY+x} ]]; then
-  echo "REGISTRY must be set to the docker registry url" >&2
-  exit 1
-fi
-
-image_base="${1:-${REGISTRY}/mu-plugins}"
+image_base="${1:-mu-plugins}"
 tag=$(git describe --always --tags HEAD)
 image="${image_base}:${tag}"
 latest="${image_base}:latest"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -31,10 +31,12 @@ function build {
 
 # push the image to the registry
 function push {
-  docker push "${image}"
+  # as a test, push only the latest image
+  # @@@ TODO: also push tagged image
+  #docker push "${image}"
   docker push "${latest}"
 }
 
 prepare
 build
-#push
+push

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,9 +6,8 @@
 #
 set -euxo pipefail
 
-sha=$(git describe --always --tags HEAD)
 image_base="${1:-mu-plugins}"
-image="${image_base}:${sha}"
+image_sha="${image_base}:${SHA}"
 
 # update all submodules
 function prepare {
@@ -20,7 +19,7 @@ function prepare {
 
 # build the image
 function build {
-  docker build --pull -t "${image}" .
+  docker build --pull -t "${image_sha}" .
 }
 
 prepare

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,22 +1,16 @@
 #!/bin/bash
 #
-# Usage: $0 <image-base-name>
-#  e.g. $0 registry.example.com/mu-plugins
+# Usage: $0 <image-name>
 #
-# build and push the container image
-# - run this from the directory with the Dockerfile
-# - supply image basename as the first argument
-# - image will be tagged with the commit sha and the latest tag
+# build and tag the container image as <image-name>:latest
 #
-set -euo pipefail
-set -x
+set -euxo pipefail
 
+sha=$(git describe --always --tags HEAD)
 image_base="${1:-mu-plugins}"
-tag=$(git describe --always --tags HEAD)
-image="${image_base}:${tag}"
-latest="${image_base}:latest"
+image="${image_base}:${sha}"
 
-# prepare repo
+# update all submodules
 function prepare {
   # git checkout master
   # git pull
@@ -26,17 +20,8 @@ function prepare {
 
 # build the image
 function build {
-  docker build --pull -t "${image}" -t "${latest}" .
-}
-
-# push the image to the registry
-function push {
-  # as a test, push only the latest image
-  # @@@ TODO: also push tagged image
-  #docker push "${image}"
-  docker push "${latest}"
+  docker build --pull -t "${image}" .
 }
 
 prepare
 build
-push

--- a/ci/push.sh
+++ b/ci/push.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Usage: $0 <source-image> <target-image>
+#
+# tag the <source-image>:<sha> as <target-image>:latest
+# and <target-image>:<sha>, and push both image tags
+#
+# e.g.$0 my-app hub.docker.com/my-app
+# will tag and push my-app:<sha> as:
+#   - hub.docker.com/my-app:latest
+#   - hub.docker.com/my-app:<sha>
+#
+set -euxo pipefail
+
+if [[ $# != 2 ]]; then
+  echo "Usage: $(basename "$0") <source-image-base> <target-image-base>" >&2
+  exit 1
+fi
+
+sha=$(git describe --always --tags HEAD)
+
+source="$1:${sha}"
+image_sha="$2:${sha}"
+image_latest="$2:latest"
+
+# tag and push latest image
+docker tag "${source}" "${image_latest}"
+docker push "${image_latest}"
+
+# @@@ TODO: also push sha-tagged image
+docker tag "${source}" "${image_sha}"
+#docker push "${image_sha}"

--- a/ci/push.sh
+++ b/ci/push.sh
@@ -17,10 +17,8 @@ if [[ $# != 2 ]]; then
   exit 1
 fi
 
-sha=$(git describe --always --tags HEAD)
-
-source="$1:${sha}"
-image_sha="$2:${sha}"
+source="$1:${SHA}"
+image_sha="$2:${SHA}"
 image_latest="$2:latest"
 
 # tag and push latest image


### PR DESCRIPTION
## Description

**This is a Draft**

Package mu-plugins into a container. This is intended to be used as an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to install mu-plugins onto the host at app start up. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Built the container with the following command:
```
docker build -t mu-plugins:test2  . 
```
Ran the container with the following command, and it copied the mu-plugins to the host's `/tmp/bar` directory.
```
docker run --name mu -d --mount type=bind,source=/tmp/bar,target=/host/mu-plugins -e MU_PLUGINS_DIR=/host/mu-plugins mu-plugins:test2 
```

I also configured a CI build job (on Automattic's internal CI system) to test the `build` and `push` to on-prem docker registry.