### PR TITLE
Update/es wp query to latest

### DIFF
--- a/search/es-wp-query/class-es-wp-query-wrapper.php
+++ b/search/es-wp-query/class-es-wp-query-wrapper.php
@@ -1202,12 +1202,15 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 			$size                  = apply_filters( 'es_query_max_results', 1000 );
 			$this->es_args['size'] = $size;
 		}
+		
+		// ES > 7.0 doesn't return the actual total hits by default (capped at 10k), but we need accurate counts
+		$this->es_args[ 'track_total_hits' ] = true;
 
 		if ( ! $q['suppress_filters'] ) {
 			$this->es_args = apply_filters_ref_array( 'es_posts_request', array( $this->es_args, &$this ) );
 		}
 
-		if ( 'ids' === $q['fields'] || 'id=>parent' === $q['fields'] ) {
+		if ( 'ids' === $q['fields'] || 'id=>parent' === $q['fields'] || apply_filters( 'es_query_use_source', false ) ) {
 			$this->es_response = $this->query_es( $this->es_args );
 			$this->set_posts( $q, $this->es_response );
 			$this->post_count = count( $this->posts );


### PR DESCRIPTION
## Description

Update the es-wp-query subtree to the latest.

This adds a new filter for forcing es-wp-query to use the `_source` fields (`es_query_use_source`) and turns on hit tracking by default to get accurate post counts in ES > 7.0

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Example:

1. Check out PR.
1. On a site with more than 10000 posts, try a query that is offloaded to es-wp-query and see if the total posts is counted correctly
