### PR TITLE
Search: Set render_contents_diff function to private so it isn't registered as a command

### DIFF
--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -280,7 +280,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		$this->render_contents_diff( $results, $assoc_args['format'], $assoc_args['max_diff_size'], isset( $assoc_args['silent'] ) );
 	}
 
-	public function render_contents_diff( $diff, $format = 'csv', $max_diff_size, $silent = false ) {
+	private function render_contents_diff( $diff, $format = 'csv', $max_diff_size, $silent = false ) {
 		if ( ! is_array( $diff ) || empty( $diff ) || 0 >= $max_diff_size ) {
 			return;
 		}


### PR DESCRIPTION
## Description

This isn't a useable command, it's just a helper function, so marking it as `private` so WP-CLI doesn't register it.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `lando wp help vip-search health` - should print `render_contents_diff` as a subcommand
1. Check out PR.
1. `lando wp help vip-search health` - should _not_ print `render_contents_diff` as a subcommand
1. `lando wp vip-search health validate-contents` - just to make sure the command still works as expected
