### PR TITLE
Search: Hook up index version aliases to functions and CLI commands

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -236,6 +236,11 @@ class Versioning {
 				return $this->get_previous_existing_version_number( $indexable );
 
 			default:
+				// Was it a number, but passed through as a string? return it as an ant
+				if ( ctype_digit( strval( $version_number ) ) ) {
+					return intval( $version_number );
+				}
+
 				return new WP_Error( 'invalid-version-number-alias', 'Unknown version number alias. Please use "active", "next" or "previous"' );
 		}
 	}

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -242,7 +242,7 @@ class Versioning {
 				return $this->get_previous_existing_version_number( $indexable );
 
 			default:
-				// Was it a number, but passed through as a string? return it as an ant
+				// Was it a number, but passed through as a string? return it as an int
 				if ( ctype_digit( strval( $version_number ) ) ) {
 					return intval( $version_number );
 				}

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -245,13 +245,13 @@ class Versioning {
 
 		// If there is no active version, we can't determine what next is
 		if ( ! $active_version_number ) {
-			return null;
+			return new WP_Error( 'no-active-index-found', 'There is no active index version so the "next" version cannot be determined' );
 		}
 
 		$versions = $this->get_versions( $indexable );
 
 		if ( empty( $versions ) ) {
-			return null;
+			return new WP_Error( 'no-index-versions-found', 'No index versions found' );
 		}
 
 		// The next existing is the lowest index number after $active_version_number that exists, or null
@@ -262,14 +262,14 @@ class Versioning {
 		$active_version_array_index = array_search( $active_version_number, $version_numbers, true );
 
 		if ( false === $active_version_array_index ) {
-			return null;
+			return new WP_Error( 'active-index-not-found-in-versions-list', 'Active index not found in list of index versions' );
 		}
 
 		$target_array_index = $active_version_array_index + 1;
 
 		// Is there another?
 		if ( ! isset( $version_numbers[ $target_array_index ] ) ) {
-			return null;
+			return new WP_Error( 'no-next-version', 'There is no "next" index version defined' );
 		}
 
 		return $version_numbers[ $target_array_index ];
@@ -280,13 +280,13 @@ class Versioning {
 
 		// If there is no active version, we can't determine what previous is
 		if ( ! $active_version_number ) {
-			return null;
+			return new WP_Error( 'no-active-index-found', 'There is no active index version so the "next" version cannot be determined' );
 		}
 
 		$versions = $this->get_versions( $indexable );
 
 		if ( empty( $versions ) ) {
-			return null;
+			return new WP_Error( 'no-index-versions-found', 'No index versions found' );
 		}
 
 		// The previous existing is the highest index number before $active_version_number that exists, or null
@@ -297,14 +297,14 @@ class Versioning {
 		$active_version_array_index = array_search( $active_version_number, $version_numbers, true );
 
 		if ( false === $active_version_array_index ) {
-			return null;
+			return new WP_Error( 'active-index-not-found-in-versions-list', 'Active index not found in list of index versions' );
 		}
 
 		$target_array_index = $active_version_array_index - 1;
 
 		// Is there another?
 		if ( ! isset( $version_numbers[ $target_array_index ] ) ) {
-			return null;
+			return new WP_Error( 'no-previous-version', 'There is no "previous" index version defined' );
 		}
 
 		return $version_numbers[ $target_array_index ];

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -57,6 +57,12 @@ class Versioning {
 	 * @return bool|WP_Error True on success, or WP_Error on failure
 	 */
 	public function set_current_version_number( Indexable $indexable, $version_number ) {
+		$version_number = $this->normalize_version_number( $indexable, $version_number );
+
+		if ( is_wp_error( $version_number ) ) {
+			return $version_number;
+		}
+
 		// Validate that the requested version is known
 		$versions = $this->get_versions( $indexable );
 
@@ -323,6 +329,12 @@ class Versioning {
 	 */
 	public function get_version( Indexable $indexable, $version_number ) {
 		$slug = $indexable->slug;
+
+		$version_number = $this->normalize_version_number( $indexable, $version_number );
+
+		if ( is_wp_error( $version_number ) ) {
+			return $version_number;
+		}
 	
 		$versions = $this->get_versions( $indexable );
 
@@ -378,6 +390,12 @@ class Versioning {
 	 * @param int|string $version_number The index version number to create
 	 */
 	public function create_versioned_index_with_mapping( $indexable, $version_number ) {
+		$version_number = $this->normalize_version_number( $indexable, $version_number );
+
+		if ( is_wp_error( $version_number ) ) {
+			return $version_number;
+		}
+
 		$this->set_current_version_number( $indexable, $version_number );
 
 		$result = $indexable->put_mapping();
@@ -446,6 +464,12 @@ class Versioning {
 	 * @return bool|WP_Error Boolean indicating success, or WP_Error on error 
 	 */
 	public function activate_version( Indexable $indexable, $version_number ) {
+		$version_number = $this->normalize_version_number( $indexable, $version_number );
+
+		if ( is_wp_error( $version_number ) ) {
+			return $version_number;
+		}
+
 		$versions = $this->get_versions( $indexable );
 
 		// If this wasn't a valid version, abort with error
@@ -478,6 +502,12 @@ class Versioning {
 	 * @return bool|WP_Error Boolean indicating success, or WP_Error on error 
 	 */
 	public function delete_version( Indexable $indexable, $version_number ) {
+		$version_number = $this->normalize_version_number( $indexable, $version_number );
+
+		if ( is_wp_error( $version_number ) ) {
+			return $version_number;
+		}
+
 		// Can't delete active version
 		$active_version_number = $this->get_active_version_number( $indexable );
 
@@ -510,6 +540,12 @@ class Versioning {
 	 * @return bool Boolean indicating success or failure 
 	 */
 	public function delete_versioned_index( $indexable, $version_number ) {
+		$version_number = $this->normalize_version_number( $indexable, $version_number );
+
+		if ( is_wp_error( $version_number ) ) {
+			return $version_number;
+		}
+
 		$this->set_current_version_number( $indexable, $version_number );
 
 		$result = $indexable->delete_index();

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -308,7 +308,7 @@ class Versioning {
 		$target_array_index = $active_version_array_index - 1;
 
 		// Is there another?
-		if ( ! isset( $version_numbers[ $target_array_index ] ) ) {
+		if ( 0 > $target_array_index || ! isset( $version_numbers[ $target_array_index ] ) ) {
 			return new WP_Error( 'no-previous-version', 'There is no "previous" index version defined' );
 		}
 

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -69,11 +69,6 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 */
 	public function get( $args, $assoc_args ) {
 		$type = $args[0];
-		$version_number = intval( $args[1] );
-
-		if ( $version_number <= 0 ) {
-			return WP_CLI::error( 'New version number must be a positive int' );
-		}
 	
 		$search = \Automattic\VIP\Search\Search::instance();
 
@@ -81,6 +76,12 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		if ( ! $indexable ) {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
+		}
+	
+		$version_number = $search->versioning->normalize_version_number( $indexable, $args[1] );
+
+		if ( is_wp_error( $version_number ) ) {
+			return WP_CLI::error( sprintf( 'Index version %s is not valid: %s', $args[1], $version_number->get_error_message() ) );
 		}
 
 		$version = $search->versioning->get_version( $indexable, $version_number );
@@ -150,11 +151,6 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 */
 	public function activate( $args, $assoc_args ) {
 		$type = $args[0];
-		$new_version_number = intval( $args[1] );
-
-		if ( $new_version_number <= 0 ) {
-			return WP_CLI::error( 'New version number must be a positive int' );
-		}
 	
 		$search = \Automattic\VIP\Search\Search::instance();
 
@@ -162,6 +158,12 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		if ( ! $indexable ) {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
+		}
+	
+		$new_version_number = $search->versioning->normalize_version_number( $indexable, $args[1] );
+
+		if ( is_wp_error( $new_version_number ) ) {
+			return WP_CLI::error( sprintf( 'Index version %s is not valid: %s', $args[1], $new_version_number->get_error_message() ) );
 		}
 
 		$active_version_number = $search->versioning->get_active_version_number( $indexable );
@@ -206,11 +208,6 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 */
 	public function delete( $args, $assoc_args ) {
 		$type = $args[0];
-		$version_number = intval( $args[1] );
-
-		if ( $version_number <= 0 ) {
-			return WP_CLI::error( 'New version number must be a positive int' );
-		}
 	
 		$search = \Automattic\VIP\Search\Search::instance();
 
@@ -218,6 +215,12 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		if ( ! $indexable ) {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
+		}
+	
+		$version_number = $search->versioning->normalize_version_number( $indexable, $args[1] );
+
+		if ( is_wp_error( $version_number ) ) {
+			return WP_CLI::error( sprintf( 'Index version %s is not valid: %s', $args[1], $version_number->get_error_message() ) );
 		}
 
 		$active_version_number = $search->versioning->get_active_version_number( $indexable );

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -399,7 +399,7 @@ class Versioning_Test extends \WP_UnitTestCase {
 				// Version string to be normalized
 				'previous',
 				// Expected normalized version number
-				null,
+				new \WP_Error( 'no-previous-version' ),
 			),
 
 			// No next
@@ -420,7 +420,7 @@ class Versioning_Test extends \WP_UnitTestCase {
 				// Version string to be normalized
 				'next',
 				// Expected normalized version number
-				null,
+				new \WP_Error( 'no-next-version' ),
 			),
 
 			// No active
@@ -462,7 +462,7 @@ class Versioning_Test extends \WP_UnitTestCase {
 				// Version string to be normalized
 				'next',
 				// Expected active version
-				null,
+				new \WP_Error( 'active-index-not-found-in-versions-list' ), // NOTE - like above, this is because the default active version is 1, even if it doesn't exist in the list. Likely to change
 			),
 		);
 	}
@@ -477,7 +477,13 @@ class Versioning_Test extends \WP_UnitTestCase {
 
 		$normalized_version_number = self::$version_instance->normalize_version_number( $indexable, $version_string );
 
-		$this->assertEquals( $expected_version_number, $normalized_version_number );
+		if ( is_wp_error( $expected_version_number ) ) {
+			// Just validate the code on WP_Errors
+			$this->assertTrue( is_wp_error( $normalized_version_number ), 'Expected normalized version to be a WP_Error' );
+			$this->assertEquals( $expected_version_number->get_error_code(), $normalized_version_number->get_error_code(), 'Unexpected WP_Error code' );
+		} else {
+			$this->assertEquals( $expected_version_number, $normalized_version_number );
+		}
 	}
 
 	public function add_version_data() {

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -281,6 +281,31 @@ class Versioning_Test extends \WP_UnitTestCase {
 
 	public function normalize_version_number_data() {
 		return array(
+			// Regular, normalizes string representation of a version into an int
+			array(
+				// Input array of versions
+				array(
+					1 => array( 
+						'number' => 1,
+						'active' => false,
+					),
+					2 => array(
+						'number' => 2,
+						'active' => true,
+					),
+					3 => array(
+						'number' => 3,
+						'active' => false,
+					),
+				),
+				// Indexable slug
+				'post',
+				// Version string to be normalized
+				'2',
+				// Expected normalized version number
+				2,
+			),
+
 			// Regular, 'next'
 			array(
 				// Input array of versions


### PR DESCRIPTION
## Description

This makes the previous index alias functionality live by normalizing the index version on internal functions that use it along with the `wp vip-search index-versions` CLI commands.

Once this is merged, we can add `--network-wide` support to the `index-version` commands, and we'll be able to manage versions on multisites easily.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Make sure your site has a few index versions - `lando wp vip-search index-versions add post` (make sure you have 3)
1. Now activate the next version: `lando wp vip-search index-versions activate post next` - it should succeed
1. `lando wp vip-search index-versions list post` should now show the new version as active
1. Switch back to the previous version ``lando wp vip-search index-versions activate post previous`
1. Get the active version `lando wp vip-search index-versions get post active`
1. Activate an inactive version - (assuming the first version is active and there is no previous version) - `lando wp vip-search index-versions activate post previous`
