### PR TITLE
Search: Add --network-wide support to index version commands

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -167,11 +167,7 @@ class Versioning {
 	 * @return array Array of index versions
 	 */
 	public function get_versions( Indexable $indexable ) {
-		if ( Search::is_network_mode() ) {
-			$versions = get_site_option( self::INDEX_VERSIONS_OPTION, array() );
-		} else {
-			$versions = get_option( self::INDEX_VERSIONS_OPTION, array() );
-		}
+		$versions = get_option( self::INDEX_VERSIONS_OPTION, array() );
 
 		$slug = $indexable->slug;
 

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -57,19 +57,20 @@ class Versioning {
 	 * @return bool|WP_Error True on success, or WP_Error on failure
 	 */
 	public function set_current_version_number( Indexable $indexable, $version_number ) {
-		$version_number = $this->normalize_version_number( $indexable, $version_number );
+		$actual_version_number = $this->normalize_version_number( $indexable, $version_number );
 
-		if ( is_wp_error( $version_number ) ) {
-			return $version_number;
+		if ( is_wp_error( $actual_version_number ) ) {
+			return $actual_version_number;
 		}
 
 		// Validate that the requested version is known
 		$versions = $this->get_versions( $indexable );
 
-		if ( ! isset( $versions[ $version_number ] ) ) {
+		if ( ! isset( $versions[ $actual_version_number ] ) ) {
 			return new WP_Error( 'invalid-index-version', sprintf( 'The requested index version %d does not exist', $version_number ) );
 		}
 
+		// Store as $version_number (not $actual_version_number) so that we can resolve aliases like next/previous at runtime in get_current_version_number()
 		$this->current_index_version_by_type[ $indexable->slug ] = $version_number;
 
 		return true;
@@ -106,8 +107,9 @@ class Versioning {
 	public function get_current_version_number( $indexable ) {
 		$override = isset( $this->current_index_version_by_type[ $indexable->slug ] ) ? $this->current_index_version_by_type[ $indexable->slug ] : null;
 
-		if ( is_int( $override ) ) {
-			return $override;
+		// If an override is specified, normalize it (in case it's an alias) and return
+		if ( $override ) {
+			return $this->normalize_version_number( $indexable, $override );
 		}
 
 		return $this->get_active_version_number( $indexable );

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -16,7 +16,7 @@ class CoreCommand extends \ElasticPress\Command {
 
 	protected function _maybe_setup_index_version( &$assoc_args ) {
 		if ( $assoc_args['version'] ) {
-			$desired_version_number = $assoc_args['version'];
+			$version_number = $assoc_args['version'];
 
 			// If version is specified, the indexable must also be specified, as different indexables can have different versions
 			if ( ! isset( $assoc_args['indexables'] ) ) {
@@ -35,13 +35,7 @@ class CoreCommand extends \ElasticPress\Command {
 					return WP_CLI::error( sprintf( 'Indexable %s not found - is the feature active?' ) );
 				}
 
-				$new_version_number = $search->versioning->normalize_version_number( $indexable, $desired_version_number );
-
-				if ( is_wp_error( $new_version_number ) ) {
-					return WP_CLI::error( sprintf( 'Index version %s is not valid: %s', $desired_version_number, $new_version_number->get_error_message() ) );
-				}
-
-				$result = $search->versioning->set_current_version_number( $indexable, $new_version_number );
+				$result = $search->versioning->set_current_version_number( $indexable, $version_number );
 
 				if ( is_wp_error( $result ) ) {
 					return WP_CLI::error( sprintf( 'Error setting version number: %s', $result->get_error_message() ) );

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -174,6 +174,9 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 * 
 	 * <version_number>
 	 * : The version number of the index to activate
+	 * 
+	 * [--network-wide]
+	 * : Optional - activate the version to all subsites. Best used with version aliases like `next` instead of individual version numbers
 	 *
 	 * ## EXAMPLES
 	 *     wp vip-search index-versions activate post
@@ -182,19 +185,66 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 	 */
 	public function activate( $args, $assoc_args ) {
 		$type = $args[0];
-	
-		$search = \Automattic\VIP\Search\Search::instance();
+		$desired_version_number = $args[1];
 
 		$indexable = \ElasticPress\Indexables::factory()->get( $type );
 
 		if ( ! $indexable ) {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
 		}
-	
-		$new_version_number = $search->versioning->normalize_version_number( $indexable, $args[1] );
+
+		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
+			WP_CLI::confirm( sprintf( 'Are you sure you want to activate index version %s for type %s on all sites in this network?', $desired_version_number, $type ), $assoc_args );
+
+			if ( ! is_numeric( $assoc_args['network-wide'] ) ) {
+				$assoc_args['network-wide'] = 0;
+			}
+
+			$sites = \ElasticPress\Utils\get_sites( $assoc_args['network-wide'] );
+
+			foreach ( $sites as $site ) {
+				switch_to_blog( $site['blog_id'] );
+
+				$result = $this->activate_helper( $indexable, $desired_version_number );
+
+				restore_current_blog();
+
+				if ( is_wp_error( $result ) ) {
+					return WP_CLI::error( sprintf( 'Received error for index version %s on site %s - %s', $desired_version_number, $site['domain'] . $site['path'], $result->get_error_message() ) );
+				}
+
+				if ( ! $result ) {
+					return WP_CLI::error( sprintf( 'Failed to activate index version %s for type %s on blog %d (%s)', $desired_version_number, $type, $site['domain'] . $site['path'] ) );
+				}
+
+				WP_CLI::line( sprintf( 'Successfully activated index version %s for type %s on blog %d (%s)', $desired_version_number, $type, $site['blog_id'], $site['domain'] . $site['path'] ) );
+			}
+
+			WP_CLI::success( 'Done!' );
+		} else {
+			WP_CLI::confirm( sprintf( 'Are you sure you want to activate index version %s for type %s?', $desired_version_number, $type ), $assoc_args );
+
+			$result = $this->activate_helper( $indexable, $desired_version_number );
+
+			if ( is_wp_error( $result ) ) {
+				return WP_CLI::error( sprintf( 'Received error for index version %s - %s', $desired_version_number, $result->get_error_message() ) );
+			}
+
+			if ( ! $result ) {
+				return WP_CLI::error( sprintf( 'Failed to activate index version %s for type %s', $desired_version_number, $type ) );
+			}
+
+			WP_CLI::success( sprintf( 'Successfully activated index version %s for type %s', $desired_version_number, $type ) );
+		}
+	}
+
+	protected function activate_helper( Indexable $indexable, $version_number_to_activate ) {
+		$search = \Automattic\VIP\Search\Search::instance();
+
+		$new_version_number = $search->versioning->normalize_version_number( $indexable, $version_number_to_activate );
 
 		if ( is_wp_error( $new_version_number ) ) {
-			return WP_CLI::error( sprintf( 'Index version %s is not valid: %s', $args[1], $new_version_number->get_error_message() ) );
+			return WP_CLI::error( sprintf( 'Index version %s is not valid: %s', $version_number_to_activate, $new_version_number->get_error_message() ) );
 		}
 
 		$active_version_number = $search->versioning->get_active_version_number( $indexable );
@@ -203,19 +253,9 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			return WP_CLI::error( sprintf( 'Index version %d is already active for type %s', $new_version_number, $type ) );
 		}
 
-		WP_CLI::confirm( sprintf( 'Are you sure you want to activate index version %d for type %s?', $new_version_number, $type ), $assoc_args );
-
 		$result = $search->versioning->activate_version( $indexable, $new_version_number );
 
-		if ( is_wp_error( $result ) ) {
-			return WP_CLI::error( $result->get_error_message() );
-		}
-
-		if ( ! $result ) {
-			return WP_CLI::error( sprintf( 'Failed to activate index version %d for type %s', $new_version_number, $type ) );
-		}
-
-		WP_CLI::success( sprintf( 'Successfully activated index version %d for type %s', $new_version_number, $type ) );
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
## Description

Adds `--network-wide` support to the `wp vip-search index-versions` `add` and `activate` commands, for working with index versions on multisites. This lets us create a new index version, index the content, then activate it across all subsites.

```
wp vip-search index-versions add post --network-wide
wp vip-search index --network-wide --version=next --indexables=post
wp vip-search index-versions activate post next --network-wide
```

There are other commands that don't yet support `--network-wide` (`delete`, `get`, `list`, `get-active`), but those are lower priority so I don't want to hold up this PR for them.

## Deployment

This makes a change to how index versions are stored - instead of using a site-wide option on multisites in network mode, each index version list is stored per-site, in regular blog options.

This will affect any production multisites sites that have multiple index versions, so we need to check for those and copy over the option manually there.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Pull down PR
1. Make sure your local environment is a multisite - `lando setup-multisite` if not, then add a site or two via WP Admin
1. `lando wp vip-search index-versions add post --network-wide` to add a new index version on all subsites
1. `lando wp vip-search index-versions list --url=<subsite_url>` to verify the versions exist
1. Index content on all subsites with `lando wp vip-search index --network-wide --version=next --indexables=post`
1. Activate the new indexes with `lando wp vip-search index-versions activate post next --network-wide`
1. Verify that the new index versions are active with `lando wp vip-search index-versions list --url=<subsite_url>`
1. Try the same steps again, but without `--network-wide` (so just single site) to ensure it works as expected
1. Then can add another new version and see how the `next` alias makes it work regardless of the current version for a specific site (site 1 can be on version 2, while site 2 can be on version 3, for example).