### PR TITLE
Pass local date to wpcom_vip_top_posts_array()

### DIFF
--- a/vip-helpers/vip-stats.php
+++ b/vip-helpers/vip-stats.php
@@ -24,9 +24,15 @@
  * }
  */
 function wpcom_vip_top_posts_array( $num_days = 30, $limit = 10, $end_date = false ) {
-
+	
 	// Check Jetpack is present and active
 	if ( class_exists( 'Jetpack' ) && Jetpack::is_active() ) {
+		
+		// WordPress.com stats defaults to current UTC date, default to site's local date instead
+		if ( ! $end_date ) {
+			$end_date = current_datetime()->format( 'Y-m-d' );
+		}
+		
 		$args = array(
 			'days'  => $num_days,
 			'limit' => $limit,

--- a/vip-helpers/vip-stats.php
+++ b/vip-helpers/vip-stats.php
@@ -24,7 +24,6 @@
  * }
  */
 function wpcom_vip_top_posts_array( $num_days = 30, $limit = 10, $end_date = false ) {
-	
 	// Check Jetpack is present and active
 	if ( class_exists( 'Jetpack' ) && Jetpack::is_active() ) {
 		


### PR DESCRIPTION
##  Description

Fixes #1755 - sets the default `$end_date` to the site's local date.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Follow steps to reproduce the issue described in #1755.
1. Check out PR.
1. Run `wpcom_vip_top_posts_array(1)` between midnight UTC and midnight in the site's local time.
1. Verify a non-empty array is returned.

