### PR TITLE
Adds WP CLI command to get a specific document

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -91,6 +91,7 @@ class Search {
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 			require_once __DIR__ . '/commands/class-queuecommand.php';
 			require_once __DIR__ . '/commands/class-versioncommand.php';
+			require_once __DIR__ . '/commands/class-documentcommand.php';
 
 			// Remove elasticpress command. Need a better way.
 			//WP_CLI::add_hook( 'before_add_command:elasticpress', [ $this, 'abort_elasticpress_add_command' ] );
@@ -225,6 +226,7 @@ class Search {
 			WP_CLI::add_command( 'vip-search health', __NAMESPACE__ . '\Commands\HealthCommand' );
 			WP_CLI::add_command( 'vip-search queue', __NAMESPACE__ . '\Commands\QueueCommand' );
 			WP_CLI::add_command( 'vip-search index-versions', __NAMESPACE__ . '\Commands\VersionCommand' );
+			WP_CLI::add_command( 'vip-search documents', __NAMESPACE__ . '\Commands\DocumentCommand' );
 			WP_CLI::add_command( 'vip-search', __NAMESPACE__ . '\Commands\CoreCommand' );
 		}
 	}

--- a/search/includes/classes/commands/class-documentcommand.php
+++ b/search/includes/classes/commands/class-documentcommand.php
@@ -43,12 +43,12 @@ class DocumentCommand extends \WPCOM_VIP_CLI_Command {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
 		}
 
-		$document = $indexable->get($object_id);
+		$document = $indexable->get( $object_id );
 	
 		if ( ! $document ) {
 			return WP_CLI::error( sprintf( 'Document with ID %s of type %s was not found.', $object_id, $type ) );
 		}
 
-		\WP_CLI::success(print_r($document, true));
+		\WP_CLI::success( print_r( $document, true ) );
 	}
 }

--- a/search/includes/classes/commands/class-documentcommand.php
+++ b/search/includes/classes/commands/class-documentcommand.php
@@ -26,6 +26,9 @@ class DocumentCommand extends \WPCOM_VIP_CLI_Command {
 	 * <object_id>
 	 * : The ID of the object
 	 * 
+	 * [--format=<string>]
+	 * : Optional one of: table json csv yaml ids count
+	 * 
 	 * ## EXAMPLES
 	 *     wp vip-search documents get post 2
 	 *
@@ -49,6 +52,7 @@ class DocumentCommand extends \WPCOM_VIP_CLI_Command {
 			return WP_CLI::error( sprintf( 'Document with ID %s of type %s was not found.', $object_id, $type ) );
 		}
 
-		\WP_CLI::success( print_r( $document, true ) );
+		$keys = array_keys( $document );
+		\WP_CLI\Utils\format_items( $assoc_args['format'], array( $document ), $keys );
 	}
 }

--- a/search/includes/classes/commands/class-documentcommand.php
+++ b/search/includes/classes/commands/class-documentcommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Automattic\VIP\Search\Commands;
+
+use \WP_CLI;
+use \WP_CLI\Utils;
+
+/**
+ * Commands to view and manage individual documents
+ *
+ * @package Automattic\VIP\Search
+ */
+class DocumentCommand extends \WPCOM_VIP_CLI_Command {
+	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
+	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
+
+
+	/**
+	 * Get details about a document by type and an id
+	 *
+	 * ## OPTIONS
+	 *
+	 * <type>
+	 * : The index type (the slug of the Indexable, such as 'post', 'user', etc)
+	 * 
+	 * <object_id>
+	 * : The ID of the object
+	 * 
+	 * ## EXAMPLES
+	 *     wp vip-search documents get post 2
+	 *
+	 * @subcommand get
+	 */
+	public function get( $args, $assoc_args ) {
+		$type = $args[0];
+		$object_id = $args[1];
+	
+		$search = \Automattic\VIP\Search\Search::instance();
+
+		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+
+		if ( ! $indexable ) {
+			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
+		}
+
+		$document = $indexable->get($object_id);
+	
+		if ( ! $document ) {
+			return WP_CLI::error( sprintf( 'Document with ID %s of type %s was not found.', $object_id, $type ) );
+		}
+
+		\WP_CLI::success(print_r($document, true));
+	}
+}


### PR DESCRIPTION
## Description

Adds WP CLI command to get a specific document. This helps us debug VIP search functionality.
```
wp vip-search documents get post 1
```
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. `lando wp vip-search documents get post 1`
1. Verify a document is returned
1. Add a new post and get it's ID
1. `lando wp vip-search documents get post <new-post-id>`
1. Verify a document populated by the new data is returned.
