### PR TITLE
Disable do_pings on sites that use `pre_schedule_event`

### DIFF
--- a/performance/do-pings.php
+++ b/performance/do-pings.php
@@ -15,6 +15,7 @@ function disable_pings( $event ) {
 
 	return $event;
 }
+// Hooking on priority 20 to ensure they run after Cron Control (or anything else that hooks on the default priority)
 add_action( 'pre_schedule_event', __NAMESPACE__ . '\disable_pings', 20 );
 add_action( 'schedule_event', __NAMESPACE__ . '\disable_pings', 20 );
 

--- a/performance/do-pings.php
+++ b/performance/do-pings.php
@@ -15,7 +15,8 @@ function disable_pings( $event ) {
 
 	return $event;
 }
-add_action( 'schedule_event', __NAMESPACE__ . '\disable_pings' );
+add_action( 'pre_schedule_event', __NAMESPACE__ . '\disable_pings', 20 );
+add_action( 'schedule_event', __NAMESPACE__ . '\disable_pings', 20 );
 
 // Don't allow new _encloseme metas
 function block_encloseme_metadata_filter( $should_update, $object_id, $meta_key, $meta_value, $unique ) {


### PR DESCRIPTION
The new (pending) version of Cron Control utilizes the `pre_*` hooks to hook into cron, allowing for a much cleaner way to move cron to its own table. When that plugin is active, we hook on `pre_schedule_event` which short-circuits the schedule_event function before we disable do_pings.

Here we're disabling on both pre_schedule_event as well as schedule_event for backwards compatibility.