### PR TITLE
Search: Change vip_search_enabled QS to use dashes

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -15,7 +15,7 @@ class Search {
 
 	public const QUERY_COUNT_CACHE_KEY = 'query_count';
 	public const QUERY_COUNT_CACHE_GROUP = 'vip_search';
-	public const QUERY_INTEGRATION_FORCE_ENABLE_KEY = 'vip_search_enabled';
+	public const QUERY_INTEGRATION_FORCE_ENABLE_KEY = 'vip-search-enabled';
 	public static $max_query_count = 50000 + 1; // 10 requests per second plus one for cleanliness of comparing with Search::query_count_incr
 	public static $query_db_fallback_value = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
 	private const QUERY_COUNT_TTL = 300; // 5 minutes in seconds 
@@ -635,7 +635,7 @@ class Search {
 	 *
 	 * This function determines if VIP Search should take over queries (search, 'ep_integrate' => true, and 'es' => true)
 	 *
-	 * The integration can be tested at any time by setting an `es` query argument (?vip_search_enabled=true).
+	 * The integration can be tested at any time by setting an `es` query argument (?vip-search-enabled=true).
 	 * 
 	 * When the index is ready to serve requests in production, the `VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION`
 	 * constant should be set to `true`, which will enable query integration for all requests


### PR DESCRIPTION
## Description

There are a few other behaviour-affecting querystring values that customers and Automatticians can use, and they all use hyphens.

For consistency with them, and a general understanding that hyphens are more frequently used in URLs than underscores anyway, this change updates the `vip_search_enabled` querystring key to `vip-search-enabled`.

The GitHub search didn't reveal any other files using it, so I'm not sure if there are any tests for this querystring feature.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Unknown.

## Aside

I noticed that the QS value is not checked; the presence of the key is enough to enable the ES queries, so if someone did `vip-search-enabled=false` (as might be reasonably expected given the `=true` part of the docs), then they would get an incorrect situation.

Would be better to update the check to either look for `true` value, or change the DocBlock to not include the `=true` part. I've not amended that here.