### PR TITLE
Disable do_pings via pre_schedule_event

### DIFF
--- a/performance/do-pings.php
+++ b/performance/do-pings.php
@@ -15,9 +15,13 @@ function disable_pings( $event ) {
 
 	return $event;
 }
-// Hooking at 0 to get in before cron control on pre_schedule_event
-add_filter( 'pre_schedule_event', __NAMESPACE__ . '\disable_pings', 0 );
 add_action( 'schedule_event', __NAMESPACE__ . '\disable_pings' );
+
+// Hooking at 0 to get in before cron control on pre_schedule_event
+add_filter( 'pre_schedule_event', function( $scheduled, $event ) {
+	$disable_pings = disable_pings( $event );
+	return $disable_pings;
+}, 0, 2 );
 
 // Don't allow new _encloseme metas
 function block_encloseme_metadata_filter( $should_update, $object_id, $meta_key, $meta_value, $unique ) {

--- a/performance/do-pings.php
+++ b/performance/do-pings.php
@@ -17,11 +17,19 @@ function disable_pings( $event ) {
 }
 add_action( 'schedule_event', __NAMESPACE__ . '\disable_pings' );
 
+function pre_disable_pings( $scheduled, $event ) {
+	if ( null !== $scheduled ) {
+		return $scheduled;
+	}
+	
+	if ( 'do_pings' === $event->hook ) {
+		return false;
+	}
+	
+	return $scheduled;
+}
 // Hooking at 0 to get in before cron control on pre_schedule_event
-add_filter( 'pre_schedule_event', function( $scheduled, $event ) {
-	$disable_pings = disable_pings( $event );
-	return $disable_pings;
-}, 0, 2 );
+add_filter( 'pre_schedule_event', __NAMESPACE__ . '\pre_disable_pings', 0, 2 );
 
 // Don't allow new _encloseme metas
 function block_encloseme_metadata_filter( $should_update, $object_id, $meta_key, $meta_value, $unique ) {


### PR DESCRIPTION
## Description

Fixes the disabling of do_pings via pre_schedule_event. The new filter
takes an extra argument, so we can't use the exact same function. Here
we're wrapping the disable_pings function in a helper to normalize
the arguments.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Example:

1. Check out PR.
1. Ensure cron-control-next is enabled on the test site
1. Publish a new post
1. Confirm do_pings event was not scheduled

The easiest way I've found to verify this is to dump the values to the error log with something like `error_log( var_export( $event, true ) )`.

cron-control-next is important because that's where we're using the pre_schedule_event filter.