### PR TITLE
Update es-wp-query to latest Automattic/es-wp-query

### DIFF
--- a/search/es-wp-query/adapters/vip-search.php
+++ b/search/es-wp-query/adapters/vip-search.php
@@ -133,7 +133,7 @@ function vip_es_field_map( $es_map ) {
 			'post_date_gmt.second'          => 'date_gmt_terms.second',
 			'post_content'                  => 'post_content',
 			'post_content.analyzed'         => 'post_content',
-			'post_title'                    => 'post_title',
+			'post_title'                    => 'post_title.raw',
 			'post_title.analyzed'           => 'post_title',
 			'post_type'                     => 'post_type.raw',
 			'post_excerpt'                  => 'post_excerpt',


### PR DESCRIPTION
## Description

Use `post_title.raw` rather than `post_title.` 

Since `fielddata` is off by default for text fields making sorting, aggregations, scripting, etc... on `post_title` not possible due to various issues that would present. 

The `raw` keyword field is an easy workaround for that issue and still lets `post_title` be used properly as an inverted index.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Add to themes functions.php:
```
add_action( 'pre_get_posts', function( $q ) { 
  $q->set( 'es', true );
} );
```
2. Visit `http://vip-go-dev.lndo.site/wp-admin/edit.php` or equivalent.
3. You will get no results and an Elasticsearch error.
4. Apply PR.
5. Visit `http://vip-go-dev.lndo.site/wp-admin/edit.php` or equivalent.
6. It will load as you'd expect.

