### PR TITLE
Update/es wp query 7f661cfa39d074e55600f4b66dca731320c6e01f

### DIFF
--- a/search/es-wp-query/adapters/vip-search.php
+++ b/search/es-wp-query/adapters/vip-search.php
@@ -138,7 +138,7 @@ function vip_es_field_map( $es_map ) {
 			'post_type'                     => 'post_type.raw',
 			'post_excerpt'                  => 'post_excerpt',
 			'post_password'                 => 'post_password',  // This isn't indexed on VIP.
-			'post_name'                     => 'post_name',
+			'post_name'                     => 'post_name.raw',
 			'post_modified'                 => 'post_modified',
 			'post_modified.year'            => 'modified_date_terms.year',
 			'post_modified.month'           => 'modified_date_terms.month',


### PR DESCRIPTION
## Description

Updated `post_name` mapping in es-wp-query from `post_name` to `post_name.raw`.

props @t-wright 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Add to themes functions.php:
```
add_action( 'pre_get_posts', function( $q ) { 
    $q->set( 'es', true );
    $q->set( 'orderby', 'post_name' );
} );
```

2. Visit http://vip-go-dev.lndo.site/wp-admin/edit.php or equivalent.
1. You will get no results and an Elasticsearch error.
1. Apply PR.
1. Visit http://vip-go-dev.lndo.site/wp-admin/edit.php or equivalent.
1. It will load as you'd expect.