### PR TITLE
Search: remove 2341 from meta allow bypass list

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -22,9 +22,7 @@ class Search {
 
 	private const MAX_SEARCH_LENGTH = 255;
 
-	private const DISABLE_POST_META_ALLOW_LIST = array(
-		2341,
-	);
+	private const DISABLE_POST_META_ALLOW_LIST = array();
 
 	// Empty for now. Will flesh out once migration path discussions are underway and/or the same meta are added to the filter across many
 	// sites


### PR DESCRIPTION
## Description

This particular site was included in meta allow bypass list as an interim measure. This should not be needed anymore. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

