### PR TITLE
Add link to VIP (Automattic) Privacy Policy on the login page

### DIFF
--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -4,6 +4,10 @@ namespace Automattic\VIP\Core\Privacy;
 
 use WP_Error;
 
+// Disable the VIP Privacy policy by default while we work on the rollout.
+// Priority is set to 0 to allow for easier overrides.
+add_filter( 'vip_show_login_privacy_policy', '__return_false', 0 );
+
 // Display a link to the VIP/Automattic Privacy Policy if the site doesn't already define one.
 add_action( 'the_privacy_policy_link', __NAMESPACE__ . '\the_vip_privacy_policy_link', PHP_INT_MAX, 2 ); // Hook in later so we don't override existing filters
 
@@ -13,7 +17,7 @@ function the_vip_privacy_policy_link( $link, $privacy_policy_url ) {
 		return $link;
 	}
 
-	// Allow VIP customers to opt-out of the privacy notice.
+	// Allow customers to opt-out of the privacy notice.
 	$show_vip_privacy_policy = apply_filters( 'vip_show_login_privacy_policy', true );
 	if ( ! $show_vip_privacy_policy ) {
 		return;

--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -4,6 +4,30 @@ namespace Automattic\VIP\Core\Privacy;
 
 use WP_Error;
 
+// Display a link to the VIP/Automattic Privacy Policy if the site doesn't already define one.
+add_action( 'the_privacy_policy_link', __NAMESPACE__ . '\the_vip_privacy_policy_link', PHP_INT_MAX, 2 ); // Hook in later so we don't override existing filters
+
+function the_vip_privacy_policy_link( $link, $privacy_policy_url ) {
+	// Don't change if the link has already been rendered.
+	if ( $link ) {
+		return $link;
+	}
+
+	// Allow VIP customers to opt-out of the privacy notice.
+	$show_vip_privacy_policy = apply_filters( 'vip_show_login_privacy_policy', true );
+	if ( ! $show_vip_privacy_policy ) {
+		return;
+	}
+
+	$link = sprintf(
+		'%s<br/><a href="https://automattic.com/privacy/">%s</a>',
+		esc_html__( 'Powered by WordPress VIP' ),
+		esc_html__( 'Privacy Policy' )
+	);
+
+	return $link;
+}
+
 /**
  * Core privacy data export handler doesn't work by default on Go.
  *

--- a/tests/001-core/test-privacy.php
+++ b/tests/001-core/test-privacy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Automattic\VIP\Core\Privacy;
+
+class Privacy_Policy_Link_Test extends \WP_UnitTestCase {
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once( __DIR__ . '/../../001-core/privacy.php' );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		// Override the default to make testing easier.
+		add_filter( 'vip_show_login_privacy_policy', '__return_true' );
+	}
+
+	public function test__skip_vip_link_if_customer_link_set() {
+		$post = $this->factory->post->create_and_get();
+		update_option( 'wp_page_for_privacy_policy', $post->ID );
+
+		// Should show the custom one
+		$expected_link = sprintf( '<div><a class="privacy-policy-link" href="%s">%s</a></div>', get_permalink( $post->ID ), get_the_title( $post->ID ) );
+
+		$actual_link = get_the_privacy_policy_link( '<div>', '</div>' );
+
+		$this->assertEquals( $expected_link, $actual_link );
+	}
+
+	public function test__skip_vip_link_if_filtered_to_false() {
+		add_filter( 'vip_show_login_privacy_policy', '__return_false', PHP_INT_MAX );
+
+		// Should be empty.
+		$expected_link = '';
+
+		$actual_link = get_the_privacy_policy_link( '<div>', '</div>' );
+
+		$this->assertEquals( $expected_link, $actual_link );
+	}
+
+	public function test__show_vip_link_when_all_else_fails() {
+		$expected_link = '<div>Powered by WordPress VIP<br/><a href="https://automattic.com/privacy/">Privacy Policy</a></div>';
+
+		$actual_link = get_the_privacy_policy_link( '<div>', '</div>' );
+
+		$this->assertEquals( $expected_link, $actual_link );
+	}
+}


### PR DESCRIPTION
On the login page, display a link to the Automattic Privacy Policy page so users better understand what information we collect, use, and share, and what choices they have with respect to that information.

It hooks in to core's Privacy Policy page feature. If a customer has a privacy policy page set, we do not display the Automattic one. If a customer does not, we fall back to the Automattic one.

Note that this is currently disabled by default so no changes are expected to ViP sites on deploy. To enable for a site, we can add:

```
add_filter( 'vip_show_login_privacy_policy', '__return_true' );
```

If a customer would prefer never to show ours:

```
add_filter( 'vip_show_login_privacy_policy', '__return_false', PHP_INT_MAX );
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Go to `/wp-login.php`; there should be no changes
1. Add the following to a `client-mu-plugins` file: `add_filter( 'vip_show_login_privacy_policy', '__return_true' );`
1. The page should now show "Powered by WordPress VIP" and a link to the Automattic Privacy Policy page.
1. Add a Privacy Policy page (Settings > Privacy > Select a Privacy Policy page); verify that the Automattic link is gone and replaced with the new page link.
