### PR TITLE
Log Elasticsearch warnings and errors

### DIFF
--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -516,7 +516,7 @@ class Logger {
 	 * @param array $entry Data.
 	 */
 	public static function wp_debug_log( array $entry ) : void {
-		if ( ! defined( 'VIP_GO_ENV' ) || ! VIP_GO_ENV ) {
+		if ( defined( 'VIP_GO_ENV' ) && VIP_GO_ENV ) {
 			// Don't run this on VIP Go
 			return;
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -605,6 +605,7 @@ class Search {
 			// Check for the 'Warning' header and log it
 			if ( isset( $response_headers['warning'] ) ) {
 				$warning_message = $response_headers['warning'];
+				trigger_error( $warning_message, \E_USER_WARNING );
 				\Automattic\VIP\Logstash\log2logstash( array(
 					'severity' => 'warning',
 					'feature' => 'vip_search_es_warning',

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -611,7 +611,6 @@ class Search {
 					'message' => $warning_message,
 				) );
 			}
-
 		}
 	
 		return $response;

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -550,14 +550,14 @@ class Search {
 
 		$timeout = $this->get_http_timeout_for_query( $query, $args );
 
-		$request = vip_safe_wp_remote_request( $query['url'], $fallback_error, 3, $timeout, 20, $args );
+		$response = vip_safe_wp_remote_request( $query['url'], $fallback_error, 3, $timeout, 20, $args );
 
 		$end_time = microtime( true );
 
 		$duration = ( $end_time - $start_time ) * 1000;
 
-		if ( is_wp_error( $request ) ) {
-			$error_messages = $request->get_error_messages();
+		if ( is_wp_error( $response ) ) {
+			$error_messages = $response->get_error_messages();
 			
 			foreach ( $error_messages as $error_message ) {
 				// Default stat for errors is 'error'
@@ -572,21 +572,22 @@ class Search {
 			}
 		} else {
 			// Record engine time (have to parse JSON to get it)
-			$response_body = wp_remote_retrieve_body( $request );
-			$response = json_decode( $response_body, true );
+			$response_body_json = wp_remote_retrieve_body( $response );
+			$response_body = json_decode( $response_body_json, true );
 
-			if ( $response && isset( $response['took'] ) && is_int( $response['took'] ) ) {
-				$statsd->timing( $statsd_prefix . '.engine', $response['took'] );
-				$statsd->timing( $statsd_per_site_prefix . '.engine', $response['took'] );
+			if ( $response_body && isset( $response_body['took'] ) && is_int( $response_body['took'] ) ) {
+				$statsd->timing( $statsd_prefix . '.engine', $response_body['took'] );
+				$statsd->timing( $statsd_per_site_prefix . '.engine', $response_body['took'] );
 			}
 
 			$statsd->timing( $statsd_prefix . '.total', $duration );
 			$statsd->timing( $statsd_per_site_prefix . '.total', $duration );
 
-			// Check for errors in the response and log them
-			$response_code = (int) wp_remote_retrieve_response_code( $request );
+			$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+			// Check for an error HTTP code and log the Elasticsearch error
 			if ( $response_code >= 400 ) {
-				$response_error = $response['error'];
+				$response_error = $response_body['error'];
 				$error_message = $response_error['reason'] ?? 'Unknown Elasticsearch query error';
 				\Automattic\VIP\Logstash\log2logstash( array(
 					'severity' => 'error',
@@ -599,8 +600,9 @@ class Search {
 				) );
 			}
 
-			// Check for the 'Warning' header in the response and log it
-			$response_headers = wp_remote_retrieve_headers( $request );
+			$response_headers = wp_remote_retrieve_headers( $response );
+
+			// Check for the 'Warning' header and log it
 			if ( isset( $response_headers['warning'] ) ) {
 				$warning_message = $response_headers['warning'];
 				\Automattic\VIP\Logstash\log2logstash( array(
@@ -612,7 +614,7 @@ class Search {
 
 		}
 	
-		return $request;
+		return $response;
 	}
 
 	/*

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -605,7 +605,7 @@ class Search {
 			// Check for the 'Warning' header and log it
 			if ( isset( $response_headers['warning'] ) ) {
 				$warning_message = $response_headers['warning'];
-				trigger_error( $warning_message, \E_USER_WARNING );
+				trigger_error( esc_html( $warning_message ), \E_USER_WARNING );
 				\Automattic\VIP\Logstash\log2logstash( array(
 					'severity' => 'warning',
 					'feature' => 'vip_search_es_warning',


### PR DESCRIPTION
## Description

Detect errors (HTTP code error + error section in the response) and warnings (HTTP header) in Elasticsearch responses and log them to logstash, so they get more visibility and we don't depend on someone looking at Elasticsearch logs.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Enforce some error/warning in Elasticsearch queries (e.g., adding `orderby` on some text field, or adding `'_source' => [ 'exclude' => 'meta.*' ]`.
1. In the local dev environment it should appear in `debug.log`. In a sandbox it should appear in logstash under features `vip_search_query_error` or `vip_search_es_warning`
