### PR TITLE
Add notices when trying to load es-wp-query or vip-search adapter, but either another copy of es-wp-query or a different adapter is loaded

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -303,7 +303,7 @@ class Search {
 		// To fail gracefully we simply won't try to load our adapter.
 		// But we also need to surface the error.
 		if ( class_exists( '\\ES_WP_Query' ) ) {
-			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'vip-search' adapter, but another adapter is already loaded. Please disable standalone 'es-wp-query' and remove calls to 'es_wp_query_load_adapter' in your code.", '1.0' );
+			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'vip-search' adapter, but another adapter is already loaded. Please disable standalone 'es-wp-query' and remove calls to 'es_wp_query_load_adapter' in your code.", null );
 		}
 
 		// If no other adapter has already been loaded, load ours.
@@ -323,7 +323,7 @@ class Search {
 	public static function should_load_es_wp_query() {
 		// Don't load if plugin already loaded elsewhere.
 		if ( class_exists( '\\ES_WP_Query_Shoehorn' ) ) {
-			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'es-wp-query', but another copy is already loaded. Please disable your copy of 'es-wp-query'.", '1.0' );
+			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'es-wp-query', but another copy is already loaded. Please disable your copy of 'es-wp-query'.", null );
 			return false;
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -321,7 +321,6 @@ class Search {
 	 * @return boolean
 	 */
 	public static function should_load_es_wp_query() {
-		require_once __DIR__ . '/../../es-wp-query/es-wp-query.php';
 		// Don't load if plugin already loaded elsewhere.
 		if ( class_exists( '\\ES_WP_Query_Shoehorn' ) ) {
 			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'es-wp-query', but another copy is already loaded. Please disable your copy of 'es-wp-query'.", '1.0' );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -303,6 +303,7 @@ class Search {
 		// To fail gracefully we simply won't try to load our adapter.
 		// But we also need to surface the error.
 		if ( class_exists( '\\ES_WP_Query' ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'vip-search' adapter, but another adapter is already loaded. Please disable standalone 'es-wp-query' and remove calls to 'es_wp_query_load_adapter' in your code.", null );
 		}
 
@@ -323,6 +324,7 @@ class Search {
 	public static function should_load_es_wp_query() {
 		// Don't load if plugin already loaded elsewhere.
 		if ( class_exists( '\\ES_WP_Query_Shoehorn' ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'es-wp-query', but another copy is already loaded. Please disable your copy of 'es-wp-query'.", null );
 			return false;
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -299,16 +299,32 @@ class Search {
 
 		require_once __DIR__ . '/../../es-wp-query/es-wp-query.php';
 
-		// If no other adapter has loaded, load ours. This is to prevent fatals (duplicate function/class definitions) if other
-		// adapters were somehow loaded before ours
+		// There's another adapter loaded already, this should be avoided.
+		// To fail gracefully we simply won't try to load our adapter.
+		// But we also need to surface the error.
+		if ( class_exists( '\\ES_WP_Query' ) ) {
+			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'vip-search' adapter, but another adapter is already loaded. Please disable standalone 'es-wp-query' and remove calls to 'es_wp_query_load_adapter' in your code.", '1.0' );
+		}
+
+		// If no other adapter has already been loaded, load ours.
+		// This is to prevent fatals (duplicate function/class definitions),
+		// if other adapters were somehow loaded before ours.
 		if ( ! class_exists( '\\ES_WP_Query' ) && function_exists( 'es_wp_query_load_adapter' ) ) {
 			es_wp_query_load_adapter( 'vip-search' );
 		}
 	}
 
+	/**
+	 * Helper to determine whether to load the bundled version of `es-wp-query`:
+	 * we only need to load it if either query mirroring or query integration enabled.
+	 *
+	 * @return boolean
+	 */
 	public static function should_load_es_wp_query() {
-		// Don't load if plugin already loaded elsewhere
+		require_once __DIR__ . '/../../es-wp-query/es-wp-query.php';
+		// Don't load if plugin already loaded elsewhere.
 		if ( class_exists( '\\ES_WP_Query_Shoehorn' ) ) {
+			_doing_it_wrong( self::class . '::' . __FUNCTION__, "Search: tried to load 'es-wp-query', but another copy is already loaded. Please disable your copy of 'es-wp-query'.", '1.0' );
 			return false;
 		}
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1234,6 +1234,8 @@ class Search_Test extends \WP_UnitTestCase {
 
 		require_once __DIR__ . '/../../search/es-wp-query/es-wp-query.php';
 
+		$this->expectException( \PHPUnit\Framework\Error\Notice::class );
+
 		$should = \Automattic\VIP\Search\Search::should_load_es_wp_query();
 
 		$this->assertFalse( $should );


### PR DESCRIPTION
## Description

Currently, we just silently not load our bundled `es-wp-query` or another adapter is loaded. This allows us to fail gracefully, but, on the flip side, it may lead to not-that-obvious bugs, where a different adapter is loaded and the queries just don't return correct results. 

This PR adds `_doing_ot_wrong` notices for the scenarios described, so it's easier to spot during debugging and developing.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Activate a version of `es-wp-query` via Plugins UI or `wp plugin activate`
1. Open Query Monitor and verify a notice about already loaded es-wp-query is present.
1. De-activate `es-wp-query` and verify that the notice is gone.
