### PR TITLE
Support multiple Warning headers on Elasticsearch responses

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -413,15 +413,21 @@ class Search {
 
 			$response_headers = wp_remote_retrieve_headers( $response );
 
-			// Check for the 'Warning' header and log it
+			// Check for 'Warning' headers and log them
 			if ( isset( $response_headers['warning'] ) ) {
-				$warning_message = $response_headers['warning'];
-				trigger_error( esc_html( $warning_message ), \E_USER_WARNING );
-				\Automattic\VIP\Logstash\log2logstash( array(
-					'severity' => 'warning',
-					'feature' => 'vip_search_es_warning',
-					'message' => $warning_message,
-				) );
+				$warning_messages = $response_headers['warning'];
+				if ( ! is_array( $warning_messages ) ) {
+					$warning_messages = array( $warning_messages );
+				}
+
+				foreach ( $warning_messages as $message ) {
+					trigger_error( esc_html( $message ), \E_USER_WARNING );
+					\Automattic\VIP\Logstash\log2logstash( array(
+						'severity' => 'warning',
+						'feature' => 'vip_search_es_warning',
+						'message' => $message,
+					) );
+				}
 			}
 		}
 	


### PR DESCRIPTION
## Description

In #1770 we added logging for `Warning` headers in Elasticsearch responses. It turns out that if there are several of them, then `wp_remote_retrieve_headers()` will return an array with all of them instead of a string. This PR adds support for that case.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Run `wp vip-search index-versions add post` (which triggers several warnings, at least in the local dev environment)
1. Verify that all warnings are shown, and there are no errors about array->string conversion
