### PR TITLE
Add --network-wide support for pending search commands

### DIFF
--- a/search/docs/versioning.md
+++ b/search/docs/versioning.md
@@ -65,7 +65,7 @@ wp vip-search index-versions activate <type> <version_number>
 Make the given index version active. The active index is the one that serves site traffic, so be sure the target index is ready for production before switching.
 
 ```
-wp vip-search index-versions get-active <type>
+wp vip-search index-versions get <type> active
 ```
 
 Get the currently active index version.

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -354,6 +354,8 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 		if ( ! $indexable ) {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
 		}
+
+		CoreCommand::confirm_destructive_operation( $assoc_args );
 	
 		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
 			if ( ! is_numeric( $assoc_args['network-wide'] ) ) {
@@ -361,8 +363,6 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			}
 
 			$sites = \ElasticPress\Utils\get_sites( $assoc_args['network-wide'] );
-
-			CoreCommand::confirm_destructive_operation( $assoc_args );
 
 			foreach ( $sites as $site ) {
 				switch_to_blog( $site['blog_id'] );
@@ -411,8 +411,6 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			if ( $version['active'] ) {
 				return WP_CLI::error( sprintf( 'Index version %d is active for type %s and cannot be deleted', $version['number'], $type ) );
 			}
-
-			CoreCommand::confirm_destructive_operation( $assoc_args );
 
 			$result = $search->versioning->delete_version( $indexable, $args[1] );
 

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -378,41 +378,4 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 		WP_CLI::success( sprintf( 'Successfully deleted index version %d for type %s', $version_number, $type ) );
 	}
-
-	/**
-	 * Get details about the currently active index version
-	 *
-	 * ## OPTIONS
-	 * 
-	 * <type>
-	 * : The index type (the slug of the Indexable, such as 'post', 'user', etc)
-	 *
-	 * ## EXAMPLES
-	 *     wp vip-search index-versions get-active post
-	 *
-	 * @subcommand get-active
-	 */
-	public function get_active( $args, $assoc_args ) {
-		$type = $args[0];
-	
-		$search = \Automattic\VIP\Search\Search::instance();
-
-		$indexable = \ElasticPress\Indexables::factory()->get( $type );
-
-		if ( ! $indexable ) {
-			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
-		}
-
-		$version = $search->versioning->get_active_version( $indexable );
-
-		if ( is_wp_error( $version ) ) {
-			return WP_CLI::error( $version->get_error_message() );
-		}
-
-		if ( ! is_array( $version ) ) {
-			return WP_CLI::error( 'Failed to retrieve the active index version' );
-		}
-		
-		\WP_CLI\Utils\format_items( $assoc_args['format'], array( $version ), array( 'number', 'active', 'created_time', 'activated_time' ) );
-	}
 }


### PR DESCRIPTION
## Description

There are still four vip-search commands that don't support `--network-wide` parameter (get, get-active, list, delete). This PR addresses them.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Create a multisite testing site
1. Add a couple of index versions with `vip-search index-versions add post --network-wide`
1. Run `vip-search index-versions get post active --network-wide` and verify that the active version is returned for all sites
1. Run `vip-search index-versions list post --network-wide` and verify that all index versions are returned for all sites
