### PR TITLE
APC Cache Interceptor: Don't offload subsite information in network admin

### DIFF
--- a/lib/class-apc-cache-interceptor.php
+++ b/lib/class-apc-cache-interceptor.php
@@ -17,8 +17,11 @@ function do_apcu_hot_cache_init( $hc ) {
 	// Cache the wpcomvip user ID
 	$hc->add_passive_rx( 'userlogins', '/userlogins:wpcomvip$/', 300 );
 
-	// Cache subsite information for 10 seconds
-	$hc->add_passive_rx( 'sites', '/sites:\d+$/', 10 );
+	// Cache subsite information for 10 seconds unless we're in the
+	// network admin, where we may be editing this information.
+	if ( ! function_exists( 'is_network_admin' ) || ! is_network_admin() ) {
+		$hc->add_passive_rx( 'sites', '/sites:\d+$/', 10 );
+	}
 }
 
 if ( ! class_exists( 'APC_Cache_Interceptor' ) ) :

--- a/lib/class-apc-cache-interceptor.php
+++ b/lib/class-apc-cache-interceptor.php
@@ -13,14 +13,26 @@
  * $hc->hardcode( 'global', 'global:apcu-test-key', 'works' );
  */
 function do_apcu_hot_cache_init( $hc ) {
+	// Don't offload to apcu in WP_CLI
+	// Every command runs as a new process, so the benefits
+	// of apc are very minimal when combined with our regular
+	// object cache dropin
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return;
+	}
 
 	// Cache the wpcomvip user ID
 	$hc->add_passive_rx( 'userlogins', '/userlogins:wpcomvip$/', 300 );
 
-	// Cache subsite information for 10 seconds unless we're in the
-	// network admin, where we may be editing this information.
-	if ( ! function_exists( 'is_network_admin' ) || ! is_network_admin() ) {
-		$hc->add_passive_rx( 'sites', '/sites:\d+$/', 10 );
+	// Bypass APCu offloading in the REST API for some cases where there could
+	// be concerns about stale data after writes
+	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+		
+		// Cache subsite information for 10 seconds unless we're in the
+		// network admin, where we may be editing this information.
+		if ( ! function_exists( 'is_network_admin' ) || ! is_network_admin() ) {
+			$hc->add_passive_rx( 'sites', '/sites:\d+$/', 10 );
+		}
 	}
 }
 


### PR DESCRIPTION
Offloading the subsite information in the network admin has the side effect of showing stale data after clicking save on a site. (i.e. from /wp-admin/network/site-info.php?id=<id>). The form still saves properly and if you refresh the page, you see the correct thing. It's kind of suboptimal though.

To counteract that, we're disabling apcu for these keys when you're in the network admin. That way, you still get the data directly from memcached in the screen when you could be updating this data, but in all other cases, you get the apcu offloaded data.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to wp-admin > My Sites > Network Admin -> Sites
1. Click Edit on a site record
1. Update a Site Address
1. Observe that the address is the updated version when the page reloads