### PR TITLE
Add login limit threshold filters

### DIFF
--- a/security.php
+++ b/security.php
@@ -155,22 +155,22 @@ add_action( 'lostpassword_post', 'wpcom_vip_lost_password_limit' );
 function wpcom_vip_username_is_limited( $username, $cache_group ) {
 	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 
-	$key1                   = $ip . '|' . $username;
-	$key2                   = $ip;
-	$count1                 = wp_cache_get( $key1, $cache_group );
-	$is_restricted_username = wpcom_vip_is_restricted_username( $username );
-	$threshold2             = 50;
+	$key1 = $ip . '|' . $username;
+	$key2 = $ip;
+	
+	$threshold1 = apply_filters( 'wpcom_vip_ip_username_login_threshold', 5 );
+	$threshold2 = apply_filters( 'wpcom_vip_ip_login_threshold', 50 );
+	
+	$count1 = wp_cache_get( $key1, $cache_group );
+	$count2 = wp_cache_get( $key2, $cache_group );
 
+	$is_restricted_username = wpcom_vip_is_restricted_username( $username );
 	if ( 'lost_password_limit' === $cache_group ) {
 		$threshold1 = 3;
 		$threshold2 = 3;
 	} elseif ( $is_restricted_username ) {
 		$threshold1 = 2;
-	} else {
-		$threshold1 = 5;
 	}
-
-	$count2 = wp_cache_get( $key2, $cache_group );
 
 	if ( $count1 >= $threshold1 || $count2 >= $threshold2 ) {
 

--- a/security.php
+++ b/security.php
@@ -153,13 +153,26 @@ function wpcom_vip_lost_password_limit( $errors ) {
 add_action( 'lostpassword_post', 'wpcom_vip_lost_password_limit' );
 
 function wpcom_vip_username_is_limited( $username, $cache_group ) {
+	// Strip invalid characters from the address
 	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 
 	$ip_username_cache_key = $ip . '|' . $username;
 	$ip_cache_key = $ip;
 	
-	$ip_username_threshold = apply_filters( 'wpcom_vip_ip_username_login_threshold', 5 );
-	$ip_threshold = apply_filters( 'wpcom_vip_ip_login_threshold', 50 );
+	/**
+	 * Login Limiting IP Username Threshold
+	 *
+	 * @param string $ip IP address of the login request
+	 * @param string $username Username of the login request
+	 */
+	$ip_username_threshold = apply_filters( 'wpcom_vip_ip_username_login_threshold', 5, $ip, $username );
+
+	/**
+	 * Login Limiting IP Threshold
+	 *
+	 * @param string $ip IP address of the login request
+	 */
+	$ip_threshold = apply_filters( 'wpcom_vip_ip_login_threshold', 50, $ip );
 	
 	$ip_username_count = wp_cache_get( $ip_username_cache_key, $cache_group );
 	$ip_count = wp_cache_get( $ip_cache_key, $cache_group );


### PR DESCRIPTION
Allow client sites to customize the login limit thresholds

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Testing

1. Checkout this PR
1. Filter `wpcom_vip_ip_login_threshold` to return `0`
1. Confirm trying to login gets the rate limited error message
1. Filter `wpcom_vip_ip_username_login_threshold` to return `0`
1. Confirm trying to login gets the rate limited error message
1. Remove filters
1. Confirm trying to login gets no rate limited error message

You can also experiment with various other values to show that a given username is rate limited, but other usernames from the same IP have a different rate limit.
