### PR TITLE
Speeding up git checkout for circleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ job-references:
 
   php_core_job: &php_core_job
     steps:
+      - run: sudo apt-get update && sudo apt-get -y install git ssh
       - checkout
       - run: *install_core_tests_dependencies
       - run: *prepare_repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,9 @@ job-references:
 
   php_core_job: &php_core_job
     steps:
-      - run: sudo apt-get update && sudo apt-get -y install git ssh
+      - run:
+          name: Add missing packages
+          command: sudo apt-get update && sudo apt-get -y install git ssh
       - checkout
       - run: *install_core_tests_dependencies
       - run: *prepare_repo


### PR DESCRIPTION

## Description
Speeding up git checkout for circleCI jobs. 

EDIT: turns out avoiding to use CircleCI to use it's default git+ssh, but installing one locally is way faster.

## Steps to Test

Check core tests jobs in circle CI
