### PR TITLE
Clear queue of related jobs on index version delete

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -819,6 +819,42 @@ class Queue {
 		return intval( $average_wait_time );
 	}
 
+	/**
+	 * Given an indexable slug and an index version, delete all matching jobs from the queue.
+	 *
+	 * Used to clean up after an index version deletion and prevent processing jobs that don't need to be processed.
+	 *
+	 * @param string $indexable_slug An indexable slug.
+	 * @param int | string $index_version An index version.
+	 * @return null | WP_Error | object Either null if the queue isn't enabled, a WP_Error if the parameters are incorrect, or the results of wpdb::get_results().
+	 */
+	public function delete_jobs_for_index_version( $indexable_slug, $index_version ) {
+		global $wpdb;
+
+		// If run without having the queue enabled, queue wait times are 0
+		if ( ! $this->is_enabled() ) {
+			return null;
+		}
+
+		if ( ! is_string( $indexable_slug ) ) {
+			return new WP_Error( 'invalid-slug-for-queue-cleanup-on-delete', sprintf( 'Invalid indexable slug \'%s\'', $indexable_slug ) );
+		} 
+		
+		if ( ! is_numeric( $index_version ) ) {
+			return new WP_Error( 'invalid-version-for-queue-cleanup-on-delete', sprintf( 'Invalid version \'%d\'', $index_version ) );
+		}
+
+		// If schema is null, init likely not run yet
+		// Happens when cron is scheduled/run via wp commands
+		if ( is_null( $this->schema ) ) {
+			$this->init();
+		}
+
+		$table_name = $this->schema->get_table_name();
+
+		return $wpdb->get_results( $wpdb->prepare( "DELETE FROM `{$table_name}` WHERE `object_type` = %s AND `index_version` = %d", $indexable_slug, $index_version ) ); // @codingStandardsIgnoreLine
+	}
+
 	/*
 	 * Increment the number of indexing operations that have been passed through VIP Search
 	 */

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -525,6 +525,8 @@ class Versioning {
 			return new WP_Error( 'failed-to-delete-index', sprintf( 'Failed to delete index version %d for indexable %s from Elasticsearch', $version_number, $indexable->slug ) );
 		}
 
+		\Automattic\VIP\Search\Search::instance()->queue->delete_jobs_for_index_version( $indexable->slug, $version_number );
+		
 		unset( $versions[ $version_number ] );
 
 		return $this->update_versions( $indexable, $versions );


### PR DESCRIPTION
## Description

Presently, deleting an index version doesn't stop the queued job from continuing to be processed. This is pretty inefficient, so we should just delete all jobs for the indexable slug / index version that was deleted.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Apply PR
2. `lando test --stop-on-failure tests/search/includes/classes/test-class-queue.php`

----------------------

1. Populate the `wp_vip_search_index_queue` table with various jobs with different index versions.
2. Apply PR.
3. `lando wp shell`
4. Execute `\Automattic\VIP\Search\Search::instance()->queue->delete_jobs_for_index_version( <indexable slug>, <index version> );
5. Verify that all the jobs that should be removed are gone and no others.
