### PR TITLE
Fix arguments for WP_Error invalid-indexable for queue

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -72,7 +72,7 @@ class Queue {
 			$indexable = \ElasticPress\Indexables::factory()->get( $object_type );
 
 			if ( ! $indexable ) {
-				return new WP_Error( sprintf( 'Indexable not found for type %s', 'invalid-indexable', $object_type ) );
+				return new WP_Error( 'invalid-indexable', sprintf( 'Indexable not found for type %s', $object_type ) );
 			}
 
 			$index_version = \Automattic\VIP\Search\Search::instance()->versioning->get_current_version_number( $indexable );


### PR DESCRIPTION
## Description

Previously the arguments for a WP_Error were incorrect. Due to the way sprintf works, the code was perfectly valid but would only ever error with `Indexable not found for type invalid-indexable` rather than display the actual indexable slug that failed to be found.

The arguments have been corrected.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. `lando wp shell`
2. Execute `\Automattic\VIP\Search\Search::instance()->queue->get_index_version_number_from_options( 'fake-slug-ae34f' );`
3. You should see a WP Error with `Indexable not found for for type invalid-indexable` for a code with no message.
4. Exit the shell.
5. Apply PR.
6. Execute `\Automattic\VIP\Search\Search::instance()->queue->get_index_version_number_from_options( 'fake-slug-ae34f' );`
7. You should see a WP Error with code `invalid-indexable` and message of `Indexable not found for for type fake-slug-ae34f`