### PR TITLE
Switched to use npm run phpcs:changed:remote

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-push": "npm run phplint && npm run phpcs:changed:local"
+    "pre-push": "npm run phplint && npm run phpcs:changed:remote"
   }
 }


### PR DESCRIPTION
## Description

The pre-push hook was previously firing `npm run phpcs:changed:local`, which only checks against non-committed changes. 

Since the pre-push hook is for checking what you're trying to push(which are committed changes) this is incorrect.
