### PR TITLE
Skip indexing job from queue if index version not found

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -502,21 +502,25 @@ class Queue {
 			foreach ( $jobs_by_type as $type => $jobs ) {
 				$indexable = $indexables->get( $type );
 
-				\Automattic\VIP\Search\Search::instance()->versioning->set_current_version_number( $indexable, $index_version );
-
-				$ids = wp_list_pluck( $jobs, 'object_id' );
-
-				// If the index version no longer exists, skip incrementing the ratelimiting counter and don't index the ids
+				// If the index version no longer exists, just delete the jobs and don't bother with stats or anything
+				// since the jobs weren't actually processed
 				$index_versions = \Automattic\VIP\Search\Search::instance()->versioning->get_versions( $indexable );
-				if ( array_key_exists( intval( $index_version ), $index_versions ) ) {
-					// Increment first to prevent overrunning ratelimiting
-					self::index_count_incr( count( $ids ) );
-
-					$indexable->bulk_index( $ids );
+				if ( ! array_key_exists( intval( $index_version ), $index_versions ) ) {
+					$this->delete_jobs( $jobs );
+					continue;
 				}
 
+				\Automattic\VIP\Search\Search::instance()->versioning->set_current_version_number( $indexable, $index_version );
+	
+				$ids = wp_list_pluck( $jobs, 'object_id' );
+
+				// Increment first to prevent overrunning ratelimiting
+				self::index_count_incr( count( $ids ) );
+
+				$indexable->bulk_index( $ids );
+
 				// TODO handle errors
-		
+
 				// Mark them as done in queue
 				$this->delete_jobs( $jobs );
 

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -506,10 +506,14 @@ class Queue {
 
 				$ids = wp_list_pluck( $jobs, 'object_id' );
 
-				// Increment first to prevent overrunning ratelimiting
-				self::index_count_incr( count( $ids ) );
+				// If the index version no longer exists, skip incrementing the ratelimiting counter and don't index the ids
+				$index_versions = \Automattic\VIP\Search\Search::instance()->versioning->get_versions( $indexable );
+				if ( array_key_exists( intval( $index_version ), $index_versions ) ) {
+					// Increment first to prevent overrunning ratelimiting
+					self::index_count_incr( count( $ids ) );
 
-				$indexable->bulk_index( $ids );
+					$indexable->bulk_index( $ids );
+				}
 
 				// TODO handle errors
 		


### PR DESCRIPTION
## Description

Presently there's no handling for if the index version has been deleted before the jobs are processed from the queue.

They should not be re-indexed and they should not count towards index rate limiting.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Apply PR.
2. Schedule a process jobs cron job for the queue that contains a list of valid IDs with a non-existent index version number.
3. Run the cron job.
4. There should be no warnings or errors from the process and the index rate limiting count shouldn't increase.