### PR TITLE
k8s: log2logstash: allow sending logs to regular error_log

### DIFF
--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -485,9 +485,15 @@ class Logger {
 				return;
 			}
 
-			// Log to file
-			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( $json_data . "\n", 3, ( is_dir( '/chroot' ) ? '/chroot' : '' ) . '/tmp/logstash.log' );
+			if ( ! defined( 'LOG2LOGSTASH_SYSLOG' ) || ! LOG2LOGSTASH_SYSLOG ) {
+				// Log to file
+				// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( $json_data . "\n", 3, ( is_dir( '/chroot' ) ? '/chroot' : '' ) . '/tmp/logstash.log' );
+			} else {
+				// Forward logs to regular php error logs, used by k8s and similar.
+				// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'log2logstash: ' . $json_data, 0 );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

This will allow us to control the `log2logstash` logging destination in Kubernetes-orchestrated VIP sites. The rendered wp-config for these deployments will define this constant (`define( LOG2LOGSTASH_SYSLOG, true );`) and will therefore receive these log messages on stderr, with the other FPM and PHP logs.


### Background

This was not my first choice of implementation. Originally, I planned on sending these logs directly to stdout so they would not get mixed with other FPM and php error logging (which are on stderr). However, php-fpm is fairly aggressive and [closes stdout early in the master process](https://github.com/php/php-src/blob/master/sapi/fpm/fpm/fpm_stdio.c#L34), meaning stdout is not directly usable. In the worker fpm children, stdout is captured by the parent and wrapped with "child xx said on stdout: ..." which will not necessarily keep json structured logs like these intact.

An alternative is to not modify this function, but rather open up a fifo from `/chroot/tmp/log2logstash` which will be tailed to stdout in a sidecar container. I would prefer not creating yet another container for this, if possible.

## Steps to Test

Define the variable, as above, and do some logging!
