### PR TITLE
Update es-wp-query

### DIFF
--- a/search/es-wp-query/class-es-wp-query-shoehorn.php
+++ b/search/es-wp-query/class-es-wp-query-shoehorn.php
@@ -24,7 +24,7 @@ add_filter( 'query_vars', 'es_wp_query_arg' );
  * If a WP_Query object has `'es' => true`, use Elasticsearch to run the meat of the query.
  * This is fires on the "pre_get_posts" action.
  *
- * @param  object $query WP_Query object.
+ * @param  WP_Query $query Current full WP_Query object.
  * @return void
  */
 function es_wp_query_shoehorn( &$query ) {
@@ -78,6 +78,7 @@ function es_wp_query_shoehorn( &$query ) {
 		 */
 		$es_query_args           = $query->query;
 		$es_query_args['fields'] = 'ids';
+		$es_query_args['es_is_main_query'] = $query->is_main_query();
 		$es_query                = new ES_WP_Query( $es_query_args );
 
 		// Make the post query use the post IDs from the ES results instead.

--- a/search/es-wp-query/class-es-wp-query-wrapper.php
+++ b/search/es-wp-query/class-es-wp-query-wrapper.php
@@ -44,6 +44,19 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 	abstract protected function query_es( $es_args );
 
 	/**
+	 * Override default WP_Query->is_main_query() to support
+	 * this conditional when the main query has been overridden
+	 * by this class.
+	 *
+	 * @fixes #38
+	 *
+	 * @return bool
+	 */
+	public function is_main_query() {
+		return $this->get( 'es_is_main_query', false );
+	}	
+
+	/**
 	 * Maps a field to its Elasticsearch context.
 	 *
 	 * @param string $field The field to map.


### PR DESCRIPTION
## Description

Syncs the es-wp-query subtree with Automattic/es-wp-query#master. This is a fix for `is_main_query()` inside the query wrapper class (props @rebeccahum for bringing over this fix from the upstream repo).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. In code, add logic inside a `pre_get_posts` hook that will only run if the query's `$query->is_main_query()` returns true
1. Set `'es' => true` on the main query
1. Ensure the logic from step 2 now runs (where it didn' before)
