### PR TITLE
Replace $result with $new_version since $result doesn't exist

### DIFF
--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -72,7 +72,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 		$new_version = $search->versioning->add_version( $indexable );
 
 		if ( is_wp_error( $new_version ) ) {
-			return WP_CLI::error( $result->get_error_message() );
+			return WP_CLI::error( $new_version->get_error_message() );
 		}
 
 		if ( false === $new_version ) {


### PR DESCRIPTION
## Description

WP Errors  when adding an index version couldn't be handled because `$result` doesn't exist.

Switched `$result` to `$new_version` to make it work.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Make the `add_version` function return a WP_Error.
2. Execute `lando wp vip-search index-versions add post`
3. You'll get a fatal error without the output of the underlying WP_Error. The logs will point you to `$result->get_error_message()`.
4. Apply PR.
5. Execute `lando wp vip-search index-versions add post`
6. The WP_Error will be handled properly and the error will be printed to the terminal properly.