### PR TITLE
Jetpack 9.0 as new default

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 9.0
+ * Version: 9.0.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack

--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 8.9.1
+ * Version: 9.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -13,7 +13,7 @@
  */
 
 if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
-	define( 'VIP_JETPACK_DEFAULT_VERSION', '8.9' );
+	define( 'VIP_JETPACK_DEFAULT_VERSION', '9.0' );
 }
 
 // Bump up the batch size to reduce the number of queries run to build a Jetpack sitemap.
@@ -29,10 +29,10 @@ if ( ! @constant( 'WPCOM_IS_VIP_ENV' ) ) {
 
 /**
  * Add JP broken connection debug headers
- * 
+ *
  * NOTE - this _must_ come _before_ jetpack/jetpack.php is loaded, b/c the signature verification is
  * performed in __construct() of the Jetpack class, so hooking after it has been loaded is too late
- * 
+ *
  * $error is a WP_Error (always) and contains a "signature_details" data property with this structure:
  * The error_code has one of the following values:
  * - malformed_token


### PR DESCRIPTION
## Description

Prepare the PR to roll out the new default Jetpack version

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

* Make sure you dont have pinned Jetpack version - VIP_JETPACK_PINNED_VERSION
* Check Jetpeck version
* change the code to the pr
* See the jetpack version is updated