### PR TITLE
Search: implement stale queue alerts

### DIFF
--- a/search/includes/classes/class-queuewaittimejob.php
+++ b/search/includes/classes/class-queuewaittimejob.php
@@ -9,13 +9,13 @@ class QueueWaitTimeJob {
 
 	public function init() {
 		// We always add this action so that the job can unregister itself if it no longer should be running
-		add_action( self::CRON_EVENT_NAME, [ $this, 'set_queue_wait_time_gauge' ] );
+		add_action( self::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_average_queue_time' ] );
 	}
 
 	/**
-	 * Set the queue wait time gauge for posts for the current site 
+	 * Set the queue wait time gauge for posts for the current site
 	 */
-	public function set_queue_wait_time_gauge() {
-		\Automattic\VIP\Search\Search::instance()->set_queue_wait_time_gauge();
+	public function maybe_alert_for_average_queue_time() {
+		\Automattic\VIP\Search\Search::instance()->maybe_alert_for_average_queue_time();
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -639,9 +639,9 @@ class Search {
 
 		if ( $average_wait_time > self::STALE_QUEUE_WAIT_LIMIT ) {
 			$message = sprintf(
-				'Average index queue time for application %d, exceeded %d seconds with %d seconds',
+				'Average index queue wait time for application %d - %s is currently %d seconds',
 				FILES_CLIENT_SITE_ID,
-				self::STALE_QUEUE_WAIT_LIMIT,
+				home_url(),
 				$average_wait_time
 			);
 			$this->alerts->send_to_chat( self::STALE_QUEUE_ALERT_SLACK_CHAT, $message );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -16,7 +16,8 @@ class Search {
 	private const MAX_SEARCH_LENGTH = 255;
 	private const DISABLE_POST_META_ALLOW_LIST = array();
 	private const STALE_QUEUE_WAIT_LIMIT = 3600; // 1 hour in seconds
-	private const STALE_QUEUE_ALERT_SLACK_CHAT = '#vip-platform-cantina';
+	private const STALE_QUEUE_ALERT_SLACK_CHAT = '#vip-go-es-alerts';
+	private const STALE_QUEUE_ALERT_LEVEL = 2; // Level 2 = 'alert'
 
 	public $healthcheck;
 	public $field_count_gauge;
@@ -644,7 +645,7 @@ class Search {
 				home_url(),
 				$average_wait_time
 			);
-			$this->alerts->send_to_chat( self::STALE_QUEUE_ALERT_SLACK_CHAT, $message );
+			$this->alerts->send_to_chat( self::STALE_QUEUE_ALERT_SLACK_CHAT, $message, self::STALE_QUEUE_ALERT_LEVEL );
 		}
 	}
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1820,9 +1820,9 @@ class Search_Test extends \WP_UnitTestCase {
 
 	public function test__maybe_alert_for_average_queue_time__sends_notification() {
 		$application_id = 123;
-		$stale_queue_value_limit = 3600; // 1 hour
+		$application_url = 'http://example.org';
 		$average_queue_value = 3601;
-		$expected_message = "Average index queue time for application $application_id, exceeded $stale_queue_value_limit seconds with $average_queue_value seconds";
+		$expected_message = "Average index queue wait time for application $application_id - $application_url is currently $average_queue_value seconds";
 
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1823,6 +1823,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$application_url = 'http://example.org';
 		$average_queue_value = 3601;
 		$expected_message = "Average index queue wait time for application $application_id - $application_url is currently $average_queue_value seconds";
+		$expected_level = 2;
 
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
@@ -1842,7 +1843,7 @@ class Search_Test extends \WP_UnitTestCase {
 
 		$alerts_mocked->expects( $this->once() )
 			->method( 'send_to_chat' )
-			->with( '#vip-platform-cantina', $expected_message );
+			->with( '#vip-go-es-alerts', $expected_message, $expected_level );
 
 		$es->maybe_alert_for_average_queue_time();
 	}


### PR DESCRIPTION
## Description

Sends an alert to cantina channel if the indexing queue gets stale.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Couldn't figure that out:(
