### PR TITLE
Search: Update ElasticPress submodule to f0ffd49

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -55,7 +55,7 @@ class CoreCommand extends \ElasticPress\Command {
 	 * [--version]
 	 * : The index version to index into. Used to build up a new index in parallel with the currently active index version
 	 *
-	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--version] [--skip-confirm]
+	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--start-object-id] [--end-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--version] [--skip-confirm]
 	 *
 	 * @param array $args Positional CLI args.
 	 * @since 0.1.2


### PR DESCRIPTION
This PR combines several performance improvements when doing bulk indexing:

- Implement ID ranges instead of relying on OFFSET when doing pagination. OFFSET gets progressively slower on larger datasets, using ID ranges provides consistent and fast results.
- Term preparation refactoring
- date_18in usage improvements (reduce the number of total calls)

https://github.com/Automattic/ElasticPress/pull/66