### PR TITLE
Search: Consider stuck `running` jobs as deadlocked too

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -458,7 +458,7 @@ class Queue {
 		$deadlocked_time = time() - self::DEADLOCK_TIME;
 
 		$jobs = $wpdb->get_results( $wpdb->prepare(
-			"SELECT * FROM {$table_name} WHERE `status` = 'scheduled' AND `scheduled_time` <= %s LIMIT %d", // Cannot prepare table name. @codingStandardsIgnoreLine
+			"SELECT * FROM {$table_name} WHERE `status` IN ( 'scheduled', 'running' ) AND `scheduled_time` <= %s LIMIT %d", // Cannot prepare table name. @codingStandardsIgnoreLine
 			gmdate( 'Y-m-d H:i:s', $deadlocked_time ),
 			$count
 		) );

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -522,7 +522,7 @@ class Queue_Test extends \WP_UnitTestCase {
 		$deadlocked_time = time() - $this->queue::DEADLOCK_TIME - ( 3 * DAY_IN_SECONDS );
 
 		$this->queue->update_job( $job2->job_id, array(
-			'status' => 'scheduled',
+			'status' => 'running',
 			'scheduled_time' => gmdate( 'Y-m-d H:i:s', $deadlocked_time ),
 		) );
 


### PR DESCRIPTION
## Description

`scheduled` jobs are those that have been sent to a cron job, but jobs can also get stuck `running` if they are picked up but never completed (like when process is interrupted), so we need to check for both.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation a`dditions / updates (if applicable).

## Steps to Test

There is test coverage, so manual testing not strictly necessary. But could be done like this:

1. Check out PR.
1. Insert a row into the `wp_vip_search_index_queue` table with a status of `running` and a `scheduled_time` in the distant past
1. Let the sweeper cron job run
1. Ensure the job has now been processed
