### PR TITLE
Search: Update es-wp-query subtree with fix for user_nicename field

### DIFF
--- a/search/es-wp-query/adapters/vip-search.php
+++ b/search/es-wp-query/adapters/vip-search.php
@@ -110,7 +110,7 @@ function vip_es_field_map( $es_map ) {
 	return wp_parse_args(
 		array(
 			'post_author'                   => 'post_author.id',
-			'post_author.user_nicename'     => 'post_author.display_name',
+			'post_author.user_nicename'     => 'post_author.login.raw',
 			'post_date'                     => 'post_date',
 			'post_date.year'                => 'date_terms.year',
 			'post_date.month'               => 'date_terms.month',


### PR DESCRIPTION
## Description

We were mapping the user_nicename field incorrectly - @rebeccahum has fixed this in https://github.com/Automattic/es-wp-query/pull/10

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- N/A This change has relevant unit tests (if applicable).
- N/A This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Offload an author page main query to ES
1. Ensure results are returned
