### PR TITLE
Solve a memory leak in ElasticPress when WP_DEBUG is enabled

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -135,6 +135,17 @@ class Search {
 		if ( ! defined( 'EP_DASHBOARD_SYNC' ) ) {
 			define( 'EP_DASHBOARD_SYNC', false );
 		}
+
+		// Disable DB and ES query logs for CLI commands to keep memory under control
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			if ( ! defined( 'SAVEQUERIES' ) ) {
+				define( 'SAVEQUERIES', false );
+			}
+
+			if ( ! defined( 'EP_QUERY_LOG' ) ) {
+				define( 'EP_QUERY_LOG', false );
+			}
+		}
 	}
 
 	protected function setup_hooks() {

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -66,11 +66,6 @@ class CoreCommand extends \ElasticPress\Command {
 			self::confirm_destructive_operation( $assoc_args );
 		}
 
-		// Disable ES query logs to keep memory usage under control
-		if ( ! defined( 'EP_QUERY_LOG' ) ) {
-			define( 'EP_QUERY_LOG', false );
-		}
-
 		$this->_maybe_setup_index_version( $assoc_args );
 
 		/**

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -66,6 +66,11 @@ class CoreCommand extends \ElasticPress\Command {
 			self::confirm_destructive_operation( $assoc_args );
 		}
 
+		// Disable ES query logs to keep memory usage under control
+		if ( ! defined( 'EP_QUERY_LOG' ) ) {
+			define( 'EP_QUERY_LOG', false );
+		}
+
 		$this->_maybe_setup_index_version( $assoc_args );
 
 		/**

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -243,14 +243,6 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * @subcommand validate-contents
 	 */
 	public function validate_contents( $args, $assoc_args ) {
-		// Disable DB and ES query logs to keep memory usage under control
-		if ( ! defined( 'SAVEQUERIES' ) ) {
-			define( 'SAVEQUERIES', false );
-		}
-		if ( ! defined( 'EP_QUERY_LOG' ) ) {
-			define( 'EP_QUERY_LOG', false );
-		}
-
 		$results = \Automattic\VIP\Search\Health::validate_index_posts_content( $assoc_args['start_post_id'], $assoc_args['last_post_id'], $assoc_args['batch_size'], $assoc_args['max_diff_size'], isset( $assoc_args['silent'] ), isset( $assoc_args['inspect'] ), isset( $assoc_args['do-not-heal'] ) );
 		
 		if ( is_wp_error( $results ) ) {


### PR DESCRIPTION
##  Description

This is not exactly a memory leak, it's just a log of all Elasticsearch queries that ElasticPress stores for debugging purposes. If not explicitly defined with `EP_QUERY_LOG`, it gets automatically enabled when `WP_DEBUG` is set to true.

But for long executing CLI commands it doesn't make sense to store this log even if debugging is enabled, as it takes a lot of memory and it's not being used for anything.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out master
1. Try to index a big site on a Go sandbox (WP_DEBUG will be set to true, don't enforce it to false). It will leak memory
1. Check out this PR.
1. Index the same site again. It won't leak any memory (unless it's a problem with the site code)
