### PR TITLE
Akismet 4.1.7

### DIFF
--- a/akismet.php
+++ b/akismet.php
@@ -4,7 +4,7 @@
 Plugin Name: Akismet Anti-Spam
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 4.1.6
+Version: 4.1.7
 Author: Automattic
 Author URI: https://automattic.com/wordpress-plugins/
 License: GPLv2 or later

--- a/akismet/akismet.php
+++ b/akismet/akismet.php
@@ -6,7 +6,7 @@
 Plugin Name: Akismet Anti-Spam
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 4.1.6
+Version: 4.1.7
 Author: Automattic
 Author URI: https://automattic.com/wordpress-plugins/
 License: GPLv2 or later
@@ -37,7 +37,7 @@ if ( !function_exists( 'add_action' ) ) {
 	exit;
 }
 
-define( 'AKISMET_VERSION', '4.1.6' );
+define( 'AKISMET_VERSION', '4.1.7' );
 define( 'AKISMET__MINIMUM_WP_VERSION', '4.0' );
 define( 'AKISMET__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'AKISMET_DELETE_LIMIT', 100000 );

--- a/akismet/changelog.txt
+++ b/akismet/changelog.txt
@@ -5,6 +5,53 @@
 This file contains older changelog entries, so we can keep the size of the standard WordPress readme.txt file reasonable.
 For the latest changes, please see the "Changelog" section of the [readme.txt file](https://plugins.svn.wordpress.org/akismet/trunk/readme.txt).
 
+= 4.1.5 =
+*Release Date - 29 April 2020*
+
+* Based on user feedback, we have dropped the in-admin notice explaining the availability of the "privacy notice" option in the AKismet settings screen. The option itself is available, but after displaying the notice for the last 2 years, it is now considered a known fact.
+* Updated the "Requires at least" to WP 4.6, based on recommendations from https://wp-info.org/tools/checkplugini18n.php?slug=akismet
+* Moved older changelog entries to a separate file to keep the size of this readme reasonable, also based on recommendations from https://wp-info.org/tools/checkplugini18n.php?slug=akismet
+
+= 4.1.4 =
+*Release Date - 17 March 2020*
+
+* Only redirect to the Akismet setup screen upon plugin activation if the plugin was activated manually from within the plugin-related screens, to help users with non-standard install workflows, like WP-CLI.
+* Update the layout of the initial setup screen to be more readable on small screens.
+* If no API key has been entered, don't run code that expects an API key.
+* Improve the readability of the comment history entries.
+* Don't modify the comment form HTML if no API key has been set.
+
+= 4.1.3 =
+*Release Date - 31 October 2019*
+
+* Prevented an attacker from being able to cause a user to unknowingly recheck their Pending comments for spam.
+* Improved compatibility with Jetpack 7.7+.
+* Updated the plugin activation page to use consistent language and markup.
+* Redirecting users to the Akismet connnection/settings screen upon plugin activation, in an effort to make it easier for people to get setup.
+
+= 4.1.2 =
+*Release Date - 14 May 2019*
+
+* Fixed a conflict between the Akismet setup banner and other plugin notices.
+* Reduced the number of API requests made by the plugin when attempting to verify the API key.
+* Include additional data in the pingback pre-check API request to help make the stats more accurate.
+* Fixed a bug that was enabling the "Check for Spam" button when no comments were eligible to be checked.
+* Improved Akismet's AMP compatibility.
+
+= 4.1.1 =
+*Release Date - 31 January 2019*
+
+* Fixed the "Setup Akismet" notice so it resizes responsively.
+* Only highlight the "Save Changes" button in the Akismet config when changes have been made.
+* The count of comments in your spam queue shown on the dashboard show now always be up-to-date.
+
+= 4.1 =
+*Release Date - 12 November 2018*
+
+* Added a WP-CLI method for retrieving stats.
+* Hooked into the new "Personal Data Eraser" functionality from WordPress 4.9.6.
+* Added functionality to clear outdated alerts from Akismet.com.
+
 = 4.0.8 =
 *Release Date - 19 June 2018*
 

--- a/akismet/class.akismet-admin.php
+++ b/akismet/class.akismet-admin.php
@@ -612,7 +612,12 @@ class Akismet_Admin {
 						$message = esc_html( __( 'Akismet cleared this comment.', 'akismet' ) );
 					break;
 					case 'wp-blacklisted':
-						$message = sprintf( esc_html( __( 'Comment was caught by %s.', 'akismet' ) ), '<code>wp_blacklist_check</code>' );
+					case 'wp-disallowed':
+						$message = sprintf(
+							/* translators: The placeholder is a WordPress PHP function name. */
+							esc_html( __( 'Comment was caught by %s.', 'akismet' ) ),
+							function_exists( 'wp_check_comment_disallowed_list' ) ? '<code>wp_check_comment_disallowed_list</code>' : '<code>wp_blacklist_check</code>'
+						);
 					break;
 					case 'report-spam':
 						if ( isset( $row['user'] ) ) {
@@ -1055,7 +1060,8 @@ class Akismet_Admin {
 			if ( get_option( 'akismet_alert_code' ) > 0 )
 				self::display_alert();
 		}
-		elseif ( $hook_suffix == 'plugins.php' && !Akismet::get_api_key() ) {
+		elseif ( ( 'plugins.php' === $hook_suffix || 'edit-comments.php' === $hook_suffix ) && ! Akismet::get_api_key() ) {
+			// Show the "Set Up Akismet" banner on the comments and plugin pages if no API key has been set.
 			self::display_api_key_warning();
 		}
 		elseif ( $hook_suffix == 'edit-comments.php' && wp_next_scheduled( 'akismet_schedule_cron_recheck' ) ) {

--- a/akismet/readme.txt
+++ b/akismet/readme.txt
@@ -1,12 +1,12 @@
-=== Akismet Anti-Spam ===
+=== Akismet Spam Protection ===
 Contributors: matt, ryan, andy, mdawaffe, tellyworth, josephscott, lessbloat, eoigal, cfinke, automattic, jgs, procifer, stephdau
-Tags: akismet, comments, spam, antispam, anti-spam, anti spam, comment moderation, comment spam, contact form spam, spam comments
+Tags: comments, spam, antispam, anti-spam, contact form, anti spam, comment moderation, comment spam, contact form spam, spam comments
 Requires at least: 4.6
-Tested up to: 5.4
-Stable tag: 4.1.6
+Tested up to: 5.5
+Stable tag: 4.1.7
 License: GPLv2 or later
 
-Akismet checks your comments and contact form submissions against our global database of spam to protect you and your site from malicious content.
+The best anti-spam protection to block spam comments and spam in a contact form. The most trusted antispam solution for WordPress and WooCommerce.
 
 == Description ==
 
@@ -30,57 +30,16 @@ Upload the Akismet plugin to your blog, activate it, and then enter your Akismet
 
 == Changelog ==
 
+= 4.1.7 =
+*Release Date - 22 October 2020*
+
+* Show the "Set up your Akismet account" banner on the comments admin screen, where it's relevant to mention if Akismet hasn't been configured.
+* Don't use wp_blacklist_check when the new wp_check_comment_disallowed_list function is available.
+
 = 4.1.6 =
 *Release Date - 4 June 2020*
 
 * Disable "Check for Spam" button until the page is loaded to avoid errors with clicking through to queue recheck endpoint directly.
 * Add filter "akismet_enable_mshots" to allow disabling screenshot popups on the edit comments admin page.
-
-= 4.1.5 =
-*Release Date - 29 April 2020*
-
-* Based on user feedback, we have dropped the in-admin notice explaining the availability of the "privacy notice" option in the AKismet settings screen. The option itself is available, but after displaying the notice for the last 2 years, it is now considered a known fact.
-* Updated the "Requires at least" to WP 4.6, based on recommendations from https://wp-info.org/tools/checkplugini18n.php?slug=akismet
-* Moved older changelog entries to a separate file to keep the size of this readme reasonable, also based on recommendations from https://wp-info.org/tools/checkplugini18n.php?slug=akismet
-
-= 4.1.4 =
-*Release Date - 17 March 2020*
-
-* Only redirect to the Akismet setup screen upon plugin activation if the plugin was activated manually from within the plugin-related screens, to help users with non-standard install workflows, like WP-CLI.
-* Update the layout of the initial setup screen to be more readable on small screens.
-* If no API key has been entered, don't run code that expects an API key.
-* Improve the readability of the comment history entries.
-* Don't modify the comment form HTML if no API key has been set.
-
-= 4.1.3 =
-*Release Date - 31 October 2019*
-
-* Prevented an attacker from being able to cause a user to unknowingly recheck their Pending comments for spam.
-* Improved compatibility with Jetpack 7.7+.
-* Updated the plugin activation page to use consistent language and markup.
-* Redirecting users to the Akismet connnection/settings screen upon plugin activation, in an effort to make it easier for people to get setup.
-
-= 4.1.2 =
-*Release Date - 14 May 2019*
-
-* Fixed a conflict between the Akismet setup banner and other plugin notices.
-* Reduced the number of API requests made by the plugin when attempting to verify the API key.
-* Include additional data in the pingback pre-check API request to help make the stats more accurate.
-* Fixed a bug that was enabling the "Check for Spam" button when no comments were eligible to be checked.
-* Improved Akismet's AMP compatibility.
-
-= 4.1.1 =
-*Release Date - 31 January 2019*
-
-* Fixed the "Setup Akismet" notice so it resizes responsively.
-* Only highlight the "Save Changes" button in the Akismet config when changes have been made.
-* The count of comments in your spam queue shown on the dashboard show now always be up-to-date.
-
-= 4.1 =
-*Release Date - 12 November 2018*
-
-* Added a WP-CLI method for retrieving stats.
-* Hooked into the new "Personal Data Eraser" functionality from WordPress 4.9.6.
-* Added functionality to clear outdated alerts from Akismet.com.
 
 For older changelog entries, please see the [additional changelog.txt file](https://plugins.svn.wordpress.org/akismet/trunk/changelog.txt) delivered with the plugin.

--- a/akismet/views/stats.php
+++ b/akismet/views/stats.php
@@ -1,7 +1,7 @@
 <div id="akismet-plugin-container">
 	<div class="akismet-masthead">
 		<div class="akismet-masthead__inside-container">
-			<a href="<?php echo esc_url( Akismet_Admin::get_page_url() );?>" class="akismet-right"><?php esc_html_e( 'Akismet Settings' , 'akismet' ); ?></a>
+			<a href="<?php echo esc_url( Akismet_Admin::get_page_url() ); ?>" class="akismet-right"><?php esc_html_e( 'Anti-Spam Settings', 'akismet' ); ?></a>
 			<div class="akismet-masthead__logo-container">
 				<img class="akismet-masthead__logo" src="<?php echo esc_url( plugins_url( '../_inc/img/logo-full-2x.png', __FILE__ ) ); ?>" alt="Akismet" />
 			</div>


### PR DESCRIPTION
> Release Date – 22 October 2020
>
> Show the “Set up your Akismet account” banner on the comments admin screen, where it’s relevant to mention if Akismet hasn’t been configured.
> Don’t use wp_blacklist_check when the new wp_check_comment_disallowed_list function is available.

https://wordpress.org/plugins/akismet/