### PR TITLE
Remove curly braces syntax for array access

### DIFF
--- a/lib/class-apc-cache-interceptor.php
+++ b/lib/class-apc-cache-interceptor.php
@@ -168,7 +168,7 @@ if ( ! class_exists( 'APC_Cache_Interceptor' ) ) :
 				return ( array_key_exists( 'default', $this->specific_keys ) || array_key_exists( 'default', $this->regex_keys ) );
 			}
 
-			if ( is_numeric( $group{0} ) ) {
+			if ( is_numeric( $group[0] ) ) {
 				return true; // Requires deep check
 			}
 


### PR DESCRIPTION
The array and string offset access syntax using curly braces is deprecated as of PHP 7.4

https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace

This will begin throwing a fatal error in PHP 8

https://github.com/php/php-src/blob/107962208a19d8b6dc1a190cb25fc37614411e71/UPGRADING#L198

