### PR TITLE
Fix Failing core tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ job-references:
       echo "Downgrade to Composer 1 due to compat issues"
       sudo composer self-update --1
       composer install -n
-  
+
   install_core_tests_dependencies: &install_core_tests_dependencies
     name: "Install Dependencies"
     command: |
@@ -127,7 +127,7 @@ job-references:
       - run: echo "Downgrade to Composer 1 due to compat issues"
       - run: sudo composer self-update --1
       - run: composer install -n
-      - run: 
+      - run:
           name: "Lint"
           command: npm run lint
 
@@ -164,7 +164,7 @@ jobs:
     docker:
       - image: wordpressdevelop/php:7.3-fpm
       - image: *db_image
-    
+
   php73-core-multisite-tests-mu-plugins:
     <<: *php_core_job
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ job-references:
               cp -r $HOME/project/ build/wp-content/mu-plugins
               rm -rf tests/phpunit/data/plugins/wordpress-importer
               source $HOME/project/bin/utils.sh
+              update_core_tests "$WP_TESTS_DIR"
               exclude_core_tests tests/phpunit/multisite.xml
               exclude_core_tests phpunit.xml.dist tests/phpunit/
             fi

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To investigate failing test locally you can do following (buckle up as this is n
 
 1. Switch to where you want to checkout core code e.g. `cd ~/svn/wp`
 
-1. Checkout the core code: `svn co --quiet --ignore-externals https://develop.svn.wordpress.org/trunk .`
+1. Checkout the core code (pick the latest version): `svn co --quiet --ignore-externals https://develop.svn.wordpress.org/tags/5.5.3 .`
 
 1. Create test config: `cp wp-tests-config-sample.php wp-tests-config.php && sed -i 's/youremptytestdbnamehere/wordpress_test/; s/yourusernamehere/root/; s/yourpasswordhere//; s/localhost/127.0.0.1/' wp-tests-config.php`
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,32 @@ You can also pass the path to a specific test as well as extra PHPUnit arguments
 
 PHP Linting and PHPUnit tests are run by Circle CI as part of PRs and merges. See [`.circleci/config.yml`](https://github.com/Automattic/vip-go-mu-plugins/blob/master/.circleci/config.yml) for more.
 
+##### Core tests
+
+We run core tests as part of the CI pipeline. We run core tests both with and without mu-plugins installed. There are many failures when running with mu-plugins so we had to ignore several tests. To add another test there chack `bin/utils.sh`.
+
+To investigate failing test locally you can do following (buckle up as this is not so easy:()):
+
+1. While in your mu-plugins folder do `MU_PLUGINS_DIR=$(pwd)`
+
+1. Switch to where you want to checkout core code e.g. `cd ~/svn/wp`
+
+1. Checkout the core code: `svn co --quiet --ignore-externals https://develop.svn.wordpress.org/trunk .`
+
+1. Create test config: `cp wp-tests-config-sample.php wp-tests-config.php && sed -i 's/youremptytestdbnamehere/wordpress_test/; s/yourusernamehere/root/; s/yourpasswordhere//; s/localhost/127.0.0.1/' wp-tests-config.php`
+
+1. Build core `npm ci && npm run build`
+
+1. Export env variable `export WP_TESTS_DIR="$(pwd)/tests/phpunit"`
+
+1. Start local DB: `docker run -d -p 3306:3306 circleci/mariadb:10.2`
+
+1. Create empty DB `mysqladmin create wordpress_test --user="root" --password="" --host="127.0.0.1" --protocol=tcp`
+
+1. Copy over MU-plugins `cp -r $MU_PLUGINS_DIR build/wp-content/mu-plugins`
+
+1. Run the test you want (in this case `test_allowed_anon_comments`) `$MU_PLUGINS_DIR/vendor/bin/phpunit --filter test_allowed_anon_comments`
+
 ### PHPDoc
 
 You can find selective PHPDoc documentation here: https://automattic.github.io/vip-go-mu-plugins/

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -92,6 +92,7 @@ exclude_core_tests() {
 		"tests/xmlrpc/wp/getMediaItem.php"
 		"tests/xmlrpc/wp/getComments.php"
 		"tests/xmlrpc/wp/getComment.php"
+		"tests/xmlrpc/wp/newComment.php"
 		"tests/xmlrpc/wp/editTerm.php"
 		"tests/xmlrpc/wp/editProfile.php"
 		"tests/xmlrpc/wp/editPost.php"

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -92,7 +92,6 @@ exclude_core_tests() {
 		"tests/xmlrpc/wp/getMediaItem.php"
 		"tests/xmlrpc/wp/getComments.php"
 		"tests/xmlrpc/wp/getComment.php"
-		"tests/xmlrpc/wp/newComment.php"
 		"tests/xmlrpc/wp/editTerm.php"
 		"tests/xmlrpc/wp/editProfile.php"
 		"tests/xmlrpc/wp/editPost.php"
@@ -113,5 +112,31 @@ exclude_core_tests() {
 	done
 }
 
+update_core_tests() {
+	local wp_tests_dir="$1"
+
+	if [ -z "$wp_tests_dir" ]; then
+		echo "WP_TESTS_DIR was not passed in";
+		exit 1;
+	fi
+
+
+	local header_handling_locations=(
+		"$wp_tests_dir/tests/xmlrpc/wp/newComment.php:Tests_XMLRPC_wp_newComment"
+	)
+
+	local header_handling='\/**\n * @runTestsInSeparateProcesses\n * @preserveGlobalState disabled\n *\/'
+
+	for location in "${header_handling_locations[@]}"; do
+		local location_data=(${location//:/ })
+		local file="${location_data[0]}"
+		local test_class_name="${location_data[1]}"
+
+		echo "Updating ${file} - ${test_class_name} for header test"
+		sed -i "s/\\(class $test_class_name\\)/${header_handling}\\n\\1/" "$file"
+	done
+}
+
 export -f install_db
 export -f exclude_core_tests
+export -f update_core_tests


### PR DESCRIPTION
## Description

Looking into new core test failure:
```
in ests/phpunit/tests/xmlrpc/wp/newComment.php

Cannot modify header information - headers already sent by (output started at /tmp/wordpress-develop/tests/phpunit/includes/bootstrap.php:122)
```

Our code adds a header on login failure, but the test isn't setup to work with headers (or http requests in general). The authentication fails even without our plugin and is expected in the test. So I am adding that test class to ignored ones. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Check the circleCI build pipelines
