### PR TITLE
Fix phpcs exclusion missconfiguration

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -27,7 +27,7 @@
 	<exclude-pattern>vip-support/*</exclude-pattern>
 
 	<!-- Other directories -->
-	<exclude-pattern>.git/*</exclude-pattern>
+	<exclude-pattern>\.git/*</exclude-pattern>
 	<exclude-pattern>akismet/*</exclude-pattern>
 	<exclude-pattern>bin/*</exclude-pattern>
 	<exclude-pattern>debug-bar/*</exclude-pattern>
@@ -70,7 +70,7 @@
 		https://github.com/Automattic/VIP-Coding-Standards/ -->
 	<rule ref="WordPress-VIP-Go">
 		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.internal_wpcom_vip_irc"/>
-		
+
 		<!-- These disallow anonymous functions as action callbacks -->
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
@@ -79,5 +79,5 @@
 		<!-- Allow short array syntax -->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
 	</rule>
-	
+
 </ruleset>


### PR DESCRIPTION
`.git/*` is a regular expresion so . matches anything. In my case whne I
have all the code under git/repo it would exclude the whole repo.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. clone repo to `git` folder
1. run `npm run phpcs`
1. see all the errors (files not being ignored)