### PR TITLE
vip-plugins: "VIP Featured Plugins" -> "VIP Featured Partners"

### DIFF
--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -56,7 +56,7 @@ function wpcom_vip_render_vip_featured_plugins() {
 	if ( empty( $plugins ) ) {
 		?>
 		<div class="notice notice-error">
-			<p><?php _e( 'Unable to display VIP featured partners; try refreshing this page in a few minutes. If this error persists, please contact VIP Support.', 'vip-plugins-dashboard' ); ?></p>
+			<p><?php esc_html_e( 'Unable to display VIP featured partners; try refreshing this page in a few minutes. If this error persists, please contact VIP Support.', 'vip-plugins-dashboard' ); ?></p>
 		</div>
 		<?php
 		return;
@@ -64,7 +64,7 @@ function wpcom_vip_render_vip_featured_plugins() {
 
 	?>
 	<div class="featured-plugins notice">
-		<h3><?php _e( 'VIP Featured Partners', 'vip-plugins-dashboard' ); ?></h3>
+		<h3><?php esc_html_e( 'VIP Featured Partners', 'vip-plugins-dashboard' ); ?></h3>
 		<?php
 		foreach ( $plugins as $key => $plugin ) {
 			?>

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -56,7 +56,7 @@ function wpcom_vip_render_vip_featured_plugins() {
 	if ( empty( $plugins ) ) {
 		?>
 		<div class="notice notice-error">
-			<p><?php _e( 'Unable to display VIP featured plugins; try refreshing this page in a few minutes. If this error persists, please contact VIP Support.', 'vip-plugins-dashboard' ); ?></p>
+			<p><?php _e( 'Unable to display VIP featured partners; try refreshing this page in a few minutes. If this error persists, please contact VIP Support.', 'vip-plugins-dashboard' ); ?></p>
 		</div>
 		<?php
 		return;
@@ -64,7 +64,7 @@ function wpcom_vip_render_vip_featured_plugins() {
 
 	?>
 	<div class="featured-plugins notice">
-		<h3><?php _e( 'VIP Featured Plugins', 'vip-plugins-dashboard' ); ?></h3>
+		<h3><?php _e( 'VIP Featured Partners', 'vip-plugins-dashboard' ); ?></h3>
 		<?php
 		foreach ( $plugins as $key => $plugin ) {
 			?>

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -56,7 +56,7 @@ function wpcom_vip_render_vip_featured_plugins() {
 	if ( empty( $plugins ) ) {
 		?>
 		<div class="notice notice-error">
-			<p><?php esc_html_e( 'Unable to display VIP featured partners; try refreshing this page in a few minutes. If this error persists, please contact VIP Support.', 'vip-plugins-dashboard' ); ?></p>
+			<p><?php esc_html_e( 'Unable to display VIP Featured Technology Partners; try refreshing this page in a few minutes. If this error persists, please contact VIP Support.', 'vip-plugins-dashboard' ); ?></p>
 		</div>
 		<?php
 		return;
@@ -64,7 +64,7 @@ function wpcom_vip_render_vip_featured_plugins() {
 
 	?>
 	<div class="featured-plugins notice">
-		<h3><?php esc_html_e( 'VIP Featured Partners', 'vip-plugins-dashboard' ); ?></h3>
+		<h3><?php esc_html_e( 'VIP Featured Technology Partners', 'vip-plugins-dashboard' ); ?></h3>
 		<?php
 		foreach ( $plugins as $key => $plugin ) {
 			?>


### PR DESCRIPTION
WordPress VIP doesn't have an approved list of plugins, and therefore no Featured Plugins.

It does, however, have a list of [Featured Partners](http://wpvip.com/partners), so this PR updates the title in the admin page shown in all customer WPVIP sites to reflect that.

![image](https://user-images.githubusercontent.com/4251760/99304720-bbd07f00-2820-11eb-884c-b5e7feabcb99.png)
