### PR TITLE
vip-plugins: link to post->permalink instead of post->meta->plugin_url

### DIFF
--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 /**
  * Retrieve featured plugins from the wpvip.com API
@@ -69,15 +69,15 @@ function wpcom_vip_render_vip_featured_plugins() {
 		foreach ( $plugins as $key => $plugin ) {
 			?>
 			<div class="plugin">
-				<a class="fp-content" href="<?php echo esc_attr( $plugin->meta->plugin_url ); ?>" target="_blank">
+				<a class="fp-content" href="<?php echo esc_url( $plugin->permalink ?? $plugin->meta->plugin_url ); ?>" target="_blank">
 					<img src="<?php echo esc_attr( $plugin->meta->listing_logo ); ?>" alt="<?php echo esc_attr( $plugin->post_title ); ?>" />
 					<h4><?php echo esc_html( $plugin->post_title ); ?></h4>
 					<p><?php echo esc_html( $plugin->meta->listing_description ); ?></p>
 				</a>
-				<a class="fp-overlay" href="<?php echo esc_attr( $plugin->meta->plugin_url ); ?>" target="_blank">
+				<a class="fp-overlay" href="<?php echo esc_url( $plugin->permalink ?? $plugin->meta->plugin_url ); ?>" target="_blank">
 					<div class="fp-overlay-inner">
 						<div class="fp-overlay-cell">
-							<span>	
+							<span>
 								<?php _e( 'More Information', 'vip-plugins-dashboard' ); ?>
 							</span>
 						</div>


### PR DESCRIPTION
This PR is backwards compatible and will continue to use `meta->plugin_url` if `permalink` is unavailable.

For this PR to work properly, `permalink` value must be added to response that comes from wpvip.com REST API (handled by a separate PR for that site).