### PR TITLE
Adjust health check cron interval to 1 hour

### DIFF
--- a/search/includes/classes/class-health-job.php
+++ b/search/includes/classes/class-health-job.php
@@ -21,7 +21,7 @@ class HealthJob {
 	/**
 	 * Custom cron interval value
 	 */
-	const CRON_INTERVAL = 60 * 30; // 30 minutes in seconds
+	const CRON_INTERVAL = 1 * \HOUR_IN_SECONDS;
 
 	public $health_check_disabled_sites = array();
 


### PR DESCRIPTION
## Description

Health checks happen way too frequently at present. Doubling the interval between event should help with that.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check current interval time for `vip_search_healthcheck_interval`. It should be 30 minutes.
2. Apply PR
3. Check interval time for `vip_search_healthcheck_interval`. It should be an hour.