### PR TITLE
Unset skip-confirm before passing to EP for indexing

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -94,6 +94,9 @@ class CoreCommand extends \ElasticPress\Command {
 
 			WP_CLI::line( WP_CLI::colorize( '%CNetwork-wide run took: ' . ( round( microtime( true ) - $start, 3 ) ) . '%n' ) );
 		} else {
+			// Unset skip-confirm since it doesn't exist in ElasticPress and causes
+			// an error for indexing operations exclusively for some reason.
+			unset( $assoc_args['skip-confirm'] );
 			array_unshift( $args, 'elasticpress', 'index' );
 			WP_CLI::run_command( $args, $assoc_args );
 		}


### PR DESCRIPTION
## Description

Currently the `--skip-confirm` flag is broken for indexing. This PR fixes that.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Execute `wp vip-search index --skip-confirm`
2. It will error something like `Error: Parameter errors: unknown --skip-confirm parameter`
3. Apply PR.
4. Execute `wp vip-search index --skip-confirm`
5. It shouldn't error.