### PR TITLE
Dissmiss Notice Event by Onclick

### DIFF
--- a/admin-notice/js/script.js
+++ b/admin-notice/js/script.js
@@ -1,31 +1,31 @@
 function tryGetNoticeContainer(currentElement) {
-    if (currentElement === null || currentElement.hasAttribute(dismissal_data.data_attribute)) {
-        return currentElement;
-    }
-    return tryGetNoticeContainer(currentElement.parentElement);
+	if (currentElement === null || currentElement.hasAttribute(dismissal_data.data_attribute)) {
+		return currentElement;
+	}
+	return tryGetNoticeContainer(currentElement.parentElement);
 }
 
 function persistDismissedNotice(containerElement) {
-    const dismissIdentifier = containerElement && containerElement.getAttribute(dismissal_data.data_attribute);
-    if (dismissIdentifier) {
-        var formData = new FormData();
+	const dismissIdentifier = containerElement && containerElement.getAttribute(dismissal_data.data_attribute);
+	if (dismissIdentifier) {
+		var formData = new FormData();
 
-        formData.append('_ajax_nonce', dismissal_data.nonce);
-        formData.append('action', 'dismiss_vip_notice');
-        formData.append(dismissal_data.identifier_key, dismissIdentifier);
+		formData.append('_ajax_nonce', dismissal_data.nonce);
+		formData.append('action', 'dismiss_vip_notice');
+		formData.append(dismissal_data.identifier_key, dismissIdentifier);
 
-        fetch(ajaxurl, {
-            method: "POST",
-            body: formData,
-        });
-    }
+		fetch(ajaxurl, {
+			method: "POST",
+			body: formData,
+		});
+	}
 }
 
 function onDismissed(event) {
-    const noticeContainer = tryGetNoticeContainer(event && event.target);
-    if (noticeContainer) {
-        persistDismissedNotice(noticeContainer);
-    }
+	const noticeContainer = tryGetNoticeContainer(event && event.target);
+	if (noticeContainer) {
+		persistDismissedNotice(noticeContainer);
+	}
 }
 
 function registerDismissHooks() {
@@ -37,8 +37,8 @@ function registerDismissHooks() {
 }
 
 window.onload = (function (oldLoad) {
-    return function () {
-        oldLoad && oldLoad();
-        registerDismissHooks();
-    }
+	return function () {
+		oldLoad && oldLoad();
+		registerDismissHooks();
+	}
 })(window.onload)

--- a/admin-notice/js/script.js
+++ b/admin-notice/js/script.js
@@ -29,10 +29,11 @@ function onDismissed(event) {
 }
 
 function registerDismissHooks() {
-    const buttons = document.getElementsByClassName("notice-dismiss");
-    for (const button of buttons) {
-        button.onclick = onDismissed;
-    }
+	const notices = document.querySelectorAll( '.vip-notice .notice-dismiss' );
+
+	for ( const notice of notices ) {
+		notice.addEventListener( "click", onDismissed );
+	}
 }
 
 window.onload = (function (oldLoad) {

--- a/admin-notice/js/script.js
+++ b/admin-notice/js/script.js
@@ -29,10 +29,9 @@ function onDismissed(event) {
 }
 
 function registerDismissHooks() {
-    const notices = document.getElementsByClassName("vip-notice");
-    for (const notice of notices) {
-        // Hooking up on the event caused by the core implementation of is-dismissible class, which generates dismiss button.
-        notice.addEventListener("DOMNodeRemoved", onDismissed);
+    const buttons = document.getElementsByClassName("notice-dismiss");
+    for (const button of buttons) {
+        button.onclick = onDismissed;
     }
 }
 


### PR DESCRIPTION
## Description

Previously the hook was on `DOMNodeRemoved` which cause some other operations (e.g. page unloading) to fire it even if the button was not clicked.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Create a notice
1. Navigate to wp-admin
1. Refresh few times
1. Notice is still there
1. Dismiss Notice
1. Refresh few times
1. Notice is gone