### PR TITLE
Avoid a warning on Jetpack 9.1 when enabling instagram cache

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -114,6 +114,19 @@ function vip_jetpack_load() {
 			break;
 		}
 	}
+
+	/**
+	 * Enables object caching for the response sent by Instagram when querying for Instagram image HTML.
+	 *
+	 * This cannot be included inside Jetpack because it ships with caching disabled by default.
+	 * By enabling caching it's possible to save time in uncached page renders.
+	 *
+	 * We need Jetpack to be loaded as this has been deprecated in version 9.1, and if the filter is
+	 * added in that version or newer, a warning is shown on every WordPress request
+	 */
+	if ( version_compare( JETPACK__VERSION, '9.1', '<' ) ) {
+		add_filter( 'instagram_cache_oembed_api_response_body', '__return_true' );
+	}
 }
 
 vip_jetpack_load();

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -764,11 +764,3 @@ function vip_reset_db_query_log() {
 
 	$wpdb->queries = array();
 }
-
-/**
-* Enables object caching for the response sent by Instagram when querying for Instagram image HTML.
-*
-* This cannot be included inside Jetpack because it ships with caching disabled by default.
-* By enabling caching it's possible to save time in uncached page renders.
-**/
-add_filter( 'instagram_cache_oembed_api_response_body', '__return_true' );


### PR DESCRIPTION
## Description

As described in #1859, in Jetpack 9.1 the instagram oembed cache has been deprecated. As we are adding a filter to enable this cache, it results in a warning when Jetpack 9.1 or above is in use.

This PR solves this by checking the Jetpack version before adding the filter. It had to be moved out from `vip-helpers/vip-cache.php`, as Jetpack was still not loaded, so we couldn't check the Jetpack version there. Instead, it's now directly in the mu-plugins Jetpack loader.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Ensure that the warning no longer appears if you are using Jetpack 9.1
1. If you pin Jetpack to an older version (e.g. 9.0), the filter is correctly applied.
