### PR TITLE
Uprade query monitor 3.6.4->3.6.5.

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -6,12 +6,12 @@
  * @package   query-monitor
  * @link      https://github.com/johnbillion/query-monitor
  * @author    John Blackbourn <john@johnblackbourn.com>
- * @copyright 2009-2018 John Blackbourn
+ * @copyright 2009-2020 John Blackbourn
  * @license   GPL v2 or later
  *
  * Plugin Name:  Query Monitor
- * Description:  The Developer Tools panel for WordPress.
- * Version:      3.6.4
+ * Description:  The Developer Tools Panel for WordPress.
+ * Version:      3.6.5
  * Plugin URI:   https://github.com/johnbillion/query-monitor
  * Author:       John Blackbourn & contributors
  * Author URI:   https://github.com/johnbillion/query-monitor/graphs/contributors

--- a/query-monitor/assets/query-monitor.js
+++ b/query-monitor/assets/query-monitor.js
@@ -164,7 +164,7 @@ if ( window.jQuery ) {
 			var filters = $( panel ).find('.qm-filter');
 
 			if ( filters.length ) {
-				filters.change();
+				filters.trigger('change');
 			} else {
 				stripes( $(panel).find('table') );
 			}
@@ -278,7 +278,7 @@ if ( window.jQuery ) {
 				if ( ! $(this).find('option[value="' + val + '"]').length ) {
 					$('<option>').attr('value',value).text(value).appendTo(this);
 				}
-				$(this).val(value).change();
+				$(this).val(value).trigger('change');
 			}
 		});
 
@@ -286,8 +286,8 @@ if ( window.jQuery ) {
 			var filter = $(this).data('qm-filter'),
 				value  = $(this).data('qm-value'),
 				target = $(this).data('qm-target');
-			$('#qm-' + target).find('.qm-filter').not('[data-filter="' + filter + '"]').val('').removeClass('qm-highlight').change();
-			$('#qm-' + target).find('[data-filter="' + filter + '"]').val(value).addClass('qm-highlight').change();
+			$('#qm-' + target).find('.qm-filter').not('[data-filter="' + filter + '"]').val('').removeClass('qm-highlight').trigger('change');
+			$('#qm-' + target).find('[data-filter="' + filter + '"]').val(value).addClass('qm-highlight').trigger('change');
 			show_panel( '#qm-' + target );
 			$('#qm-' + target).focus();
 			e.preventDefault();
@@ -368,7 +368,7 @@ if ( window.jQuery ) {
 
 			for ( var key = 1; key <= errors; key++ ) {
 
-				error = $.parseJSON( response.getResponseHeader( 'X-QM-php_errors-error-' + key ) );
+				error = JSON.parse( response.getResponseHeader( 'X-QM-php_errors-error-' + key ) );
 
 				if ( window.console ) {
 					switch ( error.type ) {
@@ -465,32 +465,40 @@ if ( window.jQuery ) {
 		var startY, startX, resizerHeight;
 
 		$(document).on('mousedown touchstart', '.qm-resizer', function(event) {
+			event.stopPropagation();
+
 			resizerHeight = $(this).outerHeight() - 1;
 			startY        = container.outerHeight() + ( event.clientY || event.originalEvent.targetTouches[0].pageY );
 			startX        = container.outerWidth() + ( event.clientX || event.originalEvent.targetTouches[0].pageX );
 
-			$(document).on('mousemove touchmove', qm_do_resizer_drag);
+			if ( ! container.hasClass('qm-show-right') ) {
+				$(document).on('mousemove touchmove', qm_do_resizer_drag_vertical);
+			} else {
+				$(document).on('mousemove touchmove', qm_do_resizer_drag_horizontal);
+			}
+
 			$(document).on('mouseup touchend', qm_stop_resizer_drag);
 		});
 
-		function qm_do_resizer_drag(event) {
-			if ( ! container.hasClass('qm-show-right') ) {
+		function qm_do_resizer_drag_vertical(event) {
 				var h = ( startY - ( event.clientY || event.originalEvent.targetTouches[0].pageY ) );
 				if ( h >= resizerHeight && h <= maxheight ) {
 					container.height( h );
 					body.css( 'margin-bottom', 'calc( ' + body_margin + ' + ' + h + 'px )' );
 				}
-			} else {
+		}
+
+		function qm_do_resizer_drag_horizontal(event) {
 				var w = ( startX - event.clientX );
 				if ( w >= minwidth && w <= maxwidth ) {
 					container.width( w );
 				}
 				body.css( 'margin-bottom', '' );
-			}
 		}
 
 		function qm_stop_resizer_drag(event) {
-			$(document).off('mousemove touchmove', qm_do_resizer_drag);
+			$(document).off('mousemove touchmove', qm_do_resizer_drag_vertical);
+			$(document).off('mousemove touchmove', qm_do_resizer_drag_horizontal);
 			$(document).off('mouseup touchend', qm_stop_resizer_drag);
 
 			if ( ! container.hasClass('qm-show-right') ) {
@@ -553,18 +561,18 @@ if ( window.jQuery ) {
 			}
 		});
 
-		$('.qm-button-container-close').click(function(){
+		$('.qm-button-container-close').on('click',function(){
 			container.removeClass('qm-show').height('').width('');
 			body.css( 'margin-bottom', '' );
 			localStorage.removeItem( container_pinned_key );
 		});
 
-		$('.qm-button-container-settings,a[href="#qm-settings"]').click(function(){
+		$('.qm-button-container-settings,a[href="#qm-settings"]').on('click',function(){
 			show_panel( '#qm-settings' );
 			$('#qm-settings').focus();
 		});
 
-		$('.qm-button-container-position').click(function(){
+		$('.qm-button-container-position').on('click',function(){
 			container.toggleClass('qm-show-right');
 
 			if ( container.hasClass('qm-show-right') ) {
@@ -589,7 +597,7 @@ if ( window.jQuery ) {
 			show_panel( pinned );
 		}
 
-		$('.qm-title-heading select').change(function(){
+		$('.qm-title-heading select').on('change',function(){
 			show_panel( $(this).val() );
 			$($(this).val()).focus();
 		});
@@ -713,24 +721,36 @@ if ( window.jQuery ) {
 }
 
 window.addEventListener('load', function() {
+	var main = document.getElementById( 'query-monitor-main' );
+	var broken = document.getElementById( 'qm-broken' );
+	var menu_item = document.getElementById( 'wp-admin-bar-query-monitor' );
+
 	if ( ( 'undefined' === typeof jQuery ) || ! window.jQuery ) {
-		/* Fallback for running without jQuery (`QM_NO_JQUERY`) */
-		document.getElementById( 'query-monitor-main' ).className += ' qm-broken';
-		console.error( document.getElementById( 'qm-broken' ).textContent );
+		/* Fallback for running without jQuery (`QM_NO_JQUERY`) or when jQuery is broken */
+
+		if ( main ) {
+			main.className += ' qm-broken';
+		}
+
+		if ( broken ) {
+			console.error( broken.textContent );
+		}
 
 		if ( 'undefined' === typeof jQuery ) {
 			console.error( 'QM error from JS: undefined jQuery' );
-		}
-
-		if ( ! window.jQuery ) {
+		} else if ( ! window.jQuery ) {
 			console.error( 'QM error from JS: no jQuery' );
 		}
 
-		var menu_item = document.getElementById( 'wp-admin-bar-query-monitor' );
-		if ( menu_item ) {
+		if ( menu_item && main ) {
 			menu_item.addEventListener( 'click', function() {
-				document.getElementById( 'query-monitor-main' ).className += ' qm-show';
+				main.className += ' qm-show';
 			} );
 		}
+	}
+
+	if ( ! main ) {
+		// QM's output has disappeared
+		console.error( 'QM error from JS: QM output does not exist' );
 	}
 } );

--- a/query-monitor/classes/Activation.php
+++ b/query-monitor/classes/Activation.php
@@ -99,9 +99,8 @@ class QM_Activation extends QM_Plugin {
 
 	public function php_notice() {
 		?>
-		<div id="qm_php_notice" class="error">
+		<div id="qm_php_notice" class="notice notice-error">
 			<p>
-				<span class="dashicons dashicons-warning" style="color:#dd3232" aria-hidden="true"></span>
 				<?php
 				echo esc_html( sprintf(
 					/* Translators: 1: Minimum required PHP version, 2: Current PHP version. */

--- a/query-monitor/classes/Backtrace.php
+++ b/query-monitor/classes/Backtrace.php
@@ -227,7 +227,7 @@ class QM_Backtrace {
 
 	}
 
-	public function filter_trace( array $trace ) {
+	public function filter_trace( array $frame ) {
 
 		if ( ! self::$filtered && function_exists( 'did_action' ) && did_action( 'plugins_loaded' ) ) {
 
@@ -277,48 +277,48 @@ class QM_Backtrace {
 
 		}
 
-		$return = $trace;
+		$return = $frame;
 
-		if ( isset( $trace['class'] ) ) {
-			if ( isset( self::$ignore_class[ $trace['class'] ] ) ) {
+		if ( isset( $frame['class'] ) ) {
+			if ( isset( self::$ignore_class[ $frame['class'] ] ) ) {
 				$return = null;
-			} elseif ( isset( self::$ignore_method[ $trace['class'] ][ $trace['function'] ] ) ) {
+			} elseif ( isset( self::$ignore_method[ $frame['class'] ][ $frame['function'] ] ) ) {
 				$return = null;
-			} elseif ( 0 === strpos( $trace['class'], 'QM' ) ) {
+			} elseif ( 0 === strpos( $frame['class'], 'QM' ) ) {
 				$return = null;
 			} else {
-				$return['id']      = $trace['class'] . $trace['type'] . $trace['function'] . '()';
-				$return['display'] = QM_Util::shorten_fqn( $trace['class'] . $trace['type'] . $trace['function'] ) . '()';
+				$return['id']      = $frame['class'] . $frame['type'] . $frame['function'] . '()';
+				$return['display'] = QM_Util::shorten_fqn( $frame['class'] . $frame['type'] . $frame['function'] ) . '()';
 			}
 		} else {
-			if ( isset( self::$ignore_func[ $trace['function'] ] ) ) {
+			if ( isset( self::$ignore_func[ $frame['function'] ] ) ) {
 				$return = null;
-			} elseif ( isset( self::$show_args[ $trace['function'] ] ) ) {
-				$show = self::$show_args[ $trace['function'] ];
+			} elseif ( isset( self::$show_args[ $frame['function'] ] ) ) {
+				$show = self::$show_args[ $frame['function'] ];
 
 				if ( 'dir' === $show ) {
-					if ( isset( $trace['args'][0] ) ) {
-						$arg = QM_Util::standard_dir( $trace['args'][0], '' );
-						$return['id']      = $trace['function'] . '()';
-						$return['display'] = QM_Util::shorten_fqn( $trace['function'] ) . "('{$arg}')";
+					if ( isset( $frame['args'][0] ) ) {
+						$arg = QM_Util::standard_dir( $frame['args'][0], '' );
+						$return['id']      = $frame['function'] . '()';
+						$return['display'] = QM_Util::shorten_fqn( $frame['function'] ) . "('{$arg}')";
 					}
 				} else {
 					$args = array();
 					for ( $i = 0; $i < $show; $i++ ) {
-						if ( isset( $trace['args'][ $i ] ) ) {
-							if ( is_string( $trace['args'][ $i ] ) ) {
-								$args[] = '\'' . $trace['args'][ $i ] . '\'';
+						if ( isset( $frame['args'][ $i ] ) ) {
+							if ( is_string( $frame['args'][ $i ] ) ) {
+								$args[] = '\'' . $frame['args'][ $i ] . '\'';
 							} else {
-								$args[] = QM_Util::display_variable( $trace['args'][ $i ] );
+								$args[] = QM_Util::display_variable( $frame['args'][ $i ] );
 							}
 						}
 					}
-					$return['id']      = $trace['function'] . '()';
-					$return['display'] = QM_Util::shorten_fqn( $trace['function'] ) . '(' . implode( ',', $args ) . ')';
+					$return['id']      = $frame['function'] . '()';
+					$return['display'] = QM_Util::shorten_fqn( $frame['function'] ) . '(' . implode( ',', $args ) . ')';
 				}
 			} else {
-				$return['id']      = $trace['function'] . '()';
-				$return['display'] = QM_Util::shorten_fqn( $trace['function'] ) . '()';
+				$return['id']      = $frame['function'] . '()';
+				$return['display'] = QM_Util::shorten_fqn( $frame['function'] ) . '()';
 			}
 		}
 
@@ -329,11 +329,11 @@ class QM_Backtrace {
 
 		}
 
-		if ( isset( $trace['line'] ) ) {
-			$this->calling_line = $trace['line'];
+		if ( isset( $frame['line'] ) ) {
+			$this->calling_line = $frame['line'];
 		}
-		if ( isset( $trace['file'] ) ) {
-			$this->calling_file = $trace['file'];
+		if ( isset( $frame['file'] ) ) {
+			$this->calling_file = $frame['file'];
 		}
 
 		return $return;

--- a/query-monitor/classes/Hook.php
+++ b/query-monitor/classes/Hook.php
@@ -46,7 +46,7 @@ class QM_Hook {
 			}
 		}
 
-		$parts = array_values( array_filter( preg_split( '#[_/-]#', $name ) ) );
+		$parts = array_values( array_filter( preg_split( '#[_/.-]#', $name ) ) );
 
 		return array(
 			'name'       => $name,

--- a/query-monitor/classes/Util.php
+++ b/query-monitor/classes/Util.php
@@ -94,6 +94,10 @@ class QM_Util {
 				self::$file_dirs['vip-client-mu-plugin'] = WPCOM_VIP_CLIENT_MU_PLUGIN_DIR;
 			}
 
+			if ( defined( '\Altis\ROOT_DIR' ) ) {
+				self::$file_dirs['altis-vendor'] = \Altis\ROOT_DIR . '/vendor';
+			}
+
 			self::$file_dirs['theme']      = null;
 			self::$file_dirs['stylesheet'] = get_stylesheet_directory();
 			self::$file_dirs['template']   = get_template_directory();
@@ -129,6 +133,13 @@ class QM_Util {
 		$context = $type;
 
 		switch ( $type ) {
+			case 'altis-vendor':
+				$plug = str_replace( \Altis\ROOT_DIR . '/vendor/', '', $file );
+				$plug = explode( '/', $plug, 3 );
+				$plug = $plug[0] . '/' . $plug[1];
+				/* translators: %s: Dependency name */
+				$name = sprintf( __( 'Dependency: %s', 'query-monitor' ), $plug );
+				break;
 			case 'plugin':
 			case 'mu-plugin':
 			case 'mu-vendor':

--- a/query-monitor/collectors/environment.php
+++ b/query-monitor/collectors/environment.php
@@ -74,12 +74,13 @@ class QM_Collector_Environment extends QM_Collector {
 		global $wp_version;
 
 		$mysql_vars = array(
-			'key_buffer_size'    => true,  # Key cache size limit
-			'max_allowed_packet' => false, # Individual query size limit
-			'max_connections'    => false, # Max number of client connections
-			'query_cache_limit'  => true,  # Individual query cache size limit
-			'query_cache_size'   => true,  # Total cache size limit
-			'query_cache_type'   => 'ON',  # Query cache on or off
+			'key_buffer_size'         => true,  # Key cache size limit
+			'max_allowed_packet'      => false, # Individual query size limit
+			'max_connections'         => false, # Max number of client connections
+			'query_cache_limit'       => true,  # Individual query cache size limit
+			'query_cache_size'        => true,  # Total cache size limit
+			'query_cache_type'        => 'ON',  # Query cache on or off
+			'innodb_buffer_pool_size' => false, # The amount of memory allocated to the InnoDB buffer pool
 		);
 
 		$dbq = QM_Collectors::get( 'db_queries' );

--- a/query-monitor/dispatchers/Html.php
+++ b/query-monitor/dispatchers/Html.php
@@ -584,31 +584,39 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		echo '<script type="text/javascript">' . "\n\n";
 		?>
 		window.addEventListener('load', function() {
-			if ( ( 'undefined' === typeof QM_i18n ) || ( 'undefined' === typeof jQuery ) || ! window.jQuery ) {
+			var main = document.getElementById( 'query-monitor-main' );
+			var broken = document.getElementById( 'qm-broken' );
+			var menu_item = document.getElementById( 'wp-admin-bar-query-monitor' );
+			var admin_bar = document.getElementById( 'wpadminbar' );
+
+			if ( ( 'undefined' === typeof QM_i18n ) && ( ( 'undefined' === typeof jQuery ) || ! window.jQuery ) ) {
 				/* Fallback for worst case scenario */
-				document.getElementById( 'query-monitor-main' ).className += ' qm-broken';
-				console.error( document.getElementById( 'qm-broken' ).textContent );
 
 				if ( 'undefined' === typeof QM_i18n ) {
 					console.error( 'QM error from page: undefined QM_i18n' );
 				}
 
-				if ( 'undefined' === typeof jQuery ) {
-					console.error( 'QM error from page: undefined jQuery' );
+				if ( main ) {
+					main.className += ' qm-broken';
 				}
 
-				if ( ! window.jQuery ) {
+				if ( broken ) {
+					console.error( broken.textContent );
+				}
+
+				if ( 'undefined' === typeof jQuery ) {
+					console.error( 'QM error from page: undefined jQuery' );
+				} else if ( ! window.jQuery ) {
 					console.error( 'QM error from page: no jQuery' );
 				}
 
-				var menu_item = document.getElementById( 'wp-admin-bar-query-monitor' );
-				if ( menu_item ) {
+				if ( menu_item && main ) {
 					menu_item.addEventListener( 'click', function() {
-						document.getElementById( 'query-monitor-main' ).className += ' qm-show';
+						main.className += ' qm-show';
 					} );
 				}
-			} else if ( ! document.getElementById( 'wpadminbar' ) ) {
-				document.getElementById( 'query-monitor-main' ).className += ' qm-peek';
+			} else if ( main && ! admin_bar ) {
+				main.className += ' qm-peek';
 			}
 		} );
 		<?php

--- a/query-monitor/output/html/logger.php
+++ b/query-monitor/output/html/logger.php
@@ -16,7 +16,7 @@ class QM_Output_Html_Logger extends QM_Output_Html {
 
 	public function __construct( QM_Collector $collector ) {
 		parent::__construct( $collector );
-		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 12 );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 46 );
 		add_filter( 'qm/output/menu_class', array( $this, 'admin_class' ) );
 	}
 
@@ -29,6 +29,17 @@ class QM_Output_Html_Logger extends QM_Output_Html {
 		$data = $this->collector->get_data();
 
 		if ( empty( $data['logs'] ) ) {
+			$this->before_non_tabular_output();
+
+			$notice = sprintf(
+				/* translators: %s: Link to help article */
+				__( 'No data logged. <a href="%s">Read about logging variables in Query Monitor</a>.', 'query-monitor' ),
+				'https://querymonitor.com/docs/logging-variables/'
+			);
+			echo $this->build_notice( $notice ); // WPCS: XSS ok.
+
+			$this->after_non_tabular_output();
+
 			return;
 		}
 
@@ -85,17 +96,10 @@ class QM_Output_Html_Logger extends QM_Output_Html {
 			echo esc_html( ucfirst( $row['level'] ) );
 			echo '</td>';
 
-			if ( 'dump' === $row['type'] ) {
-				printf(
-					'<td><pre>%s</pre></td>',
-					esc_html( $row['message'] )
-				);
-			} else {
-				printf(
-					'<td>%s</td>',
-					esc_html( $row['message'] )
-				);
-			}
+			printf(
+				'<td><pre>%s</pre></td>',
+				esc_html( $row['message'] )
+			);
 
 			$stack          = array();
 			$filtered_trace = $row['trace']->get_display_trace();
@@ -154,25 +158,25 @@ class QM_Output_Html_Logger extends QM_Output_Html {
 	}
 
 	public function admin_menu( array $menu ) {
-		$data = $this->collector->get_data();
+		$data  = $this->collector->get_data();
+		$key   = 'log';
+		$count = 0;
 
-		if ( empty( $data['logs'] ) ) {
-			return $menu;
-		}
-
-		$key = 'log';
-
-		foreach ( $data['logs'] as $log ) {
-			if ( in_array( $log['level'], $this->collector->get_warning_levels(), true ) ) {
-				$key = 'warning';
-				break;
+		if ( ! empty( $data['logs'] ) ) {
+			foreach ( $data['logs'] as $log ) {
+				if ( in_array( $log['level'], $this->collector->get_warning_levels(), true ) ) {
+					$key = 'warning';
+					break;
+				}
 			}
+
+			$count = count( $data['logs'] );
+
+			/* translators: %s: Number of logs that are available */
+			$label = __( 'Logs (%s)', 'query-monitor' );
+		} else {
+			$label = __( 'Logs', 'query-monitor' );
 		}
-
-		$count = count( $data['logs'] );
-
-		/* translators: %s: Number of logs that are available */
-		$label = __( 'Logs (%s)', 'query-monitor' );
 
 		$menu[ $this->collector->id() ] = $this->menu( array(
 			'id'    => "query-monitor-logger-{$key}",

--- a/query-monitor/query-monitor.php
+++ b/query-monitor/query-monitor.php
@@ -5,12 +5,12 @@
  * @package   query-monitor
  * @link      https://github.com/johnbillion/query-monitor
  * @author    John Blackbourn <john@johnblackbourn.com>
- * @copyright 2009-2019 John Blackbourn
+ * @copyright 2009-2020 John Blackbourn
  * @license   GPL v2 or later
  *
  * Plugin Name:  Query Monitor
  * Description:  The Developer Tools Panel for WordPress.
- * Version:      3.6.4
+ * Version:      3.6.5
  * Plugin URI:   https://querymonitor.com/
  * Author:       John Blackbourn
  * Author URI:   https://querymonitor.com/
@@ -47,6 +47,10 @@ foreach ( array( 'Activation', 'Util', 'QM' ) as $qm_class ) {
 
 QM_Activation::init( __FILE__ );
 
+if ( ! QM_Plugin::php_version_met() ) {
+	return;
+}
+
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once "{$qm_dir}/classes/CLI.php";
 	QM_CLI::init( __FILE__ );
@@ -70,5 +74,10 @@ if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
 foreach ( array( 'QueryMonitor', 'Backtrace', 'Collectors', 'Collector', 'Dispatchers', 'Dispatcher', 'Hook', 'Output', 'Timer' ) as $qm_class ) {
 	require_once "{$qm_dir}/classes/{$qm_class}.php";
 }
+
+unset(
+	$qm_dir,
+	$qm_class
+);
 
 QueryMonitor::init( __FILE__ );

--- a/query-monitor/readme.txt
+++ b/query-monitor/readme.txt
@@ -2,10 +2,11 @@
 Contributors: johnbillion
 Tags: debug, debug-bar, debugging, development, developer, performance, profiler, queries, query monitor, rest-api
 Requires at least: 3.7
-Tested up to: 5.5
-Stable tag: 3.6.4
+Tested up to: 5.6
+Stable tag: 3.6.5
 License: GPLv2 or later
 Requires PHP: 5.3
+Donate link: https://johnblackbourn.com/donations/
 
 Query Monitor is the developer tools panel for WordPress.
 
@@ -86,6 +87,10 @@ In addition, Query Monitor transparently supports add-ons for the Debug Bar plug
 
 Please use [the issue tracker on Query Monitor's GitHub repo](https://github.com/johnbillion/query-monitor/issues) as it's easier to keep track of issues there, rather than on the wordpress.org support forums.
 
+= Is Query Monitor available on Altis? =
+
+Yes, the [Altis Developer Tools](https://www.altis-dxp.com/resources/developer-docs/dev-tools/) are built on top of Query Monitor.
+
 = Is Query Monitor available on WordPress.com VIP Go? =
 
 Yes, it's included as part of the VIP Go platform. However, a user needs to be granted the `view_query_monitor` capability to see Query Monitor even if they're an administrator.
@@ -109,13 +114,28 @@ Yes. You can enable this on the Settings panel.
 
 = Do you accept donations? =
 
-No, I do not accept donations. If you like the plugin, I'd love for you to [leave a review](https://wordpress.org/support/view/plugin-reviews/query-monitor). Tell all your friends about the plugin too!
+### Do you accept donations?
+
+[I am accepting sponsorships via the GitHub Sponsors program](https://johnblackbourn.com/donations/) and any support you can give will help me maintain this plugin and keep it free for everyone.
+
+In addition, if you like the plugin then I'd love for you to [leave a review](https://wordpress.org/support/view/plugin-reviews/query-monitor). Tell all your friends about it too!
 
 ## Changelog ##
 
+### 3.6.5 ###
+
+* Always show the Logs panel, with a link to help docs.
+* Whole bunch of improvements to QM's "broken" state handling.
+* Remove usage of deprecated jQuery methods.
+* Add support for Altis dependencies as components.
+* Add `innodb_buffer_pool_size` variable to the mysql environment list.
+* Preformat the Logger output
+* Fix the PHP version check.
+
+
 ### 3.6.4 ###
 
-* Correct an error introduced in 3.6.3 with the extra early error handling (ironic).
+* Correct an error introduced in 3.6.2 with the extra early error handling (ironic).
 
 ### 3.6.3 ###
 
@@ -448,15 +468,3 @@ New features! Read about them here: https://querymonitor.com/blog/2019/02/new-fe
 * Add a bit of vertical breathing room.
 * Various improvements to terminology.
 * Coding standards.
-
-### 2.14.0 ###
-
-* Some more inline documentation about clickable stack traces.
-* Output a more complete list of error levels and their status.
-* Internationalisation fixes.
-* Add some wrapping to the Request and Theme output so posts with long unbroken slugs don't break the layout.
-* PHP error handler: Add new hook `qm/collect/new_php_error`
-* Built-in collectors: Add new `qm/built-in-collectors` filter on files before including them
-* More defensive CSS.
-* Fix the size of the expand/contract buttons.
-* Avoid showing two unnecessary functions in the call stack for textdomain loading.


### PR DESCRIPTION
## Description

Uprade query monitor 3.6.4->3.6.5.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Make sure query monitor still works
1. Check version of `query-monitor` using wp-cli `wp plugin list`