### PR TITLE
Changes the priority of QM shutdown to cover more operations

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -138,3 +138,23 @@ function wpcom_vip_qm_disable_on_404() {
 }
 add_action( 'wp', 'wpcom_vip_qm_disable_on_404' );
 
+
+// We are putting dispatchers as last so that QM still can catch other operations in shutdown action
+function change_dispatchers_shutdown_priority( array $dispatchers ) {
+	if ( is_array( $dispatchers ) ) {
+		if ( isset( $dispatchers['html'] ) ) {
+			$html_dispatcher = $dispatchers['html'];
+			remove_action( 'shutdown', array( $html_dispatcher, 'dispatch' ), 0 );
+			add_action( 'shutdown', array( $html_dispatcher, 'dispatch' ), PHP_INT_MAX );
+		}
+		if ( isset( $dispatchers['ajax'] ) ) {
+			$ajax_dispatcher = $dispatchers['ajax'];
+			remove_action( 'shutdown', array( $ajax_dispatcher, 'dispatch' ), 0 );
+			add_action( 'shutdown', array( $ajax_dispatcher, 'dispatch' ), PHP_INT_MAX );
+
+		}
+	}
+
+	return $dispatchers;
+}
+add_filter( 'qm/dispatchers', 'change_dispatchers_shutdown_priority', PHP_INT_MAX, 1 );


### PR DESCRIPTION
## Description

We want to see reports in Query Monitor even if results of shutdown actions. Thic change moves the dispatching of the QM as a last step in shutdown action as opose to first one so that we can cover more.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Add this code somewhere ("vip-config.php" should work):
```
function test_qm() {
	do_action( 'qm/debug', 'This happened!' );
}

add_action( 'shutdown', 'test_qm', 5 );
```
1. See there is no log in query monitor:
1. Apply PR
1. Reload and see there is the log

![Screen_log](https://user-images.githubusercontent.com/19240162/100597106-4d4def80-32fd-11eb-8204-f0e122af282c.png)
