### PR TITLE
Fixes siteurl cache corruption with wp_insert_site

### DIFF
--- a/wp-cli.php
+++ b/wp-cli.php
@@ -20,7 +20,7 @@ function init_is_ssl_toggle() {
 function init_is_ssl_toggle_for_multisite() {
 	add_action( 'switch_blog', function( $new_blog_id, $prev_blog_id ) {
 		// Not a strict equality check to match core
-		if ( $new_blog_id == $prev_blog_id ) {
+		if ( ! wp_is_site_initialized( $new_blog_id ) || $new_blog_id == $prev_blog_id ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

If a site is created via WP-CLI with `wp_insert_site()`, `Automattic\VIP\WP_CLI\maybe_toggle_is_ssl()` will call `get_option()` before the database is created, causing the `siteurl` option to be cached blank.

This fix adds a simple `wp_is_site_initialized()` check to `Automattic\VIP\WP_CLI\init_is_ssl_toggle_for_multisite()` so that we won't toggle the SSL if the site isn't initialized yet.

Found this while testing @trepmal's fancy Blog Duplicator plugin :D

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Write a WP-CLI comand to create a new site via `wp_insert_site()` and dump `site_url()` immediately afterwards and it should be blank.
1. Check out PR.
1. Create a new site, dump `site_url()` and verify it is not blank.
