### PR TITLE
Set Jetpack 9.2 as the default version

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 9.1
+ * Version: 9.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -13,7 +13,7 @@
  */
 
 if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
-	define( 'VIP_JETPACK_DEFAULT_VERSION', '9.1' );
+	define( 'VIP_JETPACK_DEFAULT_VERSION', '9.2' );
 }
 
 // Bump up the batch size to reduce the number of queries run to build a Jetpack sitemap.


### PR DESCRIPTION
## Description

Publish Jetpack 9.2 to all VIP Go sites, by setting it as the default version

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Go to the Jetpack dashboard in wp-admin
1. Ensure it works and version 9.2 is active