### PR TITLE
Ensure that a proper Jetpack version is loaded depending on WordPress version

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -12,6 +12,8 @@
  * Domain Path: /languages/
  */
 
+// Choose an appropriate default Jetpack version, ensuring that older WordPress versions
+// are not using a too modern Jetpack version that is not compatible with it
 if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	if ( version_compare( $wp_version, '5.5', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.1' );

--- a/jetpack.php
+++ b/jetpack.php
@@ -13,7 +13,11 @@
  */
 
 if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
-	define( 'VIP_JETPACK_DEFAULT_VERSION', '9.2' );
+	if ( version_compare( $wp_version, '5.5', '<' ) ) {
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.1' );
+	} else {
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.2' );
+	}
 }
 
 // Bump up the batch size to reduce the number of queries run to build a Jetpack sitemap.


### PR DESCRIPTION
## Description

As there are still VIP Go sites running on WordPress <5.5, they are failing to load Jetpack 9.2, as it's only compatible with newer WordPress versions.

With this change, we ensure that sites running older WP versions are using Jetpack 9.1 instead of 9.2.

Once they are upgraded to a newer WordPress version, they will immediately start using Jetpack 9.2.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.

## Steps to Test

1. Check out PR.
1. Set up a sandbox/dev env with WordPress 5.4.2
1. Ensure that Jetpack works and version 9.1 is loaded
1. Go back to WordPress 5.5
1. Ensure that Jetpack 9.2 is loaded
