### PR TITLE
Improve logging for failed HTTP requests to ElasticSearch

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -592,7 +592,12 @@ class Search {
 			}
 		}
 
-		return $response;
+		if ( is_wp_error( $response ) ) {
+			// Return a generic VIP Search WP_Error instead of the one from wp_remote_request
+			return new \WP_Error( 'vip-search-upstream-request-failed', 'There was an error connecting to the upstream search server' );
+		} else {
+			return $response;
+		}
 	}
 
 	public function ep_handle_failed_request( $response, $statsd_prefix ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -531,8 +531,6 @@ class Search {
 	}
 
 	public function filter__ep_do_intercept_request( $request, $query, $args, $failures ) {
-		$fallback_error = new \WP_Error( 'vip-search-upstream-request-failed', 'There was an error connecting to the upstream search server' );
-
 		// Add custom headers to identify authorized traffic
 		if ( ! isset( $args['headers'] ) || ! is_array( $args['headers'] ) ) {
 			$args['headers'] = [];
@@ -548,7 +546,7 @@ class Search {
 
 		$timeout = $this->get_http_timeout_for_query( $query, $args );
 
-		$response = vip_safe_wp_remote_request( $query['url'], $fallback_error, 3, $timeout, 20, $args );
+		$response = vip_safe_wp_remote_request( $query['url'], false, 3, $timeout, 20, $args );
 
 		$end_time = microtime( true );
 		$duration = ( $end_time - $start_time ) * 1000;
@@ -602,31 +600,36 @@ class Search {
 
 		if ( is_wp_error( $response ) ) {
 			$error_messages = $response->get_error_messages();
-			$response_error['reason'] = implode( ';', $error_messages );
 
 			foreach ( $error_messages as $error_message ) {
 				$stat = $this->is_curl_timeout( $error_message ) ? '.timeout' : '.error';
 
 				$this->maybe_increment_stat( $statsd_prefix . $stat );
 			}
+
+			$this->logger->log(
+				'error',
+				'vip_search_http_error',
+				implode( ';', $error_messages )
+			);
 		} else {
 			$response_body_json = wp_remote_retrieve_body( $response );
 			$response_body = json_decode( $response_body_json, true );
 			$response_error = $response_body['error'] ?? [];
 
 			$this->maybe_increment_stat( $statsd_prefix . '.error' );
-		}
 
-		$error_message = $response_error['reason'] ?? 'Unknown Elasticsearch query error';
-		$this->logger->log(
-			'error',
-			'vip_search_query_error',
-			$error_message,
-			[
-				'error_type' => $response_error['type'] ?? 'Unknown error type',
-				'root_cause' => $response_error['root_cause'] ?? null,
-			]
-		);
+			$error_message = $response_error['reason'] ?? 'Unknown Elasticsearch query error';
+			$this->logger->log(
+				'error',
+				'vip_search_query_error',
+				$error_message,
+				[
+					'error_type' => $response_error['type'] ?? 'Unknown error type',
+					'root_cause' => $response_error['root_cause'] ?? null,
+				]
+			);
+		}
 	}
 
 	/*


### PR DESCRIPTION
## Description

When there's a problem with the HTTP connection to ElasticSearch, we are masking it with a fallback error that prevents the actual error (e.g, a curl error) to be logged.

This branch removes that fallback error, and also creates a new logstash feature (`vip_search_http_error`) to log all those connection errors.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Just before the call to `vip_safe_wp_remote_request` in `class-search.php`, add a line to create a bad ES query. E.g: `$args['body'] = '{';`
1. Run a search on the testing site. The usual logstash error should appear in the log (including `error_type` and `root_cause` in the extra field)
1. Replace that added line for another one to provoke a HTTP error. E.g: `$query['url'] = 'http://10.0.0.1/';`
1. Run a search again. The new logstash error, including the cURL timeout error, should appear in the log
