### PR TITLE
Switched instructions to be in comments and added changelog tasks.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Please don't include internal or private links :)
 
 ## Changelog Description
 <!--
-A description of the context of the change for a change log. It should have a title, link to the PR, examples(if applicable), and why the change was made.
+A description of the context of the change for a changelog. It should have a title, link to the PR, examples(if applicable), and why the change was made.
 
 Example for a plugin upgrade:
 
@@ -72,7 +72,7 @@ Please make sure the items below have been covered before requesting a review:
 - [ ] This change works and has been tested on a Go sandbox.
 - [ ] This change has relevant unit tests (if applicable).
 - [ ] This change has relevant documentation additions / updates (if applicable).
-- [ ] (For Automatticians) I've created a change log draft. 
+- [ ] (For Automatticians) I've created a changelog draft. 
 
 ## Steps to Test
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ Should include any special considerations, decisions, and links to relevant GitH
 Please don't include internal or private links :)
 -->
 
-## Change Log Description
+## Changelog Description
 <!--
 A description of the context of the change for a change log. It should have a title, link to the PR, examples(if applicable), and why the change was made.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,68 @@
+<!--
 ## For Automatticians!
 
 :wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!
 
 If you're not an Automattician, welcome! We look forward to your contribution! :heart:
 
-Please remove this section before submitting the PR.
-
----
-
+-->
 ## Description
-
+<!--
 A few sentences describing the overall goals of the Pull Request.
 
 Should include any special considerations, decisions, and links to relevant GitHub issues.
 
 Please don't include internal or private links :)
+-->
+
+## Change Log Description
+<!--
+A description of the context of the change for a change log. It should have a title, link to the PR, examples(if applicable), and why the change was made.
+
+Example for a plugin upgrade:
+
+### Jetpack 9.2.1
+
+We upgraded Jetpack 9.2 to Jetpack 9.2.1.
+
+Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
+
+#### Improved compatibility
+
+- Site Health Tools: improve PHP 8 compatibility.
+- Twenty Twenty One: add support for Jetpack’s Content Options.
+
+#### Bug fixes
+
+- Instant Search: fix layout issues with filtering checkboxes with some themes.
+- WordPress.com Toolbar: avoid Fatal errors when the feature is not active.
+- WordPress.com Toolbar: avoid 404 errors when loading the toolbar.
+
+https://github.com/Automattic/vip-go-mu-plugins/pull/1905
+
+Example for a feature change:
+
+### New Filters: Adjust Brute Force Thresholds
+
+We’ve added two new filters to our login limiting functionality, which gives you the ability to tweak the thresholds for our application-level brute force protections. For example, you may want to lower them during situations with high security sensitivity.
+
+- `wpcom_vip_ip_username_login_threshold` : how many failed attempts to allow for an IP address and username combination
+- `wpcom_vip_ip_login_threshold` : how many failed attempts to allow for an IP address
+
+For example, if you wanted to only allow one attempt for a group of usernames per IP:
+
+```
+add_filter( 'wpcom_vip_ip_username_login_threshold', function( $threshold, $ip, $username ) {
+    if ( 'adminuser' === $username || 'otheradminuser' === $username ) {
+        $threshold = 1;
+    }
+ 
+    return $threshold;
+}, 10, 3 );
+```
+
+https://github.com/Automattic/vip-go-mu-plugins/pull/1782
+-->
 
 ## Checklist
 
@@ -24,9 +72,10 @@ Please make sure the items below have been covered before requesting a review:
 - [ ] This change works and has been tested on a Go sandbox.
 - [ ] This change has relevant unit tests (if applicable).
 - [ ] This change has relevant documentation additions / updates (if applicable).
+- [ ] (For Automatticians) I've created a change log draft. 
 
 ## Steps to Test
-
+<!--
 Outline the steps to test and verify the PR here.
 
 Example:
@@ -35,3 +84,4 @@ Example:
 1. Go to `wp-admin` > `Tools` > `Bakery`
 1. Click on "Bake Cookies" button.
 1. Verify cookies are delicious.
+-->


### PR DESCRIPTION
## Description

Deleting a whole bunch of text from the PR template is tedious. So I moved them all into comments.

Further, we're starting to look at process improvements and one of the whoppers is to have a sweet change log. So I've added both a Change Log Description(for everyone) and a task for adding a draft change log post to our change log(for Automatticians).