### PR TITLE
Update old domains and WordPress.com references

### DIFF
--- a/README-PUBLIC.md
+++ b/README-PUBLIC.md
@@ -2,7 +2,7 @@
 
 This is the mu-plugins folder for VIP Go, assembled without submodules for convenience.
 
-Please see our documentation on setting up your [local development environment](https://vip.wordpress.com/documentation/vip-go/local-vip-go-development-environment/).
+Please see our documentation on setting up your [local development environment](https://docs.wpvip.com/how-tos/set-up-a-vip-go-local-development-site/).
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VIP Go mu-plugins
 
-This is the development repo for mu-plugins on [VIP Go](http://vip.wordpress.com/documentation/vip-go/),
+This is the development repo for mu-plugins on [VIP Go](https://wpvip.com/documentation/vip-go/),
 
 ## Development
 

--- a/cache/README.md
+++ b/cache/README.md
@@ -1,10 +1,10 @@
 # VIP Cache Personalization API
 
-The [VIP CDN](https://vip.wordpress.com/documentation/vip-go/caching-on-vip-go/) has been designed for low-latency and high performance and achieves that by serving the same cached content to as many users as possible.
+The [VIP CDN](https://docs.wpvip.com/technical-references/caching/) has been designed for low-latency and high performance and achieves that by serving the same cached content to as many users as possible.
 
-For cases where a one-size-fits-all approach doesn't work, the [VIP Cache Personalization API](https://vip.wordpress.com/?p=33575) can help customize the caching behaviour of the CDN while still leveraging the power and scale that it provides.
+For cases where a one-size-fits-all approach doesn't work, the [VIP Cache Personalization API](https://docs.wpvip.com/technical-references/caching/the-vip-cache-personalization-api/) can help customize the caching behaviour of the CDN while still leveraging the power and scale that it provides.
 
-In this README, we go through some real-world examples on how to use the Cache Personalization API in your applications. Before reading ahead, make sure you've [read the docs](https://vip.wordpress.com/?p=33575) to get a better understanding of the API and its capabilities.
+In this README, we go through some real-world examples on how to use the Cache Personalization API in your applications. Before reading ahead, make sure you've [read the docs](https://docs.wpvip.com/technical-references/caching/the-vip-cache-personalization-api/) to get a better understanding of the API and its capabilities.
 
 ## Tutorial (Cache Segmentation): Beta Opt-in
 

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -93,7 +93,7 @@ add_action( 'all_admin_notices', function() {
 
 	<p><strong>Your editor of choice has not been changed</strong>.</p>
 
-	<p>Read more about the new editor below, learn about <a href="https://vip.wordpress.com/documentation/gutenberg-at-vip/" rel="noopener noreferrer" target="_blank">how it's configured on VIP</a>, or <a href="https://testgutenberg.com/" rel="noopener noreferrer" target="_blank">try it out in your browser</a>.</p>
+	<p>Read more about the new editor below, learn about <a href="https://docs.wpvip.com/technical-references/plugins/loading-gutenberg-on-vip/" rel="noopener noreferrer" target="_blank">how it's configured on VIP</a>, or <a href="https://testgutenberg.com/" rel="noopener noreferrer" target="_blank">try it out in your browser</a>.</p>
 
 	<?php if ( ! $is_using_gutenberg ) : ?>
 		<p>Need help planning your transition? The <a href="<?php echo admin_url( 'admin.php?page=vip-dashboard' ); ?>">VIP Support team is ready to help</a>!</p>

--- a/lib/proxy/ip-forward.php
+++ b/lib/proxy/ip-forward.php
@@ -6,7 +6,7 @@ namespace Automattic\VIP\Proxy;
  * Verify the remote proxy from a whitelist of IP addresses, and set the
  * end user IP if verification succeeds.
  *
- * @see https://vip.wordpress.com/documentation/vip-go/reverse-proxies-and-vip-go/
+ * @see https://docs.wpvip.com/how-tos/configure-a-reverse-proxy/
  *
  * @param (string) $user_ip IP Address of the end-user passed through by the proxy.
  * @param (string) $remote_proxy_ip IP Address of the remote proxy.
@@ -41,7 +41,7 @@ function fix_remote_address( $user_ip, $remote_proxy_ip, $proxy_ip_whitelist ) {
  *
  * Only two levels of proxies are supported.
  *
- * @see https://vip.wordpress.com/documentation/vip-go/reverse-proxies-and-vip-go/
+ * @see https://docs.wpvip.com/how-tos/configure-a-reverse-proxy/
  *
  * @param (string) $ip_trail Comma-separated list of IPs (something like `user_ip, proxy_ip`)
  * @param (string|array) $proxy_ip_whitelist Whitelisted IP addresses for the remote proxy. Supports IPv4 and IPv6, including CIDR format.
@@ -63,7 +63,7 @@ function fix_remote_address_from_ip_trail( $ip_trail, $proxy_ip_whitelist ) {
  * Verify the remote proxy via a secret verification key, and set the
  * end user IP if verification succeeds.
  *
- * @see https://vip.wordpress.com/documentation/vip-go/reverse-proxies-and-vip-go/
+ * @see https://docs.wpvip.com/how-tos/configure-a-reverse-proxy/
  *
  * @param (string) $user_ip IP Address of the end-user passed through by the proxy.
  * @param (string) $submitted_verification_key Verification key passed through request headers
@@ -92,7 +92,7 @@ function fix_remote_address_with_verification_key( $user_ip, $submitted_verifica
  *
  * Only two levels of proxies are supported.
  *
- * @see https://vip.wordpress.com/documentation/vip-go/reverse-proxies-and-vip-go/
+ * @see https://docs.wpvip.com/how-tos/configure-a-reverse-proxy/
  *
  * @param (string) $ip_trail Comma-separated list of IPs (something like `user_ip, proxy_ip`)
  * @param (string) $submitted_verification_key Verification key passed through request headers

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <phpdoc>
-	<title>WordPress.com VIP – VIP Go Function Documentation</title>
+	<title>WordPress VIP – VIP Go Function Documentation</title>
 	<parser>
 		<!-- This places the cache dirs in the root dir `/phpdoc/` for your site -->
 		<target>phpdoc/</target>

--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Plugin Name: VIP REST API Endpoints
- Plugin URI: https://vip.wordpress.com/
+ Plugin URI: https://wpvip.com
  Description: Add custom REST API endpoints for VIP requests; N.B. these endpoints are subject to change without notice, and should be considered "private".
  Author: Erick Hitter, Automattic
  Version: 0.1

--- a/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
+++ b/shared-plugins/vip-go-elasticsearch/vip-go-elasticsearch.php
@@ -476,7 +476,7 @@ class WPCOM_elasticsearch {
 	/**
 	 * Set any additional blogs to query along with the current blog
 	 *
-	 * This method accepts an array of additional blog names, in the format of vip.wordpress.com,
+	 * This method accepts an array of additional blog names, in the format of example.com,
 	 * that should be queried.
 	 *
 	 * @param array $domains The additional blogs to query

--- a/vip-cache-manager/ttl-manager.php
+++ b/vip-cache-manager/ttl-manager.php
@@ -2,7 +2,7 @@
 
 /*
 Plugin name: TTL Manager
-Description: Sets cache TTLs for site responses, see https://vip.wordpress.com/documentation/vip-go/controlling-vip-go-page-cache/
+Description: Sets cache TTLs for site responses, see https://docs.wpvip.com/technical-references/caching/page-cache/
 Author: Automattic
 Author URI: https://automattic.com/
 Version: 1.0

--- a/vip-dashboard.php
+++ b/vip-dashboard.php
@@ -2,11 +2,11 @@
 
 /*
  * Plugin Name: VIP Dashboard
- * Plugin URI: http://vip.wordpress.com
+ * Plugin URI: https://wpvip.com
  * Description: WordPress VIP Go Dashboard
- * Author: Scott Evans, Filipe Varela
+ * Author: Scott Evans, Filipe Varela, WPVIP
  * Version: 2.0.4
- * Author URI: http://vip.wordpress.com
+ * Author URI: https://wpvip.com
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: vip-dashboard

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -8,7 +8,7 @@
  *
  * @param string $slug Category slug
  * @return object|null|bool Term Row from database. Will return null if $slug doesn't match a term. If taxonomy does not exist then false will be returned.
- * @link http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
+ * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/ Uncached Functions
  */
 function wpcom_vip_get_category_by_slug( $slug ) {
 	return wpcom_vip_get_term_by( 'slug', $slug, 'category' );
@@ -26,7 +26,7 @@ function wpcom_vip_get_category_by_slug( $slug ) {
  * @param string     $output Optional. Constant OBJECT, ARRAY_A, or ARRAY_N
  * @param string     $filter Optional. Default is 'raw' or no WordPress defined filter will applied.
  * @return mixed|null|bool Term Row from database in the type specified by $filter. Will return false if $taxonomy does not exist or $term was not found.
- * @link http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
+ * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/ Uncached Functions
  */
 function wpcom_vip_get_term_by( $field, $value, $taxonomy, $output = OBJECT, $filter = 'raw' ) {
 	// ID lookups are cached
@@ -155,7 +155,7 @@ function wpcom_vip_get_term_link( $term, $taxonomy = null ) {
  * @param string $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
  * @param string $post_type Optional. Post type; default is 'page'.
  * @return WP_Post|null WP_Post on success or null on failure
- * @link http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
+ * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/ Uncached Functions
  */
 function wpcom_vip_get_page_by_title( $title, $output = OBJECT, $post_type = 'page' ) {
 	$cache_key = $post_type . '_' . sanitize_key( $title );
@@ -181,7 +181,7 @@ function wpcom_vip_get_page_by_title( $title, $output = OBJECT, $post_type = 'pa
  * @param string $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
  * @param string $post_type Optional. Post type; default is 'page'.
  * @return WP_Post|null WP_Post on success or null on failure
- * @link http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
+ * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/ Uncached Functions
  */
 function wpcom_vip_get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 	if ( is_array( $post_type ) ) {
@@ -215,7 +215,7 @@ function wpcom_vip_get_page_by_path( $page_path, $output = OBJECT, $post_type = 
  * @param string  $new_status The post's new status
  * @param string  $old_status The post's previous status
  * @param WP_Post $post The post
- * @link http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
+ * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/ Uncached Functions
  */
 function wpcom_vip_flush_get_page_by_title_cache( $new_status, $old_status, $post ) {
 	if ( 'publish' === $new_status || 'publish' === $old_status ) {
@@ -231,7 +231,7 @@ add_action( 'transition_post_status', 'wpcom_vip_flush_get_page_by_title_cache',
  * @param string  $old_status The post's previous status
  * @param WP_Post $post       The post
  *
- * @link http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
+ * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/ Uncached Functions
  */
 function wpcom_vip_flush_get_page_by_path_cache( $new_status, $old_status, $post ) {
 	if ( 'publish' === $new_status || 'publish' === $old_status ) {

--- a/vip-helpers/vip-deprecated.php
+++ b/vip-helpers/vip-deprecated.php
@@ -4,7 +4,6 @@
  * Loads the shared VIP helper file which defines some helpful functions.
  *
  * @deprecated Not applicable since VIP 2.0.0
- * @link http://vip.wordpress.com/documentation/development-environment/ Setting up your Development Environment
  */
 function wpcom_vip_load_helper() {
     _deprecated_function( __FUNCTION__, '2.0.0' );
@@ -230,8 +229,7 @@ function wpcom_vip_remove_polldaddy_rating() {
 /**
  * Removes the <media:content> tags from the RSS2 feed.
  *
- * You should really call this when creating a custom feed (best to leave them in your normal feed)
- * For details on creating a custom feed, see http://lobby.vip.wordpress.com/custom-made/altering-feeds/
+ * You should really call this when creating a custom feed (best to leave them in your normal feed).
  *
  * @deprecated Not applicable since VIP 2.0.0
  */
@@ -250,8 +248,8 @@ function wpcom_vip_disable_postpost() {
  * Outputs Open Graph tags to various pages on the site
  *
  * @deprecated Deprecated since VIP 2.0.0 - Use the `jetpack_enable_open_graph` filter
- * @link http://vip.wordpress.com/documentation/open-graph/ Adding Open Graph Tags
- * @see http://developers.facebook.com/docs/opengraph/ Open Graph
+ * @link https://developer.jetpack.com/hooks/jetpack_enable_open_graph/
+ * @see https://developers.facebook.com/docs/sharing/opengraph Open Graph
  */
 function wpcom_vip_enable_opengraph() {
 	_deprecated_function( __FUNCTION__, '2.0.0', '`jetpack_enable_open_graph` filter' );
@@ -265,7 +263,6 @@ function wpcom_vip_enable_opengraph() {
  * function forces the invitation email to match the WordPress.com user's email address.
  *
  * @deprecated Not applicable since VIP 2.0.0
- * @link http://vip.wordpress.com/documentation/customizing-invites/ Customizing Invites
  */
 function wpcom_invite_force_matching_email_address() {
     _deprecated_function( __FUNCTION__, '2.0.0' );
@@ -515,7 +512,7 @@ function vary_cache_on_function( $function ) {
  * This is the old deprecated version of wpcom_vip_file_get_contents(). Please don't use this function in any new code.
  *
  * @deprecated
- * @link http://lobby.vip.wordpress.com/best-practices/fetching-remote-data/ Fetching Remote Data
+ * @link https://wpvip.com/documentation/fetching-remote-data/ Fetching Remote Data
  * @param string $url URL to fetch
  * @param bool $echo_content Optional. If true (the default), echo the remote file's contents. If false, return it.
  * @param int $timeout Optional. The timeout limit in seconds; valid values are 1-10. Defaults to 3.
@@ -1120,7 +1117,7 @@ function wpcom_is_vip() {
  * So even though it says "remote", you can use it for attachments hosted by us, etc.
  *
  * @deprecated Deprecated since 2.0.0 - use jetpack_photon_url()
- * @link http://vip.wordpress.com/documentation/image-resizing-and-cropping/ Image Resizing And Cropping
+ * @link https://wpvip.com/documentation/image-resizing-and-cropping/ Image Resizing And Cropping
  * @param string $url The raw URL to the image (URLs that redirect are currently not supported with the exception of http://foobar.wordpress.com/files/ type URLs)
  * @param int $width The desired width of the final image
  * @param int $height The desired height of the final image
@@ -1221,7 +1218,7 @@ function wpcom_vip_theme_url( $path = '', $theme = '' ) {
 /**
  * Return the directory path for a given VIP theme
  *
- * @link http://vip.wordpress.com/documentation/mobile-theme/ Developing for Mobile Phones and Tablets
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/mobile-theme/ Developing for Mobile Phones and Tablets
  * @param string $theme Optional. Name of the theme folder
  * @return string Path for the specified theme
  */

--- a/vip-helpers/vip-newrelic.php
+++ b/vip-helpers/vip-newrelic.php
@@ -24,7 +24,7 @@ function wpcom_vip_disable_new_relic_js() {
 
 
 /**
- * The following functions are for platform level changes and should only be changed after consulting with WordPress.com VIP
+ * The following functions are for platform level changes and should only be changed after consulting with WordPress VIP
  */
 
 if ( extension_loaded( 'newrelic' ) ){

--- a/vip-helpers/vip-permastructs.php
+++ b/vip-helpers/vip-permastructs.php
@@ -5,7 +5,7 @@
  *
  * Usage: wpcom_vip_load_permastruct( '/%category%/%postname%/' );
  *
- * @link http://vip.wordpress.com/documentation/change-your-pretty-permalinks-or-add-custom-rewrite-rules/ Change Your Pretty Permalinks
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/pretty-permalinks-and-custom-rewrite-rules/ Change Your Pretty Permalinks
  * @param string $new_permastruct
  */
 function wpcom_vip_load_permastruct( $new_permastruct ) {
@@ -18,7 +18,7 @@ function wpcom_vip_load_permastruct( $new_permastruct ) {
 /**
  * Applies the new permalink structure to the option value
  *
- * @link http://vip.wordpress.com/documentation/change-your-pretty-permalinks-or-add-custom-rewrite-rules/ Change Your Pretty Permalinks
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/pretty-permalinks-and-custom-rewrite-rules/ Change Your Pretty Permalinks
  * @param string $permastruct The new permastruct
  * @return string The new permastruct
  */
@@ -34,7 +34,7 @@ function _wpcom_vip_filter_permalink_structure( $permastruct ) {
  *     wpcom_vip_load_category_base( '' );
  *     wpcom_vip_load_category_base( 'section' );
  *
- * @link http://vip.wordpress.com/documentation/change-your-pretty-permalinks-or-add-custom-rewrite-rules/ Change Your Pretty Permalinks
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/pretty-permalinks-and-custom-rewrite-rules/ Change Your Pretty Permalinks
  * @param string $new_category_base New category base prefix
  */
 function wpcom_vip_load_category_base( $new_category_base ) {
@@ -55,7 +55,7 @@ function wpcom_vip_load_category_base( $new_category_base ) {
 /**
  * Applies the new category base to the option value
  *
- * @link http://vip.wordpress.com/documentation/change-your-pretty-permalinks-or-add-custom-rewrite-rules/ Change Your Pretty Permalinks
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/pretty-permalinks-and-custom-rewrite-rules/ Change Your Pretty Permalinks
  * @param string $category_base New category base prefix
  * @return string The category base prefix
  */
@@ -70,7 +70,7 @@ function _wpcom_vip_filter_category_base( $category_base ) {
  * Usage:
  *     wpcom_vip_load_tag_base( 'section' );
  *
- * @link http://vip.wordpress.com/documentation/change-your-pretty-permalinks-or-add-custom-rewrite-rules/ Change Your Pretty Permalinks
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/pretty-permalinks-and-custom-rewrite-rules/ Change Your Pretty Permalinks
  * @param string $new_tag_base New tag base prefix
  */
 function wpcom_vip_load_tag_base( $new_tag_base ) {
@@ -83,7 +83,7 @@ function wpcom_vip_load_tag_base( $new_tag_base ) {
 /**
  * Applies the new tag base to the option value
  *
- * @link http://vip.wordpress.com/documentation/change-your-pretty-permalinks-or-add-custom-rewrite-rules/ Change Your Pretty Permalinks
+ * @link https://lobby.vip.wordpress.com/wordpress-com-documentation/pretty-permalinks-and-custom-rewrite-rules/ Change Your Pretty Permalinks
  * @param string $tag_base New tag base prefix
  * @return string The tag base prefix
  */

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -63,7 +63,7 @@ function wpcom_vip_noncdn_uri( $path ) {
 }
 
 /**
- * Returns a link the WordPress.com VIP site wrapped around an image (the VIP logo).
+ * Returns a link the WordPress VIP site wrapped around an image (the VIP logo).
  *
  * @param int $image Which variant of the VIP logo to use; between 1-6.
  * @return string HTML
@@ -89,8 +89,7 @@ function vip_powered_wpcom_img_html( $image ) {
 /**
  * Returns the "Powered by WordPress.com VIP" widget's content.
  *
- * @link http://vip.wordpress.com/documentation/code-and-theme-review-process/ Code Review
- * @link http://vip.wordpress.com/documentation/powered-by-wordpress-com-vip/ Powered By WordPress.com VIP
+ * @link https://docs.wpvip.com/how-tos/add-powered-by-wordpress-vip-to-your-site/ Powered By WordPress VIP
  * @param string $display Optional. Either: 1-6 or "text"*. If an integer, wrap an image in the VIP link. Otherwise, just return the link.
  * @param string $before_text Optional. Text to go in front of the VIP link. Defaults to 'Powered by '.
  * @return string HTML
@@ -116,7 +115,7 @@ function vip_powered_wpcom( $display = 'text', $before_text = 'Powered by ' ) {
 }
 
 /**
- * Returns the URL to the WordPress.com VIP site
+ * Returns the URL to the WordPress VIP site
  *
  * @return string
  */
@@ -138,7 +137,6 @@ function vip_powered_wpcom_url() {
  * Contrib users still can't publish.
  *
  * @author mdawaffe
- * @link http://vip.wordpress.com/documentation/allow-contributors-to-upload-images/ Allow Contributors to Upload Images
  */
 function vip_contrib_add_upload_cap() {
 	add_action( 'init', '_vip_contrib_add_upload_cap' );
@@ -148,7 +146,6 @@ function vip_contrib_add_upload_cap() {
 /**
  * Helper function for vip_contrib_add_upload_cap() to change the user roles
  *
- * @link http://vip.wordpress.com/documentation/allow-contributors-to-upload-images/ Allow Contributors to Upload Images
  * @see vip_contrib_add_upload_cap()
  */
 function _vip_contrib_add_upload_cap() {
@@ -166,7 +163,7 @@ function _vip_contrib_add_upload_cap() {
  *
  * However, this function can come in handy if you want a specific artibitrary or varying image size.
  *
- * @link http://vip.wordpress.com/documentation/image-resizing-and-cropping/
+ * @link https://docs.wpvip.com/technical-references/vip-go-files-system/image-transformation/
  *
  * @param int $attachment_id ID of the attachment
  * @param int $width Width of our resized image
@@ -489,9 +486,9 @@ function vip_regex_redirects( $vip_redirects_array = array(), $with_querystring 
  *
  * The $extra_args are:
  *  * obey_cache_control_header: uses the "cache-control" "max-age" value if greater than $cache_time.
- *  * http_api_args: see http://codex.wordpress.org/Function_API/wp_remote_get
+ *  * http_api_args: see https://developer.wordpress.org/reference/functions/wp_remote_get/
  *
- * @link http://lobby.vip.wordpress.com/best-practices/fetching-remote-data/ Fetching Remote Data
+ * @link https://docs.wpvip.com/technical-references/code-quality-and-best-practices/retrieving-remote-data/ Fetching Remote Data
  * @param string $url URL to fetch
  * @param int $timeout Optional. The timeout limit in seconds; valid values are 1-10. Defaults to 3.
  * @param int $cache_time Optional. The minimum cache time in seconds. Valid values are >= 60. Defaults to 900.
@@ -649,7 +646,7 @@ function wpcom_vip_file_get_contents( $url, $timeout = 3, $cache_time = 900, $ex
  * This can be executed before WP init because it checks the URI directly to see if the main feed is being requested.
  *
  * @author lloydbudd
- * @link http://vip.wordpress.com/documentation/redirect-the-feed-to-feedburner/ Redirect the Feed To Feedburner
+ * @link https://wpvip.com/documentation/redirect-the-feed-to-feedburner/ Redirect the Feed To Feedburner
  * @param string $target URL to direct feed services to
  */
 function vip_main_feed_redirect( $target ) {
@@ -762,7 +759,7 @@ function vip_get_random_posts( $number = 1, $post_type = 'post', $return_ids = f
  *
  * Note that like wp_remote_request(), this function does not cache.
  *
- * @link http://vip.wordpress.com/documentation/fetching-remote-data/ Fetching Remote Data
+ * @link https://docs.wpvip.com/technical-references/code-quality-and-best-practices/retrieving-remote-data/ Fetching Remote Data
  * @param string $url URL to request
  * @param string $fallback_value Optional. Set a fallback value to be returned if the external request fails.
  * @param int $threshold Optional. The number of fails required before subsequent requests automatically return the fallback value. Defaults to 3, with a maximum of 10.
@@ -882,7 +879,7 @@ function vip_safe_wp_remote_request( $url, $fallback_value = '', $threshold = 3,
  *
  * Note that like wp_remote_get(), this function does not cache.
  *
- * @link http://vip.wordpress.com/documentation/fetching-remote-data/ Fetching Remote Data
+ * @link https://docs.wpvip.com/technical-references/code-quality-and-best-practices/retrieving-remote-data/ Fetching Remote Data
  * @see vip_safe_wp_remote_request()
  * @see wp_remote_get()
  */
@@ -1099,7 +1096,6 @@ function wpcom_vip_load_plugin( $plugin = false, $folder = false, $load_release_
 
 	// Shared plugins are being deprecated.
 	// This can be removed once shared plugins have all been removed.
-	// https://vip.wordpress.com/documentation/vip-go/deprecating-shared-plugins-on-vip-go/
 	if ( ! defined( 'WPCOM_VIP_DISABLE_SHARED_PLUGINS' ) ) {
 		define( 'WPCOM_VIP_DISABLE_SHARED_PLUGINS', true );
 	}

--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -164,7 +164,7 @@ class WPCOM_VIP_Jetpack_Mandatory {
 								<span class='configure'>{{{ item.configurable }}}</span>
 							<# } #>
 							<# if ( wpcom_vip_jetpack_forced.indexOf(item.module) !== -1 ) { #>
-								<span class='wpcom-vip-no-delete' id="wpcom-vip-no-delete-{{ item.module }}"><?php _e( 'This module is required for WordPress.com VIP', 'wpcom-vip-jetpack' ); ?></span>
+								<span class='wpcom-vip-no-delete' id="wpcom-vip-no-delete-{{ item.module }}"><?php _e( 'This module is required for WordPress VIP', 'wpcom-vip-jetpack' ); ?></span>
 							<# } else if ( item.activated && 'vaultpress' !== item.module ) { #>
 								<# if ( 'omnisearch' !== item.module ) { #>
 									<span class='delete'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=deactivate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.deactivate_nonce }}}"><?php _e( 'Deactivate', 'jetpack' ); ?></a></span>

--- a/vip-rest-api.php
+++ b/vip-rest-api.php
@@ -1,8 +1,8 @@
 <?php
 /*
 Plugin Name: REST API Enhancements
-Plugin URI: https://vip.wordpress.com/
-Description: Add custom REST API endpoints for VIP requests; these endpoints are private and only for the use of WordPress.com VIP
+Plugin URI: https://wpvip.com
+Description: Add custom REST API endpoints for VIP requests; these endpoints are private and only for the use of WordPress VIP
 Author: Erick Hitter, Automattic
 Version: 0.1
 */

--- a/vip-support.php
+++ b/vip-support.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:  WordPress.com VIP Support
+ * Plugin Name:  WordPress VIP Support
  * Description:  Manages the WordPress.com Support Users on your site
  * Version:      3.1.0
  * Author:       <a href="http://automattic.com">Automattic</a>


### PR DESCRIPTION
## Description

There have been several changes recently that have not been reflected in the URLs in this repo.

- Much documentation now lives at https://docs.wpvip.com
- Main marketing site has changed from vip.wordpress.com to wpvip.com
- Branding has changed from "WordPress.com VIP" to "WordPress VIP".

This change updates each instance as needed.

Some URL references have been deleted where it makes sense, and an instance around the "Powered By WordPress.com VIP" has been left as that has wider implications that are being handled elsewhere.

## Changelog Description

Updated old documentation URLs, and WordPress.com VIP references, in code comments and some customer-facing strings.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [ ] (For Automatticians) I've created a changelog draft. 

## Steps to Test

Each old `vip.wordpress.com` references was manually tested to see where it redirected to, and then that was considered to see if it was a good replacement. For those without a successfull redirect, a replacement was manually found. If a suitable replacement couldn't be found, then the reference was deleted.

1. Review the URL changes to ensure that they make sense. 

