### PR TITLE
Log to logstash when VIP Search ratelimiting starts.

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -874,7 +874,7 @@ class Queue {
 
 			if ( ! self::is_indexing_ratelimited() ) {
 				self::turn_on_index_ratelimiting();
-				self::log_index_ratelimiting_start();
+				$this->log_index_ratelimiting_start();
 			}
 		} else {
 			$this->clear_index_limiting_start_timestamp();

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -735,6 +735,21 @@ class Queue_Test extends \WP_UnitTestCase {
 			] )
 			->getMock();
 
+		$partially_mocked_queue->logger = $this->getMockBuilder( \Automattic\VIP\Logstash\Logger::class )
+				->setMethods( [ 'log' ] )
+				->getMock();
+
+		$partially_mocked_queue->logger->expects( $this->once() )
+				->method( 'log' )
+				->with(
+					$this->equalTo( 'warning' ),
+					$this->equalTo( 'vip_search_indexing_rate_limiting' ),
+					$this->equalTo(
+						'Application 123 - http://example.org has triggered Elasticsearch indexing rate limiting, which will last for 300 seconds. Large batch indexing operations are being queued for indexing in batches over time.'
+					),
+					$this->anything()
+				);
+
 		$sync_manager = new \stdClass();
 		$sync_manager->sync_queue = range( 3, 9 );
 

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -1255,6 +1255,25 @@ class Queue_Test extends \WP_UnitTestCase {
 		$this->queue->maybe_update_stat( 'test', $value );
 	}
 
+	public function test__log_index_ratelimiting_start() {
+		$this->queue->logger = $this->getMockBuilder( \Automattic\VIP\Logstash\Logger::class )
+				->setMethods( [ 'log' ] )
+				->getMock();
+
+		$this->queue->logger->expects( $this->once() )
+				->method( 'log' )
+				->with(
+					$this->equalTo( 'warning' ),
+					$this->equalTo( 'vip_search_indexing_rate_limiting' ),
+					$this->equalTo(
+						'Application 123 - http://example.org has triggered Elasticsearch indexing rate limiting, which will last for 300 seconds. Large batch indexing operations are being queued for indexing in batches over time.'
+					),
+					$this->anything()
+				);
+
+		$this->queue->log_index_ratelimiting_start();
+	}
+
 	/**
 	 * Helper function for accessing protected methods.
 	 */


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!

If you're not an Automattician, welcome! We look forward to your contribution! :heart:

-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

We need a way to know if VIP Search is currently rate limited or not on specific sites when debugging. By logging to logstash when rate limiting kicks off and knowing how long rate limiting lasts, it makes debugging much easier since you don't need to guess.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, link to the PR, examples(if applicable), and why the change was made.

Example for a plugin upgrade:

### Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.

#### Improved compatibility

- Site Health Tools: improve PHP 8 compatibility.
- Twenty Twenty One: add support for Jetpack’s Content Options.

#### Bug fixes

- Instant Search: fix layout issues with filtering checkboxes with some themes.
- WordPress.com Toolbar: avoid Fatal errors when the feature is not active.
- WordPress.com Toolbar: avoid 404 errors when loading the toolbar.

https://github.com/Automattic/vip-go-mu-plugins/pull/1905

Example for a feature change:

### New Filters: Adjust Brute Force Thresholds

We’ve added two new filters to our login limiting functionality, which gives you the ability to tweak the thresholds for our application-level brute force protections. For example, you may want to lower them during situations with high security sensitivity.

- `wpcom_vip_ip_username_login_threshold` : how many failed attempts to allow for an IP address and username combination
- `wpcom_vip_ip_login_threshold` : how many failed attempts to allow for an IP address

For example, if you wanted to only allow one attempt for a group of usernames per IP:

```
add_filter( 'wpcom_vip_ip_username_login_threshold', function( $threshold, $ip, $username ) {
    if ( 'adminuser' === $username || 'otheradminuser' === $username ) {
        $threshold = 1;
    }
 
    return $threshold;
}, 10, 3 );
```

https://github.com/Automattic/vip-go-mu-plugins/pull/1782
-->

### Log to logstash when VIP Search rate limiting begins

To assist with debugging VIP Search related issues, we need an easy way to determine if rate limiting is currently in effect for queries or indexing operations. The easiest way to accomplish this right now is by logging when rate limiting starts to logstash.

https://github.com/Automattic/vip-go-mu-plugins/pull/1916

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] (For Automatticians) I've created a changelog draft. 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

1. Apply PR.
2. Trigger rate limiting.
3. Check for appropriate logstash-related behaviour.