### PR TITLE
Clears PHPCompatibility phpcs warnings wpcom-error-handler

### DIFF
--- a/lib/wpcom-error-handler/wpcom-error-handler.php
+++ b/lib/wpcom-error-handler/wpcom-error-handler.php
@@ -7,16 +7,18 @@ if ( ! defined( 'ABSPATH' ) || defined( 'WPINC' ) ) {
 }
 
 function wpcom_error_shutdown() {
-	if ( ! $last = error_get_last() )
+	$last = error_get_last();
+	if ( ! $last ) {
 		return;
+	}
 
 	switch ( $last['type'] ) {
-		case E_CORE_ERROR : // we may not be able to capture this one
-		case E_COMPILE_ERROR : // or this one
-		case E_PARSE : // we can't actually capture this one
-		case E_ERROR :
-		case E_USER_ERROR :
-		case E_RECOVERABLE_ERROR :
+		case E_CORE_ERROR: // we may not be able to capture this one
+		case E_COMPILE_ERROR: // or this one
+		case E_PARSE: // we can't actually capture this one
+		case E_ERROR:
+		case E_USER_ERROR:
+		case E_RECOVERABLE_ERROR:
 			wpcom_custom_error_handler( false, $last['type'], $last['message'], $last['file'], $last['line'] );
 			break;
 	}
@@ -34,6 +36,7 @@ function wpcom_get_error_backtrace( $last_error_file, $last_error_type, $for_irc
 	} elseif ( in_array( $last_error_type, array( E_ERROR, E_USER_ERROR ), 1 ) ) {
 		return ''; // The standard debug backtrace is useless for Fatal Errors
 	} else {
+		// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
 		$backtrace = debug_backtrace( 0 );
 	}
 
@@ -49,13 +52,13 @@ function wpcom_get_error_backtrace( $last_error_file, $last_error_type, $for_irc
 
 		$path = '';
 		if ( ! $for_irc ) {
-			$path = isset( $call['file'] ) ? str_replace( ABSPATH, '', $call['file'] ) : '';
+			$path  = isset( $call['file'] ) ? str_replace( ABSPATH, '', $call['file'] ) : '';
 			$path .= isset( $call['line'] ) ? ':' . $call['line'] : '';
 		}
 
 		if ( isset( $call['class'] ) ) {
 			$call_type = $call['type'] ?? '???';
-			$path .= " {$call['class']}{$call_type}{$call['function']}()";
+			$path     .= " {$call['class']}{$call_type}{$call['function']}()";
 		} elseif ( in_array( $call['function'], array( 'do_action', 'apply_filters' ) ) ) {
 			if ( is_object( $call['args'][0] ) && ! method_exists( $call['args'][0], '__toString' ) ) {
 				$path .= " {$call['function']}(Object)";
@@ -65,7 +68,7 @@ function wpcom_get_error_backtrace( $last_error_file, $last_error_type, $for_irc
 				$path .= " {$call['function']}('{$call['args'][0]}')";
 			}
 		} elseif ( in_array( $call['function'], array( 'include', 'include_once', 'require', 'require_once' ) ) ) {
-			$file = 0 == $bt_key ? $last_error_file : $call['args'][0];
+			$file  = 0 == $bt_key ? $last_error_file : $call['args'][0];
 			$path .= " {$call['function']}('" . str_replace( ABSPATH, '', $file ) . "')";
 		} else {
 			$path .= " {$call['function']}()";
@@ -83,49 +86,49 @@ function wpcom_get_error_backtrace( $last_error_file, $last_error_type, $for_irc
  */
 function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file, $line ) {
 	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
-	if ( ! is_int( $type ) || ! ( $type & error_reporting() ) ) { 
+	if ( ! is_int( $type ) || ! ( $type & error_reporting() ) ) {
 		return true;
 	}
 
 	$die = false;
 	switch ( $type ) {
-		case E_CORE_ERROR : // we may not be able to capture this one
+		case E_CORE_ERROR: // we may not be able to capture this one
 			$string = 'Core error';
-			$die = true;
+			$die    = true;
 			break;
-		case E_COMPILE_ERROR : // or this one
+		case E_COMPILE_ERROR: // or this one
 			$string = 'Compile error';
-			$die = true;
+			$die    = true;
 			break;
-		case E_PARSE : // we can't actually capture this one
+		case E_PARSE: // we can't actually capture this one
 			$string = 'Parse error';
-			$die = true;
+			$die    = true;
 			break;
-		case E_ERROR :
-		case E_USER_ERROR :
+		case E_ERROR:
+		case E_USER_ERROR:
 			$string = 'Fatal error';
-			$die = true;
+			$die    = true;
 			break;
-		case E_WARNING :
-		case E_USER_WARNING :
+		case E_WARNING:
+		case E_USER_WARNING:
 			$string = 'Warning';
 			break;
-		case E_NOTICE :
-		case E_USER_NOTICE :
+		case E_NOTICE:
+		case E_USER_NOTICE:
 			$string = 'Notice';
 			break;
-		case E_STRICT :
+		case E_STRICT:
 			$string = 'Strict Standards';
 			break;
-		case E_RECOVERABLE_ERROR :
+		case E_RECOVERABLE_ERROR:
 			$string = 'Catchable fatal error';
-			$die = true;
+			$die    = true;
 			break;
-		case E_DEPRECATED :
-		case E_USER_DEPRECATED :
+		case E_DEPRECATED:
+		case E_USER_DEPRECATED:
 			$string = 'Deprecated';
 			break;
-		case 0 :
+		case 0:
 			return true;
 	}
 
@@ -136,7 +139,7 @@ function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file,
 
 	$backtrace = wpcom_get_error_backtrace( $file, $type );
 
-	if ( !empty( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
+	if ( ! empty( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 		$source = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 	} else {
 		$source = '$ ' . @join( ' ', $GLOBALS['argv'] );
@@ -172,7 +175,8 @@ function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file,
 	return true;
 }
 
-if ( false === stripos( $_SERVER[ 'PHP_SELF' ],'phpunit' ) ) {
+$php_self = $_SERVER['PHP_SELF'] ?? '';
+if ( false === stripos( $php_self, 'phpunit' ) ) {
 	ini_set( 'a8c.enable_backtrace_on_error', 1 );
 	register_shutdown_function( 'wpcom_error_shutdown' );
 	set_error_handler( 'wpcom_error_handler' );


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!

If you're not an Automattician, welcome! We look forward to your contribution! :heart:

-->
## Description
Same as bellow
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

## Changelog Description

### Resolves PHPCompatibility phpcs warnings for PHP 7.4 - wpcom-error-handler

The warnings were already reviewed previously and deemed false positive in this case.

However, we updated the implementation here to silence/resolve the warnings.

<!--
A description of the context of the change for a changelog. It should have a title, link to the PR, examples(if applicable), and why the change was made.

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.

#### Improved compatibility

- Site Health Tools: improve PHP 8 compatibility.
- Twenty Twenty One: add support for Jetpack’s Content Options.

#### Bug fixes

- Instant Search: fix layout issues with filtering checkboxes with some themes.
- WordPress.com Toolbar: avoid Fatal errors when the feature is not active.
- WordPress.com Toolbar: avoid 404 errors when loading the toolbar.

https://github.com/Automattic/vip-go-mu-plugins/pull/1905

Example for a feature change:

### New Filters: Adjust Brute Force Thresholds

We’ve added two new filters to our login limiting functionality, which gives you the ability to tweak the thresholds for our application-level brute force protections. For example, you may want to lower them during situations with high security sensitivity.

- `wpcom_vip_ip_username_login_threshold` : how many failed attempts to allow for an IP address and username combination
- `wpcom_vip_ip_login_threshold` : how many failed attempts to allow for an IP address

For example, if you wanted to only allow one attempt for a group of usernames per IP:

```
add_filter( 'wpcom_vip_ip_username_login_threshold', function( $threshold, $ip, $username ) {
    if ( 'adminuser' === $username || 'otheradminuser' === $username ) {
        $threshold = 1;
    }
 
    return $threshold;
}, 10, 3 );
```

https://github.com/Automattic/vip-go-mu-plugins/pull/1782
-->

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] (For Automatticians) I've created a changelog draft. 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

* Add a fatal error to somewhere in mu-plugins e.g. -  `this_is_not_a_function();`
* Call `wp user list` see the error with `Fatal Error` prefix (added among other things by this handler)