### PR TITLE
Cache Manager: update stats keys, track dashboard purge action

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -40,6 +40,10 @@ class WPCOM_VIP_Cache_Manager {
 
 		if ( $this->can_purge_cache() && isset( $_GET['cm_purge_all'] ) && check_admin_referer( 'manual_purge' ) ) {
 			$this->purge_site_cache();
+			\Automattic\VIP\Stats\send_pixel( [
+				'vip-go-cache-action' => 'dashboard-site-purge',
+				'vip-go-cache-url-purge-by-site'   => VIP_GO_APP_ID,
+			] );
 			add_action( 'admin_notices' , array( $this, 'manual_purge_message' ) );
 		}
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -115,14 +115,14 @@ class WPCOM_VIP_Cache_Manager {
 
 		if ( json_last_error() ) {
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-manager-url-purge-status' => 'bad-payload',
+				'vip-go-cache-url-purge-status' => 'bad-payload',
 			] );
 			wp_send_json_error( [ 'error' => 'Malformed payload' ], 400 );
 		}
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-manager-url-purge-status' => 'deny-permissions',
+				'vip-go-cache-url-purge-status' => 'deny-permissions',
 			] );
 
 			wp_send_json_error( [ 'error' => 'Unauthorized' ], 403 );
@@ -130,7 +130,7 @@ class WPCOM_VIP_Cache_Manager {
 
 		if ( ! ( isset( $req->nonce ) && wp_verify_nonce( $req->nonce, 'purge-page' ) ) ) {
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-manager-url-purge-status' => 'deny-nonce',
+				'vip-go-cache-url-purge-status' => 'deny-nonce',
 			] );
 
 			wp_send_json_error( [ 'error' => 'Unauthorized' ], 403 );
@@ -140,7 +140,7 @@ class WPCOM_VIP_Cache_Manager {
 
 		if ( empty( $urls ) ) {
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-manager-url-purge-status' => 'deny-no-urls',
+				'vip-go-cache-url-purge-status' => 'deny-no-urls',
 			] );
 
 			wp_send_json_error( [ 'error' => 'No URLs' ], 400 );
@@ -152,9 +152,9 @@ class WPCOM_VIP_Cache_Manager {
 		}
 
 		\Automattic\VIP\Stats\send_pixel( [
-			'vip-go-cache-manager-action' => 'user-url-purge',
-			'vip-go-cache-manager-url-purge-by-site'   => VIP_GO_APP_ID,
-			'vip-go-cache-manager-url-purge-status' => 'success',
+			'vip-go-cache-action' => 'user-url-purge',
+			'vip-go-cache-url-purge-by-site'   => VIP_GO_APP_ID,
+			'vip-go-cache-url-purge-status' => 'success',
 		] );
 
 		// Optimistically tell that the operation is successful and bail.

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -41,8 +41,8 @@ class WPCOM_VIP_Cache_Manager {
 		if ( $this->can_purge_cache() && isset( $_GET['cm_purge_all'] ) && check_admin_referer( 'manual_purge' ) ) {
 			$this->purge_site_cache();
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-action' => 'dashboard-site-purge',
-				'vip-go-cache-url-purge-by-site'   => VIP_GO_APP_ID,
+				'vip-cache-action' => 'dashboard-site-purge',
+				'vip-cache-url-purge-by-site'   => VIP_GO_APP_ID,
 			] );
 			add_action( 'admin_notices' , array( $this, 'manual_purge_message' ) );
 		}
@@ -119,14 +119,14 @@ class WPCOM_VIP_Cache_Manager {
 
 		if ( json_last_error() ) {
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-url-purge-status' => 'bad-payload',
+				'vip-cache-url-purge-status' => 'bad-payload',
 			] );
 			wp_send_json_error( [ 'error' => 'Malformed payload' ], 400 );
 		}
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-url-purge-status' => 'deny-permissions',
+				'vip-cache-url-purge-status' => 'deny-permissions',
 			] );
 
 			wp_send_json_error( [ 'error' => 'Unauthorized' ], 403 );
@@ -134,7 +134,7 @@ class WPCOM_VIP_Cache_Manager {
 
 		if ( ! ( isset( $req->nonce ) && wp_verify_nonce( $req->nonce, 'purge-page' ) ) ) {
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-url-purge-status' => 'deny-nonce',
+				'vip-cache-url-purge-status' => 'deny-nonce',
 			] );
 
 			wp_send_json_error( [ 'error' => 'Unauthorized' ], 403 );
@@ -144,7 +144,7 @@ class WPCOM_VIP_Cache_Manager {
 
 		if ( empty( $urls ) ) {
 			\Automattic\VIP\Stats\send_pixel( [
-				'vip-go-cache-url-purge-status' => 'deny-no-urls',
+				'vip-cache-url-purge-status' => 'deny-no-urls',
 			] );
 
 			wp_send_json_error( [ 'error' => 'No URLs' ], 400 );
@@ -156,9 +156,9 @@ class WPCOM_VIP_Cache_Manager {
 		}
 
 		\Automattic\VIP\Stats\send_pixel( [
-			'vip-go-cache-action' => 'user-url-purge',
-			'vip-go-cache-url-purge-by-site'   => VIP_GO_APP_ID,
-			'vip-go-cache-url-purge-status' => 'success',
+			'vip-cache-action' => 'user-url-purge',
+			'vip-cache-url-purge-by-site'   => VIP_GO_APP_ID,
+			'vip-cache-url-purge-status' => 'success',
 		] );
 
 		// Optimistically tell that the operation is successful and bail.


### PR DESCRIPTION
## Description

The length of the stat key is limited to `32` characters. Our keys included `vip-go-cache-manager-` prefix, which is `21` characters long, leading to stats keys truncation. 

This PR removes `go-` and `manager-` from the prefix so that keys become `vip-cache-action`, `vip-cache-url-purge-status`, and `vip-cache-url-purge-by-site`.

Additionally, introduces `vip-cache-action=dashboard-site-purge` stat.

## Changelog Description

### Improved internal stat tracking for Cache Manager

We have updated stats keys allowing us to better track usage for Cache Manager functionality.

https://github.com/Automattic/vip-go-mu-plugins/pull/1922

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] (For Automatticians) I've created a changelog draft. 

## Steps to Test

1. Check out PR on a sandbox
1. Click 'Purge Page Cache' in Dashboard
1. Verify that 'dashboard-site-purge' is tracked now
