### PR TITLE
Add new fields to the site details data

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -187,6 +187,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 // Load elasticsearch helpers
+// Warning: Site Details depends on the existence of class Search.
+// If this changes in the future, please ensure that details for search are correctly extracted
 if ( ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) || // legacy constant name
 	defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === VIP_ENABLE_VIP_SEARCH ) {
 	require_once( __DIR__ . '/search/search.php' );

--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -63,12 +63,17 @@ class Site_Details_Index {
 
 		$site_details['timestamp'] = $this->get_current_timestamp();
 		$site_details['client_site_id'] = $site_id;
-		$site_details['environment_id'] = $site_id;
 		$site_details['environment_name'] = $environment_name;
-		$site_details['plugins'] = $this->get_plugin_info();
 		$site_details['core']['wp_version'] = strval( $wp_version );
 		$site_details['core']['blog_id'] = get_current_blog_id();
+		$site_details['core']['site_url'] = get_site_url();
 		$site_details['core']['is_multisite'] = is_multisite();
+
+		$site_details['plugins'] = $this->get_plugin_info();
+
+		if ( class_exists( 'Jetpack' ) ) {
+			$site_details['jetpack'] = $this->get_jetpack_info();
+		}
 		
 		return $site_details;
 	}
@@ -93,6 +98,7 @@ class Site_Details_Index {
 			$enabled_via_code = in_array( $key, $plugins_enabled_via_code, true );
 
 			$plugin_info[] = array(
+				'path' => $key,
 				'name' => $value['Name'],
 				'version' => $value['Version'],
 				'active' => $active,
@@ -101,6 +107,23 @@ class Site_Details_Index {
 		}
 
 		return $plugin_info;
+	}
+
+	/**
+	 * Gather all the information about Jetpack
+	 */
+	public function get_jetpack_info() {
+		$jetpack_info = array();
+
+		$jetpack_info['active'] = \Jetpack::is_active();
+		$jetpack_info['id'] = \Jetpack::get_option( 'id' );
+		$jetpack_info['version'] = JETPACK__VERSION;
+		if ( defined( 'VIP_JETPACK_LOADED_VERSION' ) ) {
+			$jetpack_info['vip_loaded_version'] = VIP_JETPACK_LOADED_VERSION;
+		}
+		$jetpack_info['active_modules'] = \Jetpack::get_active_modules();
+
+		return $jetpack_info;
 	}
 
 	/**

--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -70,12 +70,8 @@ class Site_Details_Index {
 		$site_details['core']['is_multisite'] = is_multisite();
 
 		$site_details['plugins'] = $this->get_plugin_info();
-
 		$site_details['search'] = $this->get_search_info();
-
-		if ( class_exists( 'Jetpack' ) ) {
-			$site_details['jetpack'] = $this->get_jetpack_info();
-		}
+		$site_details['jetpack'] = $this->get_jetpack_info();
 		
 		return $site_details;
 	}
@@ -134,13 +130,18 @@ class Site_Details_Index {
 	public function get_jetpack_info() {
 		$jetpack_info = array();
 
-		$jetpack_info['active'] = \Jetpack::is_active();
-		$jetpack_info['id'] = \Jetpack::get_option( 'id' );
-		$jetpack_info['version'] = JETPACK__VERSION;
-		if ( defined( 'VIP_JETPACK_LOADED_VERSION' ) ) {
-			$jetpack_info['vip_loaded_version'] = VIP_JETPACK_LOADED_VERSION;
+		if ( class_exists( 'Jetpack' ) ) {
+			$jetpack_info['available'] = true;
+			$jetpack_info['active'] = \Jetpack::is_active();
+			$jetpack_info['id'] = \Jetpack::get_option( 'id' );
+			$jetpack_info['version'] = JETPACK__VERSION;
+			if ( defined( 'VIP_JETPACK_LOADED_VERSION' ) ) {
+				$jetpack_info['vip_loaded_version'] = VIP_JETPACK_LOADED_VERSION;
+			}
+			$jetpack_info['active_modules'] = \Jetpack::get_active_modules();
+		} else {
+			$jetpack_info['available'] = false;
 		}
-		$jetpack_info['active_modules'] = \Jetpack::get_active_modules();
 
 		return $jetpack_info;
 	}

--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -71,6 +71,8 @@ class Site_Details_Index {
 
 		$site_details['plugins'] = $this->get_plugin_info();
 
+		$site_details['search'] = $this->get_search_info();
+
 		if ( class_exists( 'Jetpack' ) ) {
 			$site_details['jetpack'] = $this->get_jetpack_info();
 		}
@@ -107,6 +109,21 @@ class Site_Details_Index {
 		}
 
 		return $plugin_info;
+	}
+
+	/**
+	 * Gather basic information about VIP Search for a site
+	 */
+	public function get_search_info() {
+		$search_info = array();
+
+		$search_info['enabled'] = ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) ||
+			( defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === VIP_ENABLE_VIP_SEARCH );
+
+		$search_info['query_integration'] = ( defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION ) ||
+			( defined( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION );
+
+		return $search_info;
 	}
 
 	/**

--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -117,11 +117,13 @@ class Site_Details_Index {
 	public function get_search_info() {
 		$search_info = array();
 
-		$search_info['enabled'] = ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) ||
-			( defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === VIP_ENABLE_VIP_SEARCH );
-
-		$search_info['query_integration'] = ( defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION ) ||
-			( defined( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION' ) && true === VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION );
+		if ( class_exists( '\Automattic\VIP\Search\Search' ) ) {
+			$search_info['enabled'] = true;
+			$search_info['query_integration_enabled'] = \Automattic\VIP\Search\Search::is_query_integration_enabled();
+		} else {
+			$search_info['enabled'] = false;
+			$search_info['query_integration_enabled'] = false;
+		}
 
 		return $search_info;
 	}

--- a/tests/config/test-site-details-index.php
+++ b/tests/config/test-site-details-index.php
@@ -67,10 +67,6 @@ class Site_Details_Index_Test extends \WP_UnitTestCase {
 		$this->assertTrue( is_integer( $site_details['client_site_id'] ), 'client_site_id should be int' );
 		$this->assertEquals( 123, $site_details['client_site_id'], 'client_site_id should be 123' );
 
-		$this->assertTrue( array_key_exists( 'environment_id', $site_details ), 'environment_id should exist' );
-		$this->assertTrue( is_integer( $site_details['environment_id'] ), 'environment_id should be int' );
-		$this->assertEquals( 123, $site_details['environment_id'], 'environment_id should be 123' );
-
 		$this->assertTrue( array_key_exists( 'environment_name', $site_details ), 'environment_name should exist' );
 		$this->assertTrue( is_string( $site_details['environment_name'] ), 'environment_name should be string' );
 		$this->assertEquals( '', $site_details['environment_name'], 'environment_name should be blank since it\'s not current set' ); // Not set in test environment currently
@@ -105,6 +101,10 @@ class Site_Details_Index_Test extends \WP_UnitTestCase {
 		$this->assertTrue( array_key_exists( 'blog_id', $site_details['core'] ), 'blog_id should exist in core' );
 		$this->assertTrue( is_integer( $site_details['core']['blog_id'] ), 'blog_id should be int' );
 		$this->assertEquals( get_current_blog_id(), $site_details['core']['blog_id'], 'blog_id should be equal to get_current_blog_id()' );
+
+		$this->assertTrue( array_key_exists( 'site_url', $site_details['core'] ), 'site_url should exist in core' );
+		$this->assertTrue( is_string( $site_details['core']['site_url'] ), 'site_url should be string' );
+		$this->assertEquals( get_site_url(), $site_details['core']['site_url'], 'site_url should be equal to get_site_url()' );
 
 		$this->assertTrue( array_key_exists( 'is_multisite', $site_details['core'] ), 'is_multisite should exist in core' );
 		$this->assertTrue( is_bool( $site_details['core']['is_multisite'] ), 'is_multisite should be bool' );
@@ -145,10 +145,6 @@ class Site_Details_Index_Test extends \WP_UnitTestCase {
 		$this->assertTrue( is_integer( $site_details['client_site_id'] ), 'client_site_id should be int' );
 		$this->assertEquals( 123, $site_details['client_site_id'], 'client_site_id should be 123' );
 
-		$this->assertTrue( array_key_exists( 'environment_id', $site_details ), 'environment_id should exist' );
-		$this->assertTrue( is_integer( $site_details['environment_id'] ), 'environment_id should be int' );
-		$this->assertEquals( 123, $site_details['environment_id'], 'environment_id should be 123' );
-		
 		$this->assertTrue( array_key_exists( 'environment_name', $site_details ), 'environment_name should exist' );
 		$this->assertTrue( is_string( $site_details['environment_name'] ), 'environment_name should be string' );
 		$this->assertEquals( '', $site_details['environment_name'], 'environment_name should be blank since it\'s not current set' ); // Not set in test environment currently
@@ -183,6 +179,10 @@ class Site_Details_Index_Test extends \WP_UnitTestCase {
 		$this->assertTrue( array_key_exists( 'blog_id', $site_details['core'] ), 'blog_id should exist in core' );
 		$this->assertTrue( is_integer( $site_details['core']['blog_id'] ), 'blog_id should be int' );
 		$this->assertEquals( get_current_blog_id(), $site_details['core']['blog_id'], 'blog_id should be equal to get_current_blog_id()' );
+
+		$this->assertTrue( array_key_exists( 'site_url', $site_details['core'] ), 'site_url should exist in core' );
+		$this->assertTrue( is_string( $site_details['core']['site_url'] ), 'site_url should be string' );
+		$this->assertEquals( get_site_url(), $site_details['core']['site_url'], 'site_url should be equal to get_site_url()' );
 
 		$this->assertTrue( array_key_exists( 'is_multisite', $site_details['core'] ), 'is_multisite should exist in core' );
 		$this->assertTrue( is_bool( $site_details['core']['is_multisite'] ), 'is_multisite should be bool' );

--- a/tests/config/test-site-details-index.php
+++ b/tests/config/test-site-details-index.php
@@ -76,12 +76,14 @@ class Site_Details_Index_Test extends \WP_UnitTestCase {
 		$this->assertEquals(
 			array(
 				array(
+					'path' => 'hello.php',
 					'name' => 'Hello Tests',
 					'version' => '4.5',
 					'active' => false,
 					'enabled_via_code' => false,
 				),
 				array(
+					'path' => 'world.php',
 					'name' => 'Testing World',
 					'version' => '8.6',
 					'active' => true,
@@ -154,12 +156,14 @@ class Site_Details_Index_Test extends \WP_UnitTestCase {
 		$this->assertEquals(
 			array(
 				array(
+					'path' => 'hello.php',
 					'name' => 'Hello Tests',
 					'version' => '4.5',
 					'active' => true,
 					'enabled_via_code' => false,
 				),
 				array(
+					'path' => 'world.php',
 					'name' => 'Testing World',
 					'version' => '8.6',
 					'active' => false,


### PR DESCRIPTION
## Description

Add more fields to the site details. Namely:

- Jetpack information (version, active status, Jetpack id, active modules)
- VIP Search status (enabled, query integration)
- Site url (useful mostly for multisite installations)
- Plugin path (in some situations, easier to handle than the plugin name)

## Changelog Description

### Add more information to site details

We keep working in the Site Details functionality, that will allow us to have up to date details about sites, such as the list of plugins and their versions, whether VIP Search is enabled, Jetpack connection status...

This adds some more fields, namely the information about Jetpack (version, active status, Jetpack id, active modules). In the future, all these will be stored and be accessible to run actions on them. E.g, easily find all sites that have a certain old Jetpack version that needs upgrading.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] (For Automatticians) I've created a changelog draft. 

## Steps to Test

1. Check out PR
1. Run PHP code that calls `Site_Details_Index::instance()->get_site_details()`
1. Verify it works and has the expected values
