### PR TITLE
Temporarily store site details data in logstash

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -19,6 +19,11 @@ class Site_Details_Index {
 	private $timestamp = null;
 
 	/**
+	 * Name of the logstash feature to use for log2logstash call
+	 */
+	private const LOG_FEATURE_NAME = 'site_details';
+
+	/**
 	 * Standard singleton except accept a timestamp for mocking purposes.
 	 *
 	 * @param mixed $timestamp A fixed point in time to use for mocking.
@@ -137,6 +142,22 @@ class Site_Details_Index {
 		$site_details = apply_filters( 'vip_site_details_index_data', array() );
 
 		return $site_details;
+	}
+
+	/**
+	 * Builds the site details structure and then puts it into logstash
+	 */
+	public function put_site_details_in_logstash() {
+		$site_details = $this->get_site_details();
+
+		\Automattic\VIP\Logstash\log2logstash(
+			array(
+				'severity' => 'info',
+				'feature' => self::LOG_FEATURE_NAME,
+				'message' => 'Site details update',
+				'extra' => $site_details,
+			)
+		);
 	}
 
 	/**

--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -129,7 +129,7 @@ class Sync {
 		// In order to reduce the amount of stored documents, we increase the execution interval
 		// from 30 minutes to approximately 4 hours
 		if ( 1 === rand( 1, 8 ) ) {
-			require_once( 'class-site-details-index.php' );
+			require_once( __DIR__ . '/class-site-details-index.php' );
 
 			Site_Details_Index::instance()->put_site_details_in_logstash();
 		}

--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -65,6 +65,7 @@ class Sync {
 
 	public function do_cron() {
 		$this->maybe_sync_jetpack_privacy_settings();
+		$this->put_site_details();
 	}
 
 	public function maybe_sync_jetpack_privacy_settings() {
@@ -121,6 +122,17 @@ class Sync {
 		}
 
 		return $success;
+	}
+
+	public function put_site_details() {
+		// This is a temporary workaround while the full Site Details implementation is finished
+		// In order to reduce the amount of stored documents, we increase the execution interval
+		// from 30 minutes to approximately 4 hours
+		if ( 1 === rand( 1, 8 ) ) {
+			require_once( 'class-site-details-index.php' );
+
+			Site_Details_Index::instance()->put_site_details_in_logstash();
+		}
 	}
 
 	public function log( $severity, $message, $extra = array() ) {


### PR DESCRIPTION
## Description

We have recently found some situations where having Site Details already available would be very useful. The final implementation will still take some time, but in the meantime we would benefit of Site Details data being stored somewhere, even if it's not the final place.

This PR recovers a couple of commits from the original PR by @brandon-m-skinner - [commit1](https://github.com/Automattic/vip-go-mu-plugins/pull/1768/commits/63beab34d2df1997d3e62cd0835841bcec87b618#) [commit2](https://github.com/Automattic/vip-go-mu-plugins/pull/1768/commits/1143ba1659a733f98a39fd281f70eafb7f55f192).

Code was originally removed then because with `log2logstash` most of the relevant site details would be stored as a JSON string the `extra` field of the `vip-debug` index, which would have prevented the proposed solution of searching directly over these documents on ElasticSearch.

In the current situation, we won't query ElasticSearch to find certain values, so the JSON string limitation won't be a problem. We will possibly use this to just fetch the full JSON documents and process them with an ad-hoc script.

## Changelog Description

### Store Site Details in a temporary location

We keep working in the Site Details functionality, that will allow us to have up to date details about sites, such as the list of plugins and their versions, whether VIP Search is enabled, Jetpack connection status...

While the final implementation is still in progress, we are now storing site details in a temporary location in logstash, so that we can start using this data as soon as possible. One example is finding all sites that are running a certain version of a plugin, to prepare for an upgrade to a newer version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] (For Automatticians) I've created a changelog draft. 

## Steps to Test

1. Check out PR in a VIP Go Sandbox
1. Execute `wp cron-control events list` and find the id for the entry `vip_config_sync_cron`
1. Run it manually with `wp cron-control events run <id>`
1. Check if a new logstash entry for feature `a8c_vip_site_details`  has been added to `/chroot/tmp/logstash.log`
1. If not (it should only happen once every eight executions), keep running it until the logstash entry is added