### PR TITLE
Add pre_option_jetpack_sync_settings_checksum_disable filter to allow for a killswitch for Jetpack Checksum functionality

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -372,3 +372,11 @@ function vip_jetpack_admin_enqueue_scripts() {
 }
 
 add_action( 'admin_enqueue_scripts', 'vip_jetpack_admin_enqueue_scripts' );
+
+/**
+ * A killswitch for Jetpack Sync Checksum functionality, either disable checksum when a Platform-wide constant is set and true or pass through the value to allow for app-side control.
+ */
+add_filter( 'pre_option_jetpack_sync_settings_checksum_disable', function( $value, $option_name, $default ) {
+	// phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
+	return defined( 'VIP_DISABLE_JETPACK_SYNC_CHECKSUM' ) && VIP_DISABLE_JETPACK_SYNC_CHECKSUM ?: $value;
+}, 10, 3 );


### PR DESCRIPTION
## Description

Jetpack Sync checksums are about to be released to improve Jetpack Sync reliability. Checksum calculation is a potentially costly operation and may affect stability on very large datasets. This PR aims to account for the worst-case scenario by introducing the killswitch that would prevent the Checksum calculation from running.

## Changelog Description

### Safeguard: Override Jetpack Sync Checksum activation based on a constant

A proactive change aimed for mitigation of potential performance degradation when calculating Jetpack Sync Checksums on very large datasets.

https://github.com/Automattic/vip-go-mu-plugins/pull/1938

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] (For Automatticians) I've created a changelog draft. 

## Steps to Test

1. Apply the PR
2. define `VIP_DISABLE_JETPACK_SYNC_CHECKSUM` constant with the value of `true` in `vip-config.php` 
3. `wp shell`
4. Call the checksum logic: 
```$rs = new \Automattic\Jetpack\Sync\Replicastore(); 
$rs->checksum_all();```
5. It should print something like this and exit:
```array(7) {
  'posts' =>
  class WP_Error#2488 (3) {
    public $errors =>
    array(1) {
      'checksum_disabled' =>
      array(1) {
        [0] =>
        string(33) "Checksums are currently disabled."
      }
    }
    public $error_data =>
    array(0) {
    }
    protected $additional_data =>
    array(0) {
    }
  }
  'comments' =>
  class WP_Error#2487 (3) {
    public $errors =>
    array(1) {
      'checksum_disabled' =>
      array(1) {
        [0] =>
        string(33) "Checksums are currently disabled."
      }
    }
    public $error_data =>
    array(0) {
    }
    protected $additional_data =>
    array(0) {
    }
  }
  'post_meta' =>
  class WP_Error#2486 (3) {
    public $errors =>
    array(1) {
      'checksum_disabled' =>
      array(1) {
        [0] =>
        string(33) "Checksums are currently disabled."
      }
    }
    public $error_data =>
    array(0) {
    }
    protected $additional_data =>
    array(0) {
    }
  }
  'comment_meta' =>
  class WP_Error#2485 (3) {
    public $errors =>
    array(1) {
      'checksum_disabled' =>
      array(1) {
        [0] =>
        string(33) "Checksums are currently disabled."
      }
    }
    public $error_data =>
    array(0) {
    }
    protected $additional_data =>
    array(0) {
    }
  }
  'terms' =>
  class WP_Error#2484 (3) {
    public $errors =>
    array(1) {
      'checksum_disabled' =>
      array(1) {
        [0] =>
        string(33) "Checksums are currently disabled."
      }
    }
    public $error_data =>
    array(0) {
    }
    protected $additional_data =>
    array(0) {
    }
  }
  'term_relationships' =>
  class WP_Error#2483 (3) {
    public $errors =>
    array(1) {
      'checksum_disabled' =>
      array(1) {
        [0] =>
        string(33) "Checksums are currently disabled."
      }
    }
    public $error_data =>
    array(0) {
    }
    protected $additional_data =>
    array(0) {
    }
  }
  'term_taxonomy' =>
  class WP_Error#2482 (3) {
    public $errors =>
    array(1) {
      'checksum_disabled' =>
      array(1) {
        [0] =>
        string(33) "Checksums are currently disabled."
      }
    }
    public $error_data =>
    array(0) {
    }
    protected $additional_data =>
    array(0) {
    }
  }
}```
6. Remove the. constant, repeat steps 3-5 and verify that function runs.