### PR TITLE
Set Jetpack 9.3 as the default for all sites

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 9.2
+ * Version: 9.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -18,7 +18,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	if ( version_compare( $wp_version, '5.5', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.1' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.2' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.3' );
 	}
 }
 


### PR DESCRIPTION
## Description

Release Jetpack 9.3 to all sites (except pinned ones and sites with WordPress <5.5)

## Changelog Description

### Plugin Updated: Jetpack 9.3

We upgraded all unpinned sites to Jetpack 9.3. More details about this release in the lobby post.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] (For Automatticians) I've created a changelog draft. 

## Steps to Test

1. Check out PR.
1. Go to the Jetpack dashboard in `wp-admin`
1. Ensure it's using Jetpack version 9.3