### PR TITLE
Increase frequency of Site Details generation

### DIFF
--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -126,13 +126,9 @@ class Sync {
 
 	public function put_site_details() {
 		// This is a temporary workaround while the full Site Details implementation is finished
-		// In order to reduce the amount of stored documents, we increase the execution interval
-		// from 30 minutes to approximately 4 hours
-		if ( 1 === rand( 1, 8 ) ) {
-			require_once( __DIR__ . '/class-site-details-index.php' );
+		require_once( __DIR__ . '/class-site-details-index.php' );
 
-			Site_Details_Index::instance()->put_site_details_in_logstash();
-		}
+		Site_Details_Index::instance()->put_site_details_in_logstash();
 	}
 
 	public function log( $severity, $message, $extra = array() ) {


### PR DESCRIPTION
## Description

Site Details generation is using a temporary solution while we decide the final approach. Because of this, we decided to reduce the interval of generation to 4 hours instead of 30 minutes, using a random number. The problem is that it's not predictable at all, and we need to search in the last 24 hours to obtain all results (and some sites might not have generated anything in that period).

This PR increases the frequency to match the cron execution period (30 minutes). More than the frequency itself, the most important part is that we can know for sure that every site generates the details document predictably, so the search query can be reduced a lot (around one hour).

The amount of documents to be stored in logstash keeps being low enough (less than half a million per day) to not disturb the stability of the ES cluster. Actually, the reduced cost of the queries will vastly compensate the increase in stored documents.

## Changelog Description

### Generate Site Details more frequently

As part of the project to obtain Site Details from all VIP sites (to gather data such as the enabled plugins and their versions, Jetpack status, VIP search status...), we are now increasing the frequency of generation, from 4 hours to 30 minutes. This will allow us to fetch data in a more reliable and predictable way while we keep developing the project.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] (For Automatticians) I've created a changelog draft. 

## Steps to Test

1. Check out the PR in a VIP Go Sandbox
1. Execute `wp cron-control events list` and find the id for the entry `vip_config_sync_cron`
1. Run it manually with `wp cron-control events run <id>`
1. Check if a new logstash entry for feature `a8c_vip_site_details` has been added to `/chroot/tmp/logstash.log`. Compared to before, it should be generated on every execution

