### PR TITLE
Include the original ElasticSearch query and backtrace when logging errors

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -595,7 +595,7 @@ class Search {
 		$response_code = (int) wp_remote_retrieve_response_code( $response );
 
 		if ( is_wp_error( $response ) || $response_code >= 400 ) {
-			$this->ep_handle_failed_request( $response, $statsd_prefix );
+			$this->ep_handle_failed_request( $response, $query, $statsd_prefix );
 		} else {
 			// Record engine time (have to parse JSON to get it)
 			$response_body_json = wp_remote_retrieve_body( $response );
@@ -626,6 +626,9 @@ class Search {
 						'severity' => 'warning',
 						'feature' => 'vip_search_es_warning',
 						'message' => $message,
+						'extra' => [
+							'query' => $query,
+						],
 					) );
 				}
 			}
@@ -639,7 +642,7 @@ class Search {
 		}
 	}
 
-	public function ep_handle_failed_request( $response, $statsd_prefix ) {
+	public function ep_handle_failed_request( $response, $query, $statsd_prefix ) {
 		$response_error = [];
 
 		if ( is_wp_error( $response ) ) {
@@ -671,6 +674,7 @@ class Search {
 				[
 					'error_type' => $response_error['type'] ?? 'Unknown error type',
 					'root_cause' => $response_error['root_cause'] ?? null,
+					'query' => $query,
 				]
 			);
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -628,6 +628,7 @@ class Search {
 						'message' => $message,
 						'extra' => [
 							'query' => $query,
+							'backtrace' => wp_debug_backtrace_summary(),
 						],
 					) );
 				}
@@ -675,6 +676,7 @@ class Search {
 					'error_type' => $response_error['type'] ?? 'Unknown error type',
 					'root_cause' => $response_error['root_cause'] ?? null,
 					'query' => $query,
+					'backtrace' => wp_debug_backtrace_summary(),
 				]
 			);
 		}

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2350,7 +2350,7 @@ class Search_Test extends \WP_UnitTestCase {
 					$this->anything()
 				);
 
-		$es->ep_handle_failed_request( $response, '' );
+		$es->ep_handle_failed_request( $response, [], '' );
 	}
 
 	public function test__maybe_log_query_ratelimiting_start_should_do_nothing_if_ratelimiting_already_started() {


### PR DESCRIPTION
## Description

When an ElasticSearch query fails or it returns a warning, Include the full original query in the message sent to logstash.

## Changelog Description

### Improve logging for ElasticSearch failed queries

When a VIP Search query fails, it gets logged to Logstash so we can investigate the problems. Now we are also logging the full query sent to ElasticSearch and the PHP backtrace, so we can have much more detailed information about the root cause.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] (For Automatticians) I've created a changelog draft. 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
