### PR TITLE
Use the new jetpack-production repository for Jetpack subtrees

### DIFF
--- a/bin/add-jetpack-subtree.sh
+++ b/bin/add-jetpack-subtree.sh
@@ -21,7 +21,7 @@ fi
 
 echo "Creating new jetpack subtree $tree_dir using jetpack tag $jetpack_tag"
 
-git subtree add --squash -P $tree_dir https://github.com/Automattic/jetpack $jetpack_tag -m "Add jetpack $tree_version subtree with tag $jetpack_tag"
+git subtree add --squash -P $tree_dir https://github.com/Automattic/jetpack-production $jetpack_tag -m "Add jetpack $tree_version subtree with tag $jetpack_tag"
 
 echo "Removing unneeded bin/ and tools/ folders"
 

--- a/bin/update-jetpack-subtree.sh
+++ b/bin/update-jetpack-subtree.sh
@@ -19,4 +19,4 @@ fi
 
 echo "Updating jetpack subtree $tree_dir to the jetpack tag $jetpack_tag"
 
-git subtree pull --squash -P $tree_dir https://github.com/Automattic/jetpack $jetpack_tag -m "Update jetpack $tree_version subtree to tag $jetpack_tag"
+git subtree pull --squash -P $tree_dir https://github.com/Automattic/jetpack-production $jetpack_tag -m "Update jetpack $tree_version subtree to tag $jetpack_tag"


### PR DESCRIPTION
## Description

New production Jetpack releases will be published in [Automattic/jetpack-production](https://github.com/Automattic/jetpack-production). This PR updates the helper scripts to manage Jetpack subtrees to reflect the new repo.

## Changelog Description

### Update the Jetpack repository

Jetpack releases are now being published in a [new repository](https://github.com/Automattic/jetpack-production). We have updated the helper scripts we use to add new Jetpack versions to `vip-go-mu-plugins` to reflect the correct repository.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Check out PR.
1. Run `bin/add-jetpack-subtree.sh test 9.3.2`
1. Ensure that a new `jetpack-test` subtree is created from the new `jetpack-production`
