### PR TITLE
adds tag support

### DIFF
--- a/bin/github-changelog.php
+++ b/bin/github-changelog.php
@@ -90,7 +90,7 @@ function get_changelog_tags( $github_labels ) {
     ];
 
     foreach ( $github_labels as $label ) {
-        preg_match('/ChangelogID:\s*(\d+)/', $label['description'], $matches);
+        preg_match('/ChangelogTagID:\s*(\d+)/', $label['description'], $matches);
         if ( $matches ) {
             array_push( $tags, $matches[1] );
         }

--- a/bin/github-changelog.php
+++ b/bin/github-changelog.php
@@ -65,13 +65,13 @@ function parse_changelog_html( $changelog_html ) {
     ];
 }
 
-function create_draft_changelog( $title, $content ) {
+function create_draft_changelog( $title, $content, $tags ) {
     $fields = [
         'title' => $title,
         'content' => $content,
         'excerpt' => $title,
         'status' => 'draft',
-        'tags' => 1784989, // mu-plugins tag
+        'tags' => implode( ',', $tags ),
     ];
     $ch = curl_init( WP_CHANGELOG_ENDPOINT );
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -84,13 +84,29 @@ function create_draft_changelog( $title, $content ) {
     echo $response;
 }
 
+function get_changelog_tags( $github_labels ) {
+    $tags = [
+        '1784989' // mu-plugins
+    ];
+
+    foreach ( $github_labels as $label ) {
+        preg_match('/ChangelogID:\s*(\d+)/', $label['description'], $matches);
+        if ( $matches ) {
+            array_push( $tags, $matches[1] );
+        }
+    }
+
+    return $tags;
+}
+
 function create_changelog_for_last_PR() {
     $pr = fetch_last_PR();
 
+    $changelog_tags = get_changelog_tags( $pr['labels'] );
     $changelog_html = get_changelog_html( $pr );
     $changelog_record = parse_changelog_html( $changelog_html );
 
-    create_draft_changelog( $changelog_record['title'], $changelog_record['content'] );
+    create_draft_changelog( $changelog_record['title'], $changelog_record['content'], $changelog_tags );
     echo "\n\nAll done!";
 }
 


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, improving security, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in P2 using the MU Plugins Proposal P2tenberg Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please do not PR until your proposal has been approved. Thank you :bow:!

If you're not an Automattician, welcome! We look forward to your contribution! :heart:
-->
## Description

I first tried to have Github label => changelog tag mapping in the code, which works fine. But then I thought it is a way more flexible if we can maintain that in Github directly. So the automation is looking for `ChangelogID: <ID>` in the label description that we don't really use for anything else.

You can change it here:
https://github.com/Automattic/vip-go-mu-plugins/labels?page=2&sort=name-asc

I also added `[Tag] Jetpack` and `[Tag] Search` as examples.

<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, link to the PR, examples(if applicable), and why the change was made.

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.

#### Improved compatibility

- Site Health Tools: improve PHP 8 compatibility.
- Twenty Twenty One: add support for Jetpack’s Content Options.

#### Bug fixes

- Instant Search: fix layout issues with filtering checkboxes with some themes.
- WordPress.com Toolbar: avoid Fatal errors when the feature is not active.
- WordPress.com Toolbar: avoid 404 errors when loading the toolbar.

Example for a feature change:

### New Filters: Adjust Brute Force Thresholds

We’ve added two new filters to our login limiting functionality, which gives you the ability to tweak the thresholds for our application-level brute force protections. For example, you may want to lower them during situations with high security sensitivity.

- `wpcom_vip_ip_username_login_threshold` : how many failed attempts to allow for an IP address and username combination
- `wpcom_vip_ip_login_threshold` : how many failed attempts to allow for an IP address

For example, if you wanted to only allow one attempt for a group of usernames per IP:

```
add_filter( 'wpcom_vip_ip_username_login_threshold', function( $threshold, $ip, $username ) {
    if ( 'adminuser' === $username || 'otheradminuser' === $username ) {
        $threshold = 1;
    }
 
    return $threshold;
}, 10, 3 );
```
-->
### Changelog automation enhancement - tags

We updated changelog automation to support tags. Some Github labels will automatically be converted to the changelog tags.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

CircleCI thingie so no real testing. 
