### PR TITLE
Properly handle file paths with `sites/:id`

### DIFF
--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -14,7 +14,7 @@ const CACHE_GROUP = 'vip-files-acl';
 
 function check_file_visibility( $file_visibility, $file_path ) {
 	if ( 0 === strpos( $file_path, 'sites/' ) ) {
-		$file_path = preg_replace( '#^sites\/\d+\/#', '', $file_path );
+		$file_path = preg_replace( '#^sites/\d+/#', '', $file_path );
 	}
 
 	// Reverse lookup for the attachment ID

--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -12,7 +12,16 @@ use const Automattic\VIP\Files\Acl\FILE_IS_PRIVATE_AND_ALLOWED;
 
 const CACHE_GROUP = 'vip-files-acl';
 
+
+/**
+ * Given a path determine whether the file is private or public
+ *
+ * @param string $file_visibility one of Automattic\VIP\Files\Acl\(FILE_IS_PUBLIC | FILE_IS_PRIVATE_AND_ALLOWED | FILE_IS_PRIVATE_AND_DENIED).
+ * @param string $file_path path to file to be checked for visibility.
+ * @return string one of Automattic\VIP\Files\Acl\(FILE_IS_PUBLIC | FILE_IS_PRIVATE_AND_ALLOWED | FILE_IS_PRIVATE_AND_DENIED)
+ */
 function check_file_visibility( $file_visibility, $file_path ) {
+	// Strip the `sites/ID` part for multisite URLs, because _wp_attached_file meta doesn't store it.
 	if ( 0 === strpos( $file_path, 'sites/' ) ) {
 		$file_path = preg_replace( '#^sites/\d+/#', '', $file_path );
 	}

--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -13,6 +13,10 @@ use const Automattic\VIP\Files\Acl\FILE_IS_PRIVATE_AND_ALLOWED;
 const CACHE_GROUP = 'vip-files-acl';
 
 function check_file_visibility( $file_visibility, $file_path ) {
+	if ( 0 === strpos( $file_path, 'sites/' ) ) {
+		$file_path = preg_replace( '#^sites\/\d+\/#', '', $file_path );
+	}
+
 	// Reverse lookup for the attachment ID
 	$attachment_id = get_attachment_id_from_file_path( $file_path );
 

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -162,22 +162,6 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends \WP_UnitTestCase {
 				],
 			],
 
-			'subsite-path-with-sites-dir-non-numeric-id' => [
-				'/wp-content/uploads/sites/id-would-go-here/path/to/horses.txt',
-				[
-					'',
-					'sites/id-would-go-here/path/to/horses.txt',
-				],
-			],
-
-			'subsite-path-with-sites-dir-and-id' => [
-				'/wp-content/uploads/sites/123/path/to/horses.txt',
-				[
-					'',
-					'path/to/horses.txt',
-				],
-			],
-
 			/* TODO: not supported yet
 			'resized-image' => [
 				'/wp-content/uploads/2021/01/dinos-100x100.jpg',

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -162,6 +162,22 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends \WP_UnitTestCase {
 				],
 			],
 
+			'subsite-path-with-sites-dir-non-numeric-id' => [
+				'/wp-content/uploads/sites/id-would-go-here/path/to/horses.txt',
+				[
+					'',
+					'sites/id-would-go-here/path/to/horses.txt',
+				],
+			],
+
+			'subsite-path-with-sites-dir-and-id' => [
+				'/wp-content/uploads/sites/123/path/to/horses.txt',
+				[
+					'',
+					'path/to/horses.txt',
+				],
+			],
+
 			/* TODO: not supported yet
 			'resized-image' => [
 				'/wp-content/uploads/2021/01/dinos-100x100.jpg',

--- a/tests/files/acl/test-restrict-unpublished-files.php
+++ b/tests/files/acl/test-restrict-unpublished-files.php
@@ -70,10 +70,33 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_file_visibility, $actual_file_visibility );
 	}
 
-	public function test__check_file_visibility__attachment_no_parent() {
+	public function test__check_file_visibility__multisite_subsite_attachment_with_sites_path() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$expected_file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PUBLIC;
 
+		// Switch to a subsite
+		$subsite_id = $this->factory->blog->create();
+		switch_to_blog( $subsite_id );
+
+		// Create attachment
 		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+
+		$file_visibility = false;
+		$file_path = sprintf( 'sites/%d/%s', $subsite_id, get_post_meta( $attachment_id, '_wp_attached_file', true ) );
+
+		$actual_file_visibility = check_file_visibility( $file_visibility, $file_path );
+
+		$this->assertEquals( $expected_file_visibility, $actual_file_visibility );
+	}
+
+	public function test__check_file_visibility__attachment_with_publish_parent() {
+		$expected_file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PUBLIC;
+
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
 
 		$file_visibility = false;
 		$file_path = get_post_meta( $attachment_id, '_wp_attached_file', true );


### PR DESCRIPTION
Those need to be stripped out as well since the files paths are stored in postmeta without it.

## Changelog Description

### Private Files: Handle `/sites/` paths for Private Files

We've added a fix that properly handles files with a subsite path (e.g. `/wp-content/uploads/sites/4/2021/01/unpublished.jpg`) with our Private Files feature. We now strip the `sites/:id` portion of the path before forwarding the request to WordPress.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

See unit tests.