### PR TITLE
Fails circleCI pipeline on failure

### DIFF
--- a/bin/github-changelog.php
+++ b/bin/github-changelog.php
@@ -82,7 +82,6 @@ function create_draft_changelog( $title, $content, $tags ) {
     $http_code = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
     curl_close($ch);
 
-
     echo "Response:\n";
     echo $response;
     echo "\nHttpCode: $http_code";

--- a/bin/github-changelog.php
+++ b/bin/github-changelog.php
@@ -87,7 +87,7 @@ function create_draft_changelog( $title, $content, $tags ) {
     echo "\nHttpCode: $http_code";
 
     if ( $http_code >= 400 ) {
-        echo "\n\nFailed to create changelog post\n";
+        echo "\n\nFailed to create changelog draft post\n";
         exit( 1 );
     }
 }

--- a/bin/github-changelog.php
+++ b/bin/github-changelog.php
@@ -79,9 +79,18 @@ function create_draft_changelog( $title, $content, $tags ) {
     curl_setopt($ch, CURLOPT_HTTPHEADER, [ 'Authorization:Bearer ' . WP_CHANGELOG_AUTH_TOKEN ] );
     curl_setopt($ch, CURLOPT_POSTFIELDS, $fields);
     $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
     curl_close($ch);
+
+
     echo "Response:\n";
     echo $response;
+    echo "\nHttpCode: $http_code";
+
+    if ( $http_code >= 400 ) {
+        echo "\n\nFailed to create changelog post\n";
+        exit( 1 );
+    }
 }
 
 function get_changelog_tags( $github_labels ) {


### PR DESCRIPTION

## Description

## Changelog Description

### Continuous Integration (CI) pipeline update

This change makes it easier for us to detect if/when the changelog automation fails to create a draft post.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples. 

