### PR TITLE
Always filter the jetpack_https_test transient to 1

### DIFF
--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -160,4 +160,12 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_modules, $actual_modules );
 	}
+
+	public function test__jetpack_https_test__transient_filter() {
+		$https_test = apply_filters( 'pre_transient_jetpack_https_test', null );
+		$https_test_message = apply_filters( 'pre_transient_jetpack_https_test_message', null );
+
+		$this->assertEquals( 1, $https_test, 'Value of the jetpack_https_test pre-transient filter is incorrect' );
+		$this->assertEquals( '', $https_test_message, 'Value of the jetpack_https_test_message pre-transient filter is incorrect' );
+	}
 }

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -380,3 +380,9 @@ add_filter( 'pre_option_jetpack_sync_settings_checksum_disable', function( $valu
 	// phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 	return defined( 'VIP_DISABLE_JETPACK_SYNC_CHECKSUM' ) && VIP_DISABLE_JETPACK_SYNC_CHECKSUM ?: $value;
 }, 10, 3 );
+
+/**
+ * SSL is always supported on VIP, so avoid unnecessary checks
+ */
+add_filter( 'pre_transient_jetpack_https_test', function() { return 1; } ); // WP doesn't have __return_one (but it does have __return_zero)
+add_filter( 'pre_transient_jetpack_https_test_message', '__return_empty_string' );


### PR DESCRIPTION
## Description

Outbound SSL is always available on VIP so we can skip the HTTP requests that JP makes to determine this (since JP has to work on many different hosting providers).

props @emrikol for the idea + code

## Changelog Description

### Jetpack: Skip HTTPS support checking to reduce HTTP requests

Since Jetpack works across many different hosting providers (some which may not support HTTPS / SSL), it attempts to detect support by making an HTTPS request to WordPress.com, which is then cached for 1 day. On VIP, SSL is always supported so we can skip this check by filtering the transient used to store the result.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Check out PR.
2. In `wp shell`, run `Jetpack::permit_ssl()` - this should return `1`
3. `wp transient get jetpack_https_test` - this should return `1` as well
