### PR TITLE
Private Files: Always send X-Private header

### DIFF
--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -71,19 +71,22 @@ function send_visibility_headers( $file_visibility, $file_path ) {
 	// Default to throwing an error so we can catch unexpected problems more easily.
 	$status_code = 500;
 	$header = false;
+	$is_private = null;
 
 	switch ( $file_visibility ) {
 		case FILE_IS_PUBLIC:
 			$status_code = 202;
+			$is_private = false;
 			break;
 
 		case FILE_IS_PRIVATE_AND_ALLOWED:
 			$status_code = 202;
-			$header = 'X-Private: true';
+			$is_private = true;
 			break;
 
 		case FILE_IS_PRIVATE_AND_DENIED:
 			$status_code = 403;
+			$is_private = true;
 			$header = 'X-Private: true';
 			break;
 
@@ -95,7 +98,8 @@ function send_visibility_headers( $file_visibility, $file_path ) {
 
 	http_response_code( $status_code );
 
-	if ( $header ) {
-		header( $header );
+	if ( null !== $is_private ) {
+		$private_header_value = $is_private ? 'true' : 'false';
+		header( sprintf( 'X-Private: %s', $private_header_value ) );
 	}
 }

--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -87,7 +87,6 @@ function send_visibility_headers( $file_visibility, $file_path ) {
 		case FILE_IS_PRIVATE_AND_DENIED:
 			$status_code = 403;
 			$is_private = true;
-			$header = 'X-Private: true';
 			break;
 
 		default:

--- a/tests/files/acl/test-acl.php
+++ b/tests/files/acl/test-acl.php
@@ -149,21 +149,21 @@ class VIP_Files_Acl_Test extends \WP_UnitTestCase {
 				'FILE_IS_PUBLIC',
 				'/wp-content/uploads/public.jpg',
 				202,
-				false,
+				'false',
 			],
 
 			'private-and-allowed-file' => [
 				'FILE_IS_PRIVATE_AND_ALLOWED',
 				'/wp-content/uploads/allowed.jpg',
 				202,
-				true,
+				'true',
 			],
 
 			'private-and-denied-file' => [
 				'FILE_IS_PRIVATE_AND_DENIED',
 				'/wp-content/uploads/denied.jpg',
 				403,
-				true,
+				'true',
 			],
 		];
 	}
@@ -174,17 +174,12 @@ class VIP_Files_Acl_Test extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider data_provider__send_visibility_headers
 	 */
-	public function test__send_visibility_headers( $file_visibility, $file_path, $expected_status_code, $should_have_private_header ) {
+	public function test__send_visibility_headers( $file_visibility, $file_path, $expected_status_code, $private_header_value ) {
 		send_visibility_headers( $file_visibility, $file_path );
 
 		$this->assertEquals( $expected_status_code, http_response_code(), 'Status code does not match expected' );
 
-		// Not ideal to have a branch in tests, but good enough.
-		if ( $should_have_private_header ) {
-			$this->assertContains( 'X-Private: true', xdebug_get_headers(), 'Sent headers do not include X-Private header' );
-		} else {
-			$this->assertNotContains( 'X-Private: true', xdebug_get_headers(), 'Sent headers include the X-Private header' );
-		}
+		$this->assertContains( sprintf( 'X-Private: %s', $private_header_value ), xdebug_get_headers(), 'Sent headers do not include X-Private header or its value is unexpected' );
 	}
 
 	/**
@@ -201,6 +196,7 @@ class VIP_Files_Acl_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( 500, http_response_code(), 'Status code does not match expected' );
 
-		$this->assertNotContains( 'X-Private: true', xdebug_get_headers(), 'Sent headers include X-Private header but should not.' );
+		$this->assertNotContains( 'X-Private: true', xdebug_get_headers(), 'Sent headers include X-Private: true header but should not.' );
+		$this->assertNotContains( 'X-Private: false', xdebug_get_headers(), 'Sent headers include X-Private:false header but should not.' );
 	}
 }


### PR DESCRIPTION
Even if the file is public, send a value of false to avoid traps when we hit an error

## Changelog Description

### Private Files: Always send X-Private header

To harden the feature and avoid unexpected issues when the ACL endpoint may hit an error (e.g. fatal), we now will always send the X-Private header when the endpoint successfully processes the file. This way, we can differentiate between successful and unsuccessful requests and handle them appropriately upstream.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

Covered by unit tests.