### PR TITLE
Private Files: Restrict cross-site file access

### DIFF
--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -55,6 +55,32 @@ function get_option_as_bool( $option_name, $default = false ) {
 }
 
 /**
+ * Check if the path is allowed for the current context.
+ *
+ * @param string $file_path Path to the file, including the `/wp-content/uploads/` bit.
+ */
+function is_valid_path_for_site( $file_path ) {
+	if ( ! is_multisite() ) {
+		return true;
+	}
+
+	// If main site, don't allow access to /sites/ subdirectories.
+	if ( is_main_network() && is_main_site() ) {
+		if ( 0 === strpos( $file_path, 'sites/' ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	// Strip upload dir to start from /wp-content/
+	$upload_base_dir = trailingslashit( wp_get_upload_dir()['basedir'] );
+	list( , $upload_base_dir ) = explode( '/wp-content/uploads/', $upload_base_dir, 2 );
+
+	return 0 === strpos( $file_path, $upload_base_dir );
+}
+
+/**
  * Sends the correct response code and headers based on the specified file availability.
  *
  * Note: the nginx module for using for the subrequest limits what status codes can be returned.

--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -57,7 +57,7 @@ function get_option_as_bool( $option_name, $default = false ) {
 /**
  * Check if the path is allowed for the current context.
  *
- * @param string $file_path Path to the file, including the `/wp-content/uploads/` bit.
+ * @param string $file_path Path to the file, minus the `/wp-content/uploads/` bit. It's the second portion returned by `Pre_Wp_Utils\prepare_request()`
  */
 function is_valid_path_for_site( $file_path ) {
 	if ( ! is_multisite() ) {

--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -73,11 +73,9 @@ function is_valid_path_for_site( $file_path ) {
 		return true;
 	}
 
-	// Strip upload dir to start from /wp-content/
-	$upload_base_dir = trailingslashit( wp_get_upload_dir()['basedir'] );
-	list( , $upload_base_dir ) = explode( '/wp-content/uploads/', $upload_base_dir, 2 );
+	$base_path = sprintf( 'sites/%d', get_current_blog_id() );
 
-	return 0 === strpos( $file_path, $upload_base_dir );
+	return 0 === strpos( $file_path, $base_path );
 }
 
 /**

--- a/files/acl/endpoint-check-file-acl.php
+++ b/files/acl/endpoint-check-file-acl.php
@@ -4,7 +4,8 @@ namespace Automattic\VIP\Files\Acl;
 
 require_once __DIR__ . '/pre-wp-utils.php';
 
-$vip_files_acl_paths = Pre_WP_Utils\prepare_request( $_SERVER['HTTP_X_ORIGINAL_URI'] ?? null );
+$vip_files_acl_original_uri = $_SERVER['HTTP_X_ORIGINAL_URI'] ?? null;
+$vip_files_acl_paths = Pre_WP_Utils\prepare_request( $vip_files_acl_original_uri );
 
 if ( ! $vip_files_acl_paths ) {
 	// Note: a 400 might be more appropriate but we're limited in terms of response codes.
@@ -23,6 +24,16 @@ if ( $vip_files_acl_subsite_path ) {
 // Load WordPress
 require __DIR__ . '/../../../../wp-load.php';
 
+$vip_files_acl_is_path_allowed = is_valid_path_for_site( $vip_files_acl_sanitized_file_path );
+if ( ! $vip_files_acl_is_path_allowed ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- using htmlspecialchars, which PHPCS complains about
+	trigger_error( sprintf( 'Blocked request for file path that is not allowed (current site ID: %s | requested URI: %s)', (int) get_current_blog_id(), htmlspecialchars( $vip_files_acl_original_uri ) ), E_USER_WARNING );
+
+	http_response_code( 400 );
+
+	exit;
+}
+
 /**
  * Hook in here to adjust the visibility of a given file.
  *
@@ -31,7 +42,7 @@ require __DIR__ . '/../../../../wp-load.php';
  * @access private 
  *
  * @param string|boolean $file_visibility Return one of Automattic\VIP\Files\Acl\(FILE_IS_PUBLIC | FILE_IS_PRIVATE_AND_ALLOWED | FILE_IS_PRIVATE_AND_DENIED) to set visibility.
- * @param string $sanitized_file_path The requested file path (note: on multisite subdirectory installs, this does not includes the subdirectory).
+ * @param string $sanitized_file_path The requested file path (note: This does not include `/wp-content/uploads/`. And, on multisite subdirectory installs, this does not includes the subdirectory).
  */
 $vip_files_acl_file_visibility = apply_filters( 'vip_files_acl_file_visibility', FILE_IS_PUBLIC, $vip_files_acl_sanitized_file_path );
 

--- a/tests/files/acl/test-acl.php
+++ b/tests/files/acl/test-acl.php
@@ -203,4 +203,145 @@ class VIP_Files_Acl_Test extends \WP_UnitTestCase {
 
 		$this->assertNotContains( 'X-Private: true', xdebug_get_headers(), 'Sent headers include X-Private header but should not.' );
 	}
+
+	public function test__is_valid_path_for_site__always_true_for_not_multisite() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		$expected_is_allowed = true;
+
+		$file_path = '2021/01/kittens.jpg';
+
+		$actual_is_allowed = is_valid_path_for_site( $file_path );
+
+		$this->assertEquals( $expected_is_allowed, $actual_is_allowed );
+	}
+
+	public function test__is_valid_path_for_site__multisite_main_site_can_access_self_path_with_vip_protocol() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		$expected_is_allowed = true;
+
+		add_filter( 'upload_dir', function( $params ) {
+			$params['path'] = 'vip:/' . $params['path'];
+			$params['basedir'] = 'vip:/' . $params['basedir'];
+			return $params;
+		} );
+
+		$file_path = '2021/01/kittens.jpg';
+
+		$actual_is_allowed = is_valid_path_for_site( $file_path );
+
+		$this->assertEquals( $expected_is_allowed, $actual_is_allowed );
+	}
+
+	public function test__is_valid_path_for_site__multisite_main_site_can_access_self_path() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		$expected_is_allowed = true;
+
+		$file_path = '2021/01/kittens.jpg';
+
+		$actual_is_allowed = is_valid_path_for_site( $file_path );
+
+		$this->assertEquals( $expected_is_allowed, $actual_is_allowed );
+	}
+
+	public function test__is_valid_path_for_site__multisite_main_site_can_access_basedir_path() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		// Can access other paths from basedir, as long as they don't contain `/sites/ 
+		$expected_is_allowed = true;
+
+		$file_path = 'cache/css/cats.css';
+
+		$actual_is_allowed = is_valid_path_for_site( $file_path );
+
+		$this->assertEquals( $expected_is_allowed, $actual_is_allowed );
+	}
+
+	public function test__is_valid_path_for_site__multisite_main_site_cannot_access_subsite_path() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		$expected_is_allowed = false;
+
+		// Get file path for a subsite
+		$subsite_id = $this->factory->blog->create();
+		$file_path = sprintf( 'sites/%d/2021/01/dogs.gif', $subsite_id );
+
+		// Stay in main site context
+
+		$actual_is_allowed = is_valid_path_for_site( $file_path );
+
+		$this->assertEquals( $expected_is_allowed, $actual_is_allowed );
+	}
+
+	public function test__is_valid_path_for_site__multisite_subsite_can_access_self_path() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		$expected_is_allowed = true;
+
+		// Get file path for a subsite
+		$subsite_id = $this->factory->blog->create();
+		$file_path = sprintf( 'sites/%d/2021/01/hamster.gif', $subsite_id );
+
+		// Run test in subsite context
+		switch_to_blog( $subsite_id );
+
+		$actual_is_allowed = is_valid_path_for_site( $file_path );
+
+		$this->assertEquals( $expected_is_allowed, $actual_is_allowed );
+	}
+
+	public function test__is_valid_path_for_site__multisite_subsite_cannot_access_main_site_path() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		$expected_is_allowed = false;
+
+		// Get file path for main site
+		$file_path = '2021/01/parakeets.gif';
+
+		// Run test in a subsite context
+		$subsite_id = $this->factory->blog->create();
+		switch_to_blog( $subsite_id );
+
+		$actual_is_allowed = is_valid_path_for_site( $file_path );
+
+		$this->assertEquals( $expected_is_allowed, $actual_is_allowed );
+	}
+
+	public function test__is_valid_path_for_site__multisite_subsite_cannot_access_another_subsite_path() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		$expected_is_allowed = false;
+
+		// Create two subsites
+		$first_subsite_id = $this->factory->blog->create();
+		$second_subsite_id = $this->factory->blog->create();
+
+		// Get file path from second
+		$file_path = sprintf( 'sites/%d/2021/01/parakeets.gif', $second_subsite_id );
+
+		// Restore first subsite
+		switch_to_blog( $first_subsite_id );
+
+		$actual_is_allowed = is_valid_path_for_site( $file_path );
+
+		$this->assertEquals( $expected_is_allowed, $actual_is_allowed );
+	}
 }


### PR DESCRIPTION
In a multisite install, we support running mixed private and public sites. To harden our ACL endpoint and prevent accidentally leaking private files via public sites, we now restrict access to files on the same subsite.

So, `example.com` (main site) can access `example.com/wp-content/uploads/2021/02/donuts.jpg`. But it cannot access `example.com/wp-content/uploads/sites/2/2021/02/icecream.jpg` since that file is managed by Site ID 2.

Similarly, `example.com/en/` (subsite) can access `example.com/en/wp-content/uploads/sites/2/2021/02/icecream.jpg` but not `example.com/wp-content/uploads/2021/02/donuts.jpg`.

## Changelog Description

### Private Files: Prevent cross-site lookup

In a multisite install, we support running mixed private and public sites. To harden our ACL endpoint and prevent accidentally leaking private files via public sites, we now restrict access to files on the same subsite.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. `vip-init.sh` on mu-dev
2. `curl http://vip-go-dev.lndo.site/wp-content/mu-plugins/files/acl/endpoint-check-file-acl.php -H 'X-Original-Uri: /wp-content/uploads/fish.jpg' -I` <= should return 202
3. `lando wp core multisite-convert`
4. `lando wp site create --slug=test`
5. 4. `lando wp site create --slug=test2`
5. main site => self: `curl http://vip-go-dev.lndo.site/wp-content/mu-plugins/files/acl/endpoint-check-file-acl.php -H 'X-Original-Uri: /wp-content/uploads/fish.jpg' -I` <= returns 202
6. main site => subsite: `curl http://vip-go-dev.lndo.site/wp-content/mu-plugins/files/acl/endpoint-check-file-acl.php -H 'X-Original-Uri: /wp-content/uploads/sites/2/fish.jpg' -I` <= returns 403
7. sub site => self: `curl http://vip-go-dev.lndo.site/wp-content/mu-plugins/files/acl/endpoint-check-file-acl.php -H 'X-Original-Uri: /test/wp-content/uploads/sites/2/fish.jpg' -I` <= returns 202
8. sub site => main: `curl http://vip-go-dev.lndo.site/wp-content/mu-plugins/files/acl/endpoint-check-file-acl.php -H 'X-Original-Uri: /test/wp-content/uploads/fish.jpg' -I` <= returns 403
9. sub site => another subsite: `curl http://vip-go-dev.lndo.site/wp-content/mu-plugins/files/acl/endpoint-check-file-acl.php -H 'X-Original-Uri: /test2/wp-content/uploads/sites/3/fish.jpg' -I` <= returns 403
