### PR TITLE
Update/search skip validation if not indexed

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -10,9 +10,9 @@ use \WP_User_Query as WP_User_Query;
 use \WP_Error as WP_Error;
 
 class Health {
-	const CONTENT_VALIDATION_BATCH_SIZE = 500;
+	const CONTENT_VALIDATION_BATCH_SIZE    = 500;
 	const CONTENT_VALIDATION_MAX_DIFF_SIZE = 1000;
-	const DOCUMENT_IGNORED_KEYS = array(
+	const DOCUMENT_IGNORED_KEYS            = array(
 		// This field is proving problematic to reliably diff due to differences in the filters
 		// that run during normal indexing and this validator
 		'post_content_filtered',
@@ -31,45 +31,27 @@ class Health {
 	 * @access  public
 	 * @param array $query_args Valid WP_Query criteria, mandatory fields as in following example:
 	 * $query_args = [
-	 *		'post_type' => $post_type,
-	 *		'post_status' => array( $post_statuses )
+	 *      'post_type' => $post_type,
+	 *      'post_status' => array( $post_statuses )
 	 * ];
 	 *
 	 * @param mixed $indexable Instance of an ElasticPress Indexable Object to search on
 	 * @return WP_Error|array
 	 */
-	public static function validate_index_entity_count( array $query_args, \ElasticPress\Indexable $indexable ) {
+	public function validate_index_entity_count( array $query_args, \ElasticPress\Indexable $indexable ) {
+		$es_total = $this->get_index_entity_count_from_elastic_search( $query_args, $indexable );
+		if ( is_wp_error( $es_total ) ) {
+			return $es_total;
+		}
+
 		try {
 			// Get total count in DB
-			$result = $indexable->query_db( $query_args );
+			$db_result = $indexable->query_db( $query_args );
 
-			$db_total = (int) $result[ 'total_objects' ];
+			$db_total = (int) $db_result['total_objects'];
 		} catch ( \Exception $e ) {
 			return new WP_Error( 'db_query_error', sprintf( 'failure querying the DB: %s #vip-search', $e->get_error_message() ) );
 		}
-
-		// Get total count in ES index
-		try {
-			$query = self::query_objects( $query_args, $indexable->slug );
-			$formatted_args = $indexable->format_args( $query->query_vars, $query );
-
-			// Get exact total count since Elasticsearch default stops at 10,000.
-			$formatted_args['track_total_hits'] = true;
-
-			$es_result = $indexable->query_es( $formatted_args, $query->query_vars );
-		} catch ( \Exception $e ) {
-			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-search', $e->get_error_message() ) );
-		}
-
-		// There is not other useful information out of query_es(): it just returns false in case of failure.
-		// This may be due to different causes, e.g. index not existing or incorrect connection parameters.
-		if ( ! $es_result ) {
-			$es_total = 'N/A';
-			return new WP_Error( 'es_query_error', 'failure querying ES. #vip-search' );
-		}
-
-		// Verify actual results
-		$es_total = (int) $es_result['found_documents']['value'];
 
 		$diff = 0;
 		if ( $db_total !== $es_total ) {
@@ -77,12 +59,51 @@ class Health {
 		}
 
 		return [
-			'entity' => $indexable->slug,
-			'type' => ( array_key_exists( 'post_type', $query_args ) ? $query_args[ 'post_type' ] : 'N/A' ),
+			'entity'   => $indexable->slug,
+			'type'     => ( array_key_exists( 'post_type', $query_args ) ? $query_args['post_type'] : 'N/A' ),
 			'db_total' => $db_total,
 			'es_total' => $es_total,
-			'diff' => $diff,
+			'diff'     => $diff,
 		];
+	}
+
+	/**
+	 * Fetches the count of entities in ES index
+	 * Entities can be either posts or users.
+	 *
+	 * @since   1.0.0
+	 * @access  public
+	 * @param array $query_args Valid WP_Query criteria, mandatory fields as in following example:
+	 * $query_args = [
+	 *      'post_type' => $post_type,
+	 *      'post_status' => array( $post_statuses )
+	 * ];
+	 *
+	 * @param mixed $indexable Instance of an ElasticPress Indexable Object to search on
+	 * @return WP_Error|int
+	 */
+	public function get_index_entity_count_from_elastic_search( array $query_args, \ElasticPress\Indexable $indexable ) {
+		// Get total count in ES index
+		try {
+			$query          = self::query_objects( $query_args, $indexable->slug );
+			$formatted_args = $indexable->format_args( $query->query_vars, $query );
+
+			// Get exact total count since Elasticsearch default stops at 10,000.
+			$formatted_args['track_total_hits'] = true;
+
+			$es_result = $indexable->query_es( $formatted_args, $query->query_vars );
+		} catch ( \Exception $e ) {
+			$source = method_exists( $e, 'get_error_message' ) ? $e->get_error_message() : $e->getMessage();
+			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-search', $source ) );
+		}
+
+		// There is not other useful information out of query_es(): it just returns false in case of failure.
+		// This may be due to different causes, e.g. index not existing or incorrect connection parameters.
+		if ( ! $es_result ) {
+			return new WP_Error( 'es_query_error', 'failure querying ES. #vip-search' );
+		}
+
+		return (int) $es_result['found_documents']['value'];
 	}
 
 	/**
@@ -115,14 +136,14 @@ class Health {
 			'order' => 'asc',
 		];
 
-		$result = self::validate_index_entity_count( $query_args, $users );
+		$result = ( new self() )->validate_index_entity_count( $query_args, $users );
 
 		if ( is_wp_error( $result ) ) {
 			return new WP_Error( 'es_users_query_error', sprintf( 'failure retrieving users from ES: %s #vip-search', $result->get_error_message() ) );
 		}
 
 		$result['index_version'] = $index_version;
-	
+
 		$search->versioning->reset_current_version_number( $users );
 
 		return array( $result );
@@ -159,23 +180,24 @@ class Health {
 
 		$index_version = $search->versioning->get_current_version_number( $posts );
 
+		$health = new self();
 		foreach ( $post_types as $post_type ) {
 			$post_statuses = Indexables::factory()->get( 'post' )->get_indexable_post_status();
 
 			$query_args = [
-				'post_type' => $post_type,
+				'post_type'   => $post_type,
 				'post_status' => array_values( $post_statuses ),
 			];
 
-			$result = self::validate_index_entity_count( $query_args, $posts );
+			$result = $health->validate_index_entity_count( $query_args, $posts );
 
 			// In case of error skip to the next post type
 			// Not returning an error, otherwise there is no visibility on other post types
 			if ( is_wp_error( $result ) ) {
 				$result = [
-					'entity' => $posts->slug,
-					'type' => $post_type,
-					'error' => $result->get_error_message(),
+					'entity'        => $posts->slug,
+					'type'          => $post_type,
+					'error'         => $result->get_error_message(),
 					'index_version' => $index_version,
 				];
 			}
@@ -185,7 +207,7 @@ class Health {
 			$results[] = $result;
 
 		}
-			
+
 		$search->versioning->reset_current_version_number( $posts );
 
 		return $results;
@@ -248,7 +270,7 @@ class Health {
 			if ( $is_cli && ! $silent ) {
 				echo sprintf( 'Validating posts %d - %d', $start_post_id, $next_batch_post_id - 1 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
-			
+
 			$result = self::validate_index_posts_content_batch( $indexable, $start_post_id, $next_batch_post_id, $inspect );
 
 			if ( is_wp_error( $result ) ) {
@@ -270,7 +292,7 @@ class Health {
 				return $error;
 			}
 
-			$start_post_id += $batch_size; 
+			$start_post_id += $batch_size;
 
 			if ( $dynamic_last_post_id ) {
 				// Requery for the last post id after each batch b/c the site is probably growing
@@ -294,7 +316,7 @@ class Health {
 
 		$rows = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_type, post_status FROM $wpdb->posts WHERE ID >= %d AND ID < %d", $start_post_id, $next_batch_post_id ) );
 
-		$post_types = $indexable->get_indexable_post_types();
+		$post_types    = $indexable->get_indexable_post_types();
 		$post_statuses = $indexable->get_indexable_post_status();
 
 		// First we need to see identify which posts are actually expected in the index, by checking the same filters that
@@ -311,7 +333,7 @@ class Health {
 			return ! is_null( $document );
 		} );
 
-		$found_post_ids = wp_list_pluck( $expected_post_rows, 'ID' );
+		$found_post_ids     = wp_list_pluck( $expected_post_rows, 'ID' );
 		$found_document_ids = wp_list_pluck( $documents, 'ID' );
 
 		$diffs = $inspect ? self::get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids )
@@ -325,7 +347,7 @@ class Health {
 			                 : self::simplified_diff_document_and_prepared_document( $document, $prepared_document ); // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed
 
 			if ( $diff ) {
-				$key = self::get_post_key( $document['ID'] );
+				$key           = self::get_post_key( $document['ID'] );
 				$diffs[ $key ] = $inspect ? $diff
 				                          : self::simplified_format_post_diff( $document['ID'], 'inconsistent' ); // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed
 			}
@@ -343,7 +365,7 @@ class Health {
 		// If anything is missing from index, record it
 		if ( 0 < count( $missing_from_index ) ) {
 			foreach ( $missing_from_index as $post_id ) {
-				$key = self::get_post_key( $post_id );
+				$key           = self::get_post_key( $post_id );
 				$diffs[ $key ] = self::simplified_format_post_diff( $post_id, 'missing_from_index' );
 			}
 		}
@@ -354,7 +376,7 @@ class Health {
 		// If anything is in the index that shouldn't be, record it
 		if ( 0 < count( $extra_in_index ) ) {
 			foreach ( $extra_in_index as $document_id ) {
-				$key = self::get_post_key( $document_id );
+				$key           = self::get_post_key( $document_id );
 				$diffs[ $key ] = self::simplified_format_post_diff( $document_id, 'extra_in_index' );
 			}
 		}
@@ -364,17 +386,17 @@ class Health {
 
 	public static function get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids ) {
 		$diffs = [];
-	
+
 		// What's missing in ES?
 		$missing_from_index = array_diff( $found_post_ids, $found_document_ids );
 
 		// If anything is missing from index, record it
 		if ( 0 < count( $missing_from_index ) ) {
 			foreach ( $missing_from_index as $post_id ) {
-				$diffs[ 'post_' . $post_id ] = array( 
-					'existence' => array( 
+				$diffs[ 'post_' . $post_id ] = array(
+					'existence' => array(
 						'expected' => sprintf( 'Post %d to be indexed', $post_id ),
-						'actual' => null,
+						'actual'   => null,
 					),
 				);
 			}
@@ -386,11 +408,11 @@ class Health {
 		// If anything is in the index that shouldn't be, record it
 		if ( 0 < count( $extra_in_index ) ) {
 			foreach ( $extra_in_index as $document_id ) {
-				// Grab the actual doc from 
+				// Grab the actual doc from
 				$diffs[ 'post_' . $document_id ] = array(
-					'existence' => array( 
+					'existence' => array(
 						'expected' => null,
-						'actual' => sprintf( 'Post %d is currently indexed', $document_id ),
+						'actual'   => sprintf( 'Post %d is currently indexed', $document_id ),
 					),
 				);
 			}
@@ -404,7 +426,7 @@ class Health {
 			if ( ! in_array( $row->post_type, $post_types, true ) ) {
 				return false;
 			}
-			
+
 			if ( ! in_array( $row->post_status, $post_statuses, true ) ) {
 				return false;
 			}
@@ -425,7 +447,7 @@ class Health {
 
 			if ( is_array( $value ) ) {
 				$recursive_diff = self::simplified_diff_document_and_prepared_document( $document[ $key ], $prepared_document[ $key ] );
-			} else if ( $prepared_document[ $key ] != $document[ $key ] ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
+			} elseif ( $prepared_document[ $key ] != $document[ $key ] ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
 				return true;
 			}
 		}
@@ -447,10 +469,10 @@ class Health {
 				if ( ! empty( $recursive_diff ) ) {
 					$diff[ $key ] = $recursive_diff;
 				}
-			} else if ( $prepared_document[ $key ] != $document[ $key ] ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
+			} elseif ( $prepared_document[ $key ] != $document[ $key ] ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
 				$diff[ $key ] = array(
 					'expected' => $prepared_document[ $key ],
-					'actual' => $document[ $key ],
+					'actual'   => $document[ $key ],
 				);
 			}
 		}
@@ -504,8 +526,8 @@ class Health {
 	 * @access  private
 	 * @param array $query_args Valid WP_Query criteria, mandatory fields as in following example:
 	 * $query_args = [
-	 *		'post_type' => $post_type,
-	 *		'post_status' => array( $post_statuses )
+	 *      'post_type' => $post_type,
+	 *      'post_status' => array( $post_statuses )
 	 * ];
 	 *
 	 * @param string $type Type (Slug) of the objects to be searched (should be either 'user' or 'post')
@@ -520,8 +542,8 @@ class Health {
 
 	private static function simplified_format_post_diff( $id, $issue ) {
 		return array(
-			'id' => $id,
-			'type' => 'post',
+			'id'    => $id,
+			'type'  => 'post',
 			'issue' => $issue,
 		);
 	}

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -152,6 +152,11 @@ class HealthJob {
 		}
 
 		foreach ( $results as $result ) {
+			if ( array_key_exists( 'skipped', $result ) && $result['skipped'] ) {
+				// We don't want to alert for skipped indexes
+				continue;
+			}
+
 			// If there's an error, alert
 			if ( array_key_exists( 'error', $result ) ) {
 				$message = sprintf( 'Error while validating index for %s: %s', home_url(), $result['error'] );

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/../class-health.php';
 class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
 	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
+	private const INFO_ICON = "\u{1F7E7}"; // unicode info mark
 
 	public function __construct() {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -123,7 +124,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 				switch_to_blog( $site['blog_id'] );
 
 				$this->validate_indexable_count_for_site( $indexable_slug, $version );
-				
+
 				restore_current_blog();
 			}
 		} else {
@@ -200,15 +201,22 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 				continue;
 			}
 
-			$message = ' inconsistencies found';  
-			if ( $result['diff'] ) {
-				$icon = self::FAILURE_ICON;
+			$identification = sprintf( 'entity: %s, type: %s, index_version: %d', $result['entity'], $result['type'], $result['index_version'] );
+
+			if ( $result['skipped'] ) {
+				$message = sprintf( '%s skipping, because there are no documents in ES when ounting %s', self::INFO_ICON, $identification );
 			} else {
-				$icon = self::SUCCESS_ICON;
-				$message = 'no' . $message;
+				$message = ' inconsistencies found';
+				if ( $result['diff'] ) {
+					$icon = self::FAILURE_ICON;
+				} else {
+					$icon = self::SUCCESS_ICON;
+					$message = 'no' . $message;
+				}
+
+				$message = sprintf( '%s %s when counting %s - (DB: %s, ES: %s, Diff: %s)', $icon, $message, $identification, $result['db_total'], $result['es_total'], $result['diff'] );
 			}
 
-			$message = sprintf( '%s %s when counting entity: %s, type: %s, index_version: %d - (DB: %s, ES: %s, Diff: %s)', $icon, $message, $result['entity'], $result['type'], $result['index_version'], $result['db_total'], $result['es_total'], $result['diff'] );
 			WP_CLI::line( $message );
 		}
 	}
@@ -226,7 +234,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * ---
 	 * default: 1
 	 * ---
-	 * 
+	 *
 	 * [--last_post_id=<int>]
 	 * : Optional last post id to check
 	 *
@@ -256,12 +264,12 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *     wp vip-search health validate-contents
-	 * 
+	 *
 	 * @subcommand validate-contents
 	 */
 	public function validate_contents( $args, $assoc_args ) {
 		$results = \Automattic\VIP\Search\Health::validate_index_posts_content( $assoc_args['start_post_id'], $assoc_args['last_post_id'], $assoc_args['batch_size'], $assoc_args['max_diff_size'], isset( $assoc_args['silent'] ), isset( $assoc_args['inspect'] ), isset( $assoc_args['do-not-heal'] ) );
-		
+
 		if ( is_wp_error( $results ) ) {
 			$diff = $results->get_error_data( 'diff' );
 
@@ -319,7 +327,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		}
 
 		if ( ! empty( $truncate_msg ) && ! $silent ) {
-			WP_CLI::warning( $truncate_msg ); 
+			WP_CLI::warning( $truncate_msg );
 		}
 	}
 

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -204,7 +204,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 			$identification = sprintf( 'entity: %s, type: %s, index_version: %d', $result['entity'], $result['type'], $result['index_version'] );
 
 			if ( $result['skipped'] ) {
-				$message = sprintf( '%s skipping, because there are no documents in ES when ounting %s', self::INFO_ICON, $identification );
+				$message = sprintf( '%s skipping, because there are no documents in ES when counting %s', self::INFO_ICON, $identification );
 			} else {
 				$message = ' inconsistencies found';
 				if ( $result['diff'] ) {

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -9,7 +9,7 @@ class Health_Test extends \WP_UnitTestCase {
 	}
 
 	public function test_get_missing_docs_or_posts_diff() {
-		$found_post_ids = array( 1, 3, 5 );
+		$found_post_ids     = array( 1, 3, 5 );
 		$found_document_ids = array( 1, 3, 7 );
 
 		$diff = \Automattic\VIP\Search\Health::get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids );
@@ -18,13 +18,13 @@ class Health_Test extends \WP_UnitTestCase {
 			'post_5' => array(
 				'existence' => array(
 					'expected' => sprintf( 'Post %d to be indexed', 5 ),
-					'actual' => null,
+					'actual'   => null,
 				),
 			),
 			'post_7' => array(
 				'existence' => array(
 					'expected' => null,
-					'actual' => sprintf( 'Post %d is currently indexed', 7 ),
+					'actual'   => sprintf( 'Post %d is currently indexed', 7 ),
 				),
 			),
 		);
@@ -36,45 +36,45 @@ class Health_Test extends \WP_UnitTestCase {
 		add_filter( 'ep_post_sync_kill', function( $skip, $post_id ) {
 			return 2 === $post_id;
 		}, 10, 2 );
-	
+
 		$rows = array(
 			// Indexed
 			(object) array(
-				'ID' => 1,
-				'post_type' => 'post',
+				'ID'          => 1,
+				'post_type'   => 'post',
 				'post_status' => 'publish',
 			),
 
 			// Filtered out by ep_post_sync_kill
 			(object) array(
-				'ID' => 2,
-				'post_type' => 'post',
+				'ID'          => 2,
+				'post_type'   => 'post',
 				'post_status' => 'publish',
 			),
 
 			// Un-indexed post_type
 			(object) array(
-				'ID' => 3,
-				'post_type' => 'unindexed',
+				'ID'          => 3,
+				'post_type'   => 'unindexed',
 				'post_status' => 'publish',
 			),
 
 			// Un-indexed post_status
 			(object) array(
-				'ID' => 4,
-				'post_type' => 'post',
+				'ID'          => 4,
+				'post_type'   => 'post',
 				'post_status' => 'unindexed',
 			),
 
 			// Indexed
 			(object) array(
-				'ID' => 5,
-				'post_type' => 'post',
+				'ID'          => 5,
+				'post_type'   => 'post',
 				'post_status' => 'publish',
 			),
 		);
 
-		$indexed_post_types = array( 'post' );
+		$indexed_post_types    = array( 'post' );
 		$indexed_post_statuses = array( 'publish' );
 
 		$filtered = \Automattic\VIP\Search\Health::filter_expected_post_rows( $rows, $indexed_post_types, $indexed_post_statuses );
@@ -105,7 +105,7 @@ class Health_Test extends \WP_UnitTestCase {
 				array(
 					'post_title' => array(
 						'expected' => 'foo',
-						'actual' => 'bar',
+						'actual'   => 'bar',
 					),
 				),
 			),
@@ -115,11 +115,11 @@ class Health_Test extends \WP_UnitTestCase {
 				// Expected
 				array(
 					'post_title' => 'foo',
-					'meta' => array(
+					'meta'       => array(
 						'somemeta' => array(
-							'raw' => 'somemeta_raw',
+							'raw'   => 'somemeta_raw',
 							'value' => 'somemeta_value',
-							'date' => '1970-01-01',
+							'date'  => '1970-01-01',
 						),
 					),
 				),
@@ -127,11 +127,11 @@ class Health_Test extends \WP_UnitTestCase {
 				// Indexed
 				array(
 					'post_title' => 'bar',
-					'meta' => array(
+					'meta'       => array(
 						'somemeta' => array(
-							'raw' => 'somemeta_raw_other',
+							'raw'   => 'somemeta_raw_other',
 							'value' => 'somemeta_value_other',
-							'date' => '1970-12-31', // Should not be validated
+							'date'  => '1970-12-31', // Should not be validated
 						),
 					),
 				),
@@ -140,17 +140,17 @@ class Health_Test extends \WP_UnitTestCase {
 				array(
 					'post_title' => array(
 						'expected' => 'foo',
-						'actual' => 'bar',
+						'actual'   => 'bar',
 					),
-					'meta' => array(
+					'meta'       => array(
 						'somemeta' => array(
-							'raw' => array(
+							'raw'   => array(
 								'expected' => 'somemeta_raw',
-								'actual' => 'somemeta_raw_other',
+								'actual'   => 'somemeta_raw_other',
 							),
 							'value' => array(
 								'expected' => 'somemeta_value',
-								'actual' => 'somemeta_value_other',
+								'actual'   => 'somemeta_value_other',
 							),
 						),
 					),
@@ -201,20 +201,20 @@ class Health_Test extends \WP_UnitTestCase {
 	}
 
 	public function test_simplified_get_missing_docs_or_posts_diff() {
-		$found_post_ids = array( 1, 3, 5 );
+		$found_post_ids     = array( 1, 3, 5 );
 		$found_document_ids = array( 1, 3, 7 );
 
 		$diff = \Automattic\VIP\Search\Health::simplified_get_missing_docs_or_posts_diff( $found_post_ids, $found_document_ids );
 
 		$expected_diff = array(
 			'post_5' => array(
-				'type' => 'post',
-				'id' => 5,
+				'type'  => 'post',
+				'id'    => 5,
 				'issue' => 'missing_from_index',
 			),
 			'post_7' => array(
-				'type' => 'post',
-				'id' => 7,
+				'type'  => 'post',
+				'id'    => 7,
 				'issue' => 'extra_in_index',
 			),
 		);
@@ -245,11 +245,11 @@ class Health_Test extends \WP_UnitTestCase {
 				// Expected
 				array(
 					'post_title' => 'foo',
-					'meta' => array(
+					'meta'       => array(
 						'somemeta' => array(
-							'raw' => 'somemeta_raw',
+							'raw'   => 'somemeta_raw',
 							'value' => 'somemeta_value',
-							'date' => '1970-01-01',
+							'date'  => '1970-01-01',
 						),
 					),
 				),
@@ -257,11 +257,11 @@ class Health_Test extends \WP_UnitTestCase {
 				// Indexed
 				array(
 					'post_title' => 'bar',
-					'meta' => array(
+					'meta'       => array(
 						'somemeta' => array(
-							'raw' => 'somemeta_raw_other',
+							'raw'   => 'somemeta_raw_other',
 							'value' => 'somemeta_value_other',
-							'date' => '1970-12-31', // Should not be validated
+							'date'  => '1970-12-31', // Should not be validated
 						),
 					),
 				),
@@ -297,5 +297,83 @@ class Health_Test extends \WP_UnitTestCase {
 
 		// Should be false since there are no inconsitencies in the test data
 		$this->assertEquals( $diff, $expected_diff );
+	}
+
+	public function test_get_index_entity_count_from_elastic_search__returns_result() {
+		$health         = new \Automattic\VIP\Search\Health();
+		$expected_count = 42;
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping' ] )
+			->getMock();
+
+		$mocked_indexable->slug = 'foo';
+
+		$mocked_indexable->method( 'query_es' )
+			->willReturn( [
+				'found_documents' => [
+					'value' => $expected_count,
+				],
+			] );
+
+		$result = $health->get_index_entity_count_from_elastic_search( [], $mocked_indexable );
+
+		$this->assertEquals( $result, $expected_count );
+	}
+
+	public function test_get_index_entity_count_from_elastic_search__exception() {
+		$health = new \Automattic\VIP\Search\Health();
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping' ] )
+			->getMock();
+
+		$mocked_indexable->slug = 'foo';
+
+		$mocked_indexable->method( 'query_es' )
+			->willThrowException( new \Exception() );
+
+		$result = $health->get_index_entity_count_from_elastic_search( [], $mocked_indexable );
+
+		$this->assertTrue( is_wp_error( $result ) );
+	}
+
+	public function test_get_index_entity_count_from_elastic_search__failed_query() {
+		$health = new \Automattic\VIP\Search\Health();
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping' ] )
+			->getMock();
+
+		$mocked_indexable->slug = 'foo';
+
+		$mocked_indexable->method( 'query_es' )
+			->willReturn( false );
+
+		$result = $health->get_index_entity_count_from_elastic_search( [], $mocked_indexable );
+
+		$this->assertTrue( is_wp_error( $result ) );
+	}
+
+	public function test_validate_index_entity_count__failed_ES_should_pass_error() {
+		$error = new \WP_Error( 'test error' );
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping' ] )
+			->getMock();
+
+		$mocked_indexable->slug = 'foo';
+
+
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'get_index_entity_count_from_elastic_search' ] )
+			->getMock();
+
+		$patrtially_mocked_health->method( 'get_index_entity_count_from_elastic_search' )
+			->willReturn( $error );
+
+		$result = $patrtially_mocked_health->validate_index_entity_count( [], $mocked_indexable );
+
+		$this->assertEquals( $result, $error );
 	}
 }

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -376,4 +376,66 @@ class Health_Test extends \WP_UnitTestCase {
 
 		$this->assertEquals( $result, $error );
 	}
+
+	public function test_validate_index_entity_count__returns_all_data() {
+		$expected_result = [
+			'entity'   => 'foo',
+			'type'     => 'N/A',
+			'db_total' => 10,
+			'es_total' => 8,
+			'diff'     => -2,
+			'skipped'  => false,
+		];
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping' ] )
+			->getMock();
+
+		$mocked_indexable->slug = $expected_result['entity'];
+		$mocked_indexable->method( 'query_db' )
+			->willReturn( [
+				'total_objects' => $expected_result['db_total'],
+			] );
+
+
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'get_index_entity_count_from_elastic_search' ] )
+			->getMock();
+
+		$patrtially_mocked_health->method( 'get_index_entity_count_from_elastic_search' )
+			->willReturn( $expected_result['es_total'] );
+
+		$result = $patrtially_mocked_health->validate_index_entity_count( [], $mocked_indexable );
+
+		$this->assertEquals( $result, $expected_result );
+	}
+
+	public function test_validate_index_entity_count__skipping_non_initialized_indexes() {
+		$expected_result = [
+			'entity'   => 'foo',
+			'type'     => 'N/A',
+			'db_total' => 'N/A',
+			'es_total' => 0,
+			'diff'     => 'N/A',
+			'skipped'  => true,
+		];
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping' ] )
+			->getMock();
+
+		$mocked_indexable->slug = $expected_result['entity'];
+
+
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'get_index_entity_count_from_elastic_search' ] )
+			->getMock();
+
+		$patrtially_mocked_health->method( 'get_index_entity_count_from_elastic_search' )
+			->willReturn( $expected_result['es_total'] );
+
+		$result = $patrtially_mocked_health->validate_index_entity_count( [], $mocked_indexable );
+
+		$this->assertEquals( $result, $expected_result );
+	}
 }


### PR DESCRIPTION
## Description

## Changelog Description

### Plugin Updated: Search

This change skips count validation on indexes that have no documents - these are assumed uninitialized. This results in a special line in the CLI initiated report:
```
$ wp vip-search health validate-counts
Validating post count

✅ no inconsistencies found when counting entity: post, type: post, index_version: 2 - (DB: 5, ES: 5, Diff: 0)
✅ no inconsistencies found when counting entity: post, type: page, index_version: 2 - (DB: 1, ES: 1, Diff: 0)
🟧 skipping, because there are no documents in ES when counting entity: post, type: post, index_version: 3
🟧 skipping, because there are no documents in ES when counting entity: post, type: page, index_version: 3

Validating user count

✅ no inconsistencies found when counting entity: user, type: N/A, index_version: 1 - (DB: 3, ES: 3, Diff: 0)
✅ no inconsistencies found when counting entity: user, type: N/A, index_version: 2 - (DB: 3, ES: 3, Diff: 0)
```

Also, the health cron job will not report mismatches for indexes with 0 documents.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
1. (Optional) Add new empty version -  `wp vip-search index-versions add post`
1. wp vip-search health validate-counts
1. See the new version reported as skipped.