### PR TITLE
Activate notoptions corruption detection + mitigation by requiring file

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -163,6 +163,7 @@ require_once( __DIR__ . '/000-debug/0-load.php' );
 require_once( __DIR__ . '/lib/utils/class-alerts.php' );
 
 // Load our development and environment helpers
+require_once( __DIR__ . '/vip-helpers/vip-notoptions-mitigation.php' );
 require_once( __DIR__ . '/vip-helpers/vip-utils.php' );
 require_once( __DIR__ . '/vip-helpers/vip-newrelic.php' );
 require_once( __DIR__ . '/vip-helpers/vip-caching.php' );


### PR DESCRIPTION
## Description

The detection and mitigation code is already committed, now we need to activate it now by requiring the file.

See https://github.com/Automattic/vip-go-mu-plugins/pull/1970/

## Changelog Description

### Options: Activate notoptions error detection and mitigation code

Activated the already-deployed code to detect and mitigate problems with the notoptions cache.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Try regular requests with valid notoptions - should see normal behavior
2. Purposefully pollute the notoptions cache with invalid data (via `wp shell`):
```
$notoptions = wp_cache_get( 'notoptions', 'options' );
$notoptions['somekey'] = 'anystring';
wp_cache_set( 'notoptions', $notoptions, 'options' );
```
3. Run a CLI command (to trigger the detection code): `wp option get home`
4. Check the value of the notoptions cache - the `somekey` invalid data should be removed - `wp cache get notoptions options`