### PR TITLE
Private Files: PURGE attachment URLs on post update

### DIFF
--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -39,6 +39,8 @@ function maybe_load_restrictions() {
 		require_once( __DIR__ . '/restrict-unpublished-files.php' );
 
 		add_filter( 'vip_files_acl_file_visibility', __NAMESPACE__ . '\Restrict_Unpublished_Files\check_file_visibility', 10, 2 );
+		// Purge attachments for posts for better cacheability
+		add_filter( 'wpcom_vip_cache_purge_urls', __NAMESPACE__ . '\Restrict_Unpublished_Files\purge_attachments_for_post', 10, 2 );
 	}
 }
 

--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -131,7 +131,7 @@ function purge_attachments_for_post( $urls, $post_id ) {
 		'orderby' => 'ID', // For performance (instead of `date` as default)
 		'order' => 'ASC',
 		'fields' => 'ids',
-		'suppress_filters' => false,
+		'suppress_filters' => true,
 	] );
 
 	if ( empty( $attachment_ids ) ) {

--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -127,10 +127,11 @@ function purge_attachments_for_post( $urls, $post_id ) {
 	$attachment_ids = get_posts( [
 		'post_parent'    => $post->ID,
 		'post_type'      => 'attachment',
-		'posts_per_page' => 250, // Set a reasonably high limit (instead of -1 as default)
-		'orderby' => 'ID', // For performance (instead of `date` as default)
-		'order' => 'ASC',
-		'fields' => 'ids',
+		'posts_per_page' => 250,            // Set a reasonably high limit (instead of -1 as default)
+		'orderby'        => 'ID',           // For performance (instead of `date` as default)
+		'order'          => 'ASC',
+		'fields'         => 'ids',
+		// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFiltersTrue
 		'suppress_filters' => true,
 	] );
 

--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -127,7 +127,7 @@ function purge_attachments_for_post( $urls, $post_id ) {
 	$attachment_ids = get_posts( [
 		'post_parent'    => $post->ID,
 		'post_type'      => 'attachment',
-		'posts_per_page' => 100, // Set a reasonably high limit (instead of -1 as default)
+		'posts_per_page' => 250, // Set a reasonably high limit (instead of -1 as default)
 		'orderby' => 'ID', // For performance (instead of `date` as default)
 		'order' => 'ASC',
 		'fields' => 'ids',

--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -120,13 +120,13 @@ function get_attachment_id_from_file_path( $path ) {
 function purge_attachments_for_post( $urls, $post_id ) {
 	$post = get_post( $post_id );
 
-    if ( empty( $post ) ) {
-        return $urls;
+	if ( empty( $post ) ) {
+		return $urls;
 	}
 
 	$attachment_ids = get_posts( [
-        'post_parent'    => $post->ID,
-        'post_type'      => 'attachment',
+		'post_parent'    => $post->ID,
+		'post_type'      => 'attachment',
 		'posts_per_page' => 100, // Set a reasonably high limit (instead of -1 as default)
 		'orderby' => 'ID', // For performance (instead of `date` as default)
 		'order' => 'ASC',
@@ -142,5 +142,5 @@ function purge_attachments_for_post( $urls, $post_id ) {
 		$urls[] = wp_get_attachment_url( $attachment_id );
 	}
 
-    return $urls;
+	return $urls;
 }

--- a/tests/files/acl/test-acl.php
+++ b/tests/files/acl/test-acl.php
@@ -40,7 +40,8 @@ class VIP_Files_Acl_Test extends \WP_UnitTestCase {
 
 		maybe_load_restrictions();
 
-		$this->assertEquals( 10, has_filter( 'vip_files_acl_file_visibility', 'Automattic\VIP\Files\Acl\Restrict_All_Files\check_file_visibility' ), 'File visibility filter has no callbacks attached' );
+		$this->assertTrue( function_exists( 'Automattic\VIP\Files\Acl\Restrict_All_Files\check_file_visibility' ), 'Restrict_All_Files\check_file_visibility() is not defined; restrict-all-files.php may not have been require-d correctly' );
+		$this->assertEquals( 10, has_filter( 'vip_files_acl_file_visibility', 'Automattic\VIP\Files\Acl\Restrict_All_Files\check_file_visibility' ), 'vip_files_acl_file_visibility filter does not have the correct callback attached' );
 	}
 
 	/**
@@ -53,7 +54,9 @@ class VIP_Files_Acl_Test extends \WP_UnitTestCase {
 
 		maybe_load_restrictions();
 
-		$this->assertEquals( 10, has_filter( 'vip_files_acl_file_visibility', 'Automattic\VIP\Files\Acl\Restrict_Unpublished_Files\check_file_visibility' ), 'File visibility filter has no callbacks attached' );
+		$this->assertTrue( function_exists( 'Automattic\VIP\Files\Acl\Restrict_Unpublished_Files\check_file_visibility' ), 'Restrict_Unpublished_Files\check_file_visibility() is not defined; restrict-unpublished-files.php may not have been require-d correctly' );
+		$this->assertEquals( 10, has_filter( 'vip_files_acl_file_visibility', 'Automattic\VIP\Files\Acl\Restrict_Unpublished_Files\check_file_visibility' ), 'vip_files_acl_file_visibility filter does not have correct callback attached' );
+		$this->assertEquals( 10, has_filter( 'wpcom_vip_cache_purge_urls', 'Automattic\VIP\Files\Acl\Restrict_Unpublished_Files\purge_attachments_for_post' ), 'wpcom_vip_cache_purge_urls filter does not have correct callback attached' );
 	}
 
 	/**

--- a/tests/files/acl/test-restrict-unpublished-files.php
+++ b/tests/files/acl/test-restrict-unpublished-files.php
@@ -222,5 +222,62 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends \WP_UnitTestCase {
 	private function strip_wpcontent_uploads( $path ) {
 		return substr( $path, strlen( '/wp-content/uploads/' ) );
 	}
+
+	public function test__purge_attachments_for_post__invalid_post() {
+		// Input and output are the same; no change
+		$input_urls = [
+			'https://example.com',
+		];
+		$expected_urls = [
+			'https://example.com',
+		];
+
+		// Set a highly unlikely post ID
+		$test_post_id = PHP_INT_MAX;
+
+		$actual_urls = purge_attachments_for_post( $input_urls, $test_post_id );
+
+		$this->assertEquals( $expected_urls, $actual_urls );
+	}
+
+	public function test__purge_attachments_for_post__post_with_no_attachments() {
+		// Input and output are the same; no change
+		$input_urls = [
+			'https://example.com',
+		];
+		$expected_urls = [
+			'https://example.com',
+		];
+
+		// No attachments for post
+		$test_post_id = $this->factory->post->create();
+
+		$actual_urls = purge_attachments_for_post( $input_urls, $test_post_id );
+
+		$this->assertEquals( $expected_urls, $actual_urls );
+	}
+
+	public function test__purge_attachments_for_post__post_with_some_attachments() {
+		$input_urls = [
+			'https://example.com',
+		];
+
+		$test_post_id = $this->factory->post->create();
+		$attachment_id_1 = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
+		$attachment_id_2 = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
+		$attachment_id_3 = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
+
+		// Output should include new attachment URLs
+		$expected_urls = [
+			'https://example.com',
+			wp_get_attachment_url( $attachment_id_1 ),
+			wp_get_attachment_url( $attachment_id_2 ),
+			wp_get_attachment_url( $attachment_id_3 ),
+		];
+
+		$actual_urls = purge_attachments_for_post( $input_urls, $test_post_id );
+
+		$this->assertEquals( $expected_urls, $actual_urls );
+	}
 }
 


### PR DESCRIPTION
When a post is updated, we should purge all children attachments. This allows us to propagate changes more quickly to the edges, and also allows us to cache public files for much longer which has performance benefits.

## Changelog Description

### Private Files: Purge cache for attachments

When the Restrict Unpublished Files module is enabled, a post update will now automatically purge the URLs for any child attachments for that post. This allows us to quickly propagate visibility changes and also cache public files for much longer, which has several performance benefits.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Check out PR.
1. Add constant: `define( 'VIP_FILES_ACL_ENABLED', true );
1. `wp option set vip_files_acl_restrict_unpublished_enabled 1`
1. Create a post with attachments. Any updates to the post should add attachments to the purge list.