### PR TITLE
Prevent invalid core query args

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -118,3 +118,25 @@ add_filter(
 	20,
 	2
 );
+
+/**
+ * Prevent invalid query args from causing php errors & a limitless query.
+ *
+ * This patch can be removed when the following core ticket is resolved:
+ * @see https://core.trac.wordpress.org/ticket/17737
+ */
+function vip_prevent_invalid_core_query_args() {
+	if ( is_admin() ) {
+		return;
+	}
+
+	if ( isset( $_GET['name'] ) && ! is_string( $_GET['name'] ) ) {
+		unset( $_GET['name'] );
+	}
+
+	if ( isset( $_GET['pagename'] ) && ! is_string( $_GET['pagename'] ) ) {
+		unset( $_GET['pagename'] );
+	}
+}
+
+add_action( 'wp_loaded', 'vip_prevent_invalid_core_query_args', 1 );


### PR DESCRIPTION
## Description

Passing a query string like this will cause the below php error: `http://vip-go-dev.lndo.site/?name[]=test`

> PHP Warning:  trim() expects parameter 1 to be string, array given in /app/wp/wp-includes/class-wp-query.php on line 779

Furthermore, because WP then interprets these as single post or single page queries - it will end up with a main query that looks like this - which is notably limitless:

```
SELECT wp_posts.*
FROM wp_posts
WHERE 1=1
AND wp_posts.post_type = 'post'
ORDER BY wp_posts.post_date DESC
```

With the intention being that it would also have a `AND wp_posts.post_name = 'test'` clause  if you visited `http://vip-go-dev.lndo.site/?name[]=test` for example - but this is left out when a non-string is passed.

## Changelog Description

### Bug Fix: Prevent invalid query args from causing php errors & a limitless query

Passing a query string like `http://vip-go-dev.lndo.site/?name[]=test` will cause the below php error:

`PHP Warning:  trim() expects parameter 1 to be string, array given in /app/wp/wp-includes/class-wp-query.php on line 779`

Because WordPress interprets these sorts of query strings as single post or single page queries - it will end up with a main query that looks like the SQL query below - which is notably limitless:

```
SELECT wp_posts.*
FROM wp_posts
WHERE 1=1
AND wp_posts.post_type = 'post'
ORDER BY wp_posts.post_date DESC
```

This is a stopgap while awaiting the resolution of the following core ticket: 

https://core.trac.wordpress.org/ticket/17737

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Visit `http://vip-go-dev.lndo.site/?name[]=test` on test site. Note the php error and limitless query.
2. Apply patch, and test again.

While applicable in the admin on `edit.php`, I decided to leave this out from there in order to not interfere with perhaps other custom admin page logic.