### PR TITLE
Search: Add index allocation settings for datacenter

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1588,6 +1588,18 @@ class Search {
 		return array_merge( $keys, $vip_search_allow_list_keys );
 	}
 
+	public function get_origin_dc_from_es_host( $host ) {
+		$dc = null;
+
+		$matches = array();
+
+		if ( preg_match( '/^es-ha[-.](.*)\.vipv2\.net$/', $host, $matches ) ) {
+			$dc = $matches[ 1 ];
+		}
+
+		return strtolower( $dc );
+	}
+
 	/**
 	 * Since we've established that enabling the protected content feature causes attachments
 	 * to be indexed, we should ensure that 'attachment' is in the indexable post types if

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1588,6 +1588,10 @@ class Search {
 		return array_merge( $keys, $vip_search_allow_list_keys );
 	}
 
+	public function get_index_routing_allocation_include_dc() {
+		return defined( 'VIP_ORIGIN_DATACENTER' ) ? VIP_ORIGIN_DATACENTER : $this->get_origin_dc_from_es_host( $this->get_current_host() );
+	}
+
 	public function get_origin_dc_from_es_host( $host ) {
 		$dc = null;
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1600,7 +1600,7 @@ class Search {
 	 * Note that this hook receives the mapping and settings together
 	 */
 	public function filter__ep_indexable_mapping( $mapping ) {
-		if ( ! isset( $mapping[ 'settings' ] ) ) {
+		if ( ! isset( $mapping['settings'] ) ) {
 			return $mapping;
 		}
 
@@ -1624,7 +1624,7 @@ class Search {
 		$matches = array();
 
 		if ( preg_match( '/^es-ha[-.](.*)\.vipv2\.net$/', $host, $matches ) ) {
-			$dc = $matches[ 1 ];
+			$dc = $matches[1];
 		}
 
 		return strtolower( $dc );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -435,6 +435,12 @@ class Search {
 		// Override value of ep_prepare_meta_allowed_protected_keys with the value of vip_search_post_meta_allow_list
 		add_filter( 'ep_prepare_meta_allowed_protected_keys', array( $this, 'filter__ep_prepare_meta_allowed_protected_keys' ), PHP_INT_MAX, 2 );
 
+		// Alter the default index mapping/settings for each indexable type (primarily to add index allocation settings)
+		// NOTE - if new indexables are added, they need to be added here. EP doesn't currently have a generic ep_mapping type filter
+		add_filter( 'ep_post_mapping', array( $this, 'filter__ep_indexable_mapping' ) );
+		add_filter( 'ep_term_mapping', array( $this, 'filter__ep_indexable_mapping' ) );
+		add_filter( 'ep_user_mapping', array( $this, 'filter__ep_indexable_mapping' ) );
+
 		// Do not show the above compat notice since VIP Search will support whatever Elasticsearch version we're running
 		add_filter( 'pre_option_ep_hide_es_above_compat_notice', '__return_true' );
 
@@ -1586,6 +1592,26 @@ class Search {
 		$vip_search_allow_list_keys = $this->get_post_meta_allow_list( $post );
 
 		return array_merge( $keys, $vip_search_allow_list_keys );
+	}
+
+	/**
+	 * Hooks into the ep_$indexable_mapping hooks to add things like allocation rules
+	 * 
+	 * Note that this hook receives the mapping and settings together
+	 */
+	public function filter__ep_indexable_mapping( $mapping ) {
+		if ( ! isset( $mapping[ 'settings' ] ) ) {
+			return $mapping;
+		}
+
+		$origin_datacenter = $this->get_index_routing_allocation_include_dc();
+
+		if ( $origin_datacenter ) {
+			// We want all indexes to live in the site's origin datacenter
+			$mapping['settings']['index.routing.allocation.include.dc'] = $origin_datacenter;
+		}
+
+		return $mapping;
 	}
 
 	public function get_index_routing_allocation_include_dc() {

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1641,6 +1641,35 @@ class Search_Test extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__get_index_routing_allocation_include_dc_from_constant() {
+		define( 'VIP_ORIGIN_DATACENTER', 'foo' );
+
+		$this->search_instance->init();
+
+		$origin_dc = $this->search_instance->get_index_routing_allocation_include_dc();
+
+		$this->assertEquals( 'foo', $origin_dc );
+	}
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__get_index_routing_allocation_include_dc_from_endpoints() {
+		define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
+			'https://es-ha.bar.baz.com:1234',
+		) );
+
+		$this->search_instance->init();
+
+		$origin_dc = $this->search_instance->get_index_routing_allocation_include_dc();
+
+		$this->assertEquals( 'bar', $origin_dc );
+	}
+	
 	public function get_origin_dc_from_es_host_data() {
 		return array(
 			array(

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -1641,6 +1641,38 @@ class Search_Test extends \WP_UnitTestCase {
 		);
 	}
 
+	public function get_origin_dc_from_es_host_data() {
+		return array(
+			array(
+				'https://es-ha-bur.vipv2.net:1234',
+				'bur',
+			),
+			array(
+				'https://es-ha-dca.vipv2.net:4321',
+				'dca',
+			),
+			array(
+				'https://es-ha-DCA.vipv2.net:4321',
+				'dca',
+			),
+			array(
+				'https://es-ha.dfw.vipv2.net:4321',
+				'dfw',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_origin_dc_from_es_host_data
+	 */
+	public function test__get_origin_dc_from_es_host( $host, $expected ) {
+		$this->search_instance->init();
+
+		$origin_dc = $this->search_instance->get_origin_dc_from_es_host( $host );
+
+		$this->assertEquals( $expected, $origin_dc );
+	}
+
 	public function get_post_meta_allow_list__combinations_for_jetpack_migration_data() {
 		return [
 			[


### PR DESCRIPTION
## Description

This sets the allocation settings of all VIP Search indexes so that they are allocated in the site's origin datacenter, instead of spread throughout the cluster.

NOTE - the tests will be broken until https://github.com/Automattic/ElasticPress/pull/79 is merged into mu-plugins

This needs a coordinated rollout as there is another config change at the cluster level that needs to happen.

## Changelog Description

### Update: Allocate Search indexes in site's origin datacenter

Rather than allowing index shards to be distributed around the cluster, this change ensures that indexes are placed in a site's origin datacenter to be closer to the web containers.

This will only affect new indexes at first - existing indexes will be modified at a later time.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Check out PR
2. Define the site origin dc constant in your vip-config.php - `define( 'VIP_ORIGIN_DATACENTER', 'dfw' );`
2. Recreate the indexable mappings - note that this will delete your indexes too! `wp vip-search put-mapping`
3. Check the index settings - this can be done via direct request to Elasticsearch, like `curl http://localhost:19200/vip-200508-post-1/_settings | jq`
4. The settings should now contain `index.routing.allocation.include.dc=dfw`