### PR TITLE
Update ElasticPress to latest

### DIFF
--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -304,7 +304,7 @@ class Health_Test extends \WP_UnitTestCase {
 		$expected_count = 42;
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping' ] )
+			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
 			->getMock();
 
 		$mocked_indexable->slug = 'foo';

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -325,7 +325,7 @@ class Health_Test extends \WP_UnitTestCase {
 		$health = new \Automattic\VIP\Search\Health();
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping' ] )
+			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
 			->getMock();
 
 		$mocked_indexable->slug = 'foo';
@@ -342,7 +342,7 @@ class Health_Test extends \WP_UnitTestCase {
 		$health = new \Automattic\VIP\Search\Health();
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping' ] )
+			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
 			->getMock();
 
 		$mocked_indexable->slug = 'foo';
@@ -359,7 +359,7 @@ class Health_Test extends \WP_UnitTestCase {
 		$error = new \WP_Error( 'test error' );
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping' ] )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
 			->getMock();
 
 		$mocked_indexable->slug = 'foo';
@@ -388,7 +388,7 @@ class Health_Test extends \WP_UnitTestCase {
 		];
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping' ] )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
 			->getMock();
 
 		$mocked_indexable->slug = $expected_result['entity'];
@@ -421,7 +421,7 @@ class Health_Test extends \WP_UnitTestCase {
 		];
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping' ] )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
 			->getMock();
 
 		$mocked_indexable->slug = $expected_result['entity'];

--- a/tests/search/includes/classes/test-class-versioningcleanupjob.php
+++ b/tests/search/includes/classes/test-class-versioningcleanupjob.php
@@ -16,7 +16,7 @@ class VersioningCleanupJob_Test extends \WP_UnitTestCase {
 		}, [ 'foo', 'bar' ] );
 
 		$indexables_mock = $this->getMockBuilder( \ElasticPress\Indexables::class )
-			->setMethods( [ 'get_all', 'build_mapping', 'build_settings' ] )
+			->setMethods( [ 'get_all' ] )
 			->getMock();
 		$indexables_mock->method( 'get_all' )->willReturn( $indexables_mocks );
 

--- a/tests/search/includes/classes/test-class-versioningcleanupjob.php
+++ b/tests/search/includes/classes/test-class-versioningcleanupjob.php
@@ -16,7 +16,7 @@ class VersioningCleanupJob_Test extends \WP_UnitTestCase {
 		}, [ 'foo', 'bar' ] );
 
 		$indexables_mock = $this->getMockBuilder( \ElasticPress\Indexables::class )
-			->setMethods( [ 'get_all' ] )
+			->setMethods( [ 'get_all', 'build_mapping', 'build_settings' ] )
 			->getMock();
 		$indexables_mock->method( 'get_all' )->willReturn( $indexables_mocks );
 


### PR DESCRIPTION
## Description

Update ElasticPress to latest from Automattic/ElasticPress#develop.

The latest includes changes to how mappings are built - it breaks out the generation from the API requests to make it reusable.

See https://github.com/Automattic/ElasticPress/pull/78
See https://github.com/Automattic/ElasticPress/pull/79

## Changelog Description

### Update: ElasticPress to latest from upstream

This version of ElasticPress contains changes to how mappings are built - it breaks out the generation from the API requests to make it reusable.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Pull down PR
2. On a test site, run `wp vip-search put-mappings` (this will delete your indexes!)
3. Check the mappings/settings - they should look normal (match the mapping file in EP) - `curl http://localhost:19200/vip-200508-post-1/_settings | jq` and `curl http://localhost:19200/vip-200508-post-1/_mapping | jq`