### PR TITLE
Search: Sanitize EP query for error logging

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -728,7 +728,7 @@ class Search {
 
 			$this->maybe_increment_stat( $statsd_prefix . '.error' );
 
-			$query_for_logging = $this->sanitize_es_query_for_logging( $query );
+			$query_for_logging = $this->sanitize_ep_query_for_logging( $query );
 
 			$error_message = $response_error['reason'] ?? 'Unknown Elasticsearch query error';
 			$this->logger->log(
@@ -748,7 +748,7 @@ class Search {
 	/**
 	 * Given an ElasticPress query object, strip out anything that shouldn't be logged
 	 */
-	public function sanitize_es_query_for_logging( $query ) {
+	public function sanitize_ep_query_for_logging( $query ) {
 		if ( ! isset( $query['args']['headers']['Authorization'] ) ) {
 			return $query;
 		}

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2563,7 +2563,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es->ep_handle_failed_request( $response, [], '' );
 	}
 
-	public function get_sanitize_es_query_for_logging_data() {
+	public function get_sanitize_ep_query_for_logging_data() {
 		return array(
 			// No Auth header present
 			array(
@@ -2607,10 +2607,10 @@ class Search_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider get_sanitize_es_query_for_logging_data
+	 * @dataProvider get_sanitize_ep_query_for_logging_data
 	 */
-	public function test__sanitize_es_query_for_logging( $input, $expected ) {
-		$sanitized = $this->search_instance->sanitize_es_query_for_logging( $input );
+	public function test__sanitize_ep_query_for_logging( $input, $expected ) {
+		$sanitized = $this->search_instance->sanitize_ep_query_for_logging( $input );
 
 		$this->assertEquals( $expected, $sanitized );
 	}

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2549,7 +2549,6 @@ class Search_Test extends \WP_UnitTestCase {
 				->setMethods( [ 'log' ] )
 				->getMock();
 
-
 		$es->logger->expects( $this->once() )
 				->method( 'log' )
 				->with(
@@ -2559,7 +2558,61 @@ class Search_Test extends \WP_UnitTestCase {
 					$this->anything()
 				);
 
+
+
 		$es->ep_handle_failed_request( $response, [], '' );
+	}
+
+	public function get_sanitize_es_query_for_logging_data() {
+		return array(
+			// No Auth header present
+			array(
+				// The "query" from ElasticPress
+				array(
+					'args' => array(
+						'headers' => array(
+							'some' => 'header',
+						),
+					),
+				),
+				// Expected sanitized value
+				array(
+					'args' => array(
+						'headers' => array(
+							'some' => 'header',
+						),
+					),
+				),
+			),
+			// Auth header present, should be sanitized
+			array(
+				array(
+					'args' => array(
+						'headers' => array(
+							'Authorization' => 'foo',
+							'some' => 'header',
+						),
+					),
+				),
+				array(
+					'args' => array(
+						'headers' => array(
+							'Authorization' => '<redacted>',
+							'some' => 'header',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_sanitize_es_query_for_logging_data
+	 */
+	public function test__sanitize_es_query_for_logging( $input, $expected ) {
+		$sanitized = $this->search_instance->sanitize_es_query_for_logging( $input );
+
+		$this->assertEquals( $expected, $sanitized );
 	}
 
 	public function test__maybe_log_query_ratelimiting_start_should_do_nothing_if_ratelimiting_already_started() {


### PR DESCRIPTION
## Description

This adds a sanitization step to the logging of failed ES queries to ensure nothing sensitive is logged.

## Changelog Description

### Search: Sanitize query errors for logging

Adds a sanitization step to the generated EP query to prevent sensitive info from being logged.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Check out PR
2. Just before the call to vip_safe_wp_remote_request in class-search.php, add a line to create a bad ES query. E.g: $args['body'] = '{';
3. For a local dev install do the following. For a VIP sandbox, check the php logs
4. Make sure you have `define( 'WP_DEBUG_LOG', true );` in vip-config.php
4. Run a query - http://vip-go-dev.lndo.site/?s=test
5. Check wp-content/debug.log in your environment
6. There should be an error entry for the failed query - search for `Authorization` in the text and ensure the value is `<redacted>`