### PR TITLE
Adds argument validations

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -232,7 +232,7 @@ class Health {
 	 *
 	 * @return array Array containing counts and ids of posts with inconsistent content
 	 */
-	public static function validate_index_posts_content( $start_post_id = 1, $last_post_id = null, $batch_size, $max_diff_size, $silent, $inspect = false, $do_not_heal = false ) {
+	public static function validate_index_posts_content( $start_post_id, $last_post_id, $batch_size, $max_diff_size, $silent, $inspect, $do_not_heal ) {
 		// If batch size value NOT a numeric value over 0 but less than or equal to PHP_INT_MAX, reset to default
 		//     Otherwise, turn it into an int
 		if ( ! is_numeric( $batch_size ) || 0 >= $batch_size || $batch_size > PHP_INT_MAX ) {

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -268,7 +268,15 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * @subcommand validate-contents
 	 */
 	public function validate_contents( $args, $assoc_args ) {
-		$results = \Automattic\VIP\Search\Health::validate_index_posts_content( $assoc_args['start_post_id'], $assoc_args['last_post_id'], $assoc_args['batch_size'], $assoc_args['max_diff_size'], isset( $assoc_args['silent'] ), isset( $assoc_args['inspect'] ), isset( $assoc_args['do-not-heal'] ) );
+		$results = \Automattic\VIP\Search\Health::validate_index_posts_content(
+			$assoc_args['start_post_id'] ?? 1,
+			$assoc_args['last_post_id'] ?? null,
+			$assoc_args['batch_size'] ?? null,
+			$assoc_args['max_diff_size'] ?? null,
+			isset( $assoc_args['silent'] ),
+			isset( $assoc_args['inspect'] ),
+			isset( $assoc_args['do-not-heal'] )
+		);
 
 		if ( is_wp_error( $results ) ) {
 			$diff = $results->get_error_data( 'diff' );


### PR DESCRIPTION
## Description

Apart from checking the input, I removed the defaults arguments on the function level, as those were never used and were only misleading (we always send all of the arguments).

## Changelog Description

### Plugin Updated: Search

Removes minor warning from `wp vip-search health validate-contents` when some parameters are not set. The correct default values are set both before and after this change.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
1. Running `lando wp vip-search health validate-contents` Gives you:
```
Notice: Undefined index: last_post_id in /wp/wp-content/mu-plugins/search/includes/classes/commands/class-healthcommand.php on line 271 [$ /usr/local/bin/wp vip-search health validate-contents] [Automattic\VIP\Search\Commands\HealthCommand->validate_contents(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:98 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:451 call_user_func(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:371 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:394 WP_CLI\Runner->run_command(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1160 WP_CLI\Runner->run_command_and_exit(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23 WP_CLI\Runner->start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:74 WP_CLI\Bootstrap\LaunchRunner->process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:11 include('phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/binphp/boot-phar.php')]
```
2. Apply the change - no more Notice.
