### PR TITLE
Remove unnecessary hook on rest_api_init to schedule Search cron job

### DIFF
--- a/search/includes/classes/queue/class-cron.php
+++ b/search/includes/classes/queue/class-cron.php
@@ -74,7 +74,6 @@ class Cron {
 			add_action( 'wp_loaded', [ $this, 'schedule_sweeper_job' ], 0 );
 		} else {
 			add_action( 'admin_init', [ $this, 'schedule_sweeper_job' ], 0 );
-			add_action( 'rest_api_init', [ $this, 'schedule_sweeper_job' ], 0 );
 		}
 	}
 


### PR DESCRIPTION
## Description

The admin_init and wp_loaded (WP CLI only) hooks are plenty to ensure the job is scheduled. WP CLI gets executed every 60 seconds via cron, so this will run regularly and does not need to add overhead to REST requests

## Changelog Description

### Search: Remove cron job scheduling on rest_api_init action

Changed how a VIP Search cron job is scheduled - previously it was hooked into `rest_api_init` along with 2 other hooks, but this is unnecessary overhead as the job will be scheduled reliably via WP CLI (which runs regularly via cron).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Not too much needed here as this only removes a hook. If desired, can manually unschedule the event then run a CLI command and ensure the event is still scheduled again.
