### PR TITLE
Switch `VIP_Request_Block::block_and_log()` to public visibility

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -75,7 +75,7 @@ class VIP_Request_Block {
 	 * @param string $criteria header field used for a block.
 	 * @return void
 	 */
-	private static function block_and_log( string $value, string $criteria ) {
+	public static function block_and_log( string $value, string $criteria ) {
 		http_response_code( 410 );
 		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
 		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );


### PR DESCRIPTION
## Description

Right now, if we want to block on something more custom than what's included in this class, we'd need to copy the functionality of `VIP_Request_Block::block_and_log()` into `vip-config.php`

Changing this to public could allow us to use the functionality without duplicating code.

Example:

```
if ( isset( $_SERVER['REQUEST_URI'] ) && '/autodiscover/autodiscover.xml' === $_SERVER['REQUEST_URI'] ) {
	VIP_Request_Block::block_and_log( '/autodiscover/autodiscover.xml', 'REQUEST_URI' );
}
```

Of course, we could just add a `request_uri()` function for this _specific_ example, but switching to `public` could allow for more options (` false === strpos()`?) and allow us to iterate quicker via `vip-config.php` than requesting new updates to the `VIP_Request_Block` class.

## Changelog Description

#### Make VIP_Request_Block::block_and_log() public to stop the need for duplicating functionality

Previously if we wanted to block on something more custom that what was available in VIP_Request_Block, we'd need to copy the functionality into vip-config.php. By making VIP_Request_Block::block_and_log() public we no longer need to do this duplication.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I _think_ I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Add blocking snippet to `vip-config.php`

Test and see that it will give a fatal error:

```
$ curl -IXGET --insecure --header "Host: www.example.com" "https://sandbox-host.example.com/autodiscover/autodiscover.xml"
HTTP/2 500
server: nginx
date: Thu, 18 Feb 2021 21:24:05 GMT
content-type: text/html; charset=utf-8
content-length: 0
x-rq: 117 98 3169
age: 0
x-cache: miss

[18-Feb-2021 21:24:05 UTC] Fatal error: Uncaught Error: Call to private method VIP_Request_Block::block_and_log() from context '' in /var/www/vip-config/vip-config.php:29
Stack trace:
#0 /var/www/config/wp-config.php(233): require_once()
#1 /var/www/wp-config.php(13): require('/var/www/config...')
#2 /var/www/wp-load.php(37): require_once('/var/www/wp-con...')
#3 /var/www/wp-blog-header.php(13): require_once('/var/www/wp-loa...')
#4 /var/www/index.php(17): require('/var/www/wp-blo...')
#5 {main}
  thrown in /var/www/vip-config/vip-config.php on line 29 [www.example.com/autodiscover/autodiscover.xml] []
```
2\. Check out PR.

Test again and see that blocking works properly:

```
$ curl -IXGET --insecure --header "Host: www.example.com" "https://sandbox-host.example.com/autodiscover/autodiscover.xml"
HTTP/2 410
server: nginx
date: Thu, 18 Feb 2021 21:24:39 GMT
content-type: text/html; charset=utf-8
content-length: 0
expires: Wed, 11 Jan 1984 05:00:00 GMT
cache-control: no-cache, must-revalidate, max-age=0
x-rq: 117 98 3169
age: 0
x-cache: miss

[18-Feb-2021 21:24:39 UTC] VIP Request Block: request was blocked based on "REQUEST_URI" with value of "/autodiscover/autodiscover.xml"
```
