### PR TITLE
Move WP_EP_DEBUG defining and EP debug bar panel loading to before dependencies are loaded

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -104,6 +104,7 @@ class Search {
 	public function init() {
 		$this->apply_settings(); // Applies filters for tweakable Search settings and should run first.
 		$this->setup_constants();
+		$this->maybe_enable_ep_query_logging();
 		$this->load_dependencies();
 		$this->setup_hooks();
 		$this->load_commands();
@@ -345,6 +346,31 @@ class Search {
 		}
 	}
 
+	/**
+	 * Query logging in ElasticPress must be enabled via defining WP_EP_DEBUG as true before ElasticPress is instantiated.
+	 * This is separate from setup_hooks because some parts of setup_hooks require ElasticPress.
+	 */
+	protected function maybe_enable_ep_query_logging() {
+		add_action( 'plugins_loaded', [ $this, 'enable_ep_query_logging_if_debug_bar_or_query_monitor_enabled' ] );
+	}
+
+	/**
+	 * Check if query monitor or debug bar are enabled. If so, define WP_EP_DEBUG as true so ElasticPress enables query logging and then load the ElasticPress debug bar panel.
+	 */
+	public function enable_ep_query_logging_if_debug_bar_or_query_monitor_enabled() {
+		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
+			if ( ! defined( 'WP_EP_DEBUG' ) ) {
+				define( 'WP_EP_DEBUG', true );
+			}
+
+			// Load query log override function to remove Authorization header from requests
+			require_once __DIR__ . '/../functions/ep-get-query-log.php';
+
+			// Load ElasticPress Debug Bar
+			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
+		}
+	}
+
 	protected function setup_hooks() {
 		add_action( 'plugins_loaded', [ $this, 'action__plugins_loaded' ] );
 
@@ -526,20 +552,6 @@ class Search {
 	}
 
 	public function action__plugins_loaded() {
-		// Conditionally load only if either/both Query Monitor and Debug Bar are loaded and enabled
-		// NOTE - must hook in here b/c the wp_get_current_user function required for checking if debug bar is enabled isn't loaded earlier
-		if ( apply_filters( 'debug_bar_enable', false ) || apply_filters( 'wpcom_vip_qm_enable', false ) ) {
-			// Must be set to true to enable saving of queries in \ElasticPress\Elasticsearch
-			if ( ! defined( 'WP_EP_DEBUG' ) ) {
-				define( 'WP_EP_DEBUG', true );
-			}
-
-			// Load query log override function to remove Authorization header from requests
-			require_once __DIR__ . '/../functions/ep-get-query-log.php';
-			// Load ElasticPress Debug Bar
-			require_once __DIR__ . '/../../debug-bar-elasticpress/debug-bar-elasticpress.php';
-		}
-
 		$this->maybe_load_es_wp_query();
 	}
 

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -374,7 +374,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$es->action__plugins_loaded();
+		do_action( 'plugins_loaded' );
 
 		// Class should now exist
 		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ), 'EP Debug Bar was not found' );
@@ -401,7 +401,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$es->action__plugins_loaded();
+		do_action( 'plugins_loaded' );
 
 		// Class should now exist
 		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ) );
@@ -425,7 +425,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$es->action__plugins_loaded();
+		do_action( 'plugins_loaded' );
 
 		// Class should now exist
 		$this->assertEquals( true, function_exists( 'ep_add_debug_bar_panel' ) );
@@ -446,7 +446,7 @@ class Search_Test extends \WP_UnitTestCase {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
-		$es->action__plugins_loaded();
+		do_action( 'plugins_loaded' );
 
 		// Class should not exist
 		$this->assertEquals( false, function_exists( 'ep_add_debug_bar_panel' ) );

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2751,6 +2751,10 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertTrue( $es->is_protected_content_enabled() );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test__maybe_enable_ep_query_logging_no_debug_tools_enabled() {
 		add_filter( 'debug_bar_enable', '__return_false', PHP_INT_MAX );
 		add_filter( 'wpcom_vip_qm_enable', '__return_false', PHP_INT_MAX );
@@ -2763,6 +2767,10 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertFalse( defined( 'WP_EP_DEBUG' ) );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test__maybe_enable_ep_query_logging_qm_enabled() {
 		add_filter( 'debug_bar_enable', '__return_false', PHP_INT_MAX );
 		add_filter( 'wpcom_vip_qm_enable', '__return_true' );
@@ -2776,6 +2784,10 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertTrue( WP_EP_DEBUG );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test__maybe_enable_ep_query_logging_debug_bar_enabled() {
 		add_filter( 'wpcom_vip_qm_enable', '__return_false', PHP_INT_MAX );
 		add_filter( 'debug_bar_enable', '__return_true' );
@@ -2789,6 +2801,10 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertTrue( WP_EP_DEBUG );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test__maybe_enable_ep_query_logging_debug_bar_and_qm_enabled() {
 		add_filter( 'debug_bar_enable', '__return_true' );
 		add_filter( 'wpcom_vip_qm_enable', '__return_true' );

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2751,6 +2751,57 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertTrue( $es->is_protected_content_enabled() );
 	}
 
+	public function test__maybe_enable_ep_query_logging_no_debug_tools_enabled() {
+		add_filter( 'debug_bar_enable', '__return_false', PHP_INT_MAX );
+		add_filter( 'wpcom_vip_qm_enable', '__return_false', PHP_INT_MAX );
+
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( defined( 'WP_EP_DEBUG' ) );
+	}
+
+	public function test__maybe_enable_ep_query_logging_qm_enabled() {
+		add_filter( 'debug_bar_enable', '__return_false', PHP_INT_MAX );
+		add_filter( 'wpcom_vip_qm_enable', '__return_true' );
+
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		do_action( 'plugins_loaded' );
+
+		$this->assertTrue( defined( 'WP_EP_DEBUG' ) );
+		$this->assertTrue( WP_EP_DEBUG );
+	}
+
+	public function test__maybe_enable_ep_query_logging_debug_bar_enabled() {
+		add_filter( 'wpcom_vip_qm_enable', '__return_false', PHP_INT_MAX );
+		add_filter( 'debug_bar_enable', '__return_true' );
+
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		do_action( 'plugins_loaded' );
+
+		$this->assertTrue( defined( 'WP_EP_DEBUG' ) );
+		$this->assertTrue( WP_EP_DEBUG );
+	}
+
+	public function test__maybe_enable_ep_query_logging_debug_bar_and_qm_enabled() {
+		add_filter( 'debug_bar_enable', '__return_true' );
+		add_filter( 'wpcom_vip_qm_enable', '__return_true' );
+
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		do_action( 'plugins_loaded' );
+
+		$this->assertTrue( defined( 'WP_EP_DEBUG' ) );
+		$this->assertTrue( WP_EP_DEBUG );
+	}
+
 	/**
 	 * Helper function for accessing protected methods.
 	 */


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, improving security, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in P2 using the MU Plugins Proposal P2tenberg Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please do not PR until your proposal has been approved. Thank you :bow:!

If you're not an Automattician, welcome! We look forward to your contribution! :heart:
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

We changed the loading order for VIP Search a little while back. This was done because we needed ElasticPress to correctly check if the protected content feature was enabled or not so we could add attachments as a default indexable post type under the right circumstances.

This seemed fine, but apparently broke the ElasticPress debug bar panel when it's loaded into debug bar. If it was loaded into query monitor it worked as expected. It also worked fine if WP_DEBUG or WP_EP_DEBUG or EP_QUERY_LOG were true in the config.

This PR moves the all important defining of WP_EP_DEBUG when debug bar or query monitor are enabled to before dependencies are loaded. Thereby having the constant set appropriately for when ElasticPress is instantiated.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, link to the PR, examples(if applicable), and why the change was made.

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.

#### Improved compatibility

- Site Health Tools: improve PHP 8 compatibility.
- Twenty Twenty One: add support for Jetpack’s Content Options.

#### Bug fixes

- Instant Search: fix layout issues with filtering checkboxes with some themes.
- WordPress.com Toolbar: avoid Fatal errors when the feature is not active.
- WordPress.com Toolbar: avoid 404 errors when loading the toolbar.

Example for a feature change:

### New Filters: Adjust Brute Force Thresholds

We’ve added two new filters to our login limiting functionality, which gives you the ability to tweak the thresholds for our application-level brute force protections. For example, you may want to lower them during situations with high security sensitivity.

- `wpcom_vip_ip_username_login_threshold` : how many failed attempts to allow for an IP address and username combination
- `wpcom_vip_ip_login_threshold` : how many failed attempts to allow for an IP address

For example, if you wanted to only allow one attempt for a group of usernames per IP:

```
add_filter( 'wpcom_vip_ip_username_login_threshold', function( $threshold, $ip, $username ) {
    if ( 'adminuser' === $username || 'otheradminuser' === $username ) {
        $threshold = 1;
    }
 
    return $threshold;
}, 10, 3 );
```
-->
### Plugin Updated: Search

Fixed an issue where the ElasticPress debug bar panel wasn't showing the expected data when used with debug bar without WP_DEBUG or equivalent constant set to true.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
1. Disable WP_DEBUG.
2. Perform a search query using VIP Search.
3. View the ElasticPress panel in debug bar and note that it has no queries.
4. Apply PR.
5. Repeat 2.
6. The expected data should now be in the ElasticPress panel in debug bar.