### PR TITLE
Update async publish actions

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -11,7 +11,7 @@ namespace Automattic\VIP\Stats;
 
 // Limit tracking to production
 if ( true === WPCOM_IS_VIP_ENV && false === WPCOM_SANDBOXED ) {
-	add_action( 'async_transition_post_status', __NAMESPACE__ . '\track_publish_post', 9999, 2 );
+	add_action( 'transition_post_status', __NAMESPACE__ . '\track_publish_post', 9999, 2 );
 	add_filter( 'wp_handle_upload', __NAMESPACE__ . '\handle_file_upload', 9999, 2 );
 	// Hook early because overrides in a8c-files and stream wrapper return empty.
 	// Which makes it hard to differentiate between full size and thumbs.

--- a/tests/test-async-publish-actions.php
+++ b/tests/test-async-publish-actions.php
@@ -202,7 +202,7 @@ class Async_Publish_Actions_Test extends WP_UnitTestCase {
 	/**
 	 * Confirm no events are scheduled when there are no active hooks.
 	 */
-	function test_events_are_not_scheduled_when_not_needed() {
+	public function test_events_are_not_scheduled_when_not_needed() {
 		remove_action( 'async_transition_post_status', '__return_true' );
 
 		$post = [

--- a/tests/test-async-publish-actions.php
+++ b/tests/test-async-publish-actions.php
@@ -19,6 +19,9 @@ class Async_Publish_Actions_Test extends WP_UnitTestCase {
 
 		// make sure the schedule is clear.
 		_set_cron_array( array() );
+
+		// Add simple hook to trigger async events by default.
+		add_action( 'async_transition_post_status', '__return_true' );
 	}
 
 	/**
@@ -28,6 +31,7 @@ class Async_Publish_Actions_Test extends WP_UnitTestCase {
 		// make sure the schedule is clear.
 		_set_cron_array( array() );
 
+		remove_action( 'async_transition_post_status', '__return_true' );
 		parent::tearDown();
 	}
 
@@ -193,5 +197,33 @@ class Async_Publish_Actions_Test extends WP_UnitTestCase {
 
 		$this->assertInternalType( 'int', $scheduled_for_first, 'No event for first post' );
 		$this->assertInternalType( 'int', $scheduled_for_second, 'No event for second post' );
+	}
+
+	/**
+	 * Confirm no events are scheduled when there are no active hooks.
+	 */
+	function test_events_are_not_scheduled_when_not_needed() {
+		remove_action( 'async_transition_post_status', '__return_true' );
+
+		$post = [
+			'post_title'   => 'Blank Space - Taylor Swift',
+			'post_content' => 'https://www.youtube.com/watch?v=e-ORhEE9VVg',
+			'post_status'  => 'draft',
+		];
+
+		$pid = wp_insert_post( $post, true );
+		wp_publish_post( $pid );
+
+		$args = [
+			'post_id'    => (int) $pid,
+			'new_status' => 'publish',
+			'old_status' => 'draft',
+		];
+
+		$next = wp_next_scheduled( Async_Publish_Actions\ASYNC_TRANSITION_EVENT, $args );
+
+		$this->assertFalse( $next );
+
+		add_action( 'async_transition_post_status', '__return_true' );
 	}
 }


### PR DESCRIPTION
## Description

Prevents a large number of cron jobs from being registered, unless they are truly needed.

This PR includes 3 steps:

1) Track the usage of this feature, to better help make future decisions.
2) Remove the two "default" offloads.
3) Only register the cron job when the hooks are being used.

### Some Considerations

For 2, by removing the two default offloads - the [track_publish_post()](https://github.com/Automattic/vip-go-mu-plugins/blob/82308873535a775d263daa3f2cc24a36d8774ccd/stats.php#L24) and [_publish_post_hook()](https://github.com/WordPress/WordPress/blob/c6c1ef3c32ee4bfdc86a7dc2290604aee3bc3de8/wp-includes/post.php#L7289) logic will now happen synchronously when a post is published, the effects of which quite minimal here. One additional note is that `track_publish_post()` would have technically only have been run when the async cron job was truly added based on the `should_offload()` default logic, meaning it was also excluded from being run on new posts created during cron, cli, and xmlrpc. This could be replicated if desired by checking for more than just `WP_IMPORTING` in this function.

For 3, if one of these hooks was for some reason only conditionally registered underneath cli/cron checks specifically - then we'd possibly be missing out that the cron needed to be registered. This is quite unlikely though, and I have searched for all use cases I can find and the few out there do not fall into this trap. But if desired, we could move step 3 into a future PR for after we have more usage information.

## Changelog Description
### Plugin Updated: Async Publish Actions

This change removes the creation of async post publish cron jobs if they are not being utilized. If the relevant hooks _are_ in use, the cron jobs will continue to be created normally.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

Documentation: https://docs.wpvip.com/how-tos/code-quality-and-best-practices/write-asynchronous-publishing-actions/. Will be updated when applicable.

## Steps to Test

1. Check out PR.
1. Create and publish a new post.
1. Quickly run `wp cron-control events list` and notice how no `wpcom_vip_async_transition_post_status` job was added.
1. Now add something like the below, and note how a cron job is registered and run after publishing a post:

```
add_action( 'async_transition_post_status', function() {
	error_log('hello');
} );
```

For phpunit, `phpunit --group async-publish-actions` to skip to the relevant parts.