### PR TITLE
Refresh Jetpack Connection Pilot (A Space Odyssey)

### DIFF
--- a/vip-jetpack/connection-pilot/bin/partner-provision.sh
+++ b/vip-jetpack/connection-pilot/bin/partner-provision.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# Duplicate of JP core's script: https://github.com/Automattic/jetpack/blob/ed89a18f91c4a8915c36d63267e0610bda1f515e/bin/partner-provision.sh
+# Duplicate of JP core's script: https://github.com/Automattic/jetpack/blob/e13487d0dbbe4c743739b6f1a3e37c143a8c2614/tools/partner-provision.sh
 # Except for the two changes marked below by "EDIT" comments.
 
 # accepts: partner client ID and secret key, and some site info
@@ -20,7 +20,16 @@ usage () {
 	[--force_connect=1] \
 	[--force_register=1] \
 	[--allow-root] \
-	[--partner-tracking-id=1]'
+	[--partner-tracking-id=1] \
+	[--ssh-host=example.com] \
+	[--ssh-user=user_name] \
+	[--ssh-pass=user_pass] \
+	[--ssh-private-key=/path/to/private_key] \
+	[--ssh-port=22] \
+	[--ftp-host=example.com] \
+	[--ftp-user=user_name] \
+	[--ftp-pass=user_pass] \
+	[--ftp-port=21] '
 }
 
 # Note: this script should always be designed to keep wp-cli OPTIONAL
@@ -30,9 +39,9 @@ WP_CLI_ARGS=""
 
 # EDIT: Added this block for VIP Go compatability
 if [ "$WP_CLI_COMMAND" = "wp" ]; then
-    # change to script directory so that wp finds the wordpress install part for this Jetpack instance
-    SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
-    cd "$SCRIPT_DIR" || exit
+	# change to script directory so that wp finds the wordpress install part for this Jetpack instance
+	SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
+	cd "$SCRIPT_DIR" || exit
 fi
 
 # Default API host that can be overridden.
@@ -91,6 +100,42 @@ for i in "$@"; do
 			;;
 		--partner-tracking-id=* )
 			PROVISION_REQUEST_URL="$PROVISION_REQUEST_URL?partner_tracking_id=${i#*=}" # EDIT: Changed partner-tracking-id to partner_tracking_id
+			shift
+			;;
+		--ssh-host=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_host=${i#*=}"
+			shift
+			;;
+		--ssh-user=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_user=${i#*=}"
+			shift
+			;;
+		--ssh-pass=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_pass=${i#*=}"
+			shift
+			;;
+		--ssh-private-key=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_private_key=<${i#*=}"
+			shift
+			;;
+		--ssh-port=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_port=${i#*=}"
+			shift
+			;;
+		--ftp-host=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ftp_host=${i#*=}"
+			shift
+			;;
+		--ftp-user=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ftp_user=${i#*=}"
+			shift
+			;;
+		--ftp-pass=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ftp_pass=${i#*=}"
+			shift
+			;;
+		--ftp-port=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ftp_port=${i#*=}"
 			shift
 			;;
 		--allow-root )

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -231,7 +231,7 @@ class Controls {
 	 * This helps prevent cache issues for times where the database was directly updated.
 	 */
 	private static function refresh_options_cache() {
-		$options_to_refresh = array( 
+		$options_to_refresh = array(
 			'jetpack_options',
 			'jetpack_private_options',
 			'alloptions',

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -57,9 +57,9 @@ class Controls {
 	 * @return mixed bool|\WP_Error True if test connection succeeded, \WP_Error otherwise.
 	 */
 	private static function test_jetpack_connection() {
-		$response = \Jetpack_Client::wpcom_json_api_request_as_blog(
+		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
 			sprintf( '/jetpack-blogs/%d/test-connection', \Jetpack_Options::get_option( 'id' ) ),
-			\Jetpack_Client::WPCOM_JSON_API_VERSION
+			\Automattic\Jetpack\Connection\Client::WPCOM_JSON_API_VERSION
 		);
 
 		if ( is_wp_error( $response ) ) {

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -203,13 +203,13 @@ class Connection_Pilot {
 	 *
 	 * @param string   $message optional.
 	 * @param \WP_Error $wp_error optional.
-	 * @param array    $last_heartbeat optional.
 	 *
 	 * @return mixed True if the message was sent to IRC, false if it failed. If sandboxed, will just return the message string.
 	 */
-	protected function send_alert( $message = '', $wp_error = null, $last_heartbeat = null ) {
+	protected function send_alert( $message = '', $wp_error = null ) {
 		$message .= sprintf( ' Site: %s (ID %d).', get_site_url(), defined( 'VIP_GO_APP_ID' ) ? VIP_GO_APP_ID : 0 );
 
+		$last_heartbeat = $this->last_heartbeat;
 		if ( isset( $last_heartbeat['site_url'], $last_heartbeat['cache_site_id'], $last_heartbeat['timestamp'] ) ) {
 			$message .= sprintf(
 				' The last known connection was on %s UTC to Cache Site ID %d (%s).',

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -229,7 +229,12 @@ class Connection_Pilot {
 		if ( ( defined( 'WPCOM_SANDBOXED' ) && WPCOM_SANDBOXED ) ||
 			( ! defined( 'ALERT_SERVICE_ADDRESS' ) ) ||
 			( defined( 'VIP_JETPACK_CONNECTION_PILOT_SILENCE_ALERTS' ) && VIP_JETPACK_CONNECTION_PILOT_SILENCE_ALERTS ) ) {
-			error_log( $message );
+		\Automattic\VIP\Logstash\log2logstash( [
+			'severity' => 'error',
+			'feature' => 'jetpack-connection-pilot',
+			'message' => $message,
+			'extra' => [], 
+		] );
 
 			return $message; // Just return the message, as posting to IRC won't work.
 		}

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -69,7 +69,12 @@ class Connection_Pilot {
 	 */
 	public function init_actions() {
 		// Ensure the internal cron job has been added. Should already exist as an internal Cron Control job.
-		add_action( 'init', array( $this, 'schedule_cron' ) );
+		if ( defined( 'WP_CLI' ) && \WP_CLI ) {
+			add_action( 'wp_loaded', array( $this, 'schedule_cron' ) );
+		} else {
+			add_action( 'admin_init', array( $this, 'schedule_cron' ) );
+		}
+
 		add_action( self::CRON_ACTION, array( '\Automattic\VIP\Jetpack\Connection_Pilot', 'do_cron' ) );
 
 		add_filter( 'vip_jetpack_connection_pilot_should_reconnect', array( $this, 'filter_vip_jetpack_connection_pilot_should_reconnect' ), 10, 2 );


### PR DESCRIPTION
## Description

1) By checking against `hashed_site_url`, we can better ensure there won't be a mixup due to search/replaces & migrations/data syncs.
2) Log "last connection info" every time when possible.
3) Only attempt to register the cron job in admin/cron (prevent every FE request from triggering).
4) Remove deprecated `Jetpack_Client::wpcom_json_api_request_as_blog` call. Was deprecated in JP 7.5, and supposed to be removed in 8.1 (but still there).
5) Refresh bash script from JP source. We still need to override though ([more info](https://github.com/Automattic/vip-go-mu-plugins/pull/986#issuecomment-784730476)).


## Changelog Description
### Refresh the Jetpack Connection Pilot module

In preparation for the rollout for improved Jetpack connection monitoring, the following notable changes have been made:

- Hash and save the existing site_url in the healtcheck so it can be more safely compared in the future before auto-reconnecting.
- Prevent the cron schedule from being checked/registered on `init`, instead only checking during admin_init/cli.
- Update calls to deprecated JP methods to prevent php warnings.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

Needs to be done on an active sandbox. A few scenarios worth testing (be sure to apply PR on sandbox):

### Active Connections

Ensure `define( 'VIP_JETPACK_CONNECTION_PILOT_SHOULD_RUN', true );` is added in vip-config.

```
# Make sure JP is connected
wp jetpack status
// wp jetpack-start connect

# Delete the heartbeat option
wp option delete vip_jetpack_connection_pilot_heartbeat

# Run the cron job on the sandbox
wp shell
\Automattic\VIP\Jetpack\Connection_Pilot::do_cron();

# Now check that the heartbeat updated correctly
wp option get vip_jetpack_connection_pilot_heartbeat
```

### Inactive Connections

Additionally add `define( 'VIP_JETPACK_CONNECTION_PILOT_SHOULD_RECONNECT', true );` this time.

```
# Kill the connection
// wp jetpack disconnect blog

# You'll want to have a heartbeat option set still.
wp option get vip_jetpack_connection_pilot_heartbeat

# Run the cron job on the sandbox
wp shell
\Automattic\VIP\Jetpack\Connection_Pilot::do_cron();

# Now JP should be reconnected
wp jetpack status
```

You can't really test the full logging on a sandbox, but once deployed we'll be able to test the full thing with similar steps as above. Except to trigger the full logging, you'll run the cron on a "real" container:

```
# Find the ID for wpcom_vip_run_jetpack_connection_pilot, and run it
vip @<name>.<env> -- wp cron-control events list
vip @<name>.<env> -- wp cron-control events run 27
```
Note you'll want the constant(s) actually committed to the site in this case.