### PR TITLE
Feature lib updates: add usage examples, some basic PHP Doc and enable Jetpack connection Pilot

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -16,7 +16,7 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	protected static $feature_percentages = array(
+	public static $feature_percentages = array(
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
 	);

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -1,9 +1,25 @@
 <?php
 
 namespace Automattic\VIP;
-
+/**
+ * Feature provides a simple interface to gate the functionality by the Go Site Id
+ * 
+ * To register a feature add it to the $feature_percentages array (per example below)
+ * 
+ * To check whether a feature is enabled: \Automattic\VIP::is_enabled( 'feature-flag' )
+ */
 class Feature {
-	public static $feature_percentages = array();
+	/**
+	 * Holds feature slug and corresponding percentages as a float. E.g.
+	 * // Enable feature for roughly half of the websites
+	 * // 'feature-flag' => 0.5,
+	 *
+	 * @var array
+	 */
+	protected static $feature_percentages = array(
+		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
+		'jetpack-cxn-pilot' => 0.25,
+	);
 
 	public static $site_id = false;
 


### PR DESCRIPTION
## Description

The original intent of the PR was to enable Jetpack Connection Pilot for 25% of the websites, during that work we also decided to add some documentation in the code.

- Add usage examples
- Add PHPDoc for $feature_percentages
- Register `jetpack-cxn-pilot' and 0.25

We've also discussed potentially adding an API for feature registration and/or changing the visibility for $feature_percentages to `protected` to better signal the intent - we want to keep the feature definition central and prevent any other code from modifying the value. but that needs some additional thought

## Changelog Description

### Integration: Jetpack Connection Pilot

Jetpack Connection Pilot is an internal system that allows us to better monitor the state of Jetpack connections and quickly address any issues.

### Feature lib updates.

Minor updates to our internal library that we use for partial rollouts of new features to increase our engineering work velocity.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

