### PR TITLE
Hotfix: jetpack-start WP CLI command compatibility with Jetpack 9.5

### DIFF
--- a/jetpack-start/wp-cli-provision.php
+++ b/jetpack-start/wp-cli-provision.php
@@ -152,9 +152,9 @@ class Jetpack_Start_Provision_CLI_Command extends WP_CLI_Command {
 			$user = wp_get_current_user();
 
 			// role
-			$role = Jetpack::translate_current_user_to_role();
-			$signed_role = Jetpack::sign_role( $role );
-
+			$roles_instance = new \Automattic\Jetpack\Roles();
+			$role = $roles_instance->translate_current_user_to_role();
+			$signed_role = Jetpack::connection()->sign_role( $role );
 			$secrets = Jetpack::init()->generate_secrets( 'authorize' );
 
 			// Jetpack auth stuff


### PR DESCRIPTION
Due to some deprecations/updates in Jetpack 9.5 jetpack-start needs some refresh.


## Description

Updates deprecated functions calls to their modern counterparts from Jetpack 9.5 

## Changelog Description

### Jetpack 9.5 Compatibility

We've fixed some compatibility issues for internal tooling due to code deprecations in Jetpack 9.5. 
This change doesn't affect customer workflows

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Apply the PR
2. Establish A Jetpack connection via `wp jetpack-start connect`