### PR TITLE
Fix the potential race condition with notoptions

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -101,10 +101,7 @@ function _vip_maybe_clear_notoptions_cache( $option ) {
 	}
 }
 
-// Just testing for now
-if ( defined( 'WP_ENVIRONMENT_TYPE' ) && 'production' !== WP_ENVIRONMENT_TYPE ) {
-	add_action( 'add_option', '_vip_maybe_clear_notoptions_cache' );
-}
+add_action( 'add_option', '_vip_maybe_clear_notoptions_cache' );
 
 /**
  * On Go, all API usage must be over HTTPS for security


### PR DESCRIPTION
## Description
Check https://github.com/Automattic/vip-go-mu-plugins/pull/1978 for context

## Changelog Description

### Handle potential race conditions around notoptions

There is a possibility in the core that if a notoptions are being updated at the same time, a change could be rewritten.
This would then result in option being stored in DB but also marked as non-existing in notoptions making further attempts to add such option always fail without removing the options from the list of non-existing options.

We have deployed a fix for this over a week ago but decided to do 2 phase deployment. The first phase was all non-prod environments. As we did not see any negative effects of this change we will roll it out to prod environments with this change.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
As this is race condition it is really hard to reproduce without changing the core code. But we can try the regular flow isnt affected.
1. Try to get non-existing option - `lando wp eval "var_dump(get_option( 'foo' ));"` (should return false)
2. Verify the `foo` option is in notoptions now - `lando wp eval "var_dump(wp_cache_get( 'notoptions', 'options' ));"` 
3. Update foo option. - lando wp eval "var_dump(update_option( 'foo', 'bar' ));" - This will clear the option from notoptions in most cases, but sometimes during the race condition that would fail
4. Get option to verify it was persisted - `lando wp eval "var_dump(get_option( 'foo' ));"`
