### PR TITLE
Enforce strict username sanitization

### DIFF
--- a/security.php
+++ b/security.php
@@ -30,7 +30,8 @@ if ( \Automattic\VIP\Security\Private_Sites::has_privacy_restrictions() ) {
  */
 function wpcom_vip_ensure_strict_username_sanitization( $username ) {
 	if ( is_email( $username ) ) {
-		// We don't want to do this strict filter on email addresses.
+		// We don't want to do this strict filter on email addresses. Sanitize the email and return.
+		$username = sanitize_email( $username );
 		return $username;
 	}
 
@@ -121,13 +122,8 @@ function wpcom_vip_login_limit_dont_show_login_form() {
 		return;
 	}
 
-	$username = $_POST['log'];
-	if ( is_email( $username ) ) {
-		$username = sanitize_email( $username );
-	} else {
-		// Do some extra sanitization on the username.
-		$username = wpcom_vip_ensure_strict_username_sanitization( $username );
-	}
+	// Do some sanitization on the username.
+	$username = wpcom_vip_ensure_strict_username_sanitization( $_POST['log'] );
 
 	if ( $error = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOGIN_LIMIT ) ) {
 		login_header( __( 'Error' ), '', $error );
@@ -166,13 +162,8 @@ function wpcom_vip_lost_password_limit( $errors ) {
 		return $errors;
 	}
 
-	$username = trim( wp_unslash( $_POST['user_login'] ) );
-	if ( is_email( $username ) ) {
-		$username = sanitize_email( $username );
-	} else {
-		// Do some extra sanitization on the username.
-		$username = wpcom_vip_ensure_strict_username_sanitization( $username );
-	}
+	// Do some sanitization on the username.
+	$username         = wpcom_vip_ensure_strict_username_sanitization( $_POST['user_login'] );
 	$is_login_limited = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOST_PASSWORD_LIMIT );
 
 	if ( is_wp_error( $is_login_limited ) ) {
@@ -237,3 +228,4 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 
 	return false;
 }
+

--- a/security.php
+++ b/security.php
@@ -121,7 +121,14 @@ function wpcom_vip_login_limit_dont_show_login_form() {
 		return;
 	}
 
-	$username = sanitize_user( $_POST['log'] );
+	$username = $_POST['log'];
+	if ( is_email( $username ) ) {
+		$username = sanitize_email( $username );
+	} else {
+		// Do some extra sanitization on the username.
+		$username = wpcom_vip_ensure_strict_username_sanitization( $username );
+	}
+
 	if ( $error = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOGIN_LIMIT ) ) {
 		login_header( __( 'Error' ), '', $error );
 		login_footer();

--- a/security.php
+++ b/security.php
@@ -123,7 +123,7 @@ function wpcom_vip_login_limit_dont_show_login_form() {
 	}
 
 	// Do some sanitization on the username.
-	$username = vip_strict_sanitize_username( $_POST['log'] );
+	$username = vip_strict_sanitize_username( $_POST['log'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 	if ( $error = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOGIN_LIMIT ) ) {
 		login_header( __( 'Error' ), '', $error );
@@ -163,7 +163,7 @@ function wpcom_vip_lost_password_limit( $errors ) {
 	}
 
 	// Do some sanitization on the username.
-	$username         = vip_strict_sanitize_username( $_POST['user_login'] );
+	$username         = vip_strict_sanitize_username( $_POST['user_login'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 	$is_login_limited = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOST_PASSWORD_LIMIT );
 
 	if ( is_wp_error( $is_login_limited ) ) {

--- a/security.php
+++ b/security.php
@@ -22,6 +22,29 @@ if ( \Automattic\VIP\Security\Private_Sites::has_privacy_restrictions() ) {
 	\Automattic\VIP\Security\Private_Sites::instance();
 }
 
+/**
+ * Enforces strict username sanitization.
+ *
+ * @param string  $username
+ * @param string  $raw_username
+ * @param boolean $strict
+ * @return string
+ */
+function wpcom_vip_ensure_strict_username_sanitization( $username, $raw_username, $strict ) {
+	if ( $strict ) {
+		// Username has already been strictly sanitized, return.
+		return $username;
+	}
+
+	// Reduce the username to ASCII. All valid usernames should already be in this format.
+	// This is the equivalent of calling sanitize_user( $username, true ).
+	// https://github.com/WordPress/WordPress/blob/497171a1c8da9e93cac5fbcc75b6f2e3e222dfc9/wp-includes/formatting.php#L2108
+	$username = preg_replace( '|[^a-z0-9 _.\-@]|i', '', $username );
+
+	return $username;
+}
+add_filter( 'sanitize_user', 'wpcom_vip_ensure_strict_username_sanitization', 10, 3 );
+
 function wpcom_vip_is_restricted_username( $username ) {
 	return 'admin' === $username
 		|| WPCOM_VIP_MACHINE_USER_LOGIN === $username

--- a/security.php
+++ b/security.php
@@ -163,7 +163,8 @@ function wpcom_vip_lost_password_limit( $errors ) {
 	}
 
 	// Do some sanitization on the username.
-	$username         = vip_strict_sanitize_username( $_POST['user_login'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+	// ignoring WordPress.Security.NonceVerification.Missing and WordPress.Security.ValidatedSanitizedInput.InputNotValidated below
+	$username         = vip_strict_sanitize_username( $_POST['user_login'] ); // phpcs:ignore
 	$is_login_limited = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOST_PASSWORD_LIMIT );
 
 	if ( is_wp_error( $is_login_limited ) ) {

--- a/security.php
+++ b/security.php
@@ -28,7 +28,7 @@ if ( \Automattic\VIP\Security\Private_Sites::has_privacy_restrictions() ) {
  * @param string  $username
  * @return string
  */
-function wpcom_vip_ensure_strict_username_sanitization( $username ) {
+function vip_strict_sanitize_username( $username ) {
 	if ( is_email( $username ) ) {
 		// We don't want to do this strict filter on email addresses. Sanitize the email and return.
 		$username = sanitize_email( $username );
@@ -72,7 +72,7 @@ function wpcom_vip_track_auth_attempt( $username, $cache_group, $cache_expiry ) 
 
 function wpcom_vip_login_limiter( $username ) {
 	// Do some extra sanitization on the username.
-	$username = wpcom_vip_ensure_strict_username_sanitization( $username );
+	$username = vip_strict_sanitize_username( $username );
 
 	wpcom_vip_track_auth_attempt( $username, CACHE_GROUP_LOGIN_LIMIT, MINUTE_IN_SECONDS * 5 );
 }
@@ -80,7 +80,7 @@ add_action( 'wp_login_failed', 'wpcom_vip_login_limiter' );
 
 function wpcom_vip_login_limiter_on_success( $username, $user ) {
 	// Do some extra sanitization on the username.
-	$username = wpcom_vip_ensure_strict_username_sanitization( $username );
+	$username = vip_strict_sanitize_username( $username );
 
 	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 	$ip_username_cache_key = $ip . '|' . $username; // IP + username
@@ -106,7 +106,7 @@ function wpcom_vip_login_limiter_authenticate( $user, $username, $password ) {
 		return $user;
 
 	// Do some extra sanitization on the username.
-	$username = wpcom_vip_ensure_strict_username_sanitization( $username );
+	$username = vip_strict_sanitize_username( $username );
 
 	$is_login_limited = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOGIN_LIMIT );
 	if ( is_wp_error( $is_login_limited ) ) {
@@ -123,7 +123,7 @@ function wpcom_vip_login_limit_dont_show_login_form() {
 	}
 
 	// Do some sanitization on the username.
-	$username = wpcom_vip_ensure_strict_username_sanitization( $_POST['log'] );
+	$username = vip_strict_sanitize_username( $_POST['log'] );
 
 	if ( $error = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOGIN_LIMIT ) ) {
 		login_header( __( 'Error' ), '', $error );
@@ -163,7 +163,7 @@ function wpcom_vip_lost_password_limit( $errors ) {
 	}
 
 	// Do some sanitization on the username.
-	$username         = wpcom_vip_ensure_strict_username_sanitization( $_POST['user_login'] );
+	$username         = vip_strict_sanitize_username( $_POST['user_login'] );
 	$is_login_limited = wpcom_vip_username_is_limited( $username, CACHE_GROUP_LOST_PASSWORD_LIMIT );
 
 	if ( is_wp_error( $is_login_limited ) ) {

--- a/security.php
+++ b/security.php
@@ -34,10 +34,7 @@ function wpcom_vip_ensure_strict_username_sanitization( $username ) {
 		return $username;
 	}
 
-	// Reduce the username to ASCII. All valid usernames should already be in this format.
-	// This is the equivalent of calling sanitize_user( $username, true ).
-	// https://github.com/WordPress/WordPress/blob/497171a1c8da9e93cac5fbcc75b6f2e3e222dfc9/wp-includes/formatting.php#L2108
-	$username = preg_replace( '|[^a-z0-9 _.\-@]|i', '', $username );
+	$username = sanitize_user( $username, true );
 
 	return $username;
 }


### PR DESCRIPTION
Reduces the username to ASCII. All valid usernames should already be in this format. This is the equivalent of calling `sanitize_user( $username, true )` every time `sanitize_user()` is called.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.