### PR TITLE
Ensure hosts not empty before randomly picking one

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1109,8 +1109,8 @@ class Search {
 	 * Given a list of hosts, randomly select one for load balancing purposes.
 	 */
 	public function get_random_host( $hosts ) {
-		if ( ! is_array( $hosts ) ) {
-			return $hosts;
+		if ( ! $hosts || ! is_array( $hosts ) ) {
+			return null;
 		}
 
 		return $hosts[ array_rand( $hosts ) ];

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2751,6 +2751,18 @@ class Search_Test extends \WP_UnitTestCase {
 		$this->assertTrue( $es->is_protected_content_enabled() );
 	}
 
+    public function test__get_random_host_return_null_if_no_host() {
+        $es = new \Automattic\VIP\Search\Search();
+
+        $this->assertSame( null, $es->get_random_host( array() ) );
+    }
+
+    public function test__get_random_host_return_null_if_hosts_is_not_array() {
+        $es = new \Automattic\VIP\Search\Search();
+
+        $this->assertSame( null, $es->get_random_host( false ) );
+    }
+
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled


### PR DESCRIPTION
## Description

Check #2018 for context

## Changelog Description

### Search: Fix the issue raised when trying to randomly determine Elasticsearch host but no hosts available.

PHP `array_rand()` functions require a non-empty array, and it will raise a PHP warning in PHP 7.1-7.4 and a fatal error in PHP 8 in the case the array is empty. 

## Checklist
Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Testing the issue would involve the possibilty to control Elasticsearch server, so that's not easy to test. However, the fact that `array_rand` requires a non-empty array and that `Search::get_random_host()` currently doesn't ensure that is self-evident.

