### PR TITLE
Add PHP version field to the site details data

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -70,6 +70,7 @@ class Site_Details_Index {
 		$site_details['client_site_id'] = $site_id;
 		$site_details['environment_name'] = $environment_name;
 		$site_details['core']['wp_version'] = strval( $wp_version );
+		$site_details['core']['php_version'] = phpversion();
 		$site_details['core']['blog_id'] = get_current_blog_id();
 		$site_details['core']['site_url'] = get_site_url();
 		$site_details['core']['is_multisite'] = is_multisite();


### PR DESCRIPTION
## Description

Add a field with the PHP version to the site details document.

## Changelog Description

### Add PHP version to site details

The site details data contains information that is extracted from WP sites in run time. This PR adds an extra field with the PHP version to the site details data. This will help us to identify which sites are running old PHP versions, so we can investigate the reason and ensure they are upgraded.

## Checklist

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Check out PR in a VIP Go Sandbox
1. Execute wp cron-control events list and find the id for the entry `vip_config_sync_cron`
1. Run it manually with `wp cron-control events run <id>`
1. Check the output in `/chroot/tmp/logstash.log` and ensure the PHP version is now included in the JSON document
