### PR TITLE
Search: Add index setting automation

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -20,6 +20,7 @@ class Feature {
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
 		'search_indexable_settings_health_monitor' => 0.25,
+		'search_indexable_settings_auto_heal' => 0.10,
 	);
 
 	public static $site_id = false;

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -3,9 +3,9 @@
 namespace Automattic\VIP;
 /**
  * Feature provides a simple interface to gate the functionality by the Go Site Id
- * 
+ *
  * To register a feature add it to the $feature_percentages array (per example below)
- * 
+ *
  * To check whether a feature is enabled: \Automattic\VIP::is_enabled( 'feature-flag' )
  */
 class Feature {

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -20,7 +20,7 @@ class Feature {
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
 		'search_indexable_settings_health_monitor' => 0.25,
-		'search_indexable_settings_auto_heal' => 0.10,
+		'search_indexable_settings_auto_heal' => 0,
 	);
 
 	public static $site_id = false;

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -658,8 +658,8 @@ class Health {
 		$desired_settings = $indexable->build_settings();
 
 		// We only monitor certain settings
-		$actual_settings_to_check = self::limit_index_settings_to_monitored_keys( $actual_settings, self::INDEX_SETTINGS_HEALTH_MONITORED_KEYS );
-		$desired_settings_to_check = self::limit_index_settings_to_monitored_keys( $desired_settings, self::INDEX_SETTINGS_HEALTH_MONITORED_KEYS );
+		$actual_settings_to_check = self::limit_index_settings_to_keys( $actual_settings, self::INDEX_SETTINGS_HEALTH_MONITORED_KEYS );
+		$desired_settings_to_check = self::limit_index_settings_to_keys( $desired_settings, self::INDEX_SETTINGS_HEALTH_MONITORED_KEYS );
 
 		$diff = self::get_index_settings_diff( $actual_settings_to_check, $desired_settings_to_check );
 
@@ -668,7 +668,7 @@ class Health {
 		return $diff;
 	}
 
-	public static function limit_index_settings_to_monitored_keys( $settings, $keys ) {
+	public static function limit_index_settings_to_keys( $settings, $keys ) {
 		// array_intersect_key() expects 2 associative arrays, so convert the allowed $keys to associative
 		$assoc_keys = array_fill_keys( $keys, true );
 

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -716,8 +716,15 @@ class Health {
 
 		$result = $indexable->update_index_settings( $desired_settings_to_heal );
 
+		$index_name = $indexable->get_index_name();
+		$index_version = $this->search->versioning->get_current_version_number( $indexable );
+
 		$this->search->versioning->reset_current_version_number( $indexable );
 
-		return $result;
+		return array(
+			'index_name' => $index_name,
+			'index_version' => $index_version,
+			'result' => $result,
+		);
 	}
 }

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -27,20 +27,29 @@ class HealthJob {
 
 	/**
 	 * Instance of the Health class
-	 * 
+	 *
 	 * Useful for overriding in tests via dependency injection
 	 */
 	public $health;
 
 	/**
 	 * Instance of Search class
-	 * 
+	 *
 	 * Useful for overriding (dependency injection) for tests
 	 */
 	public $search;
 
+	/**
+	 * Instance of \ElasticPress\Indexables
+	 *
+	 * Useful for overriding (dependency injection) for tests
+	 */
+	public $indexables;
+
 	public function __construct( \Automattic\VIP\Search\Search $search ) {
+		$this->search = $search;
 		$this->health = new Health( $search );
+		$this->indexables = \ElasticPress\Indexables::factory();
 	}
 
 	/**
@@ -182,7 +191,7 @@ class HealthJob {
 		}
 	}
 
-	public function heal_index_settings( array $unhealthy_indexables ) {
+	public function heal_index_settings( $unhealthy_indexables ) {
 		// If the whole thing failed, error
 		if ( is_wp_error( $unhealthy_indexables ) ) {
 			$message = sprintf( 'Error while attempting to heal index settings for %s: %s', home_url(), $unhealthy_indexables->get_error_message() );
@@ -192,18 +201,21 @@ class HealthJob {
 			return;
 		}
 
-		foreach ( $results as $indexable_slug => $versions ) {
+		foreach ( $unhealthy_indexables as $indexable_slug => $versions ) {
 			// If there's an error, alert
 			if ( is_wp_error( $versions ) ) {
 				$message = sprintf( 'Error while attempting to heal index settings for indexable %s on %s: %s', $indexable_slug, home_url(), $versions->get_error_message() );
 
 				$this->send_alert( '#vip-go-es-alerts', $message, 2 );
+
+				continue;
 			}
 
-			$indexable = \ElasticPress\Indexables::factory()->get( $indexable_slug );
+			$indexable = $this->indexables->get( $indexable_slug );
 
 			if ( is_wp_error( $indexable ) || ! $indexable ) {
-				$message = sprintf( 'Failed to load indexable %s when healing index settings on %s: %s', $indexable_slug, home_url(), $versions->get_error_message() );
+				$error_message = is_wp_error( $indexable ) ? $indexable->get_error_message() : 'Indexable not found';
+				$message = sprintf( 'Failed to load indexable %s when healing index settings on %s: %s', $indexable_slug, home_url(), $error_message );
 
 				$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 
@@ -227,21 +239,19 @@ class HealthJob {
 
 				if ( is_wp_error( $result ) ) {
 					$message = sprintf( 'Failed to heal index settings for indexable %s and index version %d on %s: %s', $indexable_slug, $result['index_version'], home_url(), $versions->get_error_message() );
-	
+
 					$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 
 					continue;
 				}
 
-				// TODO handle $result - check value
-
 				$message = sprintf(
 					'Index settings updated for %s: (indexable: %s, index_version: %d, index_name: %s, diff: %s)',
 					home_url(),
 					$indexable_slug,
-					$result['index_version'],
-					$result['index_name'],
-					var_export( $result['diff'], true )
+					$result['index_version'] ?? '<missing version>',
+					$result['index_name'] ?? '<missing name>',
+					var_export( $result['diff'] ?? '<missing diff>', true )
 				);
 
 				$this->send_alert( '#vip-go-es-alerts', $message, 2, "{$indexable_slug}" );
@@ -250,14 +260,12 @@ class HealthJob {
 	}
 
 	public function check_document_count_health() {
-		$search = \Automattic\VIP\Search\Search::instance();
-
 		$users_feature = \ElasticPress\Features::factory()->get_registered_feature( 'users' );
 
 		if ( $users_feature instanceof \ElasticPress\Feature && $users_feature->is_active() ) {
 			$users_indexable = \ElasticPress\Indexables::factory()->get( 'user' );
 
-			$users_versions = $search->versioning->get_versions( $users_indexable );
+			$users_versions = $this->search->versioning->get_versions( $users_indexable );
 
 			foreach ( $users_versions as $version ) {
 				$user_results = Health::validate_index_users_count( array(
@@ -270,7 +278,7 @@ class HealthJob {
 
 		$post_indexable = \ElasticPress\Indexables::factory()->get( 'post' );
 
-		$posts_versions = $search->versioning->get_versions( $post_indexable );
+		$posts_versions = $this->search->versioning->get_versions( $post_indexable );
 
 		foreach ( $posts_versions as $version ) {
 			$post_results = Health::validate_index_posts_count( array(

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -246,12 +246,11 @@ class HealthJob {
 				}
 
 				$message = sprintf(
-					'Index settings updated for %s: (indexable: %s, index_version: %d, index_name: %s, diff: %s)',
+					'Index settings updated for %s: (indexable: %s, index_version: %d, index_name: %s)',
 					home_url(),
 					$indexable_slug,
-					$result['index_version'] ?? '<missing version>',
-					$result['index_name'] ?? '<missing name>',
-					var_export( $result['diff'] ?? '<missing diff>', true )
+					$result['index_version'] ?? '<missing index version>',
+					$result['index_name'] ?? '<missing name>'
 				);
 
 				$this->send_alert( '#vip-go-es-alerts', $message, 2, "{$indexable_slug}" );

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -237,8 +237,8 @@ class HealthJob {
 
 				$result = $this->health->heal_index_settings_for_indexable( $indexable, $options );
 
-				if ( is_wp_error( $result ) ) {
-					$message = sprintf( 'Failed to heal index settings for indexable %s and index version %d on %s: %s', $indexable_slug, $result['index_version'], home_url(), $versions->get_error_message() );
+				if ( is_wp_error( $result['result'] ) ) {
+					$message = sprintf( 'Failed to heal index settings for indexable %s and index version %d on %s: %s', $indexable_slug, $result['index_version'], home_url(), $result['result']->get_error_message() );
 
 					$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -640,9 +640,7 @@ class Health_Test extends \WP_UnitTestCase {
 	 */
 	public function test_heal_index_settings_for_indexable( $desired_settings, $options ) {
 		// Mock search and the versioning instance
-		$mock_search = $this->getMockBuilder( Search::class )
-			->setMethods( [] )
-			->getMock();
+		$mock_search = $this->createMock( Search::class );
 
 		$mock_search->versioning = $this->getMockBuilder( Versioning::class )
 			->setMethods( [ 'set_current_version_number', 'reset_current_version_number' ] )

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -596,6 +596,103 @@ class Health_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $actual_diff, $expected_diff );
 	}
 
+	public function heal_index_settings_for_indexable_data() {
+		return array(
+			// Regular healing
+			array(
+				// Desired index settings from ElasticPress
+				array(
+					'index.number_of_shards' => 1,
+					'index.number_of_replicas' => 2,
+				),
+				// Options
+				array(),
+			),
+			// Includes unhealed settings
+			array(
+				// Desired index settings from ElasticPress
+				array(
+					'index.number_of_shards' => 1,
+					'index.number_of_replicas' => 1,
+					'foo' => 'baz',
+				),
+				// Options
+				array(),
+			),
+			// With specific index version
+			array(
+				// Desired index settings from ElasticPress
+				array(
+					'index.number_of_shards' => 1,
+					'index.number_of_replicas' => 1,
+					'foo' => 'baz',
+				),
+				// Options
+				array(
+					'version_number' => 2,
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider heal_index_settings_for_indexable_data
+	 */
+	public function test_heal_index_settings_for_indexable( $desired_settings, $options ) {
+		// Mock search and the versioning instance
+		$mock_search = $this->getMockBuilder( Search::class )
+			->setMethods( [] )
+			->getMock();
+
+		$mock_search->versioning = $this->getMockBuilder( Versioning::class )
+			->setMethods( [ 'set_current_version_number', 'reset_current_version_number' ] )
+			->getMock();
+
+		// If we're healing a specific version, make sure we actually switch
+		if ( isset( $options['index_version'] ) ) {
+			$mock_search->versioning->expects( $this->once() )
+				->method( 'set_current_version_number' )
+				->with( $options['index_version'] );
+
+			$mock_search->versioning->expects( $this->once() )
+				->method( 'reset_current_version_number' );
+		}
+
+		$health = new Health( $mock_search );
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'update_index_settings', 'build_settings', 'get_index_name' ] )
+			->getMock();
+
+		$mocked_indexable->slug = 'post';
+
+		$mocked_indexable->method( 'get_index_name' )
+			->willReturn( 'foo-index-name' );
+
+		$mocked_indexable->method( 'build_settings' )
+			->willReturn( $desired_settings );
+
+		$mocked_indexable->method( 'update_index_settings' )
+			->willReturn( true );
+
+		// Expected updated settings
+		$expected_updated_settings = Health::limit_index_settings_to_keys( $desired_settings, Health::INDEX_SETTINGS_HEALTH_AUTO_HEAL_KEYS );
+
+		$mocked_indexable->expects( $this->once() )
+			->method( 'update_index_settings' )
+			->with( $expected_updated_settings );
+	
+		$result = $health->heal_index_settings_for_indexable( $mocked_indexable, $options );
+
+		$expected_result = array(
+			'index_name' => 'foo-index-name',
+			'index_version' => $options['index_version'] ?? 1,
+			'result' => true,
+		);
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
 	public function limit_index_settings_to_keys_data() {
 		return array(
 			// Mix of monitored and not monitored keys

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -596,7 +596,7 @@ class Health_Test extends \WP_UnitTestCase {
 		$this->assertEquals( $actual_diff, $expected_diff );
 	}
 
-	public function limit_index_settings_to_monitored_keys_data() {
+	public function limit_index_settings_to_keys_data() {
 		return array(
 			// Mix of monitored and not monitored keys
 			array(
@@ -620,12 +620,12 @@ class Health_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider limit_index_settings_to_monitored_keys_data
+	 * @dataProvider limit_index_settings_to_keys_data
 	 */
-	public function test_limit_index_settings_to_monitored_keys( $input, $keys, $expected ) {
+	public function test_limit_index_settings_to_keys( $input, $keys, $expected ) {
 		$health = new Health( Search::instance() );
-	
-		$limited_settings = $health->limit_index_settings_to_monitored_keys( $input, $keys );
+
+		$limited_settings = $health->limit_index_settings_to_keys( $input, $keys );
 
 		$this->assertEquals( $expected, $limited_settings );
 	}

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -459,6 +459,12 @@ class HealthJob_Test extends \WP_UnitTestCase {
 			->setMethods( [ 'heal_index_settings_for_indexable' ] )
 			->getMock();
 
+		$health_mock->method( 'heal_index_settings_for_indexable' )->willReturn( array(
+			'result' => true,
+			'index_version' => 1,
+			'index_name' => 'foo-index',
+		) );
+
 		$stub = $this->getMockBuilder( \Automattic\VIP\Search\HealthJob::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'send_alert' ] )


### PR DESCRIPTION
## Description

When index settings are determined to be inconsistent with the desired settings, automatically update the (specific) settings to keep it in sync.

## Changelog Description

### Search: Add auto-updating of index settings

This change adds support for automatically updating an index's settings to match the desired state, enabled on only a subset of sites. This provides the ability to easily control index settings both per-site and across the VIP platform.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Add a `var_dump()` to `HealthJob::check_all_indexables_settings_health()` - `var_dump( $unhealthy_indexables );` - this is a super hack but this method sends alerts to Slack / IRC which doesn't work in local dev or sandbox (need a better way to do this)
1. `wp eval "(new \Automattic\VIP\Search\HealthJob(\Automattic\VIP\Search\Search::instance()))->check_all_indexables_settings_health();"`
1. Depending on your settings, this may or may not produce any output
1. If it doesn't, you can change a setting. The easiest way is to change the value returned from `Search::filter__ep_default_index_number_of_replicas()` from `2` to anything else. Alternatively you can implement `ep_default_index_number_of_replicas` to return some other number in your theme
1. In `lib/feature/class-feature.php` change `search_indexable_settings_auto_heal` from `0.1` to `1.0` to gurantee it will be triggered on 100% environments including yours.
1. Once there is a discrepancy between what VIP Search thinks the settings should be and what they are, you'll see it in the `var_dump()` output
1. Running `wp eval "(new \Automattic\VIP\Search\HealthJob(\Automattic\VIP\Search\Search::instance()))->check_all_indexables_settings_health();"` should result in no diff.