### PR TITLE
Exclude basic file tests from core run

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -79,6 +79,7 @@ exclude_core_tests() {
 		"tests/user/wpSendUserRequest.php"
 		"tests/xmlrpc/basic.php"
 		"tests/xmlrpc/wp/getUser.php"
+		"tests/basic.php"
 	);
 
 	for testFile in "${TO_EXCLUDE[@]}"; do


### PR DESCRIPTION
## Description

These tests don't really make sense for us as they check among other
things if .md/packache files are correct. Those are core developer aimed
tests.

The current failing one is that SECURITY.md didn't have some expected line in it.

## Changelog Description

### Development Pipeline Update

We have excluded some of the core WordPress tests from running as part of our mu-plugins build pipeline to avoid false failures.


