### PR TITLE
Search: Enable index settings monitoring on all sites

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -19,7 +19,6 @@ class Feature {
 	public static $feature_percentages = array(
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
-		'search_indexable_settings_health_monitor' => 0.25,
 	);
 
 	public static $site_id = false;

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -166,7 +166,7 @@ class Health {
 			'order' => 'asc',
 		];
 
-		$result = ( new self() )->validate_index_entity_count( $query_args, $users );
+		$result = ( new self( $search ) )->validate_index_entity_count( $query_args, $users );
 
 		if ( is_wp_error( $result ) ) {
 			return new WP_Error( 'es_users_query_error', sprintf( 'failure retrieving users from ES: %s #vip-search', $result->get_error_message() ) );

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -122,9 +122,7 @@ class HealthJob {
 			return;
 		}
 
-		if ( \Automattic\VIP\Feature::is_enabled( 'search_indexable_settings_health_monitor' ) ) {
-			$this->check_all_indexables_settings_health();
-		}
+		$this->check_all_indexables_settings_health();
 
 		$this->check_document_count_health();
 	}


### PR DESCRIPTION
## Description

This enables index settings monitoring on all sites with VIP Search by removing the feature gate. Auto healing of mismatched settings is currently disabled.

## Changelog Description

### Search: Enable index settings monitoring for all sites

Enables the automatic monitoring of inconsistent index settings for all sites (previously limited to 25%).

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Check out PR.
1. Add a `var_dump( $unhealth_indexables )` to `HealthJob::check_all_indexables_settings_health()` (so we can tell it's running)
2. NOTE - depending on your local setup, you may have to comment out the early returns in `HealthJob::check_health()` (which prevent the check from running when the job isn't enabled or the index isn't built).
1. In `wp shell`...
1. `$search = \Automattic\VIP\Search\Search::instance();`
2. `$job = new \Automattic\VIP\Search\HealthJob( $search );`
3. `$job->check_health();`
4. Above should reach the `var_dump()` if settings monitoring is enabled
