### PR TITLE
Ignore the bin and tests directories of object-cache dropin for deployment

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -64,6 +64,8 @@ yarn.lock
 /cron-control-next/bin/
 /cron-control-next/runner/
 /cron-control-next/tests/
+/drop-ins/object-cache/bin/
+/drop-ins/object-cache/tests/
 /search/docs/
 /search/elasticpress/bin/
 /search/elasticpress/config/


### PR DESCRIPTION
## Description

Adds the `bin` and `tests` directory for the object-cache dropin to the `.deployignore` file so our deploy system ignores them.

## Changelog Description

### Deployment: Ignore development directories of object-cache drop-in

This change has no production impact - it simply adds 2 directories to the `.deployignore` file to prevent them from being deployed. NOTE - the object-cache drop-in file referenced here is not currently used in production (but it is the same version).

## Checklist

Please make sure the items below have been covered before requesting a review:

- n/a This change works and has been tested locally (or has an appropriate fallback).
- n/a This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- n/a I've created a changelog description that aligns with the provided examples. 

## Steps to Test

No testing necessary, this change only affects the deployment process.