### PR TITLE
Remove Photon srcset filter when Photon is active 

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -174,7 +174,13 @@ class A8C_Files {
 
 		// If Photon isn't active, we need to init the necessary filters.
 		// This takes care of rewriting intermediate images for us.
-		Jetpack_Photon::instance();
+		$jetpack_photon = Jetpack_Photon::instance();
+
+		// Remove this filter from Photon so that we can use VIP filters for srcset
+		// Filter reference: https://github.com/Automattic/jetpack/blob/26db3e436ccca3e16a62d02d95e792a81f38a1e4/projects/plugins/jetpack/class.photon.php#L85
+		if (  defined( 'WPCOM_VIP_USE_JETPACK_PHOTON_WITHOUT_SRCSET' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON_WITHOUT_SRCSET ) {
+			remove_filter( 'wp_calculate_image_srcset', array( $jetpack_photon, 'filter_srcset_array' ), 10, 5 );
+		}
 
 		// Jetpack_Photon's downsize filter doesn't run when is_admin(), so we need to fallback to the Go filters.
 		// This is temporary until Jetpack allows more easily running these filters for is_admin().
@@ -1064,7 +1070,7 @@ function wpcom_intermediate_sizes( $sizes ) {
  */
 function is_vip_go_srcset_enabled() {
 	// Allow override via querystring for easy testing
-	if ( isset( $_GET['disable_vip_srcset'] ) ) {
+	if ( isset( $_GET['disable_vip_srcset'] ) ) { // phpcs:disable
 		return '0' === $_GET['disable_vip_srcset'];
 	}
 

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -1070,7 +1070,7 @@ function wpcom_intermediate_sizes( $sizes ) {
  */
 function is_vip_go_srcset_enabled() {
 	// Allow override via querystring for easy testing
-	if ( isset( $_GET['disable_vip_srcset'] ) ) { // phpcs:disable
+	if ( isset( $_GET['disable_vip_srcset'] ) ) {
 		return '0' === $_GET['disable_vip_srcset'];
 	}
 

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -178,7 +178,7 @@ class A8C_Files {
 
 		// Remove this filter from Photon so that we can use VIP filters for srcset
 		// Filter reference: https://github.com/Automattic/jetpack/blob/26db3e436ccca3e16a62d02d95e792a81f38a1e4/projects/plugins/jetpack/class.photon.php#L85
-		if (  defined( 'WPCOM_VIP_USE_JETPACK_PHOTON_WITHOUT_SRCSET' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON_WITHOUT_SRCSET ) {
+		if ( defined( 'WPCOM_VIP_USE_JETPACK_PHOTON_WITHOUT_SRCSET' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON_WITHOUT_SRCSET ) {
 			remove_filter( 'wp_calculate_image_srcset', array( $jetpack_photon, 'filter_srcset_array' ), 10, 5 );
 		}
 


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, improving security, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in P2 using the MU Plugins Proposal P2tenberg Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please do not PR until your proposal has been approved. Thank you :bow:!

If you're not an Automattician, welcome! We look forward to your contribution! :heart:
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

More details about this issue is here p9GBOq-1Tz-p2

One use case for Jetpack Photon (with this constant `WPCOM_VIP_USE_JETPACK_PHOTON`) is to overcome intermediate image links after an import: 

- from https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34-2-150x150.jpg
- to https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34-1.jpg?resize=150%2C150

However, it comes with the wrong crop issues for srcset attributes of new images (after the import) as Jetpack Photon just uses `w` parameter like: 

```
srcset="https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34-2.jpg?w=150 150w, https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34-2.jpg?w=300 300w, https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34-2.jpg?w=100 100w, https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34-2.jpg?zoom=3&amp;resize=150%2C150 450w" sizes="(max-width: 150px) 100vw, 150px">
``` 

**By introducing this PR, we make sure new images still have the expected srcset like this**: 

```
https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34.jpg?resize=150,150 150w, https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34.jpg?resize=300,300 300w, https://mikey.go-vip.co/wp-content/uploads/2020/06/chickens34.jpg?resize=100,100 100w
``` 

I introduced `WPCOM_VIP_USE_JETPACK_PHOTON_WITHOUT_SRCSET` to make sure it does not break any other intentions with Jetpack Photon srcset filter. 

## Changelog Description

### Remove Photon srcset filter when Photon is active.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

1. Add this line into vip-config.php. 

```php
define( 'WPCOM_VIP_USE_JETPACK_PHOTON', true );
``` 
2. Add a new thumbnail image. 
3. Check the srcset attribute of this image, it's using `w` parameter - not what we want.
4. Add this line  in step 1.
```php
define( 'WPCOM_VIP_USE_JETPACK_PHOTON_WITHOUT_SRCSET', true );
```
5. Check srcset again, they should use `resize` parameter. 
 