### PR TITLE
Adds validate content interruption recovery

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -387,7 +387,7 @@ class Health {
 	}
 
 	public function update_validate_content_process( $next_post_id ) {
-		update_option( self::CONTENT_VALIDATION_PROCESS_OPTION, $next_post_id );
+		update_option( self::CONTENT_VALIDATION_PROCESS_OPTION, $next_post_id, false );
 	}
 
 	public function remove_validate_content_process() {

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -14,6 +14,7 @@ class Health {
 	const CONTENT_VALIDATION_MAX_DIFF_SIZE = 1000;
 	const CONTENT_VALIDATION_LOCK_NAME = 'vip_search_content_validation_lock';
 	const CONTENT_VALIDATION_LOCK_TIMEOUT = 900; // 15 min
+	const CONTENT_VALIDATION_PROCESS_OPTION = 'vip_search_content_validation_process_post_id';
 	const DOCUMENT_IGNORED_KEYS            = array(
 		// This field is proving problematic to reliably diff due to differences in the filters
 		// that run during normal indexing and this validator
@@ -261,6 +262,10 @@ class Health {
 		if ( $process_parallel_execution_lock && $this->is_validate_content_ongoing() ) {
 			return new WP_Error( 'content_validation_already_ongoing', 'Content validation is already ongoing' );
 		}
+		$interrupted_start_post_id = $this->get_validate_content_abandoned_process();
+		if ( $process_parallel_execution_lock && $interrupted_start_post_id ) {
+			$start_post_id = $interrupted_start_post_id;
+		}
 
 		// If batch size value NOT a numeric value over 0 but less than or equal to PHP_INT_MAX, reset to default
 		//     Otherwise, turn it into an int
@@ -306,6 +311,8 @@ class Health {
 		do {
 			if ( $process_parallel_execution_lock ) {
 				$this->set_validate_content_lock();
+				// We only work with process if we can guarantee no parallel execution
+				$this->update_validate_content_process( $start_post_id );
 			}
 
 			$next_batch_post_id = $start_post_id + $batch_size;
@@ -338,6 +345,7 @@ class Health {
 
 				if ( $process_parallel_execution_lock ) {
 					$this->remove_validate_content_lock();
+					$this->remove_validate_content_process();
 				}
 
 				return $error;
@@ -361,9 +369,29 @@ class Health {
 
 		if ( $process_parallel_execution_lock ) {
 			$this->remove_validate_content_lock();
+			$this->remove_validate_content_process();
 		}
 
 		return $results;
+	}
+
+	/**
+	 * Method checks if there is an abandoned process stored. This should only happen when the validate_contents process exits unexpectedly.
+	 * In all other cases the process information should have been removed at the end of processing. This tool enables us
+	 * to potentially pick-up where we left of on long running validate contents that got interrupted.
+	 *
+	 * @return int|bool returns the ID of the first post in a batch that was process when process was updated OR false if no such values is saved.
+	 */
+	public function get_validate_content_abandoned_process() {
+		return get_option( self::CONTENT_VALIDATION_PROCESS_OPTION );
+	}
+
+	public function update_validate_content_process( $next_post_id ) {
+		update_option( self::CONTENT_VALIDATION_PROCESS_OPTION, $next_post_id );
+	}
+
+	public function remove_validate_content_process() {
+		delete_option( self::CONTENT_VALIDATION_PROCESS_OPTION );
 	}
 
 	public function is_validate_content_ongoing(): bool {

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -481,7 +481,7 @@ class Health_Test extends \WP_UnitTestCase {
 	}
 
 	public function test_validate_index_posts_content__should_set_and_clear_last_processed() {
-		$first_post_id = 5;
+		$first_post_id = 1;
 		$last_post_id = 100;
 		$batch_size = 50;
 		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
@@ -538,9 +538,36 @@ class Health_Test extends \WP_UnitTestCase {
 		$patrtially_mocked_health->validate_index_posts_content( 1, null, null, null, false, false, false, $allow_running_in_parallel );
 	}
 
+	public function test_validate_index_posts_content__should_not_interact_with_process_if_non_default_start_id_is_sent_in() {
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'validate_index_posts_content_batch' ] )
+			->disableOriginalConstructor()
+			->getMock();
+		$patrtially_mocked_health->method( 'validate_index_posts_content_batch' )->willReturn( [] );
+
+		$mocked_indexables = $this->getMockBuilder( \ElasticPress\Indexables::class )
+			->setMethods( [ 'get' ] )
+			->getMock();
+		$patrtially_mocked_health->indexables = $mocked_indexables;
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->getMock();
+
+		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
+
+		$patrtially_mocked_health->expects( $this->never() )->method( 'update_validate_content_process' );
+
+		$patrtially_mocked_health->expects( $this->never() )->method( 'remove_validate_content_process' );
+
+
+		$start_post_id = 25;
+		$patrtially_mocked_health->validate_index_posts_content( $start_post_id, null, null, null, false, false, false );
+	}
+
 	public function test_validate_index_posts_content__pick_up_after_interuption() {
 		$interrupted_post_id = 5;
-		$first_post_id = 2;
+		$first_post_id = 1;
 		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
 			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'get_validate_content_abandoned_process', 'validate_index_posts_content_batch' ] )
 			->disableOriginalConstructor()
@@ -569,7 +596,7 @@ class Health_Test extends \WP_UnitTestCase {
 
 	public function test_validate_index_posts_content__do_not_pick_up_after_interuption_when_running_in_parallel() {
 		$interrupted_post_id = 5;
-		$first_post_id = 2;
+		$first_post_id = 1;
 		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
 			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'get_validate_content_abandoned_process', 'validate_index_posts_content_batch' ] )
 			->disableOriginalConstructor()
@@ -594,6 +621,34 @@ class Health_Test extends \WP_UnitTestCase {
 
 		$allow_running_in_parallel = true;
 		$patrtially_mocked_health->validate_index_posts_content( $first_post_id, null, null, null, false, false, false, $allow_running_in_parallel );
+	}
+
+	public function test_validate_index_posts_content__do_not_pick_up_after_interuption_when_non_default_start_post_id() {
+		$interrupted_post_id = 5;
+		$first_post_id = 2;
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'get_validate_content_abandoned_process', 'validate_index_posts_content_batch' ] )
+			->disableOriginalConstructor()
+			->getMock();
+		$patrtially_mocked_health->method( 'validate_index_posts_content_batch' )->willReturn( [] );
+		$patrtially_mocked_health->method( 'get_validate_content_abandoned_process' )->willReturn( $interrupted_post_id );
+
+		$mocked_indexables = $this->getMockBuilder( \ElasticPress\Indexables::class )
+			->setMethods( [ 'get' ] )
+			->getMock();
+		$patrtially_mocked_health->indexables = $mocked_indexables;
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->getMock();
+
+		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
+
+		$patrtially_mocked_health->expects( $this->once() )
+			->method( 'validate_index_posts_content_batch' )
+			->with( $this->anything(), $first_post_id, $this->anything(), $this->anything() );
+
+		$patrtially_mocked_health->validate_index_posts_content( $first_post_id, null, null, null, false, false, false );
 	}
 
 	public function get_index_settings_diff_for_indexable_data() {

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -480,6 +480,122 @@ class Health_Test extends \WP_UnitTestCase {
 		$patrtially_mocked_health->validate_index_posts_content( 1, null, null, null, false, false, false );
 	}
 
+	public function test_validate_index_posts_content__should_set_and_clear_last_processed() {
+		$first_post_id = 5;
+		$last_post_id = 100;
+		$batch_size = 50;
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'validate_index_posts_content_batch' ] )
+			->disableOriginalConstructor()
+			->getMock();
+		$patrtially_mocked_health->method( 'validate_index_posts_content_batch' )->willReturn( [] );
+
+		$mocked_indexables = $this->getMockBuilder( \ElasticPress\Indexables::class )
+			->setMethods( [ 'get' ] )
+			->getMock();
+		$patrtially_mocked_health->indexables = $mocked_indexables;
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->getMock();
+
+		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
+
+		$patrtially_mocked_health->expects( $this->exactly( 2 ) )
+			->method( 'update_validate_content_process' )
+			->withConsecutive( [ $first_post_id ], [ $first_post_id + $batch_size ] );
+
+		$patrtially_mocked_health->expects( $this->once() )->method( 'remove_validate_content_process' );
+
+
+		$patrtially_mocked_health->validate_index_posts_content( $first_post_id, $last_post_id, $batch_size, null, false, false, false );
+	}
+
+	public function test_validate_index_posts_content__should_not_interact_with_process_if_paralel_run() {
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'validate_index_posts_content_batch' ] )
+			->disableOriginalConstructor()
+			->getMock();
+		$patrtially_mocked_health->method( 'validate_index_posts_content_batch' )->willReturn( [] );
+
+		$mocked_indexables = $this->getMockBuilder( \ElasticPress\Indexables::class )
+			->setMethods( [ 'get' ] )
+			->getMock();
+		$patrtially_mocked_health->indexables = $mocked_indexables;
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->getMock();
+
+		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
+
+		$patrtially_mocked_health->expects( $this->never() )->method( 'update_validate_content_process' );
+
+		$patrtially_mocked_health->expects( $this->never() )->method( 'remove_validate_content_process' );
+
+
+		$allow_running_in_parallel = true;
+		$patrtially_mocked_health->validate_index_posts_content( 1, null, null, null, false, false, false, $allow_running_in_parallel );
+	}
+
+	public function test_validate_index_posts_content__pick_up_after_interuption() {
+		$interrupted_post_id = 5;
+		$first_post_id = 2;
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'get_validate_content_abandoned_process', 'validate_index_posts_content_batch' ] )
+			->disableOriginalConstructor()
+			->getMock();
+		$patrtially_mocked_health->method( 'validate_index_posts_content_batch' )->willReturn( [] );
+		$patrtially_mocked_health->method( 'get_validate_content_abandoned_process' )->willReturn( $interrupted_post_id );
+
+		$mocked_indexables = $this->getMockBuilder( \ElasticPress\Indexables::class )
+			->setMethods( [ 'get' ] )
+			->getMock();
+		$patrtially_mocked_health->indexables = $mocked_indexables;
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->getMock();
+
+		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
+
+		$patrtially_mocked_health->expects( $this->once() )
+			->method( 'validate_index_posts_content_batch' )
+			->with( $this->anything(), $interrupted_post_id, $this->anything(), $this->anything() );
+
+
+		$patrtially_mocked_health->validate_index_posts_content( $first_post_id, null, null, null, false, false, false );
+	}
+
+	public function test_validate_index_posts_content__do_not_pick_up_after_interuption_when_running_in_parallel() {
+		$interrupted_post_id = 5;
+		$first_post_id = 2;
+		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
+			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'get_validate_content_abandoned_process', 'validate_index_posts_content_batch' ] )
+			->disableOriginalConstructor()
+			->getMock();
+		$patrtially_mocked_health->method( 'validate_index_posts_content_batch' )->willReturn( [] );
+		$patrtially_mocked_health->method( 'get_validate_content_abandoned_process' )->willReturn( $interrupted_post_id );
+
+		$mocked_indexables = $this->getMockBuilder( \ElasticPress\Indexables::class )
+			->setMethods( [ 'get' ] )
+			->getMock();
+		$patrtially_mocked_health->indexables = $mocked_indexables;
+
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->getMock();
+
+		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
+
+		$patrtially_mocked_health->expects( $this->once() )
+			->method( 'validate_index_posts_content_batch' )
+			->with( $this->anything(), $first_post_id, $this->anything(), $this->anything() );
+
+		$allow_running_in_parallel = true;
+		$patrtially_mocked_health->validate_index_posts_content( $first_post_id, null, null, null, false, false, false, $allow_running_in_parallel );
+	}
+
 	public function get_index_settings_diff_for_indexable_data() {
 		return array(
 			// No diff expected, empty arrays


### PR DESCRIPTION


## Description
* When processing validate_contents we store the id we are working of
* IF the process would end unexpectly we would recover that id and start
from where we left of.

## Changelog Description

### Plugin Updated: Search

Adds an interruption recovery mechanism to the validate content feature. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
The hardest part here is to simulate interruption.One way you can do this is by adding `exit()` in the validate-contnets loop.

1. add `exit()` call in `search/includes/classes/class-health.php` somewhere in the loop around line `323`
2. Run validate_contents with some start_id (so that it doesnt get interrupted on index 1 so that we can see it works)
`lando wp vip-search health validate-contents --start_post_id=5`
3. Clear parallel execution lock (as we killed the process it didnt clean up properly) - `lando wp eval "var_dump(delete_transient('vip_search_content_validation_lock'));";`
4. Remove the `exit()` line you added in the first step
5. Run validate_contents **without** start_id (so that we can see the interupted was used instead)
`lando wp vip-search health validate-contents`
6. In the logs you should see something like `Validating posts 5 - X` as oppose to `Validating posts 1 - X`. 