### PR TITLE
Stepwise disabling of Gutenberg Ramp plugin

### DIFF
--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -16,6 +16,11 @@ if ( defined( 'VIP_GO_DISABLE_RAMP' ) && true === VIP_GO_DISABLE_RAMP ) {
 	return;
 }
 
+/** Effectively remove Gutenberg Ramp plugin for some sites */
+if ( \Automattic\VIP\Feature::is_enabled( 'remove-gutenberg-ramp' ) ) {
+	return;
+}
+
 /** load Gutenberg Ramp **/
 if ( file_exists( __DIR__ . '/gutenberg-ramp/gutenberg-ramp.php' ) ) {
 	require_once( __DIR__ . '/gutenberg-ramp/gutenberg-ramp.php' );

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -20,6 +20,7 @@ class Feature {
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
 		'search_indexable_settings_auto_heal' => 0,
+		'remove-gutenberg-ramp' => 0.1,
 	);
 
 	public static $site_id = false;


### PR DESCRIPTION
## Description

We are aiming to remove the Gutenberg Ramp plugin, and we wish to do this step-wise. This Pull-Request will disable Gutenberg Ramp for 10% of sites by making use of the Feature Flags -- this is as close it comes to remove it without removing it. If successful, we will then disable it for further 10 percent of sites and so forth, until 100%. If problems arise, we might change strategy.

Previous PRs are #1986, #1958.

Another Pull-Request, #1992 will remove it; we will merge it when we have reached 100% with the Feature Flags used in the current Pull-Request.

We have already taken steps to remove any invocations to the plugin by submitting Pull-Requests.

## Changelog Description

### Effectively remove Gutenberg Ramp for 10% of sites

This Pull-Request will disable Gutenberg Ramp plugin for 10% of sites, using the Feature Flags. When merged and if everything looks good, we will disable it for further 10%, and so forth.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [N/A] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [N/A] This change has relevant unit tests (if applicable).
- [N/A] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Start a sandbox for a site
2. Apply the Pull-Request patch on the site
3. Observe that `wp-admin` and the site works
4. Start a `wp shell` and check if Gutenberg Ramp is loaded or not by executing `gutenberg_ramp_load_gutenberg()`
