### PR TITLE
Add validate content cron

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -20,6 +20,7 @@ class Feature {
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
 		'search_indexable_settings_auto_heal' => 0,
+		'search_content_validation_and_auto_heal_cron_job' => 0.1,
 	);
 
 	public static $site_id = false;

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -255,9 +255,48 @@ class Health {
 	/**
 	 * Validate DB and ES index post content
 	 *
+	 * ## OPTIONS
+	 *
+	 * [inspect]
+	 * : Optional gives more verbose output for index inconsistencies
+	 *
+	 * [start_post_id=<int>]
+	 * : Optional starting post id (defaults to 1)
+	 *
+	 * [last_post_id=<int>]
+	 * : Optional last post id to check
+	 *
+	 * [batch_size=<int>]
+	 * : Optional batch size
+	 *
+	 * [max_diff_size=<int>]
+	 * : Optional max count of diff before exiting
+	 *
+	 * [do_not_heal]
+	 * : Optional Don't try to correct inconsistencies
+	 *
+	 * [silent]
+	 * : Optional silences all non-error output except for the final results
+	 *
+	 * [force_parallel_execution]
+	 * : Optional Force execution even if the process is already ongoing
+	 *
+	 *
+	 * @param array $options list of options
+	 *
+	 *
 	 * @return array Array containing counts and ids of posts with inconsistent content
 	 */
-	public function validate_index_posts_content( $start_post_id, $last_post_id, $batch_size, $max_diff_size, $silent, $inspect, $do_not_heal, $force_parallel_execution = false ) {
+	public function validate_index_posts_content( $options ) {
+		$start_post_id = $options['start_post_id'] ?? 1;
+		$last_post_id = $options['last_post_id'] ?? null;
+		$batch_size = $options['batch_size'] ?? null;
+		$max_diff_size = $options['max_diff_size'] ?? null;
+		$silent = isset( $options['silent'] );
+		$inspect = isset( $options['inspect'] );
+		$do_not_heal = isset( $options['do_not_heal'] );
+		$force_parallel_execution = isset( $options['force_parallel_execution'] );
+
 		$process_parallel_execution_lock = ! $force_parallel_execution;
 		// We only work with process if we can guarantee no parallel execution and user did't pick specific start_post_id to avoid unexpected overwriting of that.
 		$track_process = ( ! $start_post_id || 1 === $start_post_id ) && ! $force_parallel_execution;

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -100,6 +100,9 @@ class HealthJob {
 		if ( wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
 			wp_clear_scheduled_hook( self::CRON_EVENT_NAME );
 		}
+		if ( wp_next_scheduled( self::CRON_EVENT_VALIDATE_CONTENT_NAME ) ) {
+			wp_clear_scheduled_hook( self::CRON_EVENT_VALIDATE_CONTENT_NAME );
+		}
 	}
 
 	/**

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -138,6 +138,10 @@ class HealthJob {
 			return;
 		}
 
+		if ( ! \Automattic\VIP\Feature::is_enabled( 'search_content_validation_and_auto_heal_cron_job' ) ) {
+			return;
+		}
+
 		// Don't run the checks if the index is not built.
 		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {
 			return;

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -140,15 +140,7 @@ class HealthJob {
 			return;
 		}
 
-		$results = $this->health->validate_index_posts_content(
-			1,
-			null,
-			null,
-			null,
-			true, // silent
-			false,
-			false,
-		);
+		$results = $this->health->validate_index_posts_content( [ 'silent' => true ] );
 
 		if ( is_wp_error( $results ) ) {
 			$message = 'Cron validate-contentes error: ' . $results->get_error_message();

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -256,13 +256,13 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * default: csv
 	 * ---
 	 *
-	 * [--do-not-heal]
+	 * [--do_not_heal]
 	 * : Optional Don't try to correct inconsistencies
 	 *
 	 * [--silent]
 	 * : Optional silences all non-error output except for the final results
 	 *
-	 * [--force-parallel-execution]
+	 * [--force_parallel_execution]
 	 * : Optional Force execution even if the process is already ongoing
 	 *
 	 * ## EXAMPLES
@@ -273,16 +273,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	public function validate_contents( $args, $assoc_args ) {
 		$health = new \Automattic\VIP\Search\Health( \Automattic\VIP\Search\Search::instance() );
 
-		$results = $health->validate_index_posts_content(
-			$assoc_args['start_post_id'] ?? 1,
-			$assoc_args['last_post_id'] ?? null,
-			$assoc_args['batch_size'] ?? null,
-			$assoc_args['max_diff_size'] ?? null,
-			isset( $assoc_args['silent'] ),
-			isset( $assoc_args['inspect'] ),
-			isset( $assoc_args['do-not-heal'] ),
-			isset( $assoc_args['force-parallel-execution'] )
-		);
+		$results = $health->validate_index_posts_content( $assoc_args );
 
 		if ( is_wp_error( $results ) ) {
 			$diff = $results->get_error_data( 'diff' );


### PR DESCRIPTION
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

## Changelog Description

### Plugin Updated: Search

Adds automated cron task that will run once a week and will validate all the post contents by comparing data in database against the documents in elasticsearch. It will automatically fix any issues it finds.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [`n/a`] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
1. There are some hacking needed first - in `class-healthjob.php:152` add `var_dump($results);` - to see stuff
1. In  `class-healthjob.php:is_enabled` add `return true;` right at the beginning (to enable it outside of prod)
1. In `lib/feature/class-feature.php` change `'search_content_validation_and_auto_heal_cron_job' => 0.1` to `'search_content_validation_and_auto_heal_cron_job' => 1`
1. `wp eval "var_dump(do_action('vip_search_health_validate_content'));"`
1. Now introduce some issue (like delete post from DB directly)
1. `wp eval "var_dump(do_action('vip_search_health_validate_content'));"` - should show the diff
1. Running `wp eval "var_dump(do_action('vip_search_health_validate_content'));"` again should show no difference as the first run healed the issue. 