### PR TITLE
Search Cron - validate contents: Update alert text with site ID

### DIFF
--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -150,10 +150,10 @@ class HealthJob {
 		$results = $this->health->validate_index_posts_content( [ 'silent' => true ] );
 
 		if ( is_wp_error( $results ) ) {
-			$message = sprintf( 'Cron validate-contentes error for %s: %s', home_url(), $results->get_error_message() );
+			$message = sprintf( 'Cron validate-contentes error for site %d (%s): %s', FILES_CLIENT_SITE_ID, home_url(), $results->get_error_message() );
 			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 		} else if ( ! empty( $results ) ) {
-			$message = sprintf( 'Cron validate-contentes for %s: Autohealing executed for %d records.', home_url(), count( $results ) );
+			$message = sprintf( 'Cron validate-contentes for site %d (%s): Autohealing executed for %d records.', FILES_CLIENT_SITE_ID, home_url(), count( $results ) );
 			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 		}
 

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -150,10 +150,10 @@ class HealthJob {
 		$results = $this->health->validate_index_posts_content( [ 'silent' => true ] );
 
 		if ( is_wp_error( $results ) ) {
-			$message = 'Cron validate-contentes error: ' . $results->get_error_message();
+			$message = sprintf( 'Cron validate-contentes error for %s: %s', home_url(), $results->get_error_message() );
 			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 		} else if ( ! empty( $results ) ) {
-			$message = 'Cron validate-contentes: Autohealing executed: ' . print_r( $results, true );
+			$message = sprintf( 'Cron validate-contentes for %s: Autohealing executed for %d records.', home_url(), count( $results ) );
 			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 		}
 

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -150,10 +150,10 @@ class HealthJob {
 		$results = $this->health->validate_index_posts_content( [ 'silent' => true ] );
 
 		if ( is_wp_error( $results ) ) {
-			$message = sprintf( 'Cron validate-contentes error for site %d (%s): %s', FILES_CLIENT_SITE_ID, home_url(), $results->get_error_message() );
+			$message = sprintf( 'Cron validate-contents error for site %d (%s): %s', FILES_CLIENT_SITE_ID, home_url(), $results->get_error_message() );
 			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 		} else if ( ! empty( $results ) ) {
-			$message = sprintf( 'Cron validate-contentes for site %d (%s): Autohealing executed for %d records.', FILES_CLIENT_SITE_ID, home_url(), count( $results ) );
+			$message = sprintf( 'Cron validate-contents for site %d (%s): Autohealing executed for %d records.', FILES_CLIENT_SITE_ID, home_url(), count( $results ) );
 			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 		}
 


### PR DESCRIPTION

## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, link to the PR, examples(if applicable), and why the change was made.

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.

#### Improved compatibility

- Site Health Tools: improve PHP 8 compatibility.
- Twenty Twenty One: add support for Jetpack’s Content Options.

#### Bug fixes

- Instant Search: fix layout issues with filtering checkboxes with some themes.
- WordPress.com Toolbar: avoid Fatal errors when the feature is not active.
- WordPress.com Toolbar: avoid 404 errors when loading the toolbar.

Example for a feature change:

### New Filters: Adjust Brute Force Thresholds

We’ve added two new filters to our login limiting functionality, which gives you the ability to tweak the thresholds for our application-level brute force protections. For example, you may want to lower them during situations with high security sensitivity.

- `wpcom_vip_ip_username_login_threshold` : how many failed attempts to allow for an IP address and username combination
- `wpcom_vip_ip_login_threshold` : how many failed attempts to allow for an IP address

For example, if you wanted to only allow one attempt for a group of usernames per IP:

```
add_filter( 'wpcom_vip_ip_username_login_threshold', function( $threshold, $ip, $username ) {
    if ( 'adminuser' === $username || 'otheradminuser' === $username ) {
        $threshold = 1;
    }
 
    return $threshold;
}, 10, 3 );
```
-->
### Plugin Updated: Search

Update to the alert message received for validate-contents search cron. This change adds site URL and switches from detailed to summary report.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [`n/a` ] This change has relevant unit tests (if applicable).
- [ `n/a`] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
1. There are some hacking needed first - in `class-healthjob.php:156` (in the `else if ( ! empty( $results ) )` path ) add `var_dump($message);` - to see stuff
1. In  `class-healthjob.php:is_enabled` add `return true;` right at the beginning (to enable it outside of prod)
1. In `lib/feature/class-feature.php` change `'search_content_validation_and_auto_heal_cron_job' => 0.1` to `'search_content_validation_and_auto_heal_cron_job' => 1`
1. Now introduce some issue (like delete post from DB directly)
1. `wp eval "var_dump(do_action('vip_search_health_validate_content'));"` - should show the message with site URL and count of differences as oppose to the actuall changes