### PR TITLE
Extract sandbox/cli container detection to new Environment class

### DIFF
--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Automattic\VIP;
+
+class Environment {
+	public static function is_sandbox_container( $hostname, $env = array() ) {
+		if ( false !== strpos( $hostname, '_web_dev_' ) ) {
+			return true;
+		}
+
+		if ( isset( $env['IS_VIP_SANDBOX_CONTAINER'] ) && 'true' === $env['IS_VIP_SANDBOX_CONTAINER'] ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public static function is_batch_container( $hostname, $env = array() ) {
+		if ( false !== strpos( $hostname, '_wpcli_' ) || false !== strpos( $hostname, '_wp_cli_' ) ) {
+			return true;
+		}
+
+		if ( isset( $env['IS_VIP_BATCH_CONTAINER'] ) && 'true' === $env['IS_VIP_BATCH_CONTAINER'] ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Automattic\VIP;
+
+class Environment_Test extends \PHPUnit_Framework_TestCase {
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once( __DIR__ . '/../../../lib/environment/class-environment.php' );
+	}
+
+	public function is_sandbox_container_data() {
+		return array(
+			// Non-sandbox hostname, no env vars
+			array(
+				// Hostname
+				'foo',
+				// Env vars
+				array(),
+				// Expected result
+				false,
+			),
+			// Sandbox hostname, no env vars
+			array(
+				// Hostname
+				'foo_web_dev_0001',
+				// Env vars
+				array(),
+				// Expected result
+				true,
+			),
+			// Non-sandbox hostname, has env var
+			array(
+				// Hostname
+				'foo',
+				// Env vars
+				array(
+					'IS_VIP_SANDBOX_CONTAINER' => 'true',
+				),
+				// Expected result
+				true,
+			),
+			// Non-sandbox hostname, has env var with wrong value
+			array(
+				// Hostname
+				'foo',
+				// Env vars
+				array(
+					'IS_VIP_SANDBOX_CONTAINER' => 'not true',
+				),
+				// Expected result
+				false,
+			),
+			// Sandbox hostname, has env var
+			array(
+				// Hostname
+				'foo_web_dev_0001',
+				// Env vars
+				array(
+					'IS_VIP_SANDBOX_CONTAINER' => 'true',
+				),
+				// Expected result
+				true,
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider is_sandbox_container_data
+	 */
+	public function test_is_sandbox_container( $hostname, $env, $expected ) {
+		$result = Environment::is_sandbox_container( $hostname, $env );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	public function is_batch_container_data() {
+		return array(
+			// Non-batch hostname, no env vars
+			array(
+				// Hostname
+				'foo',
+				// Env vars
+				array(),
+				// Expected result
+				false,
+			),
+			// Batch hostname, no env vars
+			array(
+				// Hostname
+				'foo_wpcli_0001',
+				// Env vars
+				array(),
+				// Expected result
+				true,
+			),
+			// Batch hostname alternate, no env vars
+			array(
+				// Hostname
+				'foo_wp_cli_0001',
+				// Env vars
+				array(),
+				// Expected result
+				true,
+			),
+			// Non-batch hostname, has env var
+			array(
+				// Hostname
+				'foo',
+				// Env vars
+				array(
+					'IS_VIP_BATCH_CONTAINER' => 'true',
+				),
+				// Expected result
+				true,
+			),
+			// Non-batch hostname, has env var with wrong value
+			array(
+				// Hostname
+				'foo',
+				// Env vars
+				array(
+					'IS_VIP_BATCH_CONTAINER' => 'not true',
+				),
+				// Expected result
+				false,
+			),
+			// Batch hostname, has env var
+			array(
+				// Hostname
+				'foo_wpcli_0001',
+				// Env vars
+				array(
+					'IS_VIP_BATCH_CONTAINER' => 'true',
+				),
+				// Expected result
+				true,
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider is_batch_container_data
+	 */
+	public function test_is_batch_container( $hostname, $env, $expected ) {
+		$result = Environment::is_batch_container( $hostname, $env );
+
+		$this->assertEquals( $expected, $result );
+	}
+}


### PR DESCRIPTION
## Description

This adds a new `Automattic\VIP\Environment` utility class for determining details about the current environment (like if this is a sandbox or CLI/Batch container). This will replace existing logic that is hardcoded into 000-vip-init.php, making it testable. It's currently not used anywhere (but will be soon).

## Changelog Description

### Utils: Add Environment utility class for determining characteristics of current environment

This adds a new `Automattic\VIP\Environment` utility class for determining details about the current environment (like if this is a sandbox or CLI/Batch container). This will replace existing logic that is hardcoded into 000-vip-init.php, making it testable.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

The code isn't yet included from anywhere (want to get this deployed first, then include it in a later PR), so doesn't really need manual testing (has unit test coverage).