### PR TITLE
Add domain to site search columns to improve WP Admin site search results

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -170,3 +170,13 @@ add_filter( 'wp_link_query_args', 'wpcom_vip_wp_link_query_args', 10, 1 );
  * Stop Woocommerce from trying to create files on read-only filesystem
  */
 add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
+
+/**
+ * On Go, multisites are technically subdirectory installs so site search only
+ * searches the 'path' on /network/sites.php. This improves site search results by
+ * adding 'domain' to the columns to search.
+ */
+add_filter( 'site_search_columns', function( $cols ) {
+    $cols[] = 'domain';
+    return $cols;
+});

--- a/misc.php
+++ b/misc.php
@@ -177,6 +177,6 @@ add_filter( 'woocommerce_install_skip_create_files', '__return_true' );
  * adding 'domain' to the columns to search.
  */
 add_filter( 'site_search_columns', function( $cols ) {
-    $cols[] = 'domain';
-    return $cols;
+	$cols[] = 'domain';
+	return $cols;
 });


### PR DESCRIPTION
## Description

The default columns to search when searching the list of multisite sites in `/network/sites.php` include `domain` and `path`, [except when `! is_subdomain_install()`](https://github.com/WordPress/WordPress/blob/058f9903676a7efaee534a682df0a2a8b87574d8/wp-admin/includes/class-wp-ms-sites-list-table.php#L130). On Go, all multisites are technically subdirectory installs so a Site Search only searches `path`. On large multisite installations with many domains, this leads to inaccurate search results as the site domains are not considered for a search.

This PR filters [`site_search_columns`](https://developer.wordpress.org/reference/hooks/site_search_columns/) to add `domain` back into the columns to search, which greatly improves search results when searching large multisites with many domains.

## Changelog Description

### Search Domains in WP Admin Multisite Site Search

This change improves multisite site search within WP Admin by filtering `site_search_columns` to add `domain` to the columns to search in a `WP_Site_Query` search query.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- N/A - This change has relevant unit tests (if applicable).
- N/A - This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test


1. Check out PR on a multisite that includes several sub-sites
2. Go to `WP Admin` > `My Sites` > `Network Admin` > `Sites` (`/wp-admin/network/sites.php`)
3. Use the search box to perform a site search for the domain of a sub-site
4. Verify that the search results include the sub-site with the associated searched domain