### PR TITLE
Search: Enable index setting automation on 50% of sites

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -19,7 +19,7 @@ class Feature {
 	public static $feature_percentages = array(
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
-		'search_indexable_settings_auto_heal' => 0.1,
+		'search_indexable_settings_auto_heal' => 0.5,
 		'remove-gutenberg-ramp' => 0.25,
 		'search_content_validation_and_auto_heal_cron_job' => 0.1,
 	);


### PR DESCRIPTION
## Description

Previously, search index setting automation was enabled for 10% of sites, this increases it to 50%

## Changelog Description

### Search: Enable index setting automation on 50% of sites

This increases the percentage of sites that receive automated index settings from 10% to 50%

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

Not much to test manually as this is just a feature flag percentage change