### PR TITLE
Search: Temporarily disable index setting auto healing in 1 test

### DIFF
--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -65,7 +65,15 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		$job->expects( $this->exactly( 1 ) )
 			->method( 'process_document_count_health_results' );
 
+		// Disable auto-healing of index settings b/c it throws a notice currently which breaks the test
+		// Can be removed after https://github.com/10up/ElasticPress/issues/2155
+		$original_percentage = \Automattic\VIP\Feature::$feature_percentages['search_indexable_settings_auto_heal'];
+
+		\Automattic\VIP\Feature::$feature_percentages['search_indexable_settings_auto_heal'] = 0;
+
 		$job->check_health();
+
+		\Automattic\VIP\Feature::$feature_percentages['search_indexable_settings_auto_heal'] = $original_percentage;
 
 		remove_filter( 'enable_vip_search_healthchecks', '__return_true' );
 	}


### PR DESCRIPTION
## Description

Needs to be disabled because the notice from https://github.com/10up/ElasticPress/issues/2155 breaks the test. Can't use `$this->expectException()` b/c the notice is converted into an Exception that aborts the rest of the test

## Checklist

Please make sure the items below have been covered before requesting a review:

- n/a This change works and has been tested locally (or has an appropriate fallback).
- n/a This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- n/a I've created a changelog description that aligns with the provided examples. 

## Steps to Test

This is a unit-test-only change, no manual testing (or deployment) needed.