### PR TITLE
Hotfix: Restore index.max_result_window to Elasticsearch default of 10000

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -11,7 +11,7 @@ class Search {
 	public const QUERY_INTEGRATION_FORCE_ENABLE_KEY = 'vip-search-enabled';
 	public const SEARCH_ALERT_SLACK_CHAT = '#vip-go-es-alerts';
 	public const SEARCH_ALERT_LEVEL = 2; // Level 2 = 'alert'
-	public const MAX_RESULT_WINDOW = 9000;
+	public const MAX_RESULT_WINDOW = 10000;
 	/**
 	 * Empty for now. Will flesh out once migration path discussions are underway and/or the same meta are added to the filter across many
 	 * sites.

--- a/tests/search/test-class-search.php
+++ b/tests/search/test-class-search.php
@@ -2994,7 +2994,7 @@ class Search_Test extends \WP_UnitTestCase {
 			],
 			[
 				'input' => 10000,
-				'expected' => 9000,
+				'expected' => 10000,
 			],
 		];
 	}


### PR DESCRIPTION
## Description

We recently decreased the index.max_result_window to 9000 from the default of 10k, this had negative impact on some sites, this hotfix restores the default value.

## Changelog Description

### Hotfix: Search 

Set the value of index.max_result_window to 10000


## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

