### PR TITLE
Search: Enable auto index setting updating on all sites

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -19,7 +19,6 @@ class Feature {
 	public static $feature_percentages = array(
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
-		'search_indexable_settings_auto_heal' => 0.5,
 		'remove-gutenberg-ramp' => 0.25,
 		'search_content_validation_and_auto_heal_cron_job' => 0.25,
 	);

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -189,9 +189,7 @@ class HealthJob {
 
 		$this->process_indexables_settings_health_results( $unhealthy_indexables );
 
-		if ( \Automattic\VIP\Feature::is_enabled( 'search_indexable_settings_auto_heal' ) ) {
-			$this->heal_index_settings( $unhealthy_indexables );
-		}
+		$this->heal_index_settings( $unhealthy_indexables );
 	}
 
 	public function process_indexables_settings_health_results( $results ) {

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -226,9 +226,7 @@ class HealthJob {
 					var_export( $result['diff'], true )
 				);
 
-				// Temporarily disable the alerting while we roll out the index settings changes (b/c indexes will be inconsistent during)
-				// Be sure to re-enable the test for this - test__vip_search_healthjob_process_indexables_settings_health_results
-				// $this->send_alert( '#vip-go-es-alerts', $message, 2, "{$indexable_slug}" );
+				$this->send_alert( '#vip-go-es-alerts', $message, 2, "{$indexable_slug}" );
 			}
 		}
 	}

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -58,7 +58,7 @@ class HealthJob_Test extends \WP_UnitTestCase {
 		// Mock the health job
 		$job = $this->getMockBuilder( \Automattic\VIP\Search\HealthJob::class )
 			->setConstructorArgs( [ $es ] )
-			->setMethods( array( 'process_document_count_health_results' ) )
+			->setMethods( array( 'process_document_count_health_results', 'send_alert' ) )
 			->getMock();
 
 		// Only expect it to process 1 set of results (for regular posts)


### PR DESCRIPTION
## Description

Increases the percentage of sites that receive automatic index setting updating to 100%

## Changelog Description

### Seach: Enable index setting auto-updates on all sites

This will sync the settings defined in code with the ES index settings via cron for all sites. Note that only [some settings are synced](https://github.com/Automattic/vip-go-mu-plugins/blob/342572fd4d0d4c044939d5a640744f22cff95535/search/includes/classes/class-health.php#L34-L38).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Mostly just a config change, but can run the health function directly
2. `$search = \Automattic\VIP\Search\Search::instance();`
3. `$job = new \Automattic\VIP\Search\HealthJob();`
4. `$job->check_health()`
