### PR TITLE
Remove CircleCI php7.3-build-* jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ workflows:
       - php73-lint
       - php74-core-tests
       - php74-core-multisite-tests
-      - php73-build-multisite
       - php73-build-singlesite
       - php74-lint
       - php74-build-multisite
@@ -154,24 +153,6 @@ jobs:
       - WP_VERSION: "latest"
     docker:
       - image: wordpressdevelop/php:7.4-fpm
-      - image: *db_image
-
-  php73-build-multisite:
-    <<: *php_job
-    environment:
-      - WP_MULTISITE: "1"
-      - WP_VERSION: "latest"
-    docker:
-      - image: circleci/php:7.3-node
-      - image: *db_image
-
-  php73-build-singlesite:
-    <<: *php_job
-    environment:
-      - WP_MULTISITE: "0"
-      - WP_VERSION: "latest"
-    docker:
-      - image: circleci/php:7.3-node
       - image: *db_image
 
   php74-lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ workflows:
       - php73-lint
       - php74-core-tests
       - php74-core-multisite-tests
-      - php73-build-singlesite
       - php74-lint
       - php74-build-multisite
       - php74-build-singlesite


### PR DESCRIPTION
## Description

This removes `php73-build-multisite` and `php73-build-singlesite` CircleCI jobs

We'll keep the `php73-lint` in place until we officially bump the minimum supported version to 7.4

