### PR TITLE
Stepwise disabling of Gutenberg Ramp plugin: 45%

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -19,7 +19,7 @@ class Feature {
 	public static $feature_percentages = array(
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
-		'remove-gutenberg-ramp' => 0.25,
+		'remove-gutenberg-ramp' => 0.45,
 		'search_content_validation_and_auto_heal_cron_job' => 0.25,
 	);
 


### PR DESCRIPTION
## Description

We are aiming to remove the Gutenberg Ramp plugin, and we wish to do this step-wise. This Pull-Request will disable Gutenberg Ramp for 45% of sites by making use of the Feature Flags -- this is as close it comes to remove it without removing it. 

Previous PRs are #1986, #1958, #2039 and #2045.

Another Pull-Request, #1992 will remove Gutenberg Ramp; we will merge it when we have reached 100% with the Feature Flags used in the current Pull-Request.

We have already taken steps to remove any invocations to the plugin by submitting Pull-Requests.

This Pull-Request can be deployed whenever suits Platform.

## Changelog Description

### Effectively remove Gutenberg Ramp for 45% of sites

Disable Gutenberg Ramp plugin for 45% of sites, using the Feature Flags. We will then continue to iterate based on the outcome of this deployment.

## Checklist

- [N/A] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [N/A] This change has relevant unit tests (if applicable).
- [N/A] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Start a sandbox for a site
2. Apply the Pull-Request patch on the site
3. Observe that `wp-admin` and the site works
4. Start a `wp shell` and check if Gutenberg Ramp is loaded or not by executing `gutenberg_ramp_load_gutenberg()`
