### PR TITLE
Set Jetpack 9.6 as the default version for all VIP sites

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 9.5
+ * Version: 9.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -20,7 +20,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.6', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.4' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.5' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.6' );
 	}
 }
 


### PR DESCRIPTION
## Description

Set Jetpack 9.6 as the default version, so it gets rolled out to all VIP Go sites (except those that are pinned)

## Changelog Description

### Plugin Updated: Jetpack 9.6

We have rolled out Jetpack 9.6 to all VIP Go sites (except those that are pinned to a specific version).

You can find [here](https://github.com/Automattic/jetpack-production/releases/tag/9.6) the list of changes in this version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x]  I've created a changelog description that aligns with the provided examples. 

## Steps to Test

1. Check out PR.
1. Go to the Jetpack dashboard in `wp-admin`
1. Ensure the enabled version is 9.6
1. Ensure everything else keeps working

