### PR TITLE
update/bump_self-healing-to-50

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -20,7 +20,7 @@ class Feature {
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
 		'remove-gutenberg-ramp' => 0.70,
-		'search_content_validation_and_auto_heal_cron_job' => 0.25,
+		'search_content_validation_and_auto_heal_cron_job' => 0.5,
 		'admin-password-change-current' => 0.1,
 	);
 


### PR DESCRIPTION

## Description

## Changelog Description

### Plugin Updated: Search

Updates automated cron task that runs once a week and validates all the post contents by comparing data in database against the documents in elasticsearch. It will automatically fix any issues it finds. This change increases the amount of sites running this cron to 50% from 25%.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [`n/a`] This change has relevant unit tests (if applicable).
- [`n/a`] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples. 

## Steps to Test
1. There are some hacking needed first - in `class-healthjob.php:152` add `var_dump($results);` - to see stuff
1. In  `class-healthjob.php:is_enabled` add `return true;` right at the beginning (to enable it outside of prod)
1. In `lib/feature/class-feature.php` change `'search_content_validation_and_auto_heal_cron_job' => 0.1` to `'search_content_validation_and_auto_heal_cron_job' => 1`
1. `wp eval "var_dump(do_action('vip_search_health_validate_content'));"`
1. Now introduce some issue (like delete post from DB directly)
1. `wp eval "var_dump(do_action('vip_search_health_validate_content'));"` - should show the diff
1. Running `wp eval "var_dump(do_action('vip_search_health_validate_content'));"` again should show no difference as the first run healed the issue. 
