### PR TITLE
Avoid deploying some Jetpack files that throw linting errors

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -102,8 +102,8 @@ yarn.lock
 
 # A few files in Jetpack >9.7 that are giving linting errors due to incompatible PHP versions
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-ctype/bootstrap80.php
-/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-intl-grapheme/bootstrap80.php 
-/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-intl-normalizer/bootstrap80.php 
+/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-intl-grapheme/bootstrap80.php
+/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-intl-normalizer/bootstrap80.php
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-mbstring/bootstrap80.php
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-php73/Resources/stubs/JsonException.php
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/sebastian/resource-operations/build/generate.php

--- a/.deployignore
+++ b/.deployignore
@@ -99,3 +99,11 @@ yarn.lock
 /vip-support/bin/
 /vip-support/features/
 /vip-support/tests/
+
+# A few files in Jetpack >9.7 that are giving linting errors due to incompatible PHP versions
+/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-ctype/bootstrap80.php
+/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-intl-grapheme/bootstrap80.php 
+/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-intl-normalizer/bootstrap80.php 
+/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-mbstring/bootstrap80.php
+/jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-php73/Resources/stubs/JsonException.php
+/jetpack*/vendor/automattic/jetpack-password-checker/vendor/sebastian/resource-operations/build/generate.php


### PR DESCRIPTION
## Description

After adding Jetpack 9.7 subtree, there are a few files that belong to third parties that throw linting errors on the `vip-go-stacks` commit hooks. In all cases it's code that doesn't get executed because they are either compatibility code for older/newer PHP versions, or build scripts.

Ideally, we should make the linting hook skip all vendor directories, but for the moment we'll use this simple approach.

## Changelog Description

### Skip deploying some Jetpack 9.7 files

Due to recent code introduced in Jetpack 9.7, which is only to be executed on PHP <=7.2 or PHP >=8.0, some linting jobs are failing when deploying mu-plugins. This PR removes them from the deploy so the process can be completed.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Run the same rsync command used by `vip-go-utility-scripts/mu-plugins/prepare-deploy.sh`
1. Ensure the files added to `.deployignore` in this PR are not copied
