### PR TITLE
Hide VaultPress onboarding prompts when not connected

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -41,9 +41,9 @@ add_filter( 'pre_scan_file', function( $should_skip_file, $file, $real_file, $fi
 
 require_once( __DIR__ . '/vaultpress/vaultpress.php' );
 
-add_filter( 'in_admin_header', 'remove_connect_notice' );
+add_filter( 'in_admin_header', 'vip_remove_vaultpress_connect_notice' );
 
-function remove_connect_notice() {
+function vip_remove_vaultpress_connect_notice() {
 	// Not actually initializing VP, just getting the instance
 	$vaultpress = VaultPress::init();
 	remove_action( 'user_admin_notices', [ $vaultpress, 'connect_notice' ] );

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -41,9 +41,9 @@ add_filter( 'pre_scan_file', function( $should_skip_file, $file, $real_file, $fi
 
 require_once( __DIR__ . '/vaultpress/vaultpress.php' );
 
-add_filter( 'in_admin_header', 'remove_connection_notice' );
+add_filter( 'in_admin_header', 'remove_connect_notice' );
 
-function remove_connection_notice() {
+function remove_connect_notice() {
 	// Not actually initializing VP, just getting the instance
 	$vaultpress = VaultPress::init();
 	remove_action( 'user_admin_notices', [ $vaultpress, 'connect_notice' ] );

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -40,3 +40,13 @@ add_filter( 'pre_scan_file', function( $should_skip_file, $file, $real_file, $fi
 }, 10, 4 );
 
 require_once( __DIR__ . '/vaultpress/vaultpress.php' );
+
+add_filter( 'in_admin_header', 'remove_connection_notice');
+
+function remove_connection_notice() {
+	// Not actually initializing VP, just getting the instance
+	$vaultpress = VaultPress::init();
+	remove_action( 'user_admin_notices', [ $vaultpress, 'connect_notice' ] );
+	remove_action( 'vaultpress_notices', [ $vaultpress, 'connect_notice' ] );
+	remove_action( 'admin_notices', [ $vaultpress, 'connect_notice' ] );
+}

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -41,7 +41,7 @@ add_filter( 'pre_scan_file', function( $should_skip_file, $file, $real_file, $fi
 
 require_once( __DIR__ . '/vaultpress/vaultpress.php' );
 
-add_filter( 'in_admin_header', 'remove_connection_notice');
+add_filter( 'in_admin_header', 'remove_connection_notice' );
 
 function remove_connection_notice() {
 	// Not actually initializing VP, just getting the instance
@@ -49,4 +49,5 @@ function remove_connection_notice() {
 	remove_action( 'user_admin_notices', [ $vaultpress, 'connect_notice' ] );
 	remove_action( 'vaultpress_notices', [ $vaultpress, 'connect_notice' ] );
 	remove_action( 'admin_notices', [ $vaultpress, 'connect_notice' ] );
+	return null;
 }


### PR DESCRIPTION
## Description

This PR removes the ValutPress onboarding prompt asking the user to register VaultPress. In the VIP platform, we don't want users registering VaultPress since that is done by Customer Success.

However, the registration screen is still available under the VaultPress Dashboard.

**Before:**

![Screen Shot 2021-04-30 at 12 13 03](https://user-images.githubusercontent.com/7188409/116681947-e74dbd00-a9ad-11eb-90ae-db1be4dec5c5.png)

**After:**

![Screen Shot 2021-04-30 at 12 12 43](https://user-images.githubusercontent.com/7188409/116681963-eddc3480-a9ad-11eb-86bd-ea385fa0ae90.png)

## Changelog Description

### Removed VaultPress onboarding prompts

Removing the prompt asking the user to register VaultPress when launching a site without a connection to VaultPress.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Check out PR.
2. Make sure you are in a WP site without a Jetpack connection
3. Go to `wp-admin` 
4. You shouldn't see the VP banner.
