### PR TITLE
Run search validate contents on all sites

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -19,7 +19,6 @@ class Feature {
 	public static $feature_percentages = array(
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
-		'search_content_validation_and_auto_heal_cron_job' => 0.5,
 		'admin-password-change-current' => 0.1,
 	);
 

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -138,10 +138,6 @@ class HealthJob {
 			return;
 		}
 
-		if ( ! \Automattic\VIP\Feature::is_enabled( 'search_content_validation_and_auto_heal_cron_job' ) ) {
-			return;
-		}
-
 		// Don't run the checks if the index is not built.
 		if ( \ElasticPress\Utils\is_indexing() || ! \ElasticPress\Utils\get_last_sync() ) {
 			return;


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

## Changelog Description

### Plugin Updated: Search

Updates automated cron task that runs once a week and validates all the post contents by comparing data in database against the documents in elasticsearch. It will automatically fix any issues it finds. This change increases the amount of sites running this cron to 100% from 50%.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. There are some hacking needed first - in `class-healthjob.php:147` add `var_dump($results);` - to see stuff
1. In  `class-healthjob.php:is_enabled` add `return true;` right at the beginning (to enable it outside of prod)
1. `wp eval "var_dump(do_action('vip_search_health_validate_content'));"`
1. Now introduce some issue (like delete post from DB directly)
1. `wp eval "var_dump(do_action('vip_search_health_validate_content'));"` - should show the diff
1. Running `wp eval "var_dump(do_action('vip_search_health_validate_content'));"` again should show no difference as the first run healed the issue. 

