### PR TITLE
Bump Admin Password Verification to 25%

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -19,7 +19,7 @@ class Feature {
 	public static $feature_percentages = array(
 		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
 		'jetpack-cxn-pilot' => 0.25,
-		'admin-password-change-current' => 0.1,
+		'admin-password-change-current' => 0.25,
 	);
 
 	public static $site_id = false;


### PR DESCRIPTION
## Description

Bumping the password admin password change verification to 25% of the sites.

## Changelog Description

### Admin Password Verification Update

Bumping the password admin password change verification to 25% of the sites.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.