### PR TITLE
Add Jetpack Connect Notice

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -399,7 +399,6 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 // We need to add a dummy menu item if no other menu items are rendered
 function add_jetpack_menu_placeholder() {
 	$status = new Automattic\Jetpack\Status();
-
 	// is_connection_ready only exists in Jetpack 9.6 and newer
 	if ( ! $status->is_offline_mode() && method_exists('Jetpack', 'is_connection_ready') && ! Jetpack::is_connection_ready() ) {
 		add_submenu_page( 'jetpack', 'Connect Jetpack', 'Connect Jetpack', 'manage_options', 'jetpack' );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -398,7 +398,10 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 
 // We need to add a dummy menu item if no other menu items are rendered
 function add_jetpack_menu_placeholder() {
-	if ( ! Jetpack::is_connection_ready() ) {
+	$status = new Automattic\Jetpack\Status();
+
+	// is_connection_ready only exists in Jetpack 9.6 and newer
+	if ( ! $status->is_offline_mode() && method_exists('Jetpack', 'is_connection_ready') && ! Jetpack::is_connection_ready() ) {
 		add_submenu_page( 'jetpack', 'Connect Jetpack', 'Connect Jetpack', 'manage_options', 'jetpack' );
 	}
 }

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -398,16 +398,15 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 
 function vip_connect_to_jetpack_admin_page() {
 	?>
-		<h1>
-			Jetpack is not set up in this site
-		</h1>
+    <h1>Jetpack is not set up in this site</h1>
 	<p>Please open a ticket with VIP Support to set it up.</p>
 	<?php
 }
 
+// We need to add a dummy menu item if no other menu items are rendered
 function add_jetpack_menu_placeholder() {
 	if ( ! Jetpack::is_connection_ready() ) {
-		add_submenu_page( 'jetpack', 'Connect Jetpack', 'Connect Jetpack', 'manage_options', 'connect-jetpack', 'vip_connect_to_jetpack_admin_page' );
+		add_submenu_page( 'jetpack', 'Jetpack Not Connected', 'Jetpack not Connected', 'manage_options', 'connect-jetpack', 'vip_connect_to_jetpack_admin_page' );
 	}
 }
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -395,3 +395,20 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 
 	return $value;
 }, 10, 2 );
+
+function vip_connect_to_jetpack_admin_page() {
+	?>
+		<h1>
+			Jetpack is not set up in this site
+		</h1>
+	<p>Please open a ticket with VIP Support to set it up.</p>
+	<?php
+}
+
+function add_jetpack_menu_placeholder() {
+	if ( ! Jetpack::is_connection_ready() ) {
+		add_submenu_page( 'jetpack', 'Connect Jetpack', 'Connect Jetpack', 'manage_options', 'connect-jetpack', 'vip_connect_to_jetpack_admin_page' );
+	}
+}
+
+add_action( 'admin_menu', 'add_jetpack_menu_placeholder', 999 );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -396,17 +396,10 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 	return $value;
 }, 10, 2 );
 
-function vip_connect_to_jetpack_admin_page() {
-	?>
-    <h1>Jetpack is not set up in this site</h1>
-	<p>Please open a ticket with VIP Support to set it up.</p>
-	<?php
-}
-
 // We need to add a dummy menu item if no other menu items are rendered
 function add_jetpack_menu_placeholder() {
 	if ( ! Jetpack::is_connection_ready() ) {
-		add_submenu_page( 'jetpack', 'Jetpack Not Connected', 'Jetpack not Connected', 'manage_options', 'connect-jetpack', 'vip_connect_to_jetpack_admin_page' );
+		add_submenu_page( 'jetpack', 'Connect Jetpack', 'Connect Jetpack', 'manage_options', 'jetpack' );
 	}
 }
 


### PR DESCRIPTION
## Description

Jetpack UI would break if all submenu items were removed (as it might be the case when Akismet and VaultPress are not active). Therefore, this PR adds a dummy submenu item that alerts the user that Jetpack is not connected and should contact the system administrator (VIP Support) to activate it.

<img width="171" alt="Screen Shot 2021-05-04 at 1 56 48 PM" src="https://user-images.githubusercontent.com/7188409/116999892-93f6aa00-ace0-11eb-8739-ac530aabe0dd.png">

## Changelog Description

### Jetpack Connect Notice

Adding Jetpack Connect Notice to wp-admin sidebar when Jetpack is not connected.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.