### PR TITLE
Don't try to add Jetpack connect menu if Jetpack is not active

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -398,6 +398,9 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 
 // We need to add a dummy menu item if no other menu items are rendered
 function add_jetpack_menu_placeholder() {
+	if ( ! class_exists( 'Jetpack' ) )
+		return;
+
 	$status = new Automattic\Jetpack\Status();
 	// is_connection_ready only exists in Jetpack 9.6 and newer
 	if ( ! $status->is_offline_mode() && method_exists('Jetpack', 'is_connection_ready') && ! Jetpack::is_connection_ready() ) {

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -398,8 +398,9 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 
 // We need to add a dummy menu item if no other menu items are rendered
 function add_jetpack_menu_placeholder() {
-	if ( ! class_exists( 'Jetpack' ) )
+	if ( ! class_exists( 'Jetpack' ) ) {
 		return;
+	}
 
 	$status = new Automattic\Jetpack\Status();
 	// is_connection_ready only exists in Jetpack 9.6 and newer


### PR DESCRIPTION
## Description

#2095 introduced a potential fatal if Jetpack is not active. 

Address that by adding a `class_exists` check before trying to call any Jetpack methods.

## Changelog Description

### Don't try display Jetpack Connect notice if Jetpack is not active

Internal update

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check Out the PR.
2. Disable Jetpack via constant
3. Verify there are no fatals
