### PR TITLE
Update default JetPack vesion from 9.6 to 9.7

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 9.6
+ * Version: 9.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -20,7 +20,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.6', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.4' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.6' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.7' );
 	}
 }
 


### PR DESCRIPTION

## Description


## Changelog Description

### Plugin Updated: Jetpack

We upgraded the default Jetpack version from 9.6 to 9.7. This will impact all unpinned sites.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Check the version in admin -> jetpack
