### PR TITLE
Use Jetpack's offline mode in Connection Pilot

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -19,8 +19,8 @@ class Controls {
 			return new \WP_Error( 'jp-cxn-pilot-missing-constants', 'This is not a valid VIP Go environment or some required constants are missing.' );
 		}
 
-		if ( \Jetpack::is_development_mode() ) {
-			return new \WP_Error( 'jp-cxn-pilot-development-mode', 'Jetpack is in development mode.' );
+		if ( (new \Automattic\Jetpack\Status())->is_offline_mode() ) {
+			return new \WP_Error( 'jp-cxn-pilot-offline-mode', 'Jetpack is in offline mode.' );
 		}
 
 		// The Jetpack::is_active() method just checks if there are user/blog tokens in the database.


### PR DESCRIPTION
## Description

To check if Jetpack is connected, Connection Pilot was using `is_development_mode`. This method [got deprecated in `8.8.0`](https://github.com/Automattic/jetpack/blob/5648ec24f73fd69b82603d7f9cc7a38484f77bab/projects/packages/status/src/class-status.php#L25) and it is now recommended to use `is_offline_mode`.

This PR changes the check for a development mode in Jetpack for offline mode.

## Changelog Description

### Use Jetpack's offline mode in Connection Pilot

Connection Pilot now checks for Jetpack's offline mode.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.