### PR TITLE
Update Query Monitor 3.6.5 => 3.7.1

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -140,6 +140,7 @@ add_action( 'wp', 'wpcom_vip_qm_disable_on_404' );
 
 
 // We are putting dispatchers as last so that QM still can catch other operations in shutdown action
+// See https://github.com/johnbillion/query-monitor/pull/549
 function change_dispatchers_shutdown_priority( array $dispatchers ) {
 	if ( is_array( $dispatchers ) ) {
 		if ( isset( $dispatchers['html'] ) ) {

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -1,20 +1,19 @@
 <?php
-
 /**
  * Query Monitor plugin for WordPress
  *
  * @package   query-monitor
  * @link      https://github.com/johnbillion/query-monitor
  * @author    John Blackbourn <john@johnblackbourn.com>
- * @copyright 2009-2020 John Blackbourn
+ * @copyright 2009-2021 John Blackbourn
  * @license   GPL v2 or later
  *
  * Plugin Name:  Query Monitor
  * Description:  The Developer Tools Panel for WordPress.
- * Version:      3.6.5
- * Plugin URI:   https://github.com/johnbillion/query-monitor
- * Author:       John Blackbourn & contributors
- * Author URI:   https://github.com/johnbillion/query-monitor/graphs/contributors
+ * Version:      3.7.1
+ * Plugin URI:   https://querymonitor.com/
+ * Author:       John Blackbourn
+ * Author URI:   https://querymonitor.com/
  * Text Domain:  query-monitor
  * Domain Path:  /languages/
  * Requires PHP: 5.3.6

--- a/query-monitor/assets/query-monitor-dark.css
+++ b/query-monitor/assets/query-monitor-dark.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * The dark colour scheme for Query Monitor.
  *
@@ -6,19 +7,15 @@
 #wpadminbar .quicklinks .menupop ul li.qm-true > a {
   color: #8c8 !important;
 }
-
 #wpadminbar .quicklinks .menupop ul li.qm-true > a:focus, #wpadminbar .quicklinks .menupop ul li.qm-true > a:hover {
   color: #47a747 !important;
 }
-
 #wpadminbar .qm-alert {
   background-color: #f60;
 }
-
 #wpadminbar .qm-alert:hover {
   background-color: #e65c00;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-stricts a,
 #wpadminbar #wp-admin-bar-query-monitor-deprecateds a,
 #wpadminbar #wp-admin-bar-query-monitor-notices a,
@@ -27,17 +24,14 @@
 #wpadminbar .qm-notice {
   background-color: #740;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-expensive a,
 #wpadminbar .qm-expensive {
   background-color: #b60;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-expensive a:hover,
 #wpadminbar .qm-expensive:hover {
   background-color: #915700;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-logger-warning a,
 #wpadminbar #wp-admin-bar-query-monitor-warnings a,
 #wpadminbar #wp-admin-bar-query-monitor-errors a,
@@ -45,7 +39,6 @@
 #wpadminbar .qm-warning {
   background-color: #c00;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-logger-warning a:hover,
 #wpadminbar #wp-admin-bar-query-monitor-warnings a:hover,
 #wpadminbar #wp-admin-bar-query-monitor-errors a:hover,
@@ -53,7 +46,6 @@
 #wpadminbar .qm-warning:hover {
   background-color: #b30000;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor .ab-icon {
   color: #aaa !important;
   display: none !important;
@@ -61,7 +53,6 @@
   padding: 0 10px !important;
   width: auto !important;
 }
-
 @media screen and (max-width: 782px) {
   #wpadminbar #wp-admin-bar-query-monitor .ab-icon {
     display: block !important;
@@ -143,7 +134,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   -webkit-font-smoothing: auto !important;
   font-style: normal !important;
   font-weight: normal !important;
-  letter-spacing: normal !important;
+  letter-spacing: -0.1px !important;
   line-height: 18px !important;
   margin: 0 !important;
   min-height: auto !important;
@@ -160,7 +151,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   word-wrap: normal !important;
   width: auto !important;
 }
-
 #query-monitor-main dl::before, #query-monitor-main dl::after,
 #query-monitor-main dt::before,
 #query-monitor-main dt::after,
@@ -212,7 +202,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 #query-monitor-main p::after {
   display: none !important;
 }
-
 #query-monitor-main {
   background: transparent !important;
   border: none !important;
@@ -227,7 +216,7 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   -webkit-font-smoothing: auto !important;
   font-style: normal !important;
   font-weight: normal !important;
-  letter-spacing: normal !important;
+  letter-spacing: -0.1px !important;
   line-height: 18px !important;
   margin: 0 !important;
   min-height: auto !important;
@@ -254,62 +243,50 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   text-align: left !important;
   z-index: 99998 !important;
 }
-
 #query-monitor-main::before, #query-monitor-main::after {
   display: none !important;
 }
-
 #query-monitor-main ::selection {
   background-color: #B9D6FB !important;
   color: #eaeef2 !important;
 }
-
 #query-monitor-main strong,
 #query-monitor-main b {
   font-weight: bold !important;
 }
-
 #query-monitor-main em,
 #query-monitor-main i {
   font-style: italic !important;
 }
-
 #query-monitor-main.qm-show, #query-monitor-main.qm-peek {
   display: flex;
   flex-direction: column !important;
   height: 27px;
 }
-
 #query-monitor-main.qm-show {
   height: 40%;
   width: 40%;
 }
-
 #query-monitor-main:not(.qm-show-right) {
   width: 100% !important;
 }
-
 #query-monitor-main.qm-show-right {
-  height: calc( 100vh - 32px) !important;
+  height: calc( 100vh - 32px ) !important;
   top: 32px !important;
   left: unset !important;
   border-top: 0 !important;
   border-left: 1px solid #50626f !important;
 }
-
 #query-monitor-main.qm-show-right #qm-panel-menu,
 #query-monitor-main.qm-show-right #qm-title h1.qm-title-heading {
   display: none;
 }
-
 #query-monitor-main.qm-show-right #qm-title div.qm-title-heading {
   display: block;
 }
-
 #query-monitor-main.qm-show-right #qm-title {
   cursor: default !important;
 }
-
 #query-monitor-main.qm-show-right #qm-side-resizer {
   background: transparent !important;
   cursor: ew-resize !important;
@@ -321,19 +298,16 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   width: 4px !important;
   z-index: 2 !important;
 }
-
 #query-monitor-main.qm-show-right.qm-peek {
   height: 100vh !important;
   top: 0 !important;
 }
-
 #query-monitor-main #qm-wrapper {
   display: flex;
   flex-grow: 1 !important;
   /* Fix nested scrolling in Firefox. See https://bugzilla.mozilla.org/show_bug.cgi?id=1043520: */
   min-height: 0;
 }
-
 #query-monitor-main #qm-title {
   align-items: center !important;
   background: #32373c !important;
@@ -342,48 +316,40 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   display: flex !important;
   flex-shrink: 0 !important;
   height: 27px !important;
-  padding: 0 0 0 5px !important;
+  padding: 0 0 0 10px !important;
   -moz-user-select: none !important;
   -ms-user-select: none !important;
   -webkit-user-select: none !important;
   user-select: none !important;
 }
-
 #query-monitor-main #qm-title .qm-title-heading {
   border-right: 1px solid #bbb !important;
   flex-grow: 1 !important;
   margin-right: 6px !important;
 }
-
 #query-monitor-main #qm-title div.qm-title-heading {
   display: none;
 }
-
 #query-monitor-main #qm-title .qm-title-button {
   flex-shrink: 0 !important;
 }
-
 #query-monitor-main #qm-title .dashicons {
   transition: none !important;
   height: 20px !important;
   width: 20px !important;
 }
-
 #query-monitor-main #qm-title .qm-button-container-close {
   margin-right: 10px !important;
 }
-
 #query-monitor-main #qm-title .qm-button-container-close .dashicons {
   font-size: 20px !important;
   margin: 3px 0 3px !important;
 }
-
 @media screen and (max-width: 960px) {
   #query-monitor-main #qm-title .qm-button-container-position {
     display: none !important;
   }
 }
-
 #query-monitor-main #qm-title button {
   background: transparent !important;
   color: #bbc8d4 !important;
@@ -393,7 +359,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   min-width: auto !important;
   padding: 0px 4px !important;
 }
-
 #query-monitor-main #qm-title button:focus *,
 #query-monitor-main #qm-title button:hover *,
 #query-monitor-main #qm-title button:focus,
@@ -401,36 +366,29 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   background: #bbc8d4 !important;
   color: #32373c !important;
 }
-
 #query-monitor-main #qm-title button:active *,
 #query-monitor-main #qm-title button:active {
   background: #ccc !important;
 }
-
 #query-monitor-main #qm-title button.qm-button-active {
   color: #3879d9 !important;
 }
-
 #query-monitor-main #qm-title .qm-button-container-settings .dashicons {
   font-size: 17px !important;
   margin: 4px 0 2px !important;
 }
-
 #query-monitor-main #qm-title .qm-button-container-position .dashicons {
   font-size: 15px !important;
   margin: 2px -1px 3px 4px !important;
   transform: scaleX(-1) rotate(90deg) !important;
 }
-
 #query-monitor-main.qm-show-right #qm-title .qm-button-container-position .dashicons {
   margin: 4px 1px 0px 1px !important;
   transform: none !important;
 }
-
 #query-monitor-main .qm {
   display: none !important;
 }
-
 #query-monitor-main #qm-panel-menu {
   background: #23282d !important;
   flex-shrink: 0 !important;
@@ -438,7 +396,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   overscroll-behavior: contain !important;
   height: auto !important;
 }
-
 #query-monitor-main #qm-panel-menu ul {
   display: block !important;
   list-style: none !important;
@@ -447,14 +404,15 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   width: auto !important;
   height: auto !important;
 }
-
 #query-monitor-main #qm-panel-menu li {
   display: list-item !important;
   margin: 0 !important;
   padding: 0 !important;
   height: auto !important;
 }
-
+#query-monitor-main #qm-panel-menu li ul {
+  display: none !important;
+}
 #query-monitor-main #qm-panel-menu li button {
   background: #23282d !important;
   border-bottom: 1px solid #32373c !important;
@@ -462,67 +420,59 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #eaeef2 !important;
   cursor: pointer !important;
   display: block !important;
-  padding: 8px 28px 8px 6px !important;
+  padding: 6px 32px 6px 10px !important;
   position: relative !important;
   text-decoration: none !important;
   width: 100% !important;
 }
-
 #query-monitor-main #qm-panel-menu li button:focus,
 #query-monitor-main #qm-panel-menu li button:hover {
   background: #3e444a !important;
   color: #bbc8d4 !important;
 }
-
 #query-monitor-main #qm-panel-menu li button:focus {
   text-decoration: underline !important;
 }
-
 #query-monitor-main #qm-panel-menu li button:active {
   text-decoration: none !important;
   background: #0073aa !important;
   color: #fff !important;
   text-shadow: 0 -1px 1px #006291, 1px 0 1px #006291, 0 1px 1px #006291, -1px 0 1px #006291 !important;
 }
-
+#query-monitor-main #qm-panel-menu li.qm-current-menu ul {
+  display: block !important;
+}
 #query-monitor-main #qm-panel-menu li.qm-current-menu button {
   background: #32373c !important;
   color: #eaeef2 !important;
 }
-
 #query-monitor-main #qm-panel-menu li.qm-current-menu button:focus {
   background: #3e444a !important;
   color: #eaeef2 !important;
 }
-
 #query-monitor-main #qm-panel-menu li.qm-current-menu button:hover {
   background: #3e444a !important;
   color: #bbc8d4 !important;
 }
-
 #query-monitor-main #qm-panel-menu li li button::before {
-  content: "\2514" !important;
+  content: "└" !important;
   display: inline-block !important;
   margin-right: 5px !important;
 }
-
-#query-monitor-main #qm-panel-menu li button[aria-selected="true"] {
+#query-monitor-main #qm-panel-menu li button[aria-selected=true] {
   background: #0073aa !important;
   color: #fff !important;
   text-shadow: 0 -1px 1px #006291, 1px 0 1px #006291, 0 1px 1px #006291, -1px 0 1px #006291 !important;
 }
-
-#query-monitor-main #qm-panel-menu li button[aria-selected="true"]:focus {
+#query-monitor-main #qm-panel-menu li button[aria-selected=true]:focus {
   background: #0084c4 !important;
   color: #fff !important;
 }
-
-#query-monitor-main #qm-panel-menu li button[aria-selected="true"]:hover {
+#query-monitor-main #qm-panel-menu li button[aria-selected=true]:hover {
   background: #0073aa !important;
   color: #fff !important;
 }
-
-#query-monitor-main #qm-panel-menu li button[aria-selected="true"]:after {
+#query-monitor-main #qm-panel-menu li button[aria-selected=true]:after {
   border: solid 8px transparent;
   border-right-color: #23282d;
   content: " ";
@@ -535,45 +485,36 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   top: 50%;
   width: 0;
 }
-
 #query-monitor-main #qm-panels {
   flex-grow: 1 !important;
   overflow-y: scroll !important;
   overscroll-behavior: contain !important;
 }
-
 #query-monitor-main .qm.qm-panel-show {
   display: block !important;
 }
-
 #query-monitor-main .qm:focus {
   outline: 0 !important;
   /* @TODO might not need this any more */
 }
-
 #query-monitor-main .qm-boxed {
   display: flex !important;
   flex-wrap: wrap !important;
 }
-
 #query-monitor-main .qm-boxed:not(#qm-broken) + .qm-boxed {
   border-top: 1px solid #50626f !important;
   padding-top: 10px !important;
 }
-
 #query-monitor-main .qm-boxed-wrap {
   flex-wrap: wrap !important;
 }
-
 #query-monitor-main .qm .qm-none {
   margin: 2em !important;
 }
-
 #query-monitor-main .qm .qm-none p {
   font-style: italic !important;
   text-align: center !important;
 }
-
 #query-monitor-main .qm table {
   border: none !important;
   border-collapse: collapse !important;
@@ -583,16 +524,13 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   table-layout: auto !important;
   width: 100% !important;
 }
-
 #query-monitor-main .qm table + table {
   border-top: 1px solid #23282d !important;
   margin-top: 5px !important;
 }
-
 #query-monitor-main .qm tr {
   border: none !important;
 }
-
 #query-monitor-main .qm tbody th,
 #query-monitor-main .qm tbody td,
 #query-monitor-main .qm tfoot th,
@@ -601,13 +539,11 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   padding: 5px 5px 4px 5px !important;
   vertical-align: top !important;
 }
-
 #query-monitor-main .qm tbody th,
 #query-monitor-main .qm tbody td {
   border-bottom: none !important;
   border-top: none !important;
 }
-
 #query-monitor-main .qm thead th {
   background: #32373c !important;
   border: 1px solid #23282d !important;
@@ -619,16 +555,13 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   top: 0 !important;
   z-index: 1 !important;
 }
-
 #query-monitor-main .qm thead th,
 #query-monitor-main .qm thead td {
   vertical-align: top !important;
 }
-
 #query-monitor-main .qm thead .qm-th {
   display: flex !important;
 }
-
 #query-monitor-main .qm tfoot tr td,
 #query-monitor-main .qm tfoot tr th {
   background: #32373c !important;
@@ -638,170 +571,142 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   position: -webkit-sticky !important;
   position: sticky !important;
 }
-
 #query-monitor-main .qm th:first-child,
 #query-monitor-main .qm td:first-child {
   border-left: none !important;
 }
-
 #query-monitor-main .qm th:last-child,
 #query-monitor-main .qm td:last-child {
   border-right: none !important;
 }
-
 #query-monitor-main .qm tfoot td.qm-num,
 #query-monitor-main .qm tfoot th.qm-num,
 #query-monitor-main .qm thead td.qm-num,
 #query-monitor-main .qm thead th.qm-num {
   width: 5.5em !important;
 }
-
 #query-monitor-main .qm th.qm-num,
 #query-monitor-main .qm td.qm-num {
   text-align: right !important;
 }
-
 #query-monitor-main .qm td.qm-num {
   font-family: Menlo, Monaco, Consolas, monospace !important;
   font-size: 11px !important;
-  line-height: 18px !important;
+  line-height: 19px !important;
 }
-
 #query-monitor-main .qm td.qm-row-sql {
   min-width: 25em !important;
 }
-
 #query-monitor-main .qm td.qm-row-block-attrs,
+#query-monitor-main .qm td.qm-row-block-context,
 #query-monitor-main .qm td.qm-row-block-html {
   max-width: 40em !important;
 }
-
+#query-monitor-main .qm td.qm-row-block-attrs,
+#query-monitor-main .qm td.qm-row-block-context,
+#query-monitor-main .qm td.qm-row-block-html,
 #query-monitor-main .qm tr.qm-warn td.qm-col-status,
 #query-monitor-main .qm td.qm-url,
 #query-monitor-main .qm th.qm-col-message,
 #query-monitor-main .qm td.qm-row-component {
   min-width: 15em !important;
 }
-
 #query-monitor-main .qm td.qm-has-toggle {
   padding-right: 24px !important;
   position: relative !important;
 }
-
 #query-monitor-main .qm td.qm-has-toggle:not(.qm-toggled-on) .qm-supplemental {
   display: none;
 }
-
 #query-monitor-main .qm .qm-inner-toggle {
   padding: 4px 6px !important;
 }
-
 #query-monitor-main .qm .qm-has-inner .qm-toggled > table {
   border-bottom: none !important;
   border-top: 1px solid #23282d !important;
 }
-
 #query-monitor-main .qm td.qm-has-inner .qm-toggler,
 #query-monitor-main .qm td.qm-has-inner {
   padding: 0 !important;
 }
-
 #query-monitor-main .qm caption h2 {
   font-size: 14px !important;
   margin: 20px !important;
 }
-
 #query-monitor-main .qm-concerns table {
   border-top: 1px solid #23282d !important;
   margin-bottom: 20px !important;
 }
-
 #query-monitor-main .qm-non-tabular {
   padding: 10px 20px !important;
 }
-
 #query-monitor-main .qm-non-tabular h3 {
   font-size: 14px !important;
   margin: 0 0 15px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular h4 {
   font-size: 12px !important;
   margin: 20px 0 10px !important;
 }
-
 #query-monitor-main .qm-non-tabular p {
   margin-bottom: 10px !important;
 }
-
 #query-monitor-main .qm-non-tabular dl {
   display: flex !important;
   flex-wrap: wrap !important;
   max-width: 60em !important;
 }
-
 #query-monitor-main .qm-non-tabular dt {
   border-top: 1px solid #50626f !important;
   flex-grow: 0;
   flex: 1 0 16em;
   padding: 10px 10px 10px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular dd {
   border-top: 1px solid #50626f !important;
   flex: 1 0 calc(100% - 10px - 16em);
   padding: 10px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular section,
 #query-monitor-main .qm-non-tabular .qm-section {
   margin: 0 0 30px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular .qm-boxed section,
 #query-monitor-main .qm-non-tabular .qm-boxed .qm-section {
   border-right: 1px solid #50626f !important;
   margin: 0 20px 10px 0 !important;
   padding: 10px 20px 10px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular .qm-boxed section:last-child,
 #query-monitor-main .qm-non-tabular .qm-boxed .qm-section:last-child {
   border-right: none !important;
   margin-right: 0 !important;
   padding-right: 20px !important;
 }
-
 #query-monitor-main .qm-non-tabular table {
   border-bottom-color: #23282d !important;
 }
-
 #query-monitor-main #qm-conditionals li {
   display: inline-block !important;
   margin: 0 20px 5px 0 !important;
 }
-
 #query-monitor-main .qm ol,
 #query-monitor-main .qm ul {
   list-style: none !important;
 }
-
 #query-monitor-main .qm li {
   display: list-item !important;
   list-style: none !important;
 }
-
 #query-monitor-main .qm li::before {
-  content: '' !important;
+  content: "" !important;
 }
-
 #query-monitor-main .qm code,
 #query-monitor-main .qm pre {
   font-family: Menlo, Monaco, Consolas, monospace !important;
   font-size: 11px !important;
-  line-height: 18px !important;
+  line-height: 19px !important;
 }
-
 #query-monitor-main .qm pre {
   background: transparent !important;
   height: auto !important;
@@ -809,65 +714,54 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   padding: 0 !important;
   width: auto !important;
 }
-
 #query-monitor-main .qm .qm-true code,
 #query-monitor-main .qm p.qm-true,
 #query-monitor-main .qm span.qm-true,
 #query-monitor-main .qm td.qm-true {
   color: #282 !important;
 }
-
 #query-monitor-main .qm .qm-false code,
 #query-monitor-main .qm span.qm-false,
 #query-monitor-main .qm td.qm-false {
   color: #999 !important;
 }
-
 #query-monitor-main .qm .qm-num,
 #query-monitor-main .qm code,
 #query-monitor-main .qm .qm-nowrap {
   white-space: nowrap !important;
 }
-
 #query-monitor-main .qm .qm-wrap code,
 #query-monitor-main .qm .qm-wrap {
   white-space: normal !important;
   word-break: break-all !important;
   word-wrap: break-word !important;
 }
-
 #query-monitor-main .qm .qm-pre-wrap code {
   white-space: pre-wrap !important;
   word-break: break-all !important;
   word-wrap: break-word !important;
 }
-
 #query-monitor-main .qm .qm-sticky {
   position: sticky !important;
   top: 36px !important;
 }
-
 #query-monitor-main .qm .qm-current,
 #query-monitor-main .qm td.qm-has-toggle p,
 #query-monitor-main .qm .qm-nonselectsql code,
 #query-monitor-main .qm .qm-nonselectsql {
   color: #a6a !important;
 }
-
 #query-monitor-main .qm .qm-info {
   color: #aaa !important;
 }
-
 #query-monitor-main .qm .qm-supplemental {
   margin-left: 0.75em !important;
   margin-right: 0.75em !important;
 }
-
 #query-monitor-main .qm td.qm-toggled-on .qm-inverse-toggled,
 #query-monitor-main .qm td .qm-toggled {
   display: none;
 }
-
 #query-monitor-main .qm button.qm-button,
 #query-monitor-main .qm .qm-toggle {
   background: #0085ba !important;
@@ -878,7 +772,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   font-weight: normal !important;
   text-shadow: none !important;
 }
-
 #query-monitor-main .qm .qm-toggle {
   bottom: auto !important;
   font-family: Menlo, Monaco, Consolas, monospace !important;
@@ -890,22 +783,19 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   right: 5px !important;
   text-align: center !important;
   top: 5px !important;
+  user-select: none;
   width: 18px !important;
 }
-
 #query-monitor-main .qm button {
   cursor: pointer !important;
 }
-
 #query-monitor-main .qm button.qm-button {
   padding: 4px 10px !important;
 }
-
 #query-monitor-main .qm .qm-has-inner .qm-toggle {
   right: 5px !important;
   top: 5px !important;
 }
-
 #query-monitor-main .qm button.qm-button:hover,
 #query-monitor-main .qm .qm-toggle:hover {
   background: #007aab !important;
@@ -913,7 +803,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #fff !important;
   text-decoration: none !important;
 }
-
 #query-monitor-main .qm button.qm-button:focus,
 #query-monitor-main .qm .qm-toggle:focus {
   background: #007aab !important;
@@ -921,7 +810,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #fff !important;
   box-shadow: 0 0 0 1px #fff, 0 0 0 3px #007aab !important;
 }
-
 #query-monitor-main .qm button.qm-button:active,
 #query-monitor-main .qm .qm-toggle:active {
   background: #006f9b !important;
@@ -929,19 +817,16 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #fff !important;
   box-shadow: none !important;
 }
-
 #query-monitor-main .qm tbody tr.qm-odd td,
 #query-monitor-main .qm tbody tr.qm-odd th {
   background: #32373c !important;
 }
-
 #query-monitor-main .qm-non-tabular .qm-warn,
 #query-monitor-main .qm thead tr .qm-warn,
 #query-monitor-main .qm tbody tr .qm-warn {
   background-color: #522 !important;
   color: #fff0f0 !important;
 }
-
 #query-monitor-main .qm tbody tr th.qm-warn,
 #query-monitor-main .qm tbody tr td.qm-warn,
 #query-monitor-main .qm tbody tr.qm-warn td,
@@ -949,14 +834,12 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   background-color: #522 !important;
   color: #fff0f0 !important;
 }
-
 #query-monitor-main .qm tbody tr.qm-odd th.qm-warn,
 #query-monitor-main .qm tbody tr.qm-odd td.qm-warn,
 #query-monitor-main .qm tbody tr.qm-odd.qm-warn td,
 #query-monitor-main .qm tbody tr.qm-odd.qm-warn th {
   background-color: #502020 !important;
 }
-
 #query-monitor-main .qm-non-tabular .qm-warn code,
 #query-monitor-main .qm tbody .qm-warn li,
 #query-monitor-main .qm tbody .qm-warn .qm-info,
@@ -964,14 +847,12 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   background-color: transparent !important;
   color: #fff0f0 !important;
 }
-
 #query-monitor-main .qm .qm-notice {
   background: #32373c !important;
   border: 1px solid #1b1e20 !important;
   margin: 0 0 10px 0 !important;
   padding: 10px 20px 0 !important;
 }
-
 #query-monitor-main .qm .dashicons {
   font-size: 16px !important;
   height: 16px !important;
@@ -979,25 +860,23 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   transition: none !important;
   width: 16px !important;
 }
-
 #query-monitor-main .qm .qm-dashicons-yes {
   background-color: #0a0 !important;
   border-radius: 50% !important;
   color: #fff !important;
 }
-
 #query-monitor-main .qm tbody tr td.qm-highlight,
+#query-monitor-main .qm tbody tr.qm-highlight th,
 #query-monitor-main .qm tbody tr.qm-highlight td {
   background-color: #57572a !important;
   color: #eaeef2 !important;
 }
-
 #query-monitor-main .qm tbody tr.qm-odd td.qm-highlight,
+#query-monitor-main .qm tbody tr.qm-odd.qm-highlight th,
 #query-monitor-main .qm tbody tr.qm-odd.qm-highlight td {
   background-color: #494923 !important;
   color: #eaeef2 !important;
 }
-
 #query-monitor-main .qm tbody tr.qm-odd.qm-hovered th,
 #query-monitor-main .qm tbody tr.qm-odd.qm-hovered td,
 #query-monitor-main .qm tbody tr.qm-odd:hover th,
@@ -1008,12 +887,10 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 #query-monitor-main .qm tbody tr:hover td {
   background: #373c42 !important;
 }
-
 #query-monitor-main .qm thead th.qm-filtered select.qm-filter {
   background-color: #57572a !important;
   color: #eaeef2 !important;
 }
-
 #query-monitor-main .qm button.qm-filter-trigger,
 #query-monitor-main .qm button.qm-filter-trigger code,
 #query-monitor-main .qm tbody .qm-warn a code,
@@ -1023,7 +900,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   cursor: pointer !important;
   text-decoration: none !important;
 }
-
 #query-monitor-main .qm button.qm-filter-trigger:after, #query-monitor-main .qm button.qm-filter-trigger:focus, #query-monitor-main .qm button.qm-filter-trigger:hover,
 #query-monitor-main .qm button.qm-filter-trigger code:after,
 #query-monitor-main .qm button.qm-filter-trigger code:focus,
@@ -1040,7 +916,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #4092d2 !important;
   text-decoration: underline !important;
 }
-
 #query-monitor-main .qm button.qm-filter-trigger:active,
 #query-monitor-main .qm button.qm-filter-trigger code:active,
 #query-monitor-main .qm tbody .qm-warn a code:active,
@@ -1049,7 +924,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #69aadc !important;
   text-decoration: underline !important;
 }
-
 #query-monitor-main .qm a.qm-external-link:after,
 #query-monitor-main .qm a.qm-link:after,
 #query-monitor-main .qm a.qm-edit-link:after,
@@ -1059,20 +933,18 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   font-family: dashicons !important;
   font-size: 14px !important;
   left: 2px !important;
-  line-height: 15px !important;
+  line-height: 13px !important;
   position: relative !important;
   text-decoration: none !important;
   top: 2px !important;
   visibility: hidden !important;
 }
-
 #query-monitor-main .qm button.qm-filter-info:before {
   left: unset !important;
   right: 2px !important;
-  content: '\f534' !important;
+  content: "" !important;
   visibility: visible !important;
 }
-
 #query-monitor-main .qm a.qm-external-link:after,
 #query-monitor-main .qm a.qm-link:hover:after,
 #query-monitor-main .qm a.qm-link:focus:after,
@@ -1082,24 +954,19 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 #query-monitor-main .qm button.qm-filter-trigger:focus:after {
   visibility: visible !important;
 }
-
 #query-monitor-main .qm button.qm-filter-trigger:after {
-  content: '\f536' !important;
+  content: "" !important;
 }
-
 #query-monitor-main .qm a.qm-edit-link:after {
-  content: '\f464' !important;
+  content: "" !important;
 }
-
 #query-monitor-main .qm a.qm-external-link:after,
 #query-monitor-main .qm a.qm-link:after {
-  content: '\f504' !important;
+  content: "" !important;
 }
-
 #query-monitor-main #qm-ajax-errors {
   display: none;
 }
-
 #query-monitor-main button,
 #query-monitor-main select {
   background: none !important;
@@ -1108,7 +975,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   margin: 0 !important;
   width: auto !important;
 }
-
 #query-monitor-main .qm label {
   color: #eaeef2 !important;
   cursor: pointer !important;
@@ -1117,25 +983,21 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   font-weight: normal !important;
   margin: 0 !important;
 }
-
 #query-monitor-main .qm thead label {
   flex-grow: 1 !important;
 }
-
 #query-monitor-main .qm .qm-filter-container {
   display: flex !important;
 }
-
 #query-monitor-main .qm .qm-filter-container label {
   cursor: default !important;
   white-space: nowrap !important;
 }
-
 #query-monitor-main .qm .qm-filter-container div {
   /* Some themes use Select2 etc on all selects. This hides that. */
   display: none !important;
 }
-
+#query-monitor-main .qm-title-heading select,
 #query-monitor-main .qm select.qm-filter {
   -webkit-appearance: menulist !important;
   -moz-appearance: menulist !important;
@@ -1147,18 +1009,19 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   display: block !important;
   float: none !important;
   height: auto !important;
-  letter-spacing: normal !important;
+  letter-spacing: -0.1px !important;
   margin: 0 0 0 5px !important;
   max-width: 12em !important;
   outline: 1px solid #50626f !important;
   padding: 0 !important;
   width: auto !important;
 }
-
-#query-monitor-main .qm select.qm-filter:hover {
-  background: #32373c !important;
+#query-monitor-main .qm-title-heading select {
+  max-width: unset !important;
 }
-
+#query-monitor-main .qm select.qm-filter:hover {
+  background: #373c42 !important;
+}
 #query-monitor-main .qm-hide,
 #query-monitor-main .qm-hide-scripts-dependencies,
 #query-monitor-main .qm-hide-styles-dependencies,
@@ -1174,24 +1037,19 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 #query-monitor-main .qm-hide-component {
   display: none !important;
 }
-
 #query-monitor-main .qm thead th.qm-sortable-column {
   cursor: pointer !important;
 }
-
 #query-monitor-main .qm thead th.qm-sortable-column:hover {
   background: #32373c !important;
 }
-
 #query-monitor-main .qm .qm-sort-heading {
   flex-grow: 1 !important;
 }
-
 #query-monitor-main .qm .qm-sort-controls {
   flex-shrink: 0 !important;
   text-align: right !important;
 }
-
 #query-monitor-main .qm .qm-sortable-column .qm-sort-arrow {
   color: #ccc !important;
   display: block !important;
@@ -1201,39 +1059,32 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   margin: 0 !important;
   width: 16px !important;
 }
-
 #query-monitor-main .qm .qm-sortable-column .qm-sort-arrow::before {
-  content: "\f140" !important;
+  content: "" !important;
   position: absolute !important;
   right: 0 !important;
   top: 4px !important;
 }
-
 #query-monitor-main .qm .qm-sorted-desc .qm-sort-arrow,
 #query-monitor-main .qm .qm-sorted-asc .qm-sort-arrow {
   color: #eaeef2 !important;
 }
-
 #query-monitor-main .qm thead th.qm-sortable-column:hover .qm-sort-arrow {
   color: #0073aa !important;
 }
-
 #query-monitor-main .qm .qm-sortable-column.qm-sorted-asc .qm-sort-arrow::before {
-  content: "\f142" !important;
+  content: "" !important;
 }
-
 #query-monitor-main .qm button:focus,
 #query-monitor-main .qm a:focus,
 #query-monitor-main .qm select:focus {
   box-shadow: 0 0 0 1px #fff, 0 0 0 3px #007aab !important;
 }
-
 #query-monitor-main .qm button:active,
 #query-monitor-main .qm a:active,
 #query-monitor-main .qm select:active {
   box-shadow: none !important;
 }
-
 #query-monitor-main .qm-screen-reader-text,
 #query-monitor-main .screen-reader-text {
   border: 0 !important;
@@ -1245,52 +1096,41 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   position: absolute !important;
   width: 1px !important;
 }
-
 @media screen and (max-width: 782px) {
   #query-monitor-main #qm-panel-menu,
-  #query-monitor-main #qm-title h1.qm-title-heading {
+#query-monitor-main #qm-title h1.qm-title-heading {
     display: none;
   }
   #query-monitor-main #qm-title div.qm-title-heading {
     display: block;
   }
 }
-
-#query-monitor-main [data-qm-state="off"] [data-qm-state-visibility="on"],
-#query-monitor-main [data-qm-state="on"] [data-qm-state-visibility="off"] {
+#query-monitor-main [data-qm-state=off] [data-qm-state-visibility=on],
+#query-monitor-main [data-qm-state=on] [data-qm-state-visibility=off] {
   display: none;
 }
-
-#query-monitor-main.qm-no-js .qm-sort-controls,
-#query-monitor-main.qm-no-js .qm-toggle,
-#query-monitor-main.qm-no-js select.qm-filter {
+#query-monitor-main.qm-no-js .qm-sort-controls, #query-monitor-main.qm-no-js .qm-toggle, #query-monitor-main.qm-no-js select.qm-filter {
   display: none !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar textarea,
 #query-monitor-main .qm.qm-debug-bar pre {
   border: 1px solid #50626f !important;
   margin: 4px 0 !important;
   padding: 10px !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar textarea {
   resize: vertical !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar .left {
   float: left !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar .right {
   float: right !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h2 {
   font-size: 14px !important;
   margin: 4px 6px 15px !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h3 {
   clear: none !important;
   float: left !important;
@@ -1301,87 +1141,65 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   padding: 5px 10px 15px !important;
   text-align: center !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h3 small {
   font-size: 14px !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h3 span {
   display: block !important;
   margin-bottom: 8px !important;
   white-space: nowrap !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h4 {
   font-size: 13px !important;
   margin: 15px 6px 5px !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar .qm-debug-bar-output {
   position: relative !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar .qm-debug-bar-output table {
   margin-bottom: 4px !important;
   margin-top: 4px !important;
 }
-
 #query-monitor-main #debug-menu-target-Debug_Bar_Console {
   min-height: 400px !important;
 }
-
 #query-monitor-main #debug-menu-target-Debug_Bar_Cache_Lookup,
 #query-monitor-main #debug-menu-target-Debug_Bar_Rewrite_Rules,
 #query-monitor-main #debug-menu-target-Debug_Bar_Widgets {
   margin: 4px 6px !important;
 }
-
 #query-monitor-main #debug-menu-target-Debug_Bar_Rewrite_Rules_Panel .filterui,
 #query-monitor-main #debug-menu-target-Debug_Bar_Rewrite_Rules_Panel .dbrr {
   margin: 0 !important;
 }
-
 #query-monitor-main #qm-broken {
   display: none !important;
 }
-
 #query-monitor-main.qm-broken #qm-title {
   cursor: default !important;
 }
-
 #query-monitor-main.qm-broken #qm-title .qm-title-heading {
   border-right: none !important;
 }
-
-#query-monitor-main.qm-broken .qm td .qm-toggled,
-#query-monitor-main.qm-broken #qm-broken,
-#query-monitor-main.qm-broken .qm {
+#query-monitor-main.qm-broken .qm td .qm-toggled, #query-monitor-main.qm-broken #qm-broken, #query-monitor-main.qm-broken .qm {
   display: block !important;
 }
-
-#query-monitor-main.qm-broken #qm-panel-menu,
-#query-monitor-main.qm-broken #qm-settings,
-#query-monitor-main.qm-broken #qm-title .qm-title-button {
+#query-monitor-main.qm-broken #qm-panel-menu, #query-monitor-main.qm-broken #qm-settings, #query-monitor-main.qm-broken #qm-title .qm-title-button {
   display: none !important;
 }
-
 #query-monitor-main.qm-broken .qm {
   margin-bottom: 50px !important;
 }
-
 #query-monitor-main.qm-broken .qm button.qm-filter-trigger {
   color: #eaeef2 !important;
   cursor: text !important;
 }
-
 #query-monitor-main.qm-broken .qm button.qm-filter-trigger:after {
   display: none !important;
 }
-
 #query-monitor-main.qm-broken .qm button.qm-filter-trigger:focus, #query-monitor-main.qm-broken .qm button.qm-filter-trigger:hover, #query-monitor-main.qm-broken .qm button.qm-filter-trigger:active {
   text-decoration: none !important;
 }
-
 #query-monitor-main.qm-broken #qm-broken h2 {
   padding: 20px !important;
 }
@@ -1396,7 +1214,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   position: absolute !important;
   z-index: 99999 !important;
 }
-
 #qm-fatal h2 {
   font-size: 12px !important;
   font-weight: normal !important;
@@ -1404,27 +1221,22 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   background: #f3f3f3 !important;
   margin: 0 !important;
 }
-
 #qm-fatal .dashicons {
   color: #c00 !important;
 }
-
 #qm-fatal ol,
 #qm-fatal p {
   font-size: 12px !important;
   padding: 0 !important;
   margin: 1em !important;
 }
-
 #qm-fatal ol {
   padding: 0 0 1em 1em !important;
 }
-
 #qm-fatal li {
   margin: 0 0 0.7em !important;
   list-style: none !important;
 }
-
 #qm-fatal .qm-info {
   color: #666 !important;
 }

--- a/query-monitor/assets/query-monitor.css
+++ b/query-monitor/assets/query-monitor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * The standard colour scheme for Query Monitor.
  *
@@ -6,19 +7,15 @@
 #wpadminbar .quicklinks .menupop ul li.qm-true > a {
   color: #8c8 !important;
 }
-
 #wpadminbar .quicklinks .menupop ul li.qm-true > a:focus, #wpadminbar .quicklinks .menupop ul li.qm-true > a:hover {
   color: #47a747 !important;
 }
-
 #wpadminbar .qm-alert {
   background-color: #f60;
 }
-
 #wpadminbar .qm-alert:hover {
   background-color: #e65c00;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-stricts a,
 #wpadminbar #wp-admin-bar-query-monitor-deprecateds a,
 #wpadminbar #wp-admin-bar-query-monitor-notices a,
@@ -27,17 +24,14 @@
 #wpadminbar .qm-notice {
   background-color: #740;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-expensive a,
 #wpadminbar .qm-expensive {
   background-color: #b60;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-expensive a:hover,
 #wpadminbar .qm-expensive:hover {
   background-color: #915700;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-logger-warning a,
 #wpadminbar #wp-admin-bar-query-monitor-warnings a,
 #wpadminbar #wp-admin-bar-query-monitor-errors a,
@@ -45,7 +39,6 @@
 #wpadminbar .qm-warning {
   background-color: #c00;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor-logger-warning a:hover,
 #wpadminbar #wp-admin-bar-query-monitor-warnings a:hover,
 #wpadminbar #wp-admin-bar-query-monitor-errors a:hover,
@@ -53,7 +46,6 @@
 #wpadminbar .qm-warning:hover {
   background-color: #b30000;
 }
-
 #wpadminbar #wp-admin-bar-query-monitor .ab-icon {
   color: #aaa !important;
   display: none !important;
@@ -61,7 +53,6 @@
   padding: 0 10px !important;
   width: auto !important;
 }
-
 @media screen and (max-width: 782px) {
   #wpadminbar #wp-admin-bar-query-monitor .ab-icon {
     display: block !important;
@@ -136,14 +127,14 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   box-shadow: none !important;
   box-sizing: border-box !important;
   clear: both !important;
-  color: #222 !important;
+  color: #444 !important;
   float: none !important;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
   font-size: 12px !important;
   -webkit-font-smoothing: auto !important;
   font-style: normal !important;
   font-weight: normal !important;
-  letter-spacing: normal !important;
+  letter-spacing: -0.1px !important;
   line-height: 18px !important;
   margin: 0 !important;
   min-height: auto !important;
@@ -160,7 +151,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   word-wrap: normal !important;
   width: auto !important;
 }
-
 #query-monitor-main dl::before, #query-monitor-main dl::after,
 #query-monitor-main dt::before,
 #query-monitor-main dt::after,
@@ -212,7 +202,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 #query-monitor-main p::after {
   display: none !important;
 }
-
 #query-monitor-main {
   background: transparent !important;
   border: none !important;
@@ -220,14 +209,14 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   box-shadow: none !important;
   box-sizing: border-box !important;
   clear: both !important;
-  color: #222 !important;
+  color: #444 !important;
   float: none !important;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
   font-size: 12px !important;
   -webkit-font-smoothing: auto !important;
   font-style: normal !important;
   font-weight: normal !important;
-  letter-spacing: normal !important;
+  letter-spacing: -0.1px !important;
   line-height: 18px !important;
   margin: 0 !important;
   min-height: auto !important;
@@ -254,62 +243,50 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   text-align: left !important;
   z-index: 99998 !important;
 }
-
 #query-monitor-main::before, #query-monitor-main::after {
   display: none !important;
 }
-
 #query-monitor-main ::selection {
   background-color: #B9D6FB !important;
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main strong,
 #query-monitor-main b {
   font-weight: bold !important;
 }
-
 #query-monitor-main em,
 #query-monitor-main i {
   font-style: italic !important;
 }
-
 #query-monitor-main.qm-show, #query-monitor-main.qm-peek {
   display: flex;
   flex-direction: column !important;
   height: 27px;
 }
-
 #query-monitor-main.qm-show {
   height: 40%;
   width: 40%;
 }
-
 #query-monitor-main:not(.qm-show-right) {
   width: 100% !important;
 }
-
 #query-monitor-main.qm-show-right {
-  height: calc( 100vh - 32px) !important;
+  height: calc( 100vh - 32px ) !important;
   top: 32px !important;
   left: unset !important;
   border-top: 0 !important;
   border-left: 1px solid #aaa !important;
 }
-
 #query-monitor-main.qm-show-right #qm-panel-menu,
 #query-monitor-main.qm-show-right #qm-title h1.qm-title-heading {
   display: none;
 }
-
 #query-monitor-main.qm-show-right #qm-title div.qm-title-heading {
   display: block;
 }
-
 #query-monitor-main.qm-show-right #qm-title {
   cursor: default !important;
 }
-
 #query-monitor-main.qm-show-right #qm-side-resizer {
   background: transparent !important;
   cursor: ew-resize !important;
@@ -321,19 +298,16 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   width: 4px !important;
   z-index: 2 !important;
 }
-
 #query-monitor-main.qm-show-right.qm-peek {
   height: 100vh !important;
   top: 0 !important;
 }
-
 #query-monitor-main #qm-wrapper {
   display: flex;
   flex-grow: 1 !important;
   /* Fix nested scrolling in Firefox. See https://bugzilla.mozilla.org/show_bug.cgi?id=1043520: */
   min-height: 0;
 }
-
 #query-monitor-main #qm-title {
   align-items: center !important;
   background: #f3f3f3 !important;
@@ -342,48 +316,40 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   display: flex !important;
   flex-shrink: 0 !important;
   height: 27px !important;
-  padding: 0 0 0 5px !important;
+  padding: 0 0 0 10px !important;
   -moz-user-select: none !important;
   -ms-user-select: none !important;
   -webkit-user-select: none !important;
   user-select: none !important;
 }
-
 #query-monitor-main #qm-title .qm-title-heading {
   border-right: 1px solid #bbb !important;
   flex-grow: 1 !important;
   margin-right: 6px !important;
 }
-
 #query-monitor-main #qm-title div.qm-title-heading {
   display: none;
 }
-
 #query-monitor-main #qm-title .qm-title-button {
   flex-shrink: 0 !important;
 }
-
 #query-monitor-main #qm-title .dashicons {
   transition: none !important;
   height: 20px !important;
   width: 20px !important;
 }
-
 #query-monitor-main #qm-title .qm-button-container-close {
   margin-right: 10px !important;
 }
-
 #query-monitor-main #qm-title .qm-button-container-close .dashicons {
   font-size: 20px !important;
   margin: 3px 0 3px !important;
 }
-
 @media screen and (max-width: 960px) {
   #query-monitor-main #qm-title .qm-button-container-position {
     display: none !important;
   }
 }
-
 #query-monitor-main #qm-title button {
   background: transparent !important;
   color: #666 !important;
@@ -393,7 +359,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   min-width: auto !important;
   padding: 0px 4px !important;
 }
-
 #query-monitor-main #qm-title button:focus *,
 #query-monitor-main #qm-title button:hover *,
 #query-monitor-main #qm-title button:focus,
@@ -401,36 +366,29 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   background: #e6e6e6 !important;
   color: #000 !important;
 }
-
 #query-monitor-main #qm-title button:active *,
 #query-monitor-main #qm-title button:active {
   background: #ccc !important;
 }
-
 #query-monitor-main #qm-title button.qm-button-active {
   color: #3879d9 !important;
 }
-
 #query-monitor-main #qm-title .qm-button-container-settings .dashicons {
   font-size: 17px !important;
   margin: 4px 0 2px !important;
 }
-
 #query-monitor-main #qm-title .qm-button-container-position .dashicons {
   font-size: 15px !important;
   margin: 2px -1px 3px 4px !important;
   transform: scaleX(-1) rotate(90deg) !important;
 }
-
 #query-monitor-main.qm-show-right #qm-title .qm-button-container-position .dashicons {
   margin: 4px 1px 0px 1px !important;
   transform: none !important;
 }
-
 #query-monitor-main .qm {
   display: none !important;
 }
-
 #query-monitor-main #qm-panel-menu {
   background: #ececec !important;
   flex-shrink: 0 !important;
@@ -438,7 +396,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   overscroll-behavior: contain !important;
   height: auto !important;
 }
-
 #query-monitor-main #qm-panel-menu ul {
   display: block !important;
   list-style: none !important;
@@ -447,82 +404,75 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   width: auto !important;
   height: auto !important;
 }
-
 #query-monitor-main #qm-panel-menu li {
   display: list-item !important;
   margin: 0 !important;
   padding: 0 !important;
   height: auto !important;
 }
-
+#query-monitor-main #qm-panel-menu li ul {
+  display: none !important;
+}
 #query-monitor-main #qm-panel-menu li button {
   background: #f3f3f3 !important;
   border-bottom: 1px solid #ddd !important;
   border-right: 1px solid #aaa !important;
-  color: #333 !important;
+  color: #444 !important;
   cursor: pointer !important;
   display: block !important;
-  padding: 8px 28px 8px 6px !important;
+  padding: 6px 32px 6px 10px !important;
   position: relative !important;
   text-decoration: none !important;
   width: 100% !important;
 }
-
 #query-monitor-main #qm-panel-menu li button:focus,
 #query-monitor-main #qm-panel-menu li button:hover {
   background: #cde !important;
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main #qm-panel-menu li button:focus {
   text-decoration: underline !important;
 }
-
 #query-monitor-main #qm-panel-menu li button:active {
   text-decoration: none !important;
   background: #0073aa !important;
   color: #fff !important;
   text-shadow: 0 -1px 1px #006291, 1px 0 1px #006291, 0 1px 1px #006291, -1px 0 1px #006291 !important;
 }
-
+#query-monitor-main #qm-panel-menu li.qm-current-menu ul {
+  display: block !important;
+}
 #query-monitor-main #qm-panel-menu li.qm-current-menu button {
   background: #def !important;
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main #qm-panel-menu li.qm-current-menu button:focus {
   background: #f7fbff !important;
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main #qm-panel-menu li.qm-current-menu button:hover {
   background: #cde !important;
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main #qm-panel-menu li li button::before {
-  content: "\2514" !important;
+  content: "└" !important;
   display: inline-block !important;
   margin-right: 5px !important;
 }
-
-#query-monitor-main #qm-panel-menu li button[aria-selected="true"] {
+#query-monitor-main #qm-panel-menu li button[aria-selected=true] {
   background: #0073aa !important;
   color: #fff !important;
   text-shadow: 0 -1px 1px #006291, 1px 0 1px #006291, 0 1px 1px #006291, -1px 0 1px #006291 !important;
 }
-
-#query-monitor-main #qm-panel-menu li button[aria-selected="true"]:focus {
+#query-monitor-main #qm-panel-menu li button[aria-selected=true]:focus {
   background: #0084c4 !important;
   color: #fff !important;
 }
-
-#query-monitor-main #qm-panel-menu li button[aria-selected="true"]:hover {
+#query-monitor-main #qm-panel-menu li button[aria-selected=true]:hover {
   background: #0073aa !important;
   color: #fff !important;
 }
-
-#query-monitor-main #qm-panel-menu li button[aria-selected="true"]:after {
+#query-monitor-main #qm-panel-menu li button[aria-selected=true]:after {
   border: solid 8px transparent;
   border-right-color: #fff;
   content: " ";
@@ -535,64 +485,52 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   top: 50%;
   width: 0;
 }
-
 #query-monitor-main #qm-panels {
   flex-grow: 1 !important;
   overflow-y: scroll !important;
   overscroll-behavior: contain !important;
 }
-
 #query-monitor-main .qm.qm-panel-show {
   display: block !important;
 }
-
 #query-monitor-main .qm:focus {
   outline: 0 !important;
   /* @TODO might not need this any more */
 }
-
 #query-monitor-main .qm-boxed {
   display: flex !important;
   flex-wrap: wrap !important;
 }
-
 #query-monitor-main .qm-boxed:not(#qm-broken) + .qm-boxed {
   border-top: 1px solid #ddd !important;
   padding-top: 10px !important;
 }
-
 #query-monitor-main .qm-boxed-wrap {
   flex-wrap: wrap !important;
 }
-
 #query-monitor-main .qm .qm-none {
   margin: 2em !important;
 }
-
 #query-monitor-main .qm .qm-none p {
   font-style: italic !important;
   text-align: center !important;
 }
-
 #query-monitor-main .qm table {
   border: none !important;
   border-collapse: collapse !important;
   box-shadow: 0px 1px 0px 0px #aaa !important;
-  color: #222 !important;
+  color: #444 !important;
   margin: 0 !important;
   table-layout: auto !important;
   width: 100% !important;
 }
-
 #query-monitor-main .qm table + table {
   border-top: 1px solid #e0e0e0 !important;
   margin-top: 5px !important;
 }
-
 #query-monitor-main .qm tr {
   border: none !important;
 }
-
 #query-monitor-main .qm tbody th,
 #query-monitor-main .qm tbody td,
 #query-monitor-main .qm tfoot th,
@@ -601,13 +539,11 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   padding: 5px 5px 4px 5px !important;
   vertical-align: top !important;
 }
-
 #query-monitor-main .qm tbody th,
 #query-monitor-main .qm tbody td {
   border-bottom: none !important;
   border-top: none !important;
 }
-
 #query-monitor-main .qm thead th {
   background: #fff !important;
   border: 1px solid #e0e0e0 !important;
@@ -619,16 +555,13 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   top: 0 !important;
   z-index: 1 !important;
 }
-
 #query-monitor-main .qm thead th,
 #query-monitor-main .qm thead td {
   vertical-align: top !important;
 }
-
 #query-monitor-main .qm thead .qm-th {
   display: flex !important;
 }
-
 #query-monitor-main .qm tfoot tr td,
 #query-monitor-main .qm tfoot tr th {
   background: #f3f3f3 !important;
@@ -638,170 +571,142 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   position: -webkit-sticky !important;
   position: sticky !important;
 }
-
 #query-monitor-main .qm th:first-child,
 #query-monitor-main .qm td:first-child {
   border-left: none !important;
 }
-
 #query-monitor-main .qm th:last-child,
 #query-monitor-main .qm td:last-child {
   border-right: none !important;
 }
-
 #query-monitor-main .qm tfoot td.qm-num,
 #query-monitor-main .qm tfoot th.qm-num,
 #query-monitor-main .qm thead td.qm-num,
 #query-monitor-main .qm thead th.qm-num {
   width: 5.5em !important;
 }
-
 #query-monitor-main .qm th.qm-num,
 #query-monitor-main .qm td.qm-num {
   text-align: right !important;
 }
-
 #query-monitor-main .qm td.qm-num {
   font-family: Menlo, Monaco, Consolas, monospace !important;
   font-size: 11px !important;
-  line-height: 18px !important;
+  line-height: 19px !important;
 }
-
 #query-monitor-main .qm td.qm-row-sql {
   min-width: 25em !important;
 }
-
 #query-monitor-main .qm td.qm-row-block-attrs,
+#query-monitor-main .qm td.qm-row-block-context,
 #query-monitor-main .qm td.qm-row-block-html {
   max-width: 40em !important;
 }
-
+#query-monitor-main .qm td.qm-row-block-attrs,
+#query-monitor-main .qm td.qm-row-block-context,
+#query-monitor-main .qm td.qm-row-block-html,
 #query-monitor-main .qm tr.qm-warn td.qm-col-status,
 #query-monitor-main .qm td.qm-url,
 #query-monitor-main .qm th.qm-col-message,
 #query-monitor-main .qm td.qm-row-component {
   min-width: 15em !important;
 }
-
 #query-monitor-main .qm td.qm-has-toggle {
   padding-right: 24px !important;
   position: relative !important;
 }
-
 #query-monitor-main .qm td.qm-has-toggle:not(.qm-toggled-on) .qm-supplemental {
   display: none;
 }
-
 #query-monitor-main .qm .qm-inner-toggle {
   padding: 4px 6px !important;
 }
-
 #query-monitor-main .qm .qm-has-inner .qm-toggled > table {
   border-bottom: none !important;
   border-top: 1px solid #e0e0e0 !important;
 }
-
 #query-monitor-main .qm td.qm-has-inner .qm-toggler,
 #query-monitor-main .qm td.qm-has-inner {
   padding: 0 !important;
 }
-
 #query-monitor-main .qm caption h2 {
   font-size: 14px !important;
   margin: 20px !important;
 }
-
 #query-monitor-main .qm-concerns table {
   border-top: 1px solid #e0e0e0 !important;
   margin-bottom: 20px !important;
 }
-
 #query-monitor-main .qm-non-tabular {
   padding: 10px 20px !important;
 }
-
 #query-monitor-main .qm-non-tabular h3 {
   font-size: 14px !important;
   margin: 0 0 15px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular h4 {
   font-size: 12px !important;
   margin: 20px 0 10px !important;
 }
-
 #query-monitor-main .qm-non-tabular p {
   margin-bottom: 10px !important;
 }
-
 #query-monitor-main .qm-non-tabular dl {
   display: flex !important;
   flex-wrap: wrap !important;
   max-width: 60em !important;
 }
-
 #query-monitor-main .qm-non-tabular dt {
   border-top: 1px solid #ddd !important;
   flex-grow: 0;
   flex: 1 0 16em;
   padding: 10px 10px 10px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular dd {
   border-top: 1px solid #ddd !important;
   flex: 1 0 calc(100% - 10px - 16em);
   padding: 10px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular section,
 #query-monitor-main .qm-non-tabular .qm-section {
   margin: 0 0 30px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular .qm-boxed section,
 #query-monitor-main .qm-non-tabular .qm-boxed .qm-section {
   border-right: 1px solid #ddd !important;
   margin: 0 20px 10px 0 !important;
   padding: 10px 20px 10px 0 !important;
 }
-
 #query-monitor-main .qm-non-tabular .qm-boxed section:last-child,
 #query-monitor-main .qm-non-tabular .qm-boxed .qm-section:last-child {
   border-right: none !important;
   margin-right: 0 !important;
   padding-right: 20px !important;
 }
-
 #query-monitor-main .qm-non-tabular table {
   border-bottom-color: #e0e0e0 !important;
 }
-
 #query-monitor-main #qm-conditionals li {
   display: inline-block !important;
   margin: 0 20px 5px 0 !important;
 }
-
 #query-monitor-main .qm ol,
 #query-monitor-main .qm ul {
   list-style: none !important;
 }
-
 #query-monitor-main .qm li {
   display: list-item !important;
   list-style: none !important;
 }
-
 #query-monitor-main .qm li::before {
-  content: '' !important;
+  content: "" !important;
 }
-
 #query-monitor-main .qm code,
 #query-monitor-main .qm pre {
   font-family: Menlo, Monaco, Consolas, monospace !important;
   font-size: 11px !important;
-  line-height: 18px !important;
+  line-height: 19px !important;
 }
-
 #query-monitor-main .qm pre {
   background: transparent !important;
   height: auto !important;
@@ -809,65 +714,54 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   padding: 0 !important;
   width: auto !important;
 }
-
 #query-monitor-main .qm .qm-true code,
 #query-monitor-main .qm p.qm-true,
 #query-monitor-main .qm span.qm-true,
 #query-monitor-main .qm td.qm-true {
   color: #282 !important;
 }
-
 #query-monitor-main .qm .qm-false code,
 #query-monitor-main .qm span.qm-false,
 #query-monitor-main .qm td.qm-false {
   color: #999 !important;
 }
-
 #query-monitor-main .qm .qm-num,
 #query-monitor-main .qm code,
 #query-monitor-main .qm .qm-nowrap {
   white-space: nowrap !important;
 }
-
 #query-monitor-main .qm .qm-wrap code,
 #query-monitor-main .qm .qm-wrap {
   white-space: normal !important;
   word-break: break-all !important;
   word-wrap: break-word !important;
 }
-
 #query-monitor-main .qm .qm-pre-wrap code {
   white-space: pre-wrap !important;
   word-break: break-all !important;
   word-wrap: break-word !important;
 }
-
 #query-monitor-main .qm .qm-sticky {
   position: sticky !important;
   top: 36px !important;
 }
-
 #query-monitor-main .qm .qm-current,
 #query-monitor-main .qm td.qm-has-toggle p,
 #query-monitor-main .qm .qm-nonselectsql code,
 #query-monitor-main .qm .qm-nonselectsql {
   color: #a0a !important;
 }
-
 #query-monitor-main .qm .qm-info {
   color: #666 !important;
 }
-
 #query-monitor-main .qm .qm-supplemental {
   margin-left: 0.75em !important;
   margin-right: 0.75em !important;
 }
-
 #query-monitor-main .qm td.qm-toggled-on .qm-inverse-toggled,
 #query-monitor-main .qm td .qm-toggled {
   display: none;
 }
-
 #query-monitor-main .qm button.qm-button,
 #query-monitor-main .qm .qm-toggle {
   background: #007cba !important;
@@ -878,7 +772,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   font-weight: normal !important;
   text-shadow: none !important;
 }
-
 #query-monitor-main .qm .qm-toggle {
   bottom: auto !important;
   font-family: Menlo, Monaco, Consolas, monospace !important;
@@ -890,22 +783,19 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   right: 5px !important;
   text-align: center !important;
   top: 5px !important;
+  user-select: none;
   width: 18px !important;
 }
-
 #query-monitor-main .qm button {
   cursor: pointer !important;
 }
-
 #query-monitor-main .qm button.qm-button {
   padding: 4px 10px !important;
 }
-
 #query-monitor-main .qm .qm-has-inner .qm-toggle {
   right: 5px !important;
   top: 5px !important;
 }
-
 #query-monitor-main .qm button.qm-button:hover,
 #query-monitor-main .qm .qm-toggle:hover {
   background: #0072ab !important;
@@ -913,7 +803,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #fff !important;
   text-decoration: none !important;
 }
-
 #query-monitor-main .qm button.qm-button:focus,
 #query-monitor-main .qm .qm-toggle:focus {
   background: #0072ab !important;
@@ -921,7 +810,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #fff !important;
   box-shadow: 0 0 0 1px #fff, 0 0 0 3px #0072ab !important;
 }
-
 #query-monitor-main .qm button.qm-button:active,
 #query-monitor-main .qm .qm-toggle:active {
   background: #00689b !important;
@@ -929,19 +817,16 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #fff !important;
   box-shadow: none !important;
 }
-
 #query-monitor-main .qm tbody tr.qm-odd td,
 #query-monitor-main .qm tbody tr.qm-odd th {
   background: #f9f9f9 !important;
 }
-
 #query-monitor-main .qm-non-tabular .qm-warn,
 #query-monitor-main .qm thead tr .qm-warn,
 #query-monitor-main .qm tbody tr .qm-warn {
   background-color: #fff0f0 !important;
   color: #900 !important;
 }
-
 #query-monitor-main .qm tbody tr th.qm-warn,
 #query-monitor-main .qm tbody tr td.qm-warn,
 #query-monitor-main .qm tbody tr.qm-warn td,
@@ -949,14 +834,12 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   background-color: #fff0f0 !important;
   color: #900 !important;
 }
-
 #query-monitor-main .qm tbody tr.qm-odd th.qm-warn,
 #query-monitor-main .qm tbody tr.qm-odd td.qm-warn,
 #query-monitor-main .qm tbody tr.qm-odd.qm-warn td,
 #query-monitor-main .qm tbody tr.qm-odd.qm-warn th {
   background-color: #ffe8e8 !important;
 }
-
 #query-monitor-main .qm-non-tabular .qm-warn code,
 #query-monitor-main .qm tbody .qm-warn li,
 #query-monitor-main .qm tbody .qm-warn .qm-info,
@@ -964,14 +847,12 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   background-color: transparent !important;
   color: #900 !important;
 }
-
 #query-monitor-main .qm .qm-notice {
   background: #def !important;
   border: 1px solid #aad5ff !important;
   margin: 0 0 10px 0 !important;
   padding: 10px 20px 0 !important;
 }
-
 #query-monitor-main .qm .dashicons {
   font-size: 16px !important;
   height: 16px !important;
@@ -979,25 +860,23 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   transition: none !important;
   width: 16px !important;
 }
-
 #query-monitor-main .qm .qm-dashicons-yes {
   background-color: #0a0 !important;
   border-radius: 50% !important;
   color: #fff !important;
 }
-
 #query-monitor-main .qm tbody tr td.qm-highlight,
+#query-monitor-main .qm tbody tr.qm-highlight th,
 #query-monitor-main .qm tbody tr.qm-highlight td {
   background-color: #ffd !important;
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main .qm tbody tr.qm-odd td.qm-highlight,
+#query-monitor-main .qm tbody tr.qm-odd.qm-highlight th,
 #query-monitor-main .qm tbody tr.qm-odd.qm-highlight td {
   background-color: #ffffc9 !important;
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main .qm tbody tr.qm-odd.qm-hovered th,
 #query-monitor-main .qm tbody tr.qm-odd.qm-hovered td,
 #query-monitor-main .qm tbody tr.qm-odd:hover th,
@@ -1008,12 +887,10 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 #query-monitor-main .qm tbody tr:hover td {
   background: #eef3fa !important;
 }
-
 #query-monitor-main .qm thead th.qm-filtered select.qm-filter {
   background-color: #ffd !important;
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main .qm button.qm-filter-trigger,
 #query-monitor-main .qm button.qm-filter-trigger code,
 #query-monitor-main .qm tbody .qm-warn a code,
@@ -1023,7 +900,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   cursor: pointer !important;
   text-decoration: none !important;
 }
-
 #query-monitor-main .qm button.qm-filter-trigger:after, #query-monitor-main .qm button.qm-filter-trigger:focus, #query-monitor-main .qm button.qm-filter-trigger:hover,
 #query-monitor-main .qm button.qm-filter-trigger code:after,
 #query-monitor-main .qm button.qm-filter-trigger code:focus,
@@ -1040,7 +916,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #0096dd !important;
   text-decoration: underline !important;
 }
-
 #query-monitor-main .qm button.qm-filter-trigger:active,
 #query-monitor-main .qm button.qm-filter-trigger code:active,
 #query-monitor-main .qm tbody .qm-warn a code:active,
@@ -1049,7 +924,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   color: #11b2ff !important;
   text-decoration: underline !important;
 }
-
 #query-monitor-main .qm a.qm-external-link:after,
 #query-monitor-main .qm a.qm-link:after,
 #query-monitor-main .qm a.qm-edit-link:after,
@@ -1059,20 +933,18 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   font-family: dashicons !important;
   font-size: 14px !important;
   left: 2px !important;
-  line-height: 15px !important;
+  line-height: 13px !important;
   position: relative !important;
   text-decoration: none !important;
   top: 2px !important;
   visibility: hidden !important;
 }
-
 #query-monitor-main .qm button.qm-filter-info:before {
   left: unset !important;
   right: 2px !important;
-  content: '\f534' !important;
+  content: "" !important;
   visibility: visible !important;
 }
-
 #query-monitor-main .qm a.qm-external-link:after,
 #query-monitor-main .qm a.qm-link:hover:after,
 #query-monitor-main .qm a.qm-link:focus:after,
@@ -1082,24 +954,19 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 #query-monitor-main .qm button.qm-filter-trigger:focus:after {
   visibility: visible !important;
 }
-
 #query-monitor-main .qm button.qm-filter-trigger:after {
-  content: '\f536' !important;
+  content: "" !important;
 }
-
 #query-monitor-main .qm a.qm-edit-link:after {
-  content: '\f464' !important;
+  content: "" !important;
 }
-
 #query-monitor-main .qm a.qm-external-link:after,
 #query-monitor-main .qm a.qm-link:after {
-  content: '\f504' !important;
+  content: "" !important;
 }
-
 #query-monitor-main #qm-ajax-errors {
   display: none;
 }
-
 #query-monitor-main button,
 #query-monitor-main select {
   background: none !important;
@@ -1108,57 +975,53 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   margin: 0 !important;
   width: auto !important;
 }
-
 #query-monitor-main .qm label {
-  color: #222 !important;
+  color: #444 !important;
   cursor: pointer !important;
   font-size: 12px !important;
   font-style: normal !important;
   font-weight: normal !important;
   margin: 0 !important;
 }
-
 #query-monitor-main .qm thead label {
   flex-grow: 1 !important;
 }
-
 #query-monitor-main .qm .qm-filter-container {
   display: flex !important;
 }
-
 #query-monitor-main .qm .qm-filter-container label {
   cursor: default !important;
   white-space: nowrap !important;
 }
-
 #query-monitor-main .qm .qm-filter-container div {
   /* Some themes use Select2 etc on all selects. This hides that. */
   display: none !important;
 }
-
+#query-monitor-main .qm-title-heading select,
 #query-monitor-main .qm select.qm-filter {
   -webkit-appearance: menulist !important;
   -moz-appearance: menulist !important;
   appearance: menulist !important;
   background: #fff !important;
   border: none !important;
-  color: #222 !important;
+  color: #444 !important;
   cursor: pointer !important;
   display: block !important;
   float: none !important;
   height: auto !important;
-  letter-spacing: normal !important;
+  letter-spacing: -0.1px !important;
   margin: 0 0 0 5px !important;
   max-width: 12em !important;
   outline: 1px solid #aaa !important;
   padding: 0 !important;
   width: auto !important;
 }
-
-#query-monitor-main .qm select.qm-filter:hover {
-  background: #f3f3f3 !important;
+#query-monitor-main .qm-title-heading select {
+  max-width: unset !important;
 }
-
+#query-monitor-main .qm select.qm-filter:hover {
+  background: #eef3fa !important;
+}
 #query-monitor-main .qm-hide,
 #query-monitor-main .qm-hide-scripts-dependencies,
 #query-monitor-main .qm-hide-styles-dependencies,
@@ -1174,24 +1037,19 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
 #query-monitor-main .qm-hide-component {
   display: none !important;
 }
-
 #query-monitor-main .qm thead th.qm-sortable-column {
   cursor: pointer !important;
 }
-
 #query-monitor-main .qm thead th.qm-sortable-column:hover {
   background: #f3f3f3 !important;
 }
-
 #query-monitor-main .qm .qm-sort-heading {
   flex-grow: 1 !important;
 }
-
 #query-monitor-main .qm .qm-sort-controls {
   flex-shrink: 0 !important;
   text-align: right !important;
 }
-
 #query-monitor-main .qm .qm-sortable-column .qm-sort-arrow {
   color: #ccc !important;
   display: block !important;
@@ -1201,39 +1059,32 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   margin: 0 !important;
   width: 16px !important;
 }
-
 #query-monitor-main .qm .qm-sortable-column .qm-sort-arrow::before {
-  content: "\f140" !important;
+  content: "" !important;
   position: absolute !important;
   right: 0 !important;
   top: 4px !important;
 }
-
 #query-monitor-main .qm .qm-sorted-desc .qm-sort-arrow,
 #query-monitor-main .qm .qm-sorted-asc .qm-sort-arrow {
-  color: #222 !important;
+  color: #444 !important;
 }
-
 #query-monitor-main .qm thead th.qm-sortable-column:hover .qm-sort-arrow {
   color: #0073aa !important;
 }
-
 #query-monitor-main .qm .qm-sortable-column.qm-sorted-asc .qm-sort-arrow::before {
-  content: "\f142" !important;
+  content: "" !important;
 }
-
 #query-monitor-main .qm button:focus,
 #query-monitor-main .qm a:focus,
 #query-monitor-main .qm select:focus {
   box-shadow: 0 0 0 1px #fff, 0 0 0 3px #0072ab !important;
 }
-
 #query-monitor-main .qm button:active,
 #query-monitor-main .qm a:active,
 #query-monitor-main .qm select:active {
   box-shadow: none !important;
 }
-
 #query-monitor-main .qm-screen-reader-text,
 #query-monitor-main .screen-reader-text {
   border: 0 !important;
@@ -1245,52 +1096,41 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   position: absolute !important;
   width: 1px !important;
 }
-
 @media screen and (max-width: 782px) {
   #query-monitor-main #qm-panel-menu,
-  #query-monitor-main #qm-title h1.qm-title-heading {
+#query-monitor-main #qm-title h1.qm-title-heading {
     display: none;
   }
   #query-monitor-main #qm-title div.qm-title-heading {
     display: block;
   }
 }
-
-#query-monitor-main [data-qm-state="off"] [data-qm-state-visibility="on"],
-#query-monitor-main [data-qm-state="on"] [data-qm-state-visibility="off"] {
+#query-monitor-main [data-qm-state=off] [data-qm-state-visibility=on],
+#query-monitor-main [data-qm-state=on] [data-qm-state-visibility=off] {
   display: none;
 }
-
-#query-monitor-main.qm-no-js .qm-sort-controls,
-#query-monitor-main.qm-no-js .qm-toggle,
-#query-monitor-main.qm-no-js select.qm-filter {
+#query-monitor-main.qm-no-js .qm-sort-controls, #query-monitor-main.qm-no-js .qm-toggle, #query-monitor-main.qm-no-js select.qm-filter {
   display: none !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar textarea,
 #query-monitor-main .qm.qm-debug-bar pre {
   border: 1px solid #ddd !important;
   margin: 4px 0 !important;
   padding: 10px !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar textarea {
   resize: vertical !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar .left {
   float: left !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar .right {
   float: right !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h2 {
   font-size: 14px !important;
   margin: 4px 6px 15px !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h3 {
   clear: none !important;
   float: left !important;
@@ -1301,87 +1141,65 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   padding: 5px 10px 15px !important;
   text-align: center !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h3 small {
   font-size: 14px !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h3 span {
   display: block !important;
   margin-bottom: 8px !important;
   white-space: nowrap !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar h4 {
   font-size: 13px !important;
   margin: 15px 6px 5px !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar .qm-debug-bar-output {
   position: relative !important;
 }
-
 #query-monitor-main .qm.qm-debug-bar .qm-debug-bar-output table {
   margin-bottom: 4px !important;
   margin-top: 4px !important;
 }
-
 #query-monitor-main #debug-menu-target-Debug_Bar_Console {
   min-height: 400px !important;
 }
-
 #query-monitor-main #debug-menu-target-Debug_Bar_Cache_Lookup,
 #query-monitor-main #debug-menu-target-Debug_Bar_Rewrite_Rules,
 #query-monitor-main #debug-menu-target-Debug_Bar_Widgets {
   margin: 4px 6px !important;
 }
-
 #query-monitor-main #debug-menu-target-Debug_Bar_Rewrite_Rules_Panel .filterui,
 #query-monitor-main #debug-menu-target-Debug_Bar_Rewrite_Rules_Panel .dbrr {
   margin: 0 !important;
 }
-
 #query-monitor-main #qm-broken {
   display: none !important;
 }
-
 #query-monitor-main.qm-broken #qm-title {
   cursor: default !important;
 }
-
 #query-monitor-main.qm-broken #qm-title .qm-title-heading {
   border-right: none !important;
 }
-
-#query-monitor-main.qm-broken .qm td .qm-toggled,
-#query-monitor-main.qm-broken #qm-broken,
-#query-monitor-main.qm-broken .qm {
+#query-monitor-main.qm-broken .qm td .qm-toggled, #query-monitor-main.qm-broken #qm-broken, #query-monitor-main.qm-broken .qm {
   display: block !important;
 }
-
-#query-monitor-main.qm-broken #qm-panel-menu,
-#query-monitor-main.qm-broken #qm-settings,
-#query-monitor-main.qm-broken #qm-title .qm-title-button {
+#query-monitor-main.qm-broken #qm-panel-menu, #query-monitor-main.qm-broken #qm-settings, #query-monitor-main.qm-broken #qm-title .qm-title-button {
   display: none !important;
 }
-
 #query-monitor-main.qm-broken .qm {
   margin-bottom: 50px !important;
 }
-
 #query-monitor-main.qm-broken .qm button.qm-filter-trigger {
-  color: #222 !important;
+  color: #444 !important;
   cursor: text !important;
 }
-
 #query-monitor-main.qm-broken .qm button.qm-filter-trigger:after {
   display: none !important;
 }
-
 #query-monitor-main.qm-broken .qm button.qm-filter-trigger:focus, #query-monitor-main.qm-broken .qm button.qm-filter-trigger:hover, #query-monitor-main.qm-broken .qm button.qm-filter-trigger:active {
   text-decoration: none !important;
 }
-
 #query-monitor-main.qm-broken #qm-broken h2 {
   padding: 20px !important;
 }
@@ -1396,7 +1214,6 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   position: absolute !important;
   z-index: 99999 !important;
 }
-
 #qm-fatal h2 {
   font-size: 12px !important;
   font-weight: normal !important;
@@ -1404,27 +1221,22 @@ body.admin-color-light #wp-admin-bar-query-monitor:not(.qm-all-clear):not(:hover
   background: #f3f3f3 !important;
   margin: 0 !important;
 }
-
 #qm-fatal .dashicons {
   color: #c00 !important;
 }
-
 #qm-fatal ol,
 #qm-fatal p {
   font-size: 12px !important;
   padding: 0 !important;
   margin: 1em !important;
 }
-
 #qm-fatal ol {
   padding: 0 0 1em 1em !important;
 }
-
 #qm-fatal li {
   margin: 0 0 0.7em !important;
   list-style: none !important;
 }
-
 #qm-fatal .qm-info {
   color: #666 !important;
 }

--- a/query-monitor/assets/query-monitor.js
+++ b/query-monitor/assets/query-monitor.js
@@ -48,7 +48,7 @@ var QM_i18n = {
 if ( window.jQuery ) {
 
 	jQuery( function($) {
-		var toolbarHeight          = $('#wpadminbar').outerHeight();
+		var toolbarHeight          = $('#wpadminbar').length ? $('#wpadminbar').outerHeight() : 0;
 		var minheight              = 100;
 		var maxheight              = ( $(window).height() - toolbarHeight );
 		var minwidth               = 300;

--- a/query-monitor/classes/Activation.php
+++ b/query-monitor/classes/Activation.php
@@ -30,8 +30,9 @@ class QM_Activation extends QM_Plugin {
 
 	public function activate( $sitewide = false ) {
 		$db = WP_CONTENT_DIR . '/db.php';
+		$create_symlink = defined( 'QM_DB_SYMLINK' ) ? QM_DB_SYMLINK : true;
 
-		if ( ! file_exists( $db ) && function_exists( 'symlink' ) ) {
+		if ( $create_symlink && ! file_exists( $db ) && function_exists( 'symlink' ) ) {
 			@symlink( $this->plugin_path( 'wp-content/db.php' ), $db ); // phpcs:ignore
 		}
 

--- a/query-monitor/classes/Backtrace.php
+++ b/query-monitor/classes/Backtrace.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 if ( ! class_exists( 'QM_Backtrace' ) ) {
 class QM_Backtrace {
 

--- a/query-monitor/classes/CLI.php
+++ b/query-monitor/classes/CLI.php
@@ -32,6 +32,11 @@ class QM_CLI extends QM_Plugin {
 			}
 		}
 
+		if ( defined( 'QM_DB_SYMLINK' ) && ! QM_DB_SYMLINK ) {
+			WP_CLI::warning( 'Creation of symlink prevented by QM_DB_SYMLINK constant.' );
+			exit( 0 );
+		}
+
 		if ( ! function_exists( 'symlink' ) ) {
 			WP_CLI::error( 'The symlink function is not available' );
 		}

--- a/query-monitor/classes/Collector.php
+++ b/query-monitor/classes/Collector.php
@@ -221,6 +221,10 @@ abstract class QM_Collector {
 	}
 
 	public static function hide_qm() {
+		if ( ! defined( 'QM_HIDE_SELF' ) ) {
+			return false;
+		}
+
 		if ( null === self::$hide_qm ) {
 			self::$hide_qm = QM_HIDE_SELF;
 		}
@@ -231,6 +235,10 @@ abstract class QM_Collector {
 	public function filter_remove_qm( array $item ) {
 		$component = $item['trace']->get_component();
 		return ( 'query-monitor' !== $component->context );
+	}
+
+	public function filter_dupe_items( $items ) {
+		return ( count( $items ) > 1 );
 	}
 
 	public function process() {}

--- a/query-monitor/classes/Dispatcher.php
+++ b/query-monitor/classes/Dispatcher.php
@@ -52,6 +52,14 @@ abstract class QM_Dispatcher {
 		 *
 		 * The dynamic portion of the hook name, `$this->id`, refers to the dispatcher ID.
 		 *
+		 * Possible filter names include:
+		 *
+		 *  - `qm/dispatch/html`
+		 *  - `qm/dispatch/ajax`
+		 *  - `qm/dispatch/redirect`
+		 *  - `qm/dispatch/rest`
+		 *  - `qm/dispatch/wp_die`
+		 *
 		 * @since 2.8.0
 		 *
 		 * @param bool $true Whether or not the dispatcher is enabled.

--- a/query-monitor/classes/Plugin.php
+++ b/query-monitor/classes/Plugin.php
@@ -60,7 +60,7 @@ abstract class QM_Plugin {
 	/**
 	 * Populates and returns the current plugin info.
 	 */
-	final private function _plugin( $item, $file = '' ) {
+	private function _plugin( $item, $file = '' ) {
 		if ( ! array_key_exists( $item, $this->plugin ) ) {
 			switch ( $item ) {
 				case 'url':

--- a/query-monitor/classes/QM.php
+++ b/query-monitor/classes/QM.php
@@ -13,8 +13,8 @@ class QM {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $message The message.
-		 * @param array $context  The context passed.
+		 * @param mixed $message The message or data to log.
+		 * @param array $context The context passed.
 		 */
 		do_action( 'qm/emergency', $message, $context );
 	}
@@ -25,8 +25,8 @@ class QM {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $message The message.
-		 * @param array $context  The context passed.
+		 * @param mixed $message The message or data to log.
+		 * @param array $context The context passed.
 		 */
 		do_action( 'qm/alert', $message, $context );
 	}
@@ -37,8 +37,8 @@ class QM {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $message The message.
-		 * @param array $context  The context passed.
+		 * @param mixed $message The message or data to log.
+		 * @param array $context The context passed.
 		 */
 		do_action( 'qm/critical', $message, $context );
 	}
@@ -49,8 +49,8 @@ class QM {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $message The message.
-		 * @param array $context  The context passed.
+		 * @param mixed $message The message or data to log.
+		 * @param array $context The context passed.
 		 */
 		do_action( 'qm/error', $message, $context );
 	}
@@ -61,8 +61,8 @@ class QM {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $message The message.
-		 * @param array $context  The context passed.
+		 * @param mixed $message The message or data to log.
+		 * @param array $context The context passed.
 		 */
 		do_action( 'qm/warning', $message, $context );
 	}
@@ -73,8 +73,8 @@ class QM {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $message The message.
-		 * @param array $context  The context passed.
+		 * @param mixed $message The message or data to log.
+		 * @param array $context The context passed.
 		 */
 		do_action( 'qm/notice', $message, $context );
 	}
@@ -85,8 +85,8 @@ class QM {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $message The message.
-		 * @param array $context  The context passed.
+		 * @param mixed $message The message or data to log.
+		 * @param array $context The context passed.
 		 */
 		do_action( 'qm/info', $message, $context );
 	}
@@ -97,8 +97,8 @@ class QM {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $message The message.
-		 * @param array $context  The context passed.
+		 * @param mixed $message The message or data to log.
+		 * @param array $context The context passed.
 		 */
 		do_action( 'qm/debug', $message, $context );
 	}

--- a/query-monitor/classes/QueryMonitor.php
+++ b/query-monitor/classes/QueryMonitor.php
@@ -21,6 +21,7 @@ class QueryMonitor extends QM_Plugin {
 		add_filter( 'ure_capabilities_groups_tree', array( $this, 'filter_ure_groups' ) );
 		add_filter( 'network_admin_plugin_action_links_query-monitor/query-monitor.php', array( $this, 'filter_plugin_action_links' ) );
 		add_filter( 'plugin_action_links_query-monitor/query-monitor.php',               array( $this, 'filter_plugin_action_links' ) );
+		add_filter( 'plugin_row_meta', array( $this, 'filter_plugin_row_meta' ), 10, 4 );
 
 		# Parent setup:
 		parent::__construct( $file );
@@ -50,6 +51,27 @@ class QueryMonitor extends QM_Plugin {
 			'settings' => '<a href="#qm-settings">' . esc_html__( 'Settings', 'query-monitor' ) . '</a>',
 			'add-ons'  => '<a href="https://github.com/johnbillion/query-monitor/wiki/Query-Monitor-Add-on-Plugins">' . esc_html__( 'Add-ons', 'query-monitor' ) . '</a>',
 		), $actions );
+	}
+
+	/**
+	 * Filters the array of row meta for each plugin in the Plugins list table.
+	 *
+	 * @param string[] $plugin_meta An array of the plugin's metadata.
+	 * @param string   $plugin_file Path to the plugin file relative to the plugins directory.
+	 * @return string[] An array of the plugin's metadata.
+	 */
+	public function filter_plugin_row_meta( array $plugin_meta, $plugin_file ) {
+		if ( 'query-monitor/query-monitor.php' !== $plugin_file ) {
+			return $plugin_meta;
+		}
+
+		$plugin_meta[] = sprintf(
+			'<a href="%1$s"><span class="dashicons dashicons-star-filled" aria-hidden="true" style="font-size:14px;line-height:1.3"></span>%2$s</a>',
+			'https://github.com/sponsors/johnbillion',
+			esc_html_x( 'Sponsor', 'verb', 'query-monitor' )
+		);
+
+		return $plugin_meta;
 	}
 
 	/**

--- a/query-monitor/collectors/admin.php
+++ b/query-monitor/collectors/admin.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Admin extends QM_Collector {
 
 	public $id = 'response';

--- a/query-monitor/collectors/assets.php
+++ b/query-monitor/collectors/assets.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 abstract class QM_Collector_Assets extends QM_Collector {
 
 	public function __construct() {

--- a/query-monitor/collectors/assets_scripts.php
+++ b/query-monitor/collectors/assets_scripts.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Assets_Scripts extends QM_Collector_Assets {
 
 	public $id = 'assets_scripts';

--- a/query-monitor/collectors/assets_styles.php
+++ b/query-monitor/collectors/assets_styles.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Assets_Styles extends QM_Collector_Assets {
 
 	public $id = 'assets_styles';

--- a/query-monitor/collectors/block_editor.php
+++ b/query-monitor/collectors/block_editor.php
@@ -5,10 +5,13 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Block_Editor extends QM_Collector {
 
 	public $id = 'block_editor';
 
+	protected $block_context = array();
 	protected $block_timing = array();
 	protected $block_timer  = null;
 
@@ -16,6 +19,7 @@ class QM_Collector_Block_Editor extends QM_Collector {
 		parent::__construct();
 
 		add_filter( 'pre_render_block',  array( $this, 'filter_pre_render_block' ), 9999, 2 );
+		add_filter( 'render_block_context', array( $this, 'filter_render_block_context' ), -9999, 2 );
 		add_filter( 'render_block_data', array( $this, 'filter_render_block_data' ), -9999 );
 		add_filter( 'render_block',      array( $this, 'filter_render_block' ), 9999, 2 );
 	}
@@ -23,7 +27,9 @@ class QM_Collector_Block_Editor extends QM_Collector {
 	public function get_concerned_filters() {
 		return array(
 			'allowed_block_types',
+			'block_parser_class',
 			'pre_render_block',
+			'render_block_context',
 			'render_block_data',
 			'render_block',
 		);
@@ -35,6 +41,12 @@ class QM_Collector_Block_Editor extends QM_Collector {
 		}
 
 		return $pre_render;
+	}
+
+	public function filter_render_block_context( array $context, array $block ) {
+		$this->block_context[] = $context;
+
+		return $context;
 	}
 
 	public function filter_render_block_data( array $block ) {
@@ -72,6 +84,7 @@ class QM_Collector_Block_Editor extends QM_Collector {
 		$this->data['post_blocks']        = self::wp_parse_blocks( $content );
 		$this->data['all_dynamic_blocks'] = self::wp_get_dynamic_block_names();
 		$this->data['total_blocks']       = 0;
+		$this->data['has_block_context']  = false;
 		$this->data['has_block_timing']   = false;
 
 		if ( $this->data['post_has_blocks'] ) {
@@ -80,9 +93,11 @@ class QM_Collector_Block_Editor extends QM_Collector {
 	}
 
 	protected function process_block( array $block ) {
+		$context = array_shift( $this->block_context );
+		$timing  = array_shift( $this->block_timing );
+
 		// Remove empty blocks caused by two consecutive line breaks in content
 		if ( ! $block['blockName'] && ! trim( $block['innerHTML'] ) ) {
-			array_shift( $this->block_timing );
 			return null;
 		}
 
@@ -105,6 +120,11 @@ class QM_Collector_Block_Editor extends QM_Collector {
 		$block['callback']  = $callback;
 		$block['innerHTML'] = trim( $block['innerHTML'] );
 		$block['size']      = strlen( $block['innerHTML'] );
+
+		if ( $context ) {
+			$block['context'] = $context;
+			$this->data['has_block_context'] = true;
+		}
 
 		if ( $timing ) {
 			$block['timing'] = $timing->get_time();

--- a/query-monitor/collectors/cache.php
+++ b/query-monitor/collectors/cache.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Cache extends QM_Collector {
 
 	public $id = 'cache';

--- a/query-monitor/collectors/caps.php
+++ b/query-monitor/collectors/caps.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Caps extends QM_Collector {
 
 	public $id = 'caps';
@@ -57,6 +59,7 @@ class QM_Collector_Caps extends QM_Collector {
 	public function tear_down() {
 		remove_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), 9999 );
 		remove_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 9999 );
+		parent::tear_down();
 	}
 
 	/**

--- a/query-monitor/collectors/conditionals.php
+++ b/query-monitor/collectors/conditionals.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Conditionals extends QM_Collector {
 
 	public $id = 'conditionals';

--- a/query-monitor/collectors/db_callers.php
+++ b/query-monitor/collectors/db_callers.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_DB_Callers extends QM_Collector {
 
 	public $id = 'db_callers';

--- a/query-monitor/collectors/db_components.php
+++ b/query-monitor/collectors/db_components.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_DB_Components extends QM_Collector {
 
 	public $id = 'db_components';

--- a/query-monitor/collectors/db_dupes.php
+++ b/query-monitor/collectors/db_dupes.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_DB_Dupes extends QM_Collector {
 
 	public $id = 'db_dupes';
@@ -20,7 +22,7 @@ class QM_Collector_DB_Dupes extends QM_Collector {
 		}
 
 		// Filter out SQL queries that do not have dupes
-		$this->data['dupes'] = array_filter( $dbq->data['dupes'], array( $this, '_filter_dupe_queries' ) );
+		$this->data['dupes'] = array_filter( $dbq->data['dupes'], array( $this, 'filter_dupe_items' ) );
 
 		// Ignore dupes from `WP_Query->set_found_posts()`
 		unset( $this->data['dupes']['SELECT FOUND_ROWS()'] );
@@ -88,11 +90,6 @@ class QM_Collector_DB_Dupes extends QM_Collector {
 		}
 
 	}
-
-	public function _filter_dupe_queries( $queries ) {
-		return ( count( $queries ) > 1 );
-	}
-
 }
 
 function register_qm_collector_db_dupes( array $collectors, QueryMonitor $qm ) {

--- a/query-monitor/collectors/db_queries.php
+++ b/query-monitor/collectors/db_queries.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 if ( ! defined( 'SAVEQUERIES' ) ) {
 	define( 'SAVEQUERIES', true );
 }

--- a/query-monitor/collectors/debug_bar.php
+++ b/query-monitor/collectors/debug_bar.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 final class QM_Collector_Debug_Bar extends QM_Collector {
 
 	public $id     = 'debug_bar';

--- a/query-monitor/collectors/environment.php
+++ b/query-monitor/collectors/environment.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Environment extends QM_Collector {
 
 	public $id          = 'environment';

--- a/query-monitor/collectors/hooks.php
+++ b/query-monitor/collectors/hooks.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Hooks extends QM_Collector {
 
 	public $id = 'hooks';
@@ -25,7 +27,9 @@ class QM_Collector_Hooks extends QM_Collector {
 			$hooks[] = QM_Hook::process( 'all', $wp_filter, self::$hide_qm, self::$hide_core );
 		}
 
-		if ( defined( 'QM_SHOW_ALL_HOOKS' ) && QM_SHOW_ALL_HOOKS ) {
+		$this->data['all_hooks'] = defined( 'QM_SHOW_ALL_HOOKS' ) && QM_SHOW_ALL_HOOKS;
+
+		if ( $this->data['all_hooks'] ) {
 			// Show all hooks
 			$hook_names = array_keys( $wp_filter );
 		} else {

--- a/query-monitor/collectors/http.php
+++ b/query-monitor/collectors/http.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_HTTP extends QM_Collector {
 
 	public $id         = 'http';
@@ -232,6 +234,8 @@ class QM_Collector_HTTP extends QM_Collector {
 			'airplane_mode_enabled',
 		) );
 
+		$home_host = (string) parse_url( home_url(), PHP_URL_HOST );
+
 		foreach ( $this->data['http'] as $key => & $http ) {
 
 			if ( ! isset( $http['response'] ) ) {
@@ -257,10 +261,6 @@ class QM_Collector_HTTP extends QM_Collector {
 			$http['ltime'] = ( $http['end'] - $http['start'] );
 
 			if ( isset( $http['info'] ) ) {
-				if ( isset( $http['info']['total_time'] ) ) {
-					$http['ltime'] = $http['info']['total_time'];
-				}
-
 				if ( ! empty( $http['info']['url'] ) ) {
 					if ( rtrim( $http['url'], '/' ) !== rtrim( $http['info']['url'], '/' ) ) {
 						$http['redirected_to'] = $http['info']['url'];
@@ -271,6 +271,10 @@ class QM_Collector_HTTP extends QM_Collector {
 			$this->data['ltime'] += $http['ltime'];
 
 			$http['component'] = $http['trace']->get_component();
+
+			$host = (string) parse_url( $http['url'], PHP_URL_HOST );
+
+			$http['local'] = ( $host === $home_host );
 
 			$this->log_type( $http['type'] );
 			$this->log_component( $http['component'], $http['ltime'], $http['type'] );

--- a/query-monitor/collectors/languages.php
+++ b/query-monitor/collectors/languages.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Languages extends QM_Collector {
 
 	public $id = 'languages';

--- a/query-monitor/collectors/logger.php
+++ b/query-monitor/collectors/logger.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Logger extends QM_Collector {
 
 	public $id = 'logger';
@@ -88,8 +90,18 @@ class QM_Collector_Logger extends QM_Collector {
 		}
 
 		if ( ! QM_Util::is_stringy( $message ) ) {
+			if ( null === $message ) {
+				$message = 'null';
+			} elseif ( false === $message ) {
+				$message = 'false';
+			} elseif ( true === $message ) {
+				$message = 'true';
+			}
+
 			$type    = 'dump';
 			$message = print_r( $message, true );
+		} elseif ( '' === trim( $message ) ) {
+			$message = '(Empty string)';
 		}
 
 		$this->data['logs'][] = array(

--- a/query-monitor/collectors/overview.php
+++ b/query-monitor/collectors/overview.php
@@ -5,13 +5,42 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Overview extends QM_Collector {
 
 	public $id = 'overview';
 
-	public function process() {
+	public function __construct() {
+		add_action( 'shutdown', array( $this, 'process_timing' ), 0 );
+	}
 
+	public function tear_down() {
+		remove_action( 'shutdown', array( $this, 'process_timing' ), 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Processes the timing and memory related stats as early as possible, so the
+	 * data isn't skewed by collectors that are processed before this one.
+	 */
+	public function process_timing() {
 		$this->data['time_taken'] = self::timer_stop_float();
+
+		if ( function_exists( 'memory_get_peak_usage' ) ) {
+			$this->data['memory'] = memory_get_peak_usage();
+		} elseif ( function_exists( 'memory_get_usage' ) ) {
+			$this->data['memory'] = memory_get_usage();
+		} else {
+			$this->data['memory'] = 0;
+		}
+	}
+
+	public function process() {
+		if ( ! isset( $data['time_taken'] ) ) {
+			$this->process_timing();
+		}
+
 		$this->data['time_limit'] = ini_get( 'max_execution_time' );
 		$this->data['time_start'] = $GLOBALS['timestart'];
 
@@ -21,24 +50,16 @@ class QM_Collector_Overview extends QM_Collector {
 			$this->data['time_usage'] = 0;
 		}
 
-		if ( function_exists( 'memory_get_peak_usage' ) ) {
-			$this->data['memory'] = memory_get_peak_usage();
-		} elseif ( function_exists( 'memory_get_usage' ) ) {
-			$this->data['memory'] = memory_get_usage();
-		} else {
-			$this->data['memory'] = 0;
-		}
-
 		if ( is_user_logged_in() ) {
 			$this->data['current_user'] = self::format_user( wp_get_current_user() );
 		} else {
-			$this->data['current_user'] = false;
+			$this->data['current_user'] = null;
 		}
 
 		if ( function_exists( 'current_user_switched' ) && current_user_switched() ) {
 			$this->data['switched_user'] = self::format_user( current_user_switched() );
 		} else {
-			$this->data['switched_user'] = false;
+			$this->data['switched_user'] = null;
 		}
 
 		$this->data['memory_limit'] = QM_Util::convert_hr_to_bytes( ini_get( 'memory_limit' ) );
@@ -47,6 +68,14 @@ class QM_Collector_Overview extends QM_Collector {
 			$this->data['memory_usage'] = ( 100 / $this->data['memory_limit'] ) * $this->data['memory'];
 		} else {
 			$this->data['memory_usage'] = 0;
+		}
+
+		$this->data['wp_memory_limit'] = QM_Util::convert_hr_to_bytes( trim( WP_MEMORY_LIMIT ) ); // Pull the config value
+
+		if ( $this->data['wp_memory_limit'] > 0 ) {
+			$this->data['wp_memory_usage'] = ( 100 / $this->data['wp_memory_limit'] ) * $this->data['memory'];
+		} else {
+			$this->data['wp_memory_usage'] = 0;
 		}
 
 		$this->data['display_time_usage_warning']   = ( $this->data['time_usage'] >= 75 );

--- a/query-monitor/collectors/php_errors.php
+++ b/query-monitor/collectors/php_errors.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 define( 'QM_ERROR_FATALS', E_ERROR | E_PARSE | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR );
 
 class QM_Collector_PHP_Errors extends QM_Collector {

--- a/query-monitor/collectors/raw_request.php
+++ b/query-monitor/collectors/raw_request.php
@@ -1,5 +1,7 @@
 <?php
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Raw_Request extends QM_Collector {
 
 	public $id = 'raw_request';

--- a/query-monitor/collectors/redirects.php
+++ b/query-monitor/collectors/redirects.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Redirects extends QM_Collector {
 
 	public $id = 'redirects';

--- a/query-monitor/collectors/request.php
+++ b/query-monitor/collectors/request.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Request extends QM_Collector {
 
 	public $id = 'request';

--- a/query-monitor/collectors/theme.php
+++ b/query-monitor/collectors/theme.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Theme extends QM_Collector {
 
 	public $id                  = 'response';

--- a/query-monitor/collectors/timing.php
+++ b/query-monitor/collectors/timing.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Timing extends QM_Collector {
 
 	public $id           = 'timing';

--- a/query-monitor/collectors/transients.php
+++ b/query-monitor/collectors/transients.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Collector_Transients extends QM_Collector {
 
 	public $id = 'transients';
@@ -16,9 +18,9 @@ class QM_Collector_Transients extends QM_Collector {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
 		remove_action( 'setted_site_transient', array( $this, 'action_setted_site_transient' ), 10 );
 		remove_action( 'setted_transient',      array( $this, 'action_setted_blog_transient' ), 10 );
+		parent::tear_down();
 	}
 
 	public function action_setted_site_transient( $transient, $value, $expiration ) {

--- a/query-monitor/dispatchers/AJAX.php
+++ b/query-monitor/dispatchers/AJAX.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Dispatcher_AJAX extends QM_Dispatcher {
 
 	public $id = 'ajax';
@@ -12,8 +14,10 @@ class QM_Dispatcher_AJAX extends QM_Dispatcher {
 	public function __construct( QM_Plugin $qm ) {
 		parent::__construct( $qm );
 
+		// This dispatcher needs to run on a priority lower than 1 so it can output
+		// its headers before wp_ob_end_flush_all() flushes all the output buffers:
+		// https://github.com/WordPress/wordpress-develop/blob/0a3a3c5119897c6d551a42ae9b5dbfa4f576f2c9/src/wp-includes/default-filters.php#L382
 		add_action( 'shutdown', array( $this, 'dispatch' ), 0 );
-
 	}
 
 	public function init() {
@@ -23,6 +27,7 @@ class QM_Dispatcher_AJAX extends QM_Dispatcher {
 		}
 
 		if ( QM_Util::is_ajax() ) {
+			// Start an output buffer for Ajax requests so headers can be output at the end:
 			ob_start();
 		}
 

--- a/query-monitor/dispatchers/Html.php
+++ b/query-monitor/dispatchers/Html.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Dispatcher_Html extends QM_Dispatcher {
 
 	/**
@@ -33,7 +35,6 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 		add_action( 'wp_footer',                  array( $this, 'action_footer' ) );
 		add_action( 'admin_footer',               array( $this, 'action_footer' ) );
 		add_action( 'login_footer',               array( $this, 'action_footer' ) );
-		add_action( 'embed_footer',               array( $this, 'action_footer' ) );
 		add_action( 'gp_footer',                  array( $this, 'action_footer' ) );
 
 		parent::__construct( $qm );
@@ -179,11 +180,7 @@ class QM_Dispatcher_Html extends QM_Dispatcher {
 
 		$css = 'query-monitor';
 
-		if ( method_exists( 'Dark_Mode', 'is_using_dark_mode' ) && is_user_logged_in() ) {
-			if ( Dark_Mode::is_using_dark_mode() ) {
-				$css .= '-dark';
-			}
-		} elseif ( defined( 'QM_DARK_MODE' ) && QM_DARK_MODE ) {
+		if ( defined( 'QM_DARK_MODE' ) && QM_DARK_MODE ) {
 			$css .= '-dark';
 		}
 

--- a/query-monitor/dispatchers/REST.php
+++ b/query-monitor/dispatchers/REST.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Dispatcher_REST extends QM_Dispatcher {
 
 	public $id = 'rest';

--- a/query-monitor/dispatchers/REST_Envelope.php
+++ b/query-monitor/dispatchers/REST_Envelope.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * REST API enveloped request dispatcher.
+ *
+ * @package query-monitor
+ */
+
+class QM_Dispatcher_REST_Envelope extends QM_Dispatcher {
+
+	public $id = 'rest_envelope';
+
+	public function __construct( QM_Plugin $qm ) {
+		parent::__construct( $qm );
+
+		add_filter( 'rest_envelope_response', array( $this, 'filter_rest_envelope_response' ), 999, 2 );
+	}
+
+	/**
+	 * Filters the enveloped form of a REST API response to add QM's data.
+	 *
+	 * @param array            $envelope Envelope data.
+	 * @param WP_REST_Response $response Original response data.
+	 * @return array Envelope data.
+	 */
+	public function filter_rest_envelope_response( array $envelope, WP_REST_Response $response ) {
+		if ( ! $this->should_dispatch() ) {
+			return $envelope;
+		}
+
+		$data = array();
+
+		$this->before_output();
+
+		/* @var QM_Output_Raw[] */
+		foreach ( $this->get_outputters( 'raw' ) as $id => $output ) {
+			$data[ $id ] = $output->output();
+		}
+
+		$this->after_output();
+
+		$envelope['qm'] = $data;
+
+		return $envelope;
+	}
+
+	protected function before_output() {
+		require_once $this->qm->plugin_path( 'output/Raw.php' );
+
+		foreach ( glob( $this->qm->plugin_path( 'output/raw/*.php' ) ) as $file ) {
+			include_once $file;
+		}
+	}
+
+	public function is_active() {
+		if ( ! self::user_can_view() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+}
+
+function register_qm_dispatcher_rest_envelope( array $dispatchers, QM_Plugin $qm ) {
+	$dispatchers['rest_envelope'] = new QM_Dispatcher_REST_Envelope( $qm );
+	return $dispatchers;
+}
+
+add_filter( 'qm/dispatchers', 'register_qm_dispatcher_rest_envelope', 10, 2 );

--- a/query-monitor/dispatchers/Redirect.php
+++ b/query-monitor/dispatchers/Redirect.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Dispatcher_Redirect extends QM_Dispatcher {
 
 	public $id = 'redirect';

--- a/query-monitor/dispatchers/WP_Die.php
+++ b/query-monitor/dispatchers/WP_Die.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Dispatcher_WP_Die extends QM_Dispatcher {
 
 	public $id    = 'wp_die';

--- a/query-monitor/output/Raw.php
+++ b/query-monitor/output/Raw.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Abstract output class for raw output encoded as JSON.
+ *
+ * @package query-monitor
+ */
+
+abstract class QM_Output_Raw extends QM_Output {
+
+	public function output() {
+		return $this->get_output();
+	}
+
+}

--- a/query-monitor/output/headers/overview.php
+++ b/query-monitor/output/headers/overview.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Headers_Overview extends QM_Output_Headers {
 
 	/**

--- a/query-monitor/output/headers/php_errors.php
+++ b/query-monitor/output/headers/php_errors.php
@@ -4,6 +4,9 @@
  *
  * @package query-monitor
  */
+
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Headers_PHP_Errors extends QM_Output_Headers {
 
 	/**

--- a/query-monitor/output/headers/redirects.php
+++ b/query-monitor/output/headers/redirects.php
@@ -4,6 +4,9 @@
  *
  * @package query-monitor
  */
+
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Headers_Redirects extends QM_Output_Headers {
 
 	/**

--- a/query-monitor/output/html/admin.php
+++ b/query-monitor/output/html/admin.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Admin extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/assets.php
+++ b/query-monitor/output/html/assets.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 abstract class QM_Output_Html_Assets extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/assets_scripts.php
+++ b/query-monitor/output/html/assets_scripts.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Assets_Scripts extends QM_Output_Html_Assets {
 
 	/**

--- a/query-monitor/output/html/assets_styles.php
+++ b/query-monitor/output/html/assets_styles.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Assets_Styles extends QM_Output_Html_Assets {
 
 	/**

--- a/query-monitor/output/html/block_editor.php
+++ b/query-monitor/output/html/block_editor.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Block_Editor extends QM_Output_Html {
 
 	/**
@@ -48,6 +50,11 @@ class QM_Output_Html_Block_Editor extends QM_Output_Html {
 		echo '<th scope="col">#</th>';
 		echo '<th scope="col">' . esc_html__( 'Block Name', 'query-monitor' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Attributes', 'query-monitor' ) . '</th>';
+
+		if ( isset( $data['has_block_context'] ) ) {
+			echo '<th scope="col">' . esc_html__( 'Context', 'query-monitor' ) . '</th>';
+		}
+
 		echo '<th scope="col">' . esc_html__( 'Render Callback', 'query-monitor' ) . '</th>';
 
 		if ( isset( $data['has_block_timing'] ) ) {
@@ -68,8 +75,20 @@ class QM_Output_Html_Block_Editor extends QM_Output_Html {
 
 		echo '<tfoot>';
 		echo '<tr>';
+
+		$colspan = 5;
+
+		if ( isset( $data['has_block_context'] ) ) {
+			$colspan++;
+		}
+
+		if ( isset( $data['has_block_timing'] ) ) {
+			$colspan++;
+		}
+
 		printf(
-			'<td colspan="6">%s</td>',
+			'<td colspan="%1$d">%2$s</td>',
+			intval( $colspan ),
 			sprintf(
 				/* translators: %s: Total number of content blocks used */
 				esc_html( _nx( 'Total: %s', 'Total: %s', $data['total_blocks'], 'Content blocks used', 'query-monitor' ) ),
@@ -113,6 +132,7 @@ class QM_Output_Html_Block_Editor extends QM_Output_Html {
 
 		$media_blocks = array(
 			'core/audio'       => 'id',
+			'core/cover'       => 'id',
 			'core/cover-image' => 'id',
 			'core/file'        => 'id',
 			'core/image'       => 'id',
@@ -175,6 +195,14 @@ class QM_Output_Html_Block_Editor extends QM_Output_Html {
 			echo '<pre class="qm-pre-wrap"><code>' . esc_html( QM_Util::json_format( $block['attrs'] ) ) . '</code></pre>';
 		}
 		echo '</td>';
+
+		if ( $data['has_block_context'] ) {
+			echo '<td class="qm-row-block-context">';
+			if ( isset( $block['context'] ) ) {
+				echo '<pre class="qm-pre-wrap"><code>' . esc_html( QM_Util::json_format( $block['context'] ) ) . '</code></pre>';
+			}
+			echo '</td>';
+		}
 
 		if ( isset( $block['callback']['error'] ) ) {
 			$class = ' qm-warn';

--- a/query-monitor/output/html/caps.php
+++ b/query-monitor/output/html/caps.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Caps extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/conditionals.php
+++ b/query-monitor/output/html/conditionals.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Conditionals extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/db_callers.php
+++ b/query-monitor/output/html/db_callers.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_DB_Callers extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/db_components.php
+++ b/query-monitor/output/html/db_components.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_DB_Components extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/db_dupes.php
+++ b/query-monitor/output/html/db_dupes.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_DB_Dupes extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/db_queries.php
+++ b/query-monitor/output/html/db_queries.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_DB_Queries extends QM_Output_Html {
 
 	/**
@@ -174,23 +176,25 @@ class QM_Output_Html_DB_Queries extends QM_Output_Html {
 				echo '<tr>';
 				echo '<th colspan="' . intval( $span ) . '" class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
 				if ( file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
-					/* translators: 1: Symlink file name, 2: URL to wiki page */
-					$message = __( 'Extended query information such as the component and affected rows is not available. A conflicting %1$s file is present. <a href="%2$s" target="_blank" class="qm-external-link">See this wiki page for more information.</a>', 'query-monitor' );
+					/* translators: %s: File name */
+					$message = __( 'Extended query information such as the component and affected rows is not available. A conflicting %s file is present.', 'query-monitor' );
+				} elseif ( defined( 'QM_DB_SYMLINK' ) && ! QM_DB_SYMLINK ) {
+					/* translators: 1: File name, 2: Configuration constant name */
+					$message = __( 'Extended query information such as the component and affected rows is not available. Query Monitor was prevented from symlinking its %1$s file into place by the %2$s constant.', 'query-monitor' );
 				} else {
-					/* translators: 1: Symlink file name, 2: URL to wiki page */
-					$message = __( 'Extended query information such as the component and affected rows is not available. Query Monitor was unable to symlink its %1$s file into place. <a href="%2$s" target="_blank" class="qm-external-link">See this wiki page for more information.</a>', 'query-monitor' );
+					/* translators: %s: File name */
+					$message = __( 'Extended query information such as the component and affected rows is not available. Query Monitor was unable to symlink its %s file into place.', 'query-monitor' );
 				}
-				echo wp_kses( sprintf(
-					$message,
+				printf(
+					esc_html( $message ),
 					'<code>db.php</code>',
+					'<code>QM_DB_SYMLINK</code>'
+				);
+
+				printf(
+					' <a href="%s" target="_blank" class="qm-external-link">See this wiki page for more information.</a>',
 					'https://github.com/johnbillion/query-monitor/wiki/db.php-Symlink'
-				), array(
-					'a' => array(
-						'href'   => array(),
-						'target' => array(),
-						'class'  => array(),
-					),
-				) );
+				);
 				echo '</th>';
 				echo '</tr>';
 			}

--- a/query-monitor/output/html/debug_bar.php
+++ b/query-monitor/output/html/debug_bar.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Debug_Bar extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/environment.php
+++ b/query-monitor/output/html/environment.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Environment extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/headers.php
+++ b/query-monitor/output/html/headers.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Headers extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/hooks.php
+++ b/query-monitor/output/html/hooks.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Hooks extends QM_Output_Html {
 
 	/**
@@ -33,13 +35,15 @@ class QM_Output_Html_Hooks extends QM_Output_Html {
 
 		$this->before_tabular_output();
 
+		$callback_label = $data['all_hooks'] ? __( 'Callback', 'query-monitor' ) : __( 'Action', 'query-monitor' );
+
 		echo '<thead>';
 		echo '<tr>';
 		echo '<th scope="col" class="qm-filterable-column">';
 		echo $this->build_filter( 'name', $data['parts'], __( 'Hook', 'query-monitor' ) ); // WPCS: XSS ok.
 		echo '</th>';
 		echo '<th scope="col">' . esc_html__( 'Priority', 'query-monitor' ) . '</th>';
-		echo '<th scope="col">' . esc_html__( 'Action', 'query-monitor' ) . '</th>';
+		echo '<th scope="col">' . esc_html( $callback_label ) . '</th>';
 		echo '<th scope="col" class="qm-filterable-column">';
 		echo $this->build_filter( 'component', $data['components'], __( 'Component', 'query-monitor' ), array(
 			'highlight' => 'subject',

--- a/query-monitor/output/html/http.php
+++ b/query-monitor/output/html/http.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_HTTP extends QM_Output_Html {
 
 	/**
@@ -104,7 +106,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 				$url = preg_replace( '|^http:|', '<span class="qm-warn">http</span>:', $url );
 
 				if ( 'https' === parse_url( $row['url'], PHP_URL_SCHEME ) ) {
-					if ( empty( $row['args']['sslverify'] ) && empty( $row['args']['local'] ) ) {
+					if ( empty( $row['args']['sslverify'] ) && ! $row['local'] ) {
 						$info .= '<span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>' . esc_html( sprintf(
 							/* translators: An HTTP API request has disabled certificate verification. 1: Relevant argument name */
 							__( 'Certificate verification disabled (%s)', 'query-monitor' ),
@@ -142,6 +144,7 @@ class QM_Output_Html_HTTP extends QM_Output_Html {
 							'wp_remote_fopen',
 							'download_url',
 							'vip_safe_wp_remote_get',
+							'vip_safe_wp_remote_request',
 							'wpcom_vip_file_get_contents',
 						), true );
 					}

--- a/query-monitor/output/html/languages.php
+++ b/query-monitor/output/html/languages.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Languages extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/logger.php
+++ b/query-monitor/output/html/logger.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Logger extends QM_Output_Html {
 
 	/**
@@ -85,7 +87,7 @@ class QM_Output_Html_Logger extends QM_Output_Html {
 
 			echo '<tr' . $attr . ' class="' . esc_attr( $class ) . '">'; // WPCS: XSS ok.
 
-			echo '<td scope="row" class="qm-nowrap">';
+			echo '<td class="qm-nowrap">';
 
 			if ( $is_warning ) {
 				echo '<span class="dashicons dashicons-warning" aria-hidden="true"></span>';

--- a/query-monitor/output/html/overview.php
+++ b/query-monitor/output/html/overview.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Overview extends QM_Output_Html {
 
 	/**
@@ -34,12 +36,12 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 			$db_queries_data = $db_queries->get_data();
 			if ( isset( $db_queries_data['types'] ) && isset( $db_queries_data['total_time'] ) ) {
 				$db_query_num = $db_queries_data['types'];
-				$db_query_time = $db_queries_data['total_time'];
 			}
 		}
 
 		$raw_request = QM_Collectors::get( 'raw_request' );
 		$cache = QM_Collectors::get( 'cache' );
+		$http = QM_Collectors::get( 'http' );
 
 		$qm_broken   = __( 'A JavaScript problem on the page is preventing Query Monitor from working correctly. jQuery may have been blocked from loading.', 'query-monitor' );
 		$ajax_errors = __( 'PHP errors were triggered during an Ajax request. See your browser developer console for details.', 'query-monitor' );
@@ -128,7 +130,7 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 				}
 				echo esc_html( sprintf(
 					/* translators: 1: Percentage of memory limit used, 2: Memory limit in kilobytes */
-					__( '%1$s%% of %2$s kB limit', 'query-monitor' ),
+					__( '%1$s%% of %2$s kB server limit', 'query-monitor' ),
 					number_format_i18n( $data['memory_usage'], 1 ),
 					number_format_i18n( $data['memory_limit'] / 1024 )
 				) );
@@ -143,23 +145,36 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 				);
 				echo '</span>';
 			}
+
+			if ( $data['wp_memory_limit'] > 0 ) {
+				if ( $data['display_memory_usage_warning'] ) {
+					echo '<br><span class="qm-warn"><span class="dashicons dashicons-warning" aria-hidden="true"></span>';
+				} else {
+					echo '<br><span class="qm-info">';
+				}
+				echo esc_html( sprintf(
+				/* translators: 1: Percentage of memory limit used, 2: Memory limit in kilobytes */
+					__( '%1$s%% of %2$s kB WordPress limit', 'query-monitor' ),
+					number_format_i18n( $data['wp_memory_usage'], 1 ),
+					number_format_i18n( $data['wp_memory_limit'] / 1024 )
+				) );
+				echo '</span>';
+			}
 		}
 
 		echo '</p>';
 		echo '</section>';
 
-		if ( isset( $db_queries_data ) ) {
-			echo '<section>';
-			echo '<h3>' . esc_html__( 'Database Query Time', 'query-monitor' ) . '</h3>';
-			echo '<p>';
-			echo esc_html( number_format_i18n( $db_queries_data['total_time'], 4 ) );
-			echo '</p>';
-			echo '</section>';
-		}
-
 		if ( isset( $db_query_num ) && isset( $db_queries_data ) ) {
 			echo '<section>';
 			echo '<h3>' . esc_html__( 'Database Queries', 'query-monitor' ) . '</h3>';
+
+			if ( isset( $db_queries_data ) ) {
+				echo '<p>';
+				echo esc_html( number_format_i18n( $db_queries_data['total_time'], 4 ) );
+				echo '</p>';
+			}
+
 			echo '<p>';
 
 			if ( ! isset( $db_query_num['SELECT'] ) || count( $db_query_num ) > 1 ) {
@@ -180,6 +195,32 @@ class QM_Output_Html_Overview extends QM_Output_Html {
 			);
 
 			echo '</p>';
+			echo '</section>';
+		}
+
+		if ( $http ) {
+			echo '<section>';
+			echo '<h3>' . esc_html__( 'HTTP API Calls', 'query-monitor' ) . '</h3>';
+
+			$http_data = $http->get_data();
+
+			if ( ! empty( $http_data['http'] ) ) {
+				printf(
+					'<p>%s</p>',
+					esc_html( number_format_i18n( $http_data['ltime'], 4 ) )
+				);
+				printf(
+					'<button class="qm-filter-trigger" data-qm-target="http" data-qm-filter="type" data-qm-value="">%1$s: %2$s</button>',
+					esc_html( _x( 'Total', 'HTTP API calls', 'query-monitor' ) ),
+					esc_html( number_format_i18n( count( $http_data['http'] ) ) )
+				);
+			} else {
+				printf(
+					'<p><em>%s</em></p>',
+					esc_html__( 'None', 'query-monitor' )
+				);
+			}
+
 			echo '</section>';
 		}
 

--- a/query-monitor/output/html/php_errors.php
+++ b/query-monitor/output/html/php_errors.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 
 	/**
@@ -98,7 +100,7 @@ class QM_Output_Html_PHP_Errors extends QM_Output_Html {
 					}
 
 					echo '<tr ' . $attr . 'class="' . esc_attr( $class ) . '">'; // WPCS: XSS ok.
-					echo '<td scope="row" class="qm-nowrap">';
+					echo '<td class="qm-nowrap">';
 
 					if ( $is_warning ) {
 						echo '<span class="dashicons dashicons-warning" aria-hidden="true"></span>';

--- a/query-monitor/output/html/request.php
+++ b/query-monitor/output/html/request.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Request extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/theme.php
+++ b/query-monitor/output/html/theme.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Theme extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/timing.php
+++ b/query-monitor/output/html/timing.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Timing extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/html/transients.php
+++ b/query-monitor/output/html/transients.php
@@ -5,6 +5,8 @@
  * @package query-monitor
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class QM_Output_Html_Transients extends QM_Output_Html {
 
 	/**

--- a/query-monitor/output/raw/cache.php
+++ b/query-monitor/output/raw/cache.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Raw cache output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_Cache extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Cache Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Object Cache', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array(
+			'hit_percentage' => null,
+			'hits'           => null,
+			'misses'         => null,
+		);
+		$data = $this->collector->get_data();
+
+		if ( isset( $data['stats'] ) && isset( $data['cache_hit_percentage'] ) ) {
+			$output['hit_percentage'] = (float) number_format_i18n( $data['cache_hit_percentage'], 1 );
+			$output['hits'] = (int) number_format_i18n( $data['stats']['cache_hits'], 0 );
+			$output['misses'] = (int) number_format_i18n( $data['stats']['cache_misses'], 0 );
+		}
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_cache( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'cache' );
+	if ( $collector ) {
+		$output['cache'] = new QM_Output_Raw_Cache( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_cache', 30, 2 );

--- a/query-monitor/output/raw/conditionals.php
+++ b/query-monitor/output/raw/conditionals.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Raw conditionals output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_Conditionals extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Conditionals Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Conditionals', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$data = $this->collector->get_data();
+
+		return $data['conds']['true'];
+	}
+}
+
+function register_qm_output_raw_conditionals( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'conditionals' );
+	if ( $collector ) {
+		$output['conditionals'] = new QM_Output_Raw_Conditionals( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_conditionals', 20, 2 );

--- a/query-monitor/output/raw/db_queries.php
+++ b/query-monitor/output/raw/db_queries.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Raw database query output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_DB_Queries extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_DB_Queries Collector.
+	 */
+	protected $collector;
+
+	public $query_row = 0;
+
+	public function name() {
+		return __( 'Database Queries', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array();
+		$data   = $this->collector->get_data();
+
+		if ( empty( $data['dbs'] ) ) {
+			return $output;
+		}
+
+		$dbs = array();
+
+		foreach ( $data['dbs'] as $name => $db ) {
+			$dbs[ $name ] = $this->output_queries( $name, $db, $data );
+		}
+
+		$output['dbs'] = $dbs;
+
+		if ( ! empty( $data['errors'] ) ) {
+			$output['errors'] = array(
+				'total' => count( $data['errors'] ),
+				'errors' => $data['errors'],
+			);
+		}
+
+		if ( ! empty( $data['dupes'] ) ) {
+			$dupes = $data['dupes'];
+
+			// Filter out SQL queries that do not have dupes
+			$dupes = array_filter( $dupes, array( $this->collector, 'filter_dupe_items' ) );
+
+			// Ignore dupes from `WP_Query->set_found_posts()`
+			unset( $dupes['SELECT FOUND_ROWS()'] );
+
+			$output['dupes'] = array(
+				'total' => count( $dupes ),
+				'queries' => $dupes,
+			);
+		}
+
+		return $output;
+	}
+
+	protected function output_queries( $name, stdClass $db, array $data ) {
+		$this->query_row = 0;
+
+		$output = array();
+
+		if ( empty( $db->rows ) ) {
+			return $output;
+		}
+
+		foreach ( $db->rows as $row ) {
+			$output[] = $this->output_query_row( $row );
+		}
+
+		return array(
+			'total'   => $db->total_qs,
+			'time'    => (float) number_format_i18n( $db->total_time, 4 ),
+			'queries' => $output,
+		);
+	}
+
+	protected function output_query_row( array $row ) {
+		$output = array();
+
+		$output['i']    = ++$this->query_row;
+		$output['sql']  = $row['sql'];
+		$output['time'] = (float) number_format_i18n( $row['ltime'], 4 );
+
+		if ( isset( $row['trace'] ) ) {
+			$stack = array();
+			$filtered_trace = $row['trace']->get_display_trace();
+
+			foreach ( $filtered_trace as $item ) {
+				$stack[] = $item['display'];
+			}
+		} else {
+			$stack = explode( ', ', $row['stack'] );
+			$stack = array_reverse( $stack );
+		}
+
+		$output['stack'] = $stack;
+		$output['result']  = $row['result'];
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_db_queries( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'db_queries' );
+	if ( $collector ) {
+		$output['db_queries'] = new QM_Output_Raw_DB_Queries( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_db_queries', 20, 2 );

--- a/query-monitor/output/raw/http.php
+++ b/query-monitor/output/raw/http.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Raw HTTP API request output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_HTTP extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_HTTP Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'HTTP API Calls', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array();
+		$data   = $this->collector->get_data();
+
+		if ( empty( $data['http'] ) ) {
+			return $output;
+		}
+
+		$requests = array();
+
+		foreach ( $data['http'] as $http ) {
+			$stack = array();
+
+			if ( isset( $http['trace'] ) ) {
+				$filtered_trace = $http['trace']->get_display_trace();
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = $item['display'];
+				}
+			}
+
+			$requests[] = array(
+				'url' => $http['url'],
+				'method' => $http['args']['method'],
+				'response' => $http['response']['response'],
+				'time' => (float) number_format_i18n( $http['end'] - $http['start'], 4 ),
+				'stack' => $stack,
+			);
+		}
+
+		$output['total'] = count( $requests );
+		$output['time'] = (float) number_format_i18n( $data['ltime'], 4 );
+		$output['requests'] = $requests;
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_http( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'http' );
+	if ( $collector ) {
+		$output['http'] = new QM_Output_Raw_HTTP( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_http', 30, 2 );

--- a/query-monitor/output/raw/logger.php
+++ b/query-monitor/output/raw/logger.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Raw logger output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_Logger extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Logger Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Logs', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array();
+		$data   = $this->collector->get_data();
+
+		if ( empty( $data['logs'] ) ) {
+			return $output;
+		}
+
+		foreach ( $data['logs'] as $log ) {
+			$stack = array();
+
+			if ( isset( $log['trace'] ) ) {
+				$filtered_trace = $log['trace']->get_display_trace();
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = $item['display'];
+				}
+			}
+
+			$output[ $log['level'] ][] = array(
+				'message' => $log['message'],
+				'stack' => $stack,
+			);
+		}
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_logger( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'logger' );
+	if ( $collector ) {
+		$output['logger'] = new QM_Output_Raw_Logger( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_logger', 30, 2 );

--- a/query-monitor/output/raw/transients.php
+++ b/query-monitor/output/raw/transients.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Raw transients output.
+ *
+ * @package query-monitor
+ */
+
+class QM_Output_Raw_Transients extends QM_Output_Raw {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_Transients Collector.
+	 */
+	protected $collector;
+
+	public function name() {
+		return __( 'Transients', 'query-monitor' );
+	}
+
+	public function get_output() {
+		$output = array();
+		$data   = $this->collector->get_data();
+
+		if ( empty( $data['trans'] ) ) {
+			return $output;
+		}
+
+		$transients = array();
+
+		foreach ( $data['trans'] as $transient ) {
+			$stack = array();
+
+			if ( isset( $transient['filtered_trace'] ) ) {
+				$filtered_trace = $transient['filtered_trace'];
+
+				foreach ( $filtered_trace as $item ) {
+					$stack[] = $item['display'];
+				}
+			}
+
+			$transients[] = array(
+				'name' => $transient['name'],
+				'type' => $transient['type'],
+				'size' => $transient['size_formatted'],
+				'expiration' => $transient['expiration'],
+				'stack' => $stack,
+			);
+		}
+
+		$output['total'] = count( $transients );
+		$output['transients'] = $transients;
+
+		return $output;
+	}
+}
+
+function register_qm_output_raw_transients( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'transients' );
+	if ( $collector ) {
+		$output['transients'] = new QM_Output_Raw_Transients( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/raw', 'register_qm_output_raw_transients', 30, 2 );

--- a/query-monitor/query-monitor.php
+++ b/query-monitor/query-monitor.php
@@ -5,12 +5,12 @@
  * @package   query-monitor
  * @link      https://github.com/johnbillion/query-monitor
  * @author    John Blackbourn <john@johnblackbourn.com>
- * @copyright 2009-2020 John Blackbourn
+ * @copyright 2009-2021 John Blackbourn
  * @license   GPL v2 or later
  *
  * Plugin Name:  Query Monitor
  * Description:  The Developer Tools Panel for WordPress.
- * Version:      3.6.5
+ * Version:      3.7.1
  * Plugin URI:   https://querymonitor.com/
  * Author:       John Blackbourn
  * Author URI:   https://querymonitor.com/
@@ -29,7 +29,7 @@
  * GNU General Public License for more details.
  */
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || exit;
 
 $qm_dir = dirname( __FILE__ );
 

--- a/query-monitor/readme.txt
+++ b/query-monitor/readme.txt
@@ -1,16 +1,16 @@
-=== Query Monitor ===
+# Query Monitor
 Contributors: johnbillion
 Tags: debug, debug-bar, debugging, development, developer, performance, profiler, queries, query monitor, rest-api
 Requires at least: 3.7
-Tested up to: 5.6
-Stable tag: 3.6.5
+Tested up to: 5.7
+Stable tag: 3.7.1
 License: GPLv2 or later
 Requires PHP: 5.3
 Donate link: https://johnblackbourn.com/donations/
 
 Query Monitor is the developer tools panel for WordPress.
 
-== Description ==
+## Description
 
 Query Monitor is the developer tools panel for WordPress. It enables debugging of database queries, PHP errors, hooks and actions, block editor blocks, enqueued scripts and stylesheets, HTTP API calls, and more.
 
@@ -39,19 +39,26 @@ In addition:
 
 * Whenever a redirect occurs, Query Monitor adds an HTTP header containing the call stack, so you can use your favourite HTTP inspector or browser developer tools to trace what triggered the redirect.
 * The response from any jQuery-initiated Ajax request on the page will contain various debugging information in its headers. PHP errors also get output to the browser's developer console.
-* The response from an authenticated WordPress REST API request will contain various debugging information in its headers, as long as the authenticated user has permission to view Query Monitor's output.
+* The response from an authenticated WordPress REST API request will contain an overview of performance information and PHP errors in its headers, as long as the authenticated user has permission to view Query Monitor's output. An [an enveloped REST API request](https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_envelope) will include even more debugging information in the `qm` property of the response.
 
 By default, Query Monitor's output is only shown to Administrators on single-site installations, and Super Admins on Multisite installations.
 
 In addition to this, you can set an authentication cookie which allows you to view Query Monitor output when you're not logged in (or if you're logged in as a non-Administrator). See the Settings panel for details.
 
-= Privacy Statement =
+### Other Plugins
+
+I maintain several other plugins for developers. Check them out:
+
+* [User Switching](https://wordpress.org/plugins/user-switching/) provides instant switching between user accounts in WordPress.
+* [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) lets you view and control what's happening in the WP-Cron system
+
+### Privacy Statement
 
 Query Monitor is private by default and always will be. It does not persistently store any of the data that it collects. It does not send data to any third party, nor does it include any third party resources.
 
 [Query Monitor's full privacy statement can be found here](https://github.com/johnbillion/query-monitor/wiki/Privacy-Statement).
 
-== Screenshots ==
+## Screenshots
 
 1. Admin Toolbar Menu
 2. Aggregate Database Queries by Component
@@ -61,15 +68,19 @@ Query Monitor is private by default and always will be. It does not persistently
 6. HTTP API Requests
 7. Aggregate Database Queries by Calling Function
 
-== Frequently Asked Questions ==
+## Frequently Asked Questions
 
-= Who can see Query Monitor's output? =
+### Does this plugin work with PHP 8?
+
+Yes.
+
+### Who can access Query Monitor's output?
 
 By default, Query Monitor's output is only shown to Administrators on single-site installations, and Super Admins on Multisite installations.
 
 In addition to this, you can set an authentication cookie which allows you to view Query Monitor output when you're not logged in, or when you're logged in as a user who cannot usually see Query Monitor's output. See the Settings panel for details.
 
-= Does Query Monitor itself impact the page generation time or memory usage? =
+### Does Query Monitor itself impact the page generation time or memory usage?
 
 Short answer: Yes, but only a little.
 
@@ -77,42 +88,40 @@ Long answer: Query Monitor has a small impact on page generation time because it
 
 Query Monitor's memory usage typically accounts for around 10% of the total memory used to generate the page.
 
-= Are there any add-on plugins for Query Monitor? =
+### Are there any add-on plugins for Query Monitor?
 
 [A list of add-on plugins for Query Monitor can be found here.](https://github.com/johnbillion/query-monitor/wiki/Query-Monitor-Add-on-Plugins)
 
-In addition, Query Monitor transparently supports add-ons for the Debug Bar plugin. If you have any Debug Bar add-ons installed, just deactivate Debug Bar and the add-ons will show up in Query Monitor's menu.
+In addition, Query Monitor transparently supports add-ons for the Debug Bar plugin. If you have any Debug Bar add-ons installed, deactivate Debug Bar and the add-ons will show up in Query Monitor's menu.
 
-= Where can I suggest a new feature or report a bug? =
+### Where can I suggest a new feature or report a bug?
 
 Please use [the issue tracker on Query Monitor's GitHub repo](https://github.com/johnbillion/query-monitor/issues) as it's easier to keep track of issues there, rather than on the wordpress.org support forums.
 
-= Is Query Monitor available on Altis? =
+### Is Query Monitor available on Altis?
 
 Yes, the [Altis Developer Tools](https://www.altis-dxp.com/resources/developer-docs/dev-tools/) are built on top of Query Monitor.
 
-= Is Query Monitor available on WordPress.com VIP Go? =
+### Is Query Monitor available on WordPress.com VIP Go?
 
 Yes, it's included as part of the VIP Go platform. However, a user needs to be granted the `view_query_monitor` capability to see Query Monitor even if they're an administrator.
 
-= I'm using multiple instances of `wpdb`. How do I get my additional instances to show up in Query Monitor? =
+Please note that information about database queries and the environment is somewhat restricted on VIP. This is a platform restriction and not a Query Monitor issue.
+
+### I'm using multiple instances of `wpdb`. How do I get my additional instances to show up in Query Monitor?
 
 You'll need to hook into the `qm/collect/db_objects` filter and add an item to the array containing your `wpdb` instance. For example:
 
-`
-add_filter( 'qm/collect/db_objects', function( $objects ) {
-	$objects['my_db'] = $GLOBALS['my_db'];
-	return $objects;
-} );
-`
+    add_filter( 'qm/collect/db_objects', function( $objects ) {
+        $objects['my_db'] = $GLOBALS['my_db'];
+        return $objects;
+    } );
 
 Your `wpdb` instance will then show up as a separate panel, and the query time and query count will show up separately in the admin toolbar menu. Aggregate information (queries by caller and component) will not be separated.
 
-= Can I click on stack traces to open the file in my editor? =
+### Can I click on stack traces to open the file in my editor?
 
 Yes. You can enable this on the Settings panel.
-
-= Do you accept donations? =
 
 ### Do you accept donations?
 
@@ -121,6 +130,44 @@ Yes. You can enable this on the Settings panel.
 In addition, if you like the plugin then I'd love for you to [leave a review](https://wordpress.org/support/view/plugin-reviews/query-monitor). Tell all your friends about it too!
 
 ## Changelog ##
+
+### 3.7.1 ###
+
+* Add a fallback for timing processing during Ajax requests that are dispatched before the `shutdown` hook.
+
+### 3.7.0 ###
+
+* <a href="https://querymonitor.com/blog/2021/05/debugging-wordpress-rest-api-requests/">Introduce debugging output in a `qm` property in enveloped REST API responses</a>
+* Add HTTP API call information to the overview panel
+* Don't show QM output inside WordPress embeds as nobody uses this
+* Don't try to access the `QM_HIDE_SELF` constant before it's defined
+* Process the timing and memory related stats as early as possible so the data isn't too skewed
+
+
+### 3.6.8 ###
+
+* Add WordPress memory usage statistic to Overview panel
+* Add block context information to the Blocks panel
+* Fix row highlighting of TH cells
+* Fix some panel resizing bugs
+
+
+### 3.6.7 ###
+
+* Implement a `QM_DB_SYMLINK` constant to prevent the `db.php` symlink being put into place.
+* Remove a dependency on `SAVEQUERIES` in the query collector.
+* Remove invalid `scope` attributes on table cells.
+
+
+### 3.6.6 ###
+
+* PHP 8 fix.
+* Improve the display for various empty values when logging.
+* Don't display child menus until the parent menu is active. Makes the menu clearer.
+* Detect local host names in HTTP API requests and don't mark them as ignoring certificate verification.
+* Prevent the text in toggle buttons from being selected when selecting data in tables.
+* Remove support for the Dark Mode plugin which isn't Dark Mode any more.
+
 
 ### 3.6.5 ###
 
@@ -415,56 +462,3 @@ New features! Read about them here: https://querymonitor.com/blog/2019/02/new-fe
 * Add associative keys to the array passed to the `qm/built-in-collectors` filter.
 * Drop support for PHP 5.2.
 * Generally improve performance and reduce memory usage.
-
-### 2.17.0 ###
-
-* Add the current user object to the Request panel.
-* A few improvements to the appearance of the overall layout.
-* Use relative positioning in place of the nasty absolute position hack needed for some themes.
-* Ensure the `get_*_template()` function exists before calling it.
-* Add a `QM_DISABLE_ERROR_HANDLER` constant to disable QM's error handling.
-* Switch to runtime filtering of user capabilities instead of granting the `view_query_monitor` cap upon activation.
-* Correct a bunch of inline docs and code standards.
-
-
-### 2.16.2 ###
-
-* Correctly handle re-selection of filters with a saved value that contains special characters.
-* Show the correct caller for Super Admin capability checks.
-
-
-### 2.16.1 ###
-
-* Update the plugin version number (no functional changes from 2.16.0).
-
-### 2.16.0 ###
-
-* Introduce a new panel for displaying user capability checks that have been performed during the page load.
-* Remember the picked value in all the filters. Uses localStorage in the browser.
-* Add a "Non-Core" filter to the Component filter control in all panels.
-* Add a "Non-SELECT" filter to the query type filter control in the Queries panel.
-* Display collapsed stack traces by default in all panels.
-* Add the error code to the Database Errors output.
-* Improve the visual appearance of the column sorting controls.
-* Improved display for parameter values in call stacks.
-* Any files within `wp-content` which don't have a component are now grouped by the root directory or file name.
-
-
-### 2.15.0 ###
-
-* Reverse the order of stack traces so they're in natural order, and improve styling.
-* Enable query types to be clicked in the Overview.
-* Add a highlight to the currently applied table filter.
-* Improve table row highlighting when the row header spans multiple rows.
-* Expose a link to the main query from the Request panel.
-* Better stack traces for transient sets and HTTP API requests.
-* Group and sort the Languages output by textdomain.
-* Log and expose PHP extensions, and improve styling for error reporting level.
-* Better highlighting of PHP warnings and QM errors.
-* Add support for a `vendor` directory in the root of the `mu-plugins` directory when detecting components.
-* Log the size of the value of updated transients.
-* Add a help link when query components aren't available.
-* Make the Hooks table output reusable by other components.
-* Add a bit of vertical breathing room.
-* Various improvements to terminology.
-* Coding standards.

--- a/query-monitor/wp-content/db.php
+++ b/query-monitor/wp-content/db.php
@@ -12,7 +12,7 @@
  * @package query-monitor
  */
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || exit;
 
 if ( defined( 'QM_DISABLED' ) && QM_DISABLED ) {
 	return;
@@ -30,13 +30,13 @@ if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
 }
 
 # No autoloaders for us. See https://github.com/johnbillion/query-monitor/issues/7
-$qm_dir = dirname( dirname( __FILE__ ) );
-$plugin = "{$qm_dir}/classes/Plugin.php";
+$qm_dir    = dirname( dirname( __FILE__ ) );
+$qm_plugin = "{$qm_dir}/classes/Plugin.php";
 
-if ( ! is_readable( $plugin ) ) {
+if ( ! is_readable( $qm_plugin ) ) {
 	return;
 }
-require_once $plugin;
+require_once $qm_plugin;
 
 if ( ! QM_Plugin::php_version_met() ) {
 	return;
@@ -77,12 +77,13 @@ class QM_DB extends wpdb {
 	}
 
 	/**
-	 * Perform a MySQL database query, using current database connection.
+	 * Performs a MySQL database query, using current database connection.
 	 *
 	 * @see wpdb::query()
 	 *
 	 * @param string $query Database query
-	 * @return int|false Number of rows affected/selected or false on error
+	 * @return int|bool Boolean true for CREATE, ALTER, TRUNCATE and DROP queries. Number of rows
+	 *                  affected/selected for all other queries. Boolean false on error.
 	 */
 	public function query( $query ) {
 		if ( ! $this->ready ) {
@@ -98,12 +99,12 @@ class QM_DB extends wpdb {
 		}
 
 		$result = parent::query( $query );
+		$i      = $this->num_queries - 1;
 
-		if ( ! SAVEQUERIES ) {
+		if ( ! isset( $this->queries[ $i ] ) ) {
 			return $result;
 		}
 
-		$i = $this->num_queries - 1;
 		$this->queries[ $i ]['trace'] = new QM_Backtrace( array(
 			'ignore_frames' => 1,
 		) );


### PR DESCRIPTION
## Description

This updates the Query Monitor plugin from 3.6.5 to 3.7.1.

## Changelog Description

### Query Monitor updated to version 3.7.1.

Full changelog here: https://github.com/johnbillion/query-monitor/releases

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [X] This change has relevant documentation additions / updates (if applicable).
- [X] I've created a changelog description that aligns with the provided examples.

## Steps to Test

**Important:** This introduces [a new feature which exposes the SQL query logs to suitably authenticated users during REST API requests](https://querymonitor.com/blog/2021/05/debugging-wordpress-rest-api-requests/). There is no change to the privileges required to see QM's data, but this will need testing on VIP before deploying because AFAICT [VIP uses a non-standard structure for the database queries logged in the `wpdb` class](https://github.com/automattic/vip-go-mu-plugins/blob/9180eab0ff8a2792325e8a5decf59e4a25c28e56/vip-helpers/vip-query-monitor.php).