### PR TITLE
Add search-dev-tools related records to .deployignore

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -12,6 +12,7 @@
 .eslintignore
 .eslintrc
 .eslintrc.js
+.eslintrc.json
 .git
 .gitattributes
 .github
@@ -108,3 +109,7 @@ yarn.lock
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-mbstring/bootstrap80.php
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-php73/Resources/stubs/JsonException.php
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/sebastian/resource-operations/build/generate.php
+
+# Search Dev Tools
+/search/search-dev-tools/src/
+/search/search-dev-tools/preact.config.js


### PR DESCRIPTION
## Description

This adds source files and Preact-specific build-related files for Search Dev Tools to .deployignore

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Deploy and find out 
