### PR TITLE
PR template update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Please don't include internal or private links :)
 <!--
 A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.
 
-**Please keep the changelog title format same as in example bellow (### <Title>), as this is later used to generate the changelog entry title**
+**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**
 
 Example for a plugin upgrade:
 


### PR DESCRIPTION
## Description
Update to the PR template - no need to publish a changelog

## Changelog Description

### PR template change

Adds an ask to the PR template for keeping the changelog title formatted as a title 

## Checklist

## Steps to Test

