### PR TITLE
Not loading VaultPress when Jetpack is disabled

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -11,6 +11,11 @@
  * Domain Path: /languages/
  */
 
+// Avoid loading VaultPress altogether if VIP_JETPACK_SKIP_LOAD is set to true (Jetpack is required for VP to work in VIP)
+if ( defined( 'VIP_JETPACK_SKIP_LOAD' ) && true === VIP_JETPACK_SKIP_LOAD ) {
+	return;
+}
+
 // Avoid loading VaultPress altogether if VIP_VAULTPRESS_SKIP_LOAD is set to true
 if ( defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) && true === VIP_VAULTPRESS_SKIP_LOAD ) {
 	return;


### PR DESCRIPTION
## Description

At VIP, VaultPress needs Jetpack to work. If we have the `VIP_JETPACK_SKIP_LOAD` constant, we should not load VaultPress because some things would not work.

## Changelog Description

### Plugin Updated: VaultPress

Not loading VaultPress if Jetpack is disabled.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
