### PR TITLE
Loading VIP Jetpack conditionally and hiding more messaging

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -135,8 +135,8 @@ function vip_jetpack_load() {
 	if ( version_compare( JETPACK__VERSION, '9.1', '<' ) ) {
 		add_filter( 'instagram_cache_oembed_api_response_body', '__return_true' );
 	}
+
+	require_once( __DIR__ . '/vip-jetpack/vip-jetpack.php' );
 }
 
 vip_jetpack_load();
-
-require_once( __DIR__ . '/vip-jetpack/vip-jetpack.php' );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -403,8 +403,10 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 	return $value;
 }, 10, 2 );
 
-// We need to add a dummy menu item if no other menu items are rendered
-function add_jetpack_menu_placeholder() {
+/**
+ * Dummy Jetpack menu item if no other menu items are rendered
+ */
+function add_jetpack_menu_placeholder(): void {
 	$status = new Automattic\Jetpack\Status();
 	// is_connection_ready only exists in Jetpack 9.6 and newer
 	if ( ! $status->is_offline_mode() && method_exists('Jetpack', 'is_connection_ready') && ! Jetpack::is_connection_ready() ) {

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -152,6 +152,8 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 	unset( $modules['site-icon'] );
 	unset( $modules['protect'] );
 
+	error_log(print_r($modules, true));
+
 	return $modules;
 }, 999 );
 
@@ -359,6 +361,11 @@ add_filter( 'jetpack_show_promotions', function ( $is_enabled ) {
 
 	return false;
 } );
+
+/**
+ * Hide Jetpack's just in time promotions
+ */
+add_filter( 'jetpack_just_in_time_msgs', '__return_false' );
 
 /**
  * Custom CSS tweaks for the Jetpack Admin pages

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -152,8 +152,6 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 	unset( $modules['site-icon'] );
 	unset( $modules['protect'] );
 
-	error_log(print_r($modules, true));
-
 	return $modules;
 }, 999 );
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -398,10 +398,6 @@ add_filter( 'jetpack_options', function( $value, $name ) {
 
 // We need to add a dummy menu item if no other menu items are rendered
 function add_jetpack_menu_placeholder() {
-	if ( ! class_exists( 'Jetpack' ) ) {
-		return;
-	}
-
 	$status = new Automattic\Jetpack\Status();
 	// is_connection_ready only exists in Jetpack 9.6 and newer
 	if ( ! $status->is_offline_mode() && method_exists('Jetpack', 'is_connection_ready') && ! Jetpack::is_connection_ready() ) {


### PR DESCRIPTION
## Description

In this PR:

- We load VIP Jetpack customizations (`vip-jetpack.php`) only if Jetpack is enabled (we move the unconditional `require_once` to inside a function that's only reached if Jetpack is enabled).
- We disable some additional Jetpack messaging through the `jetpack_just_in_time_msgs` constant.

## Changelog Description

### Plugin Updated: Jetpack 

Better handling of Jetpack when it's disabled. Removal of some extra Jetpack messaging.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Load wp-admin with Jetpack enabled (Jetpack should function just fine).
3. Load wp-admin with Jetpack disabled (we shouldn't see any errors).
