### PR TITLE
Allow maintenance mode for wp-admin only

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -29,11 +29,21 @@ if ( '/cache-healthcheck?' === $_SERVER['REQUEST_URI'] ) {
 	die( 'ok' );
 }
 
+if ( ! defined( 'WPCOM_VIP_SITE_MAINTENANCE_MODE' ) ) {
+	define( 'WPCOM_VIP_SITE_MAINTENANCE_MODE', false );
+}
+
+if ( ! defined( 'WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE' ) ) {
+	define( 'WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE', false );
+}
+
 // Sites can be blocked for various reasons - usually maintenance, so exit
 // early if the constant has been set (defined by VIP Go in config/wp-config.php)
-if ( defined( 'WPCOM_VIP_SITE_MAINTENANCE_MODE' ) && WPCOM_VIP_SITE_MAINTENANCE_MODE ) {
+if ( WPCOM_VIP_SITE_MAINTENANCE_MODE ) {
+	$allow_front_end = WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE && ! REST_REQUEST && ! WP_ADMIN;
+
 	// WP CLI is allowed, but disable cron
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	if ( ( defined( 'WP_CLI' ) && WP_CLI ) || $allow_front_end ) {
 		add_filter( 'pre_option_a8c_cron_control_disable_run', function() {
 			return 1;
 		}, 9999 );


### PR DESCRIPTION
# Description

Introduces a new constant to exclude the front-end of a site from
maintenance mode. This can be used for Kubernetes migrations where
the front-end of the site will still work, but we want to prevent
database writes in wp-admin.

## Changelog Description

### Internal: Add WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE constant

Added a constant, `WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE`, that can be used to put a site into maintenance mode without impacting the front-end. The idea being to prevent database writes(e.g.: post creation) in wp-admin from happening at an inopportune time during periods of maintenance while still allowing the site to operate normally.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Example:

1. Check out PR.
2. Set `WPCOM_VIP_SITE_MAINTENANCE_MODE` and `WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE` to `true`
3. Confirm maintenance mode is enabled in wp-admin
4. Confirm maintenance mode is not enabled on the homepage
