### PR TITLE
Deadlock Job Cleanup Updateup

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -710,11 +710,12 @@ class Queue {
 		$filtered_deadlocked_jobs = [];
 		$jobs_to_be_deleted = [];
 
-		foreach ($all_deadlocked_jobs as $job) {
+		foreach ( $all_deadlocked_jobs as $job ) {
 			$unique_key = sprintf( '%s_%s_%s',
 				$job['object_id'] ?? '',
 				$job['object_type'] ?? '',
-				$job['index_version'] ?? '');
+				$job['index_version'] ?? ''
+			);
 
 			if ( array_key_exists( $unique_key, $found_objects ) ) {
 				$jobs_to_be_deleted[] = $job;

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -150,9 +150,9 @@ class Queue {
 		}
 
 		self::$max_indexing_op_count = intval( self::$max_indexing_op_count );
-		
+
 		$lower_bound_max_indexing_op_count = ( self::$index_count_ttl * self::LOWER_BOUND_MAX_INDEXING_OPS_PER_SECOND ) + 1;
-		
+
 		if ( self::$max_indexing_op_count < $lower_bound_max_indexing_op_count ) {
 			_doing_it_wrong(
 				'add_filter',
@@ -174,7 +174,7 @@ class Queue {
 
 			self::$max_indexing_op_count = $upper_bound_max_indexing_op_count;
 		}
-		
+
 		/**
 		 * The length of time Elasticsearch indexing rate limiting will be active once triggered.
 		 *
@@ -687,13 +687,49 @@ class Queue {
 				break;
 			}
 
-			$deadlocked_job_ids = wp_list_pluck( $deadlocked_jobs, 'job_id' );
+			$filtered_deadlocked_jobs = $this->delete_jobs_on_the_same_object( $deadlocked_jobs );
+
+			$deadlocked_job_ids = wp_list_pluck( $filtered_deadlocked_jobs, 'job_id' );
 
 			$this->update_jobs( $deadlocked_job_ids, array(
 				'status' => 'queued',
 				'scheduled_time' => null,
 			) );
 		}
+	}
+
+	/**
+	 * In some cases there could be multiple jobs for the same object stucked in deadlock state.
+	 * If we would try to update all of them at once we would break the DB contstraint
+	 * (state + object_id + object_type + index_version).
+	 *
+	 * We will delete the duplicate from the DB table as well as from the list of jobs to be re-queued.
+	 */
+	private function delete_jobs_on_the_same_object( $all_deadlocked_jobs ) {
+		$found_objects = [];
+		$filtered_deadlocked_jobs = [];
+		$jobs_to_be_deleted = [];
+
+		foreach ($all_deadlocked_jobs as $job) {
+			$unique_key = sprintf( '%s_%s_%s',
+				$job['object_id'] ?? '',
+				$job['object_type'] ?? '',
+				$job['index_version'] ?? '');
+
+			if ( array_key_exists( $unique_key, $found_objects ) ) {
+				$jobs_to_be_deleted[] = $job;
+			} else {
+				$found_objects[ $unique_key ] = true;
+
+				$filtered_deadlocked_jobs[] = $job;
+			}
+		}
+
+		if ( ! empty( $jobs_to_be_deleted ) ) {
+			$this->delete_jobs( $jobs_to_be_deleted );
+		}
+
+		return $filtered_deadlocked_jobs;
 	}
 
 	public function process_jobs( $jobs ) {
@@ -933,7 +969,7 @@ class Queue {
 		$this->alerts->send_to_chat( self::INDEX_RATE_LIMITING_ALERT_SLACK_CHAT, $message, self::INDEX_RATE_LIMITING_ALERT_LEVEL );
 
 		trigger_error( $message, \E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		
+
 		\Automattic\VIP\Logstash\log2logstash(
 			array(
 				'severity' => 'warning',

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -699,8 +699,8 @@ class Queue {
 	}
 
 	/**
-	 * In some cases there could be multiple jobs for the same object stucked in deadlock state.
-	 * If we would try to update all of them at once we would break the DB contstraint
+	 * In some cases there could be multiple jobs for the same object stuck in a deadlock state.
+	 * If we would try to update all of them at once we would break the DB constraint
 	 * (state + object_id + object_type + index_version).
 	 *
 	 * We will delete the duplicate from the DB table as well as from the list of jobs to be re-queued.

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -712,9 +712,9 @@ class Queue {
 
 		foreach ( $all_deadlocked_jobs as $job ) {
 			$unique_key = sprintf( '%s_%s_%s',
-				$job['object_id'] ?? '',
-				$job['object_type'] ?? '',
-				$job['index_version'] ?? ''
+				$job->{'object_id'},
+				$job->{'object_type'},
+				$job->{'index_version'}
 			);
 
 			if ( array_key_exists( $unique_key, $found_objects ) ) {

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -598,13 +598,13 @@ class Queue_Test extends \WP_UnitTestCase {
 
 
 	public function test_free_deadlocked_jobs_handle_duplicates() {
-		$first_job = [
+		$first_job = (object) [
 			'job_id' => 1,
 			'object_id' => 10,
 			'object_type' => 'post',
 			'index_version' => 1,
 		];
-		$second_job = [
+		$second_job = (object) [
 			'job_id' => 2,
 			'object_id' => 10,
 			'object_type' => 'post',

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -641,7 +641,7 @@ class Queue_Test extends \WP_UnitTestCase {
 
 		$partially_mocked_queue->expects( $this->once() )
 			->method( 'delete_jobs' )
-			->with( [ $second_job ]	);
+			->with( [ $second_job ] );
 
 		$partially_mocked_queue->free_deadlocked_jobs();
 	}

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -610,6 +610,12 @@ class Queue_Test extends \WP_UnitTestCase {
 			'object_type' => 'post',
 			'index_version' => 1,
 		];
+		$third_job_on_other_object = (object) [
+			'job_id' => 3,
+			'object_id' => 20,
+			'object_type' => 'post',
+			'index_version' => 1,
+		];
 
 		$partially_mocked_queue = $this->getMockBuilder( \Automattic\VIP\Search\Queue::class )
 			->setMethods( [
@@ -622,7 +628,7 @@ class Queue_Test extends \WP_UnitTestCase {
 		$partially_mocked_queue
 			->method( 'get_deadlocked_jobs' )
 			->willReturnOnConsecutiveCalls(
-				[ $first_job, $second_job ],
+				[ $first_job, $second_job, $third_job_on_other_object ],
 				[],
 				[],
 				[],
@@ -632,7 +638,7 @@ class Queue_Test extends \WP_UnitTestCase {
 		$partially_mocked_queue->expects( $this->once() )
 			->method( 'update_jobs' )
 			->with(
-				$this->equalTo( [ 1 ] ),
+				$this->equalTo( [ 1, 3 ] ),
 				$this->equalTo( [
 					'status' => 'queued',
 					'scheduled_time' => null,


### PR DESCRIPTION
## Description

There is an edge case that can cause the cleanup job of deadlocked jobs ... well to be deadlocked itself :) Please see the comment in the code for more context.

## Changelog Description

### Plugin Update: Search

Update deadlock cleanup job for the indexing queue to handle correctly multiple jobs trying to reindex the same object.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

This is quite hard to test. I think the state can happen due to a race condition in EP code.

The scenario you want is:
 * 2 jobs in the queue - wp_vip_search_index_queue db table
 * 1 needs to be in state 'running'
 * 1 needs to be in state 'scheduled'

So I guess inserting those to DB directly works:
```
INSERT into wp_vip_search_index_queue (`object_id`, `object_type`, `status`, `index_version`, `scheduled_time`) VALUES (1, 'post', 'scheduled', 1, '0000-00-00'), (1, 'post', 'running', 1, '0000-00-00');
```

Then run:
```
wp eval "do_action('vip_search_queue_sweeper');"
```

wp_vip_search_index_queue table should now have only one job in state scheduled and scheduled time now-ish
