### PR TITLE
Search Dev Tools compatibility fixes and permission restrictions

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -101,6 +101,11 @@ class Search {
 	public $time;
 	public static $stat_sampling_drop_value = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
 
+	/**
+	 * Maximum number of queries before rate-limiting kicks in.
+	 *
+	 * @var int
+	 */
 	public static $max_query_count;
 	public static $query_db_fallback_value;
 
@@ -1895,5 +1900,21 @@ class Search {
 
 	public function limit_max_result_window( $current_value ) {
 		return min( $current_value, self::MAX_RESULT_WINDOW );
+	}
+
+	/**
+	 * Determine whether the rate-limiting is in effect
+	 */
+	public static function is_rate_limited(): bool {
+		return intval( wp_cache_get( self::QUERY_COUNT_CACHE_KEY, self::SEARCH_CACHE_GROUP ) ) > self::$max_query_count;
+	}
+
+	/**
+	 * Get the total number of queries over the last rate-limiting window from object cache.
+	 *
+	 * @return integer
+	 */
+	public static function get_query_count(): int {
+		return (int) wp_cache_get( self::QUERY_COUNT_CACHE_KEY, self::SEARCH_CACHE_GROUP );
 	}
 }

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -95,15 +95,6 @@ function should_enable_search_dev_tools(): bool {
 }
 
 /**
- * Check whether the site is currently rate-limited
- *
- * @return boolean
- */
-function is_ratelimited(): bool {
-	return wp_cache_get( Search::QUERY_COUNT_CACHE_KEY, Search::QUERY_COUNT_CACHE_GROUP ) > Search::$max_query_count;
-}
-
-/**
  * Add our scripts and styles.
  *
  * @return void
@@ -154,13 +145,20 @@ function print_data() {
 		$queries
 	);
 
+	$limit_count = sprintf(
+		'%s (%d of %d limit)',
+		Search::is_rate_limited() ? 'yes' : 'no',
+		Search::get_query_count(),
+		Search::$max_query_count
+	);
+
 	$data = [
 		'status'                  => 'enabled',
 		'queries'                 => $mapped_queries,
 		'information'             => [
 			[
 				'label'   => 'Rate limited?',
-				'value'   => is_ratelimited() ? 'yes' : 'no',
+				'value'   => $limit_count,
 				'options' => [
 					'collapsible' => false,
 				],

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -16,7 +16,7 @@ namespace Automattic\VIP\Search\Dev_Tools;
 
 use Automattic\VIP\Search\Search;
 
-define( 'SEARCH_DEV_TOOLS_CAP', 'edit_others_posts' );
+define( 'SEARCH_DEV_TOOLS_CAP', 'manage_options' );
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes' );
 add_action( 'admin_bar_menu', __NAMESPACE__ . '\admin_bar_node', PHP_INT_MAX );

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -16,10 +16,6 @@ namespace Automattic\VIP\Search\Dev_Tools;
 
 use Automattic\VIP\Search\Search;
 
-if ( ! ( defined( 'VIP_ENABLE_VIP_SEARCH' ) && VIP_ENABLE_VIP_SEARCH ) ) {
-	return;
-}
-
 define( 'SEARCH_DEV_TOOLS_CAP', 'edit_others_posts' );
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes' );


### PR DESCRIPTION
## Description

This PR addresses a couple of compatibility issues:

1. Pass a correct WP_Post object instead of a null to Search::get_post_meta_allow_list, this way we'll make sure to correctly gather the meta keys for each post type and avoid potential fatals in case a user code implements a filter callback with a type hint.
2. Remove the check for VIP_ENABLE_VIP_SEARCH constant - we've changed the way things loaded and it's redundant now.

Additionally:

1. Bump the required capability to manage_options.
2. Rate-limiting tab now also shows the number of queries and the limit.
3. Minor PHPDoc improvements.


## Changelog Description

### Plugin Updated:  Search Dev Tools

- We've addressed a few incompatibilities that may have caused issues in edge case scenarios where a `vip_search_post_meta_allow_list` filter callback has a type-hinted argument.
- Rate Limiting tab also shows the number of queries for the current time window as well as the limit.
- Dev Tools now require `manage_options` capability. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out the PR.
2. Make sure nothing is broken.