### PR TITLE
Temporarily remove register_block_core_legacy_widget because it interferes with our tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,20 @@ function _manually_load_plugin() {
 
 	require_once( __DIR__ . '/../z-client-mu-plugins.php' );
 }
+
+/**
+ * Core functionality causes `WP_Block_Type_Registry::register was called <strong>incorrectly</strong>. Block type "core/legacy-widget" is already registered. 
+ *
+ * Temporarily unhook it.
+ *
+ * @return void
+ */
+function _disable_core_legacy_widget_registration() {
+	remove_action( 'init', 'register_block_core_legacy_widget', 20 );
+}
+
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+tests_add_filter( 'muplugins_loaded', '_disable_core_legacy_widget_registration' );
 
 require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
## Description

This is a hotfix for an issue that was introduced in the core commit https://core.trac.wordpress.org/browser/trunk/src/wp-includes/blocks/legacy-widget.php?rev=50997#L58 resulting in our tests failing with:

```
WP_Block_Type_Registry::register was called <strong>incorrectly</strong>. Block type "core/legacy-widget" is already registered.
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Run `circleci local execute --job php74-build-singlesite-nightly`
1. Verify no tests are failing
1. Rejoice.

