### PR TITLE
Stricter validation for URLs in Search Dev Tools

### DIFF
--- a/tests/search/test-search-dev-tools.php
+++ b/tests/search/test-search-dev-tools.php
@@ -26,15 +26,19 @@ class Search_Dev_Tools_Test extends \WP_UnitTestCase {
 	public function data_provider_endpoint_urls() {
 		return [
 			[
-				'input'    => 'http://vip-search:9200/vip-123-v1/_search',
+				'input'    => 'http://vip-search:9200/vip-123-post-1/_search',
 				'expected' => true,
 			],
 			[
-				'input'    => 'http://vip-search:9200/vip-123-v1/_search',
+				'input'    => 'http://vip-search:9200/vip-123-post-1,vip-123-post-post-2-v1/_search',
 				'expected' => true,
 			],
 			[
-				'input'    => 'http://vip-search:9200/vip-2345-v1/_search',
+				'input'    => 'http://vip-search:9200/vip-123-post-v1,vip-3456-post-2-v1/_search',
+				'expected' => new \WP_Error( 'rest_invalid_param', sprintf( '%s is not a valid allowed URL', 'url' ) ),
+			],
+			[
+				'input'    => 'http://vip-search:9200/vip-2345-post-v1/_search',
 				'expected' => new \WP_Error( 'rest_invalid_param', sprintf( '%s is not a valid allowed URL', 'url' ) ),
 			],
 			[

--- a/tests/search/test-search-dev-tools.php
+++ b/tests/search/test-search-dev-tools.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+require_once __DIR__ . '/../../search/search.php';
+require_once __DIR__ . '/../../search/includes/classes/class-versioning.php';
+require_once __DIR__ . '/../../search/elasticpress/elasticpress.php';
+class Search_Test extends \WP_UnitTestCase {
+	/**
+	 * Make tests run in separate processes since we're testing state
+	 * related to plugin init, including various constants.
+	 */
+
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+	protected $preserveGlobalState      = false;
+	protected $runTestInSeparateProcess = true;
+	// phpcs:enable
+
+	public function setUp() {
+		define( 'VIP_SEARCH_DEV_TOOLS', true );
+		$this->search_instance = new \Automattic\VIP\Search\Search();
+
+		require_once __DIR__ . '/../../search/search-dev-tools/search-dev-tools.php'; 
+	}
+
+	public function data_provider_endpoint_urls() {
+		return [
+			[
+				'input'    => 'http://vip-search:9200/vip-123-v1/_search',
+				'expected' => true,
+			],
+			[
+				'input'    => 'http://vip-search:9200/vip-123-v1/_search',
+				'expected' => true,
+			],
+			[
+				'input'    => 'http://vip-search:9200/vip-2345-v1/_search',
+				'expected' => new \WP_Error( 'rest_invalid_param', sprintf( '%s is not a valid allowed URL', 'url' ) ),
+			],
+			[
+				'input'    => 'http://vip-search:9200/restricted/_endpoint',
+				'expected' => new \WP_Error( 'rest_invalid_param', sprintf( '%s is not a valid allowed URL', 'url' ) ),
+			],
+			[
+				'input'    => 'notavalidurl',
+				'expected' => new \WP_Error( 'rest_invalid_param', sprintf( '%s is not a valid allowed URL', 'url' ) ),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider data_provider_endpoint_urls
+	 */
+	public function test__url_validation( $input, $expected ) {
+		$val = \Automattic\VIP\Search\Dev_Tools\rest_endpoint_url_validate_callback( $input, new \WP_Rest_Request( 'POST' ), 'url' );
+		$this->assertEquals( $val, $expected, 'URL validation failed' );
+	}
+}

--- a/tests/search/test-search-dev-tools.php
+++ b/tests/search/test-search-dev-tools.php
@@ -5,7 +5,7 @@ namespace Automattic\VIP\Search;
 require_once __DIR__ . '/../../search/search.php';
 require_once __DIR__ . '/../../search/includes/classes/class-versioning.php';
 require_once __DIR__ . '/../../search/elasticpress/elasticpress.php';
-class Search_Test extends \WP_UnitTestCase {
+class Search_Dev_Tools_Test extends \WP_UnitTestCase {
 	/**
 	 * Make tests run in separate processes since we're testing state
 	 * related to plugin init, including various constants.


### PR DESCRIPTION
## Description

This PR adds a strict validation for the URL argument for search/dev-tools REST endpoint. 

We used to do a fairly naive check - a valid URL ending in '_search'  would pass it. Theoretically, that can be exploited.

With PR validation is much stricter now.

## Changelog Description

### Plugin Updated: Search Dev Tools

We've added strict validation rules for the REST endpoint arguments

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1.  Add `$query['url'] = 'somethingbogus'` around https://github.com/Automattic/vip-go-mu-plugins/blob/92f77df56e3c3a3268b9abd080f14b1cedae8680/search/search-dev-tools/search-dev-tools.php#L134
2. Open Dev Tools and try to edit a query
3. The remote request to the REST endpoint should be a 400 now.
