### PR TITLE
Update renovatebot config to ignore wp-parsely and jetpack paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,5 +22,9 @@
 				"groupSlug": "all-minor-patch-eslint"
 			}
 		}
+	],
+	"ignorePaths": [
+		"wp-parsely-*/",
+		"jetpack*/"
 	]
 }


### PR DESCRIPTION
## Description

Both of those are copies from upstream, as such running renovatebot on them is unnecessary.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Merge and wait :)