### PR TITLE
Enable Connection Pilot for all sites

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -139,13 +139,13 @@ if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) && defined( 'VIP_GO_APP_ENVIRONMENT' 
 	define( 'VIP_JETPACK_IS_PRIVATE', true );
 }
 
-// Jetpack Connection Pilot disabled by default
+// Jetpack Connection Pilot is enabled by default
 if ( ! defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) ) {
 	// Keeping for historical reasons, we can remove this after clients are using the new constant
 	if ( defined( 'VIP_JETPACK_CONNECTION_PILOT_SHOULD_RUN' ) ) {
 		define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', VIP_JETPACK_CONNECTION_PILOT_SHOULD_RUN );
 	} else {
-		define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', false );
+		define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', true );
 	}
 }
 

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -16,10 +16,7 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = array(
-		// https://github.com/Automattic/vip-go-mu-plugins/tree/master/vip-jetpack/connection-pilot
-		'jetpack-cxn-pilot' => 0.25,
-	);
+	public static $feature_percentages = array();
 
 	public static $site_id = false;
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -278,6 +278,10 @@ class Connection_Pilot {
 		if ( ! is_multisite() && defined( 'VIP_GO_APP_ID' ) && VIP_GO_APP_ID < 3750 ) {
 			return false;
 		} else {
+			if ( ! function_exists( 'get_site' ) ) {
+				return false;
+			}
+
 			try {
 				$site_registered = new DateTime( get_site()->registered );
 				$threshold = new DateTime( "2021-06-01" );


### PR DESCRIPTION
## Description

Please do not deploy before https://github.com/Automattic/vip-go-mu-plugins/pull/2197

This PR enables Connection Pilot by default to all sites.

## Changelog Description

Example for a plugin upgrade:

### Plugin Updated: Jetpack

Enabling Connection Pilot by default.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.