### PR TITLE
Ignoring Akismet and VaultPress dirs for Renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,9 @@
 		}
 	],
 	"ignorePaths": [
-		"wp-parsely-*/",
-		"jetpack*/"
+		"akismet/",
+		"jetpack*/",
+		"vaultpress/",
+		"wp-parsely-*/"
 	]
 }


### PR DESCRIPTION
## Description

This is a follow-up PR to https://github.com/Automattic/vip-go-mu-plugins/pull/2198. 

Given that we're pulling VaultPress and Akismet from upstream and we don't want to update its dependencies, we're configuring the bot to ignore those repositories.

## Changelog Description

### Internal tooling update

No customer impact

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.