### PR TITLE
Adds confirm message 

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -47,7 +47,7 @@ class CoreCommand extends \ElasticPress\Command {
 			}
 
 			if ( ! $skip_confirm ) {
-				WP_CLI::confirm( '⚠️  You are about to remove previously used index version. It is advised to verify that the new version is being used before continuing. Continue?' );
+				WP_CLI::confirm( '⚠️  You are about to remove a previously used index version. It is advised to verify that the new version is being used before continuing. Continue?' );
 			}
 
 

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -37,6 +37,7 @@ class CoreCommand extends \ElasticPress\Command {
 		$search = \Automattic\VIP\Search\Search::instance();
 
 		$indexables = $this->_parse_indexables( $assoc_args );
+		$skip_confirm = isset( $assoc_args['skip-confirm'] ) && $assoc_args['skip-confirm'];
 
 		foreach ( $indexables as $indexable ) {
 			WP_CLI::line( sprintf( 'Updating active version for "%s"', $indexable->slug ) );
@@ -44,6 +45,11 @@ class CoreCommand extends \ElasticPress\Command {
 			if ( is_wp_error( $result ) ) {
 				WP_CLI::error( sprintf( 'Error activating next version: %s', $result->get_error_message() ) );
 			}
+
+			if ( ! $skip_confirm ) {
+				WP_CLI::confirm( '⚠️  You are about to remove previously used index version. It is advised to verify that the new version is being used before continuing. Continue?' );
+			}
+
 
 			WP_CLI::line( sprintf( 'Removing inactive version for "%s"', $indexable->slug ) );
 			$result = $search->versioning->delete_version( $indexable, 'previous' );
@@ -141,6 +147,7 @@ class CoreCommand extends \ElasticPress\Command {
 		$this->_verify_arguments_compatibility( $assoc_args );
 
 		$using_versions = $assoc_args['using-versions'] ?? false;
+		$skip_confirm = isset( $assoc_args['skip-confirm'] ) && $assoc_args['skip-confirm'];
 
 		$this->_maybe_setup_index_version( $assoc_args );
 
@@ -184,6 +191,8 @@ class CoreCommand extends \ElasticPress\Command {
 		}
 
 		if ( $using_versions ) {
+			// resetting skip-confirm after it was cleared for elasticpress
+			$assoc_args['skip-confirm'] = $skip_confirm;
 			$this->_shift_version_after_index( $assoc_args );
 		}
 	}

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -50,7 +50,6 @@ class CoreCommand extends \ElasticPress\Command {
 				WP_CLI::confirm( '⚠️  You are about to remove a previously used index version. It is advised to verify that the new version is being used before continuing. Continue?' );
 			}
 
-
 			WP_CLI::line( sprintf( 'Removing inactive version for "%s"', $indexable->slug ) );
 			$result = $search->versioning->delete_version( $indexable, 'previous' );
 			if ( is_wp_error( $result ) ) {


### PR DESCRIPTION

## Description
Adds a confirmation step before removing the previous index version when using automatic reindexing using versions.


## Changelog Description


### Plugin Updated: Search

Adds a confirmation step before removing the previous index version when using automatic reindexing using versions.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. run `dev-env exec -- wp vip-search index --using-versions --setup --indexables="post"`
2. See a confirm message before removing index