### PR TITLE
Remove `$wp_admin_bar` argument

### DIFF
--- a/blogpublic-notice.php
+++ b/blogpublic-notice.php
@@ -11,7 +11,7 @@ if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 /**
  * Notice for blog_public value
  */
-function notice( $wp_admin_bar ) {
+function notice() {
 	$home_url_parsed = parse_url( home_url() );
 	if (
 		! current_user_can( 'manage_options' ) ||


### PR DESCRIPTION
## Description
Removing the unused `$wp_admin_bar` argument from the `\Automattic\VIP\Blog_Public\notice()` callback since the `admin_notices` hook doesn't ever pass arguments. This doesn't seem to be a problem for WordPress in general, but if a plugin is attempting to do something with the output of notices (like move them around on it's own pages) and uses `call_user_func()` instead of `call_user_func_array()` like WordPress core, this will cause a fatal error.

## Changelog Description

### Updated blog_public notice callback

Removed the `$wp_admin_bar` parameter from the callback since the `admin_notices` hook doesn't pass any arguments.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Get a non-production App with a domain that does not end with `.go-vip.co` or `.go-vip.net` and make sure the `blog_public` option is set to `1`.
2. Apply this PR.
3. Load any wp-admin page and see if the notice still functions without the `$wp_admin_bar` parameter.