### PR TITLE
Adding Akismet autoconnection

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -134,12 +134,16 @@ class Controls {
 	 * Connect a site to Akismet.
 	 *
 	 * Uses Akismet's function to connect Akismet using the Jetpack. An active Jetpack connection is required on the site.
+	 *
+	 * @return mixed bool True if connection worked, false otherwise
 	 */
 	public static function connect_akismet() {
 		if ( class_exists( 'Akismet_Admin' ) ) {
-			return \Akismet_Admin::connect_jetpack_user();
+			if ( is_akismet_key_invalid() ) {
+				return \Akismet_Admin::connect_jetpack_user();
+			}
+			return true;
 		}
-
 		return false;
 	}
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -135,9 +135,9 @@ class Controls {
 	 *
 	 * Uses Akismet's function to connect Akismet using the Jetpack. An active Jetpack connection is required on the site.
 	 *
-	 * @return mixed bool True if connection worked, false otherwise
+	 * @return bool True if connection worked, false otherwise
 	 */
-	public static function connect_akismet() {
+	public static function connect_akismet(): bool {
 		if ( class_exists( 'Akismet_Admin' ) ) {
 			if ( is_akismet_key_invalid() ) {
 				return \Akismet_Admin::connect_jetpack_user();

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -134,17 +134,9 @@ class Controls {
 	 * Connect a site to Akismet.
 	 *
 	 * Uses Akismet's function to connect Akismet using the Jetpack. An active Jetpack connection is required on the site.
-	 *
-	 * @param bool $disconnect Set to true if it should disconnect Akismet at the start.
 	 */
-	public static function connect_akismet( bool $disconnect = false ) {
-		if ( $disconnect ) {
-			$result = false;
-		} else {
-			$result = \Akismet_Admin::connect_jetpack_user();
-		}
-
-		return $result;
+	public static function connect_akismet() {
+		return \Akismet_Admin::connect_jetpack_user();
 	}
 
 	/**

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -136,7 +136,11 @@ class Controls {
 	 * Uses Akismet's function to connect Akismet using the Jetpack. An active Jetpack connection is required on the site.
 	 */
 	public static function connect_akismet() {
-		return \Akismet_Admin::connect_jetpack_user();
+		if ( class_exists( 'Akismet_Admin' ) ) {
+			return \Akismet_Admin::connect_jetpack_user();
+		}
+
+		return false;
 	}
 
 	/**

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -90,7 +90,7 @@ class Controls {
 	 *
 	 * @return mixed bool|\WP_Error True if JP was (re)connected, \WP_Error otherwise.
 	 */
-	public static function connect_site( $skip_connection_tests = false, $disconnect = false ) {
+	public static function connect_site( bool $skip_connection_tests = false, bool $disconnect = false ) {
 		if ( ! self::validate_constants() ) {
 			return new \WP_Error( 'jp-cxn-pilot-missing-constants', 'This is not a valid VIP Go environment or some constants are missing.' );
 		}
@@ -128,6 +128,23 @@ class Controls {
 
 		// Run the tests again and return the result 🤞.
 		return self::jetpack_is_connected();
+	}
+
+	/**
+	 * Connect a site to Akismet.
+	 *
+	 * Uses Akismet's function to connect Akismet using the Jetpack. An active Jetpack connection is required on the site.
+	 *
+	 * @param bool $disconnect Set to true if it should disconnect Akismet at the start.
+	 */
+	public static function connect_akismet( bool $disconnect = false ) {
+		if ( $disconnect ) {
+			$result = false;
+		} else {
+			$result = \Akismet_Admin::connect_jetpack_user();
+		}
+
+		return $result;
 	}
 
 	/**

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -125,6 +125,12 @@ class Connection_Pilot {
 			// Everything checks out. Update the heartbeat option and move on.
 			$this->update_heartbeat();
 
+			// Attempting Akismet connection given that Jetpack is connected
+			$akismet_connection_attempt = Connection_Pilot\Controls::connect_akismet();
+			if ( ! $akismet_connection_attempt ) {
+				$this->send_alert( 'Alert: Could not connect Akismet automatically.' );
+			}
+
 			return;
 		}
 
@@ -153,16 +159,6 @@ class Connection_Pilot {
 			}
 
 			$this->send_alert( 'Jetpack was successfully (re)connected!' );
-
-			$akismet_connection_attempt = Connection_Pilot\Controls::connect_akismet();
-
-			if ( ! $akismet_connection_attempt ) {
-				$this->send_alert( 'Alert: Could not connect Akismet automatically.' );
-				return;
-			}
-
-			$this->send_alert( 'Akismet was successfuly connected!' );
-
 			return;
 		}
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -125,10 +125,13 @@ class Connection_Pilot {
 			// Everything checks out. Update the heartbeat option and move on.
 			$this->update_heartbeat();
 
-			// Attempting Akismet connection given that Jetpack is connected
-			$akismet_connection_attempt = Connection_Pilot\Controls::connect_akismet();
-			if ( ! $akismet_connection_attempt ) {
-				$this->send_alert( 'Alert: Could not connect Akismet automatically.' );
+			// TODO: Remove check after general rollout
+			if ( self::should_attempt_reconnection() ) {
+				// Attempting Akismet connection given that Jetpack is connected
+				$akismet_connection_attempt = Connection_Pilot\Controls::connect_akismet();
+				if ( ! $akismet_connection_attempt ) {
+					$this->send_alert( 'Alert: Could not connect Akismet automatically.' );
+				}
 			}
 
 			return;

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -155,6 +155,16 @@ class Connection_Pilot {
 
 			$this->send_alert( 'Jetpack was successfully (re)connected!' );
 
+			$akismet_connection_attempt = Connection_Pilot\Controls::connect_akismet();
+
+			if ( ! $akismet_connection_attempt ) {
+				$this->send_alert( 'Alert: Could not connect Akismet automatically.' );
+
+				return;
+			}
+
+			$this->send_alert( 'Akismet was successfuly connected!' );
+
 			return;
 		}
 


### PR DESCRIPTION
This PR extends Jetpack Connection Pilot capability to add autoconnection to Akismet. If a Jetpack connection is active, the system will try to connect automatically to Akismet

## Description

This PR extends Jetpack Connection Pilot capability to add autoconnection to Akismet. If a Jetpack connection is active, the system will try to connect automatically to Akismet.

## Changelog Description

### Akismet auto connection

Connection Pilot is now capable of autoconnecting to Akismet.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Go to a Sandbox and launch a CLI.
3. Run the `reconnect()` routine from Connection Pilot.