### PR TITLE
Adding VaultPress autoconnection

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -130,12 +130,24 @@ class Controls {
 		return self::jetpack_is_connected();
 	}
 
+	/**
+	 * Connect a site to VaultPress.
+	 *
+	 * Uses VaultPress' function to connect VaultPress using Jetpack. An active Jetpack connection is required on the site.
+	 *
+	 * @return bool|\WP_Error True if site is connected, error otherwise.
+	 */
 	public static function connect_vaultpress() {
 		if ( class_exists( 'VaultPress' ) ) {
-			return \VaultPress::init()->register_via_jetpack( true );
+			$vaultpress = \VaultPress::init();
+			if ( ! $vaultpress->is_registered() ) {
+				return $vaultpress->register_via_jetpack( true );
+			}
+
+			return true;
 		}
 
-		return false;
+		return new \WP_Error( 1, __( 'VaultPress could not be found.' ) );
 	}
 
 	/**

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -130,6 +130,10 @@ class Controls {
 		return self::jetpack_is_connected();
 	}
 
+	public static function connect_vaultpress() {
+		return VaultPress::init()->register_via_jetpack( true );
+	}
+
 	/**
 	 * Provision the site with WP.com.
 	 *

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -131,7 +131,11 @@ class Controls {
 	}
 
 	public static function connect_vaultpress() {
-		return VaultPress::init()->register_via_jetpack( true );
+		if ( class_exists( 'VaultPress' ) ) {
+			return \VaultPress::init()->register_via_jetpack( true );
+		}
+
+		return false;
 	}
 
 	/**

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -132,6 +132,16 @@ class Connection_Pilot {
 		if ( ! self::should_attempt_reconnection( $is_connected ) ) {
 			$this->send_alert( 'Jetpack is disconnected. No reconnection attempt was made.' );
 
+			// TODO: Remove check after general rollout
+			if ( self::should_attempt_reconnection() ) {
+				// Attempting VaultPress connection given that Jetpack is connected
+				$vaultpress_connection_attempt = Connection_Pilot\Controls::connect_vaultpress();
+				if ( is_wp_error( $vaultpress_connection_attempt ) ) {
+					$message = sprintf( 'VaultPress connection error: [%s] %s', $vaultpress_connection_attempt->get_error_code(), $vaultpress_connection_attempt->get_error_message() );
+					$this->send_alert( $message );
+				}
+			}
+
 			return;
 		}
 
@@ -153,15 +163,6 @@ class Connection_Pilot {
 			}
 
 			$this->send_alert( 'Jetpack was successfully (re)connected!' );
-
-			$vaultpress_connection_attempt = Connection_Pilot\Controls::connect_vaultpress();
-
-			if ( is_wp_error( $vaultpress_connection_attempt ) ) {
-				$this->send_alert( 'Alert: Could not connect VaultPress automatically.' );
-				return;
-			}
-
-			$this->send_alert( 'VaultPress was successfuly connected!' );
 
 			return;
 		}

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -125,13 +125,6 @@ class Connection_Pilot {
 			// Everything checks out. Update the heartbeat option and move on.
 			$this->update_heartbeat();
 
-			return;
-		}
-
-		// Not connected, maybe reconnect
-		if ( ! self::should_attempt_reconnection( $is_connected ) ) {
-			$this->send_alert( 'Jetpack is disconnected. No reconnection attempt was made.' );
-
 			// TODO: Remove check after general rollout
 			if ( self::should_attempt_reconnection() ) {
 				// Attempting VaultPress connection given that Jetpack is connected
@@ -141,6 +134,13 @@ class Connection_Pilot {
 					$this->send_alert( $message );
 				}
 			}
+
+			return;
+		}
+
+		// Not connected, maybe reconnect
+		if ( ! self::should_attempt_reconnection( $is_connected ) ) {
+			$this->send_alert( 'Jetpack is disconnected. No reconnection attempt was made.' );
 
 			return;
 		}

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -149,11 +149,19 @@ class Connection_Pilot {
 		if ( true === $connection_attempt ) {
 			if ( ! empty( $this->last_heartbeat['cache_site_id'] ) && (int) \Jetpack_Options::get_option( 'id' ) !== (int) $this->last_heartbeat['cache_site_id'] ) {
 				$this->send_alert( 'Alert: Jetpack was automatically reconnected, but the connection may have changed cache sites. Needs manual inspection.' );
-
 				return;
 			}
 
 			$this->send_alert( 'Jetpack was successfully (re)connected!' );
+
+			$vaultpress_connection_attempt = Connection_Pilot\Controls::connect_vaultpress();
+
+			if ( is_wp_error( $vaultpress_connection_attempt ) ) {
+				$this->send_alert( 'Alert: Could not connect VaultPress automatically.' );
+				return;
+			}
+
+			$this->send_alert( 'VaultPress was successfuly connected!' );
 
 			return;
 		}


### PR DESCRIPTION
This PR extends Jetpack Connection Pilot capability to add autoconnection to VaultPress. If a Jetpack connection is active, the system will try to connect automatically to VaultPress.

## Description

This PR extends Jetpack Connection Pilot capability to add autoconnection to VaultPress. If a Jetpack connection is active, the system will try to connect automatically to VaultPress.

## Changelog Description

### VaultPress auto connection

Connection Pilot is now capable of autoconnecting to VaultPress.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Go to a Sandbox and launch a CLI.
3. Run the `reconnect()` routine from Connection Pilot.