### PR TITLE
Remove index removal

### DIFF
--- a/search/includes/classes/queue/class-schema.php
+++ b/search/includes/classes/queue/class-schema.php
@@ -139,12 +139,6 @@ class Schema {
 		$table_count = count( $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) );
 
 		if ( 1 === $table_count ) {
-			// Between version 2 and 3, we added the `index_version` column, which is part of the unique index, so need to drop the old index
-			// (which doesn't happen automatically in dbDelta, sadly)
-			if ( 3 === self::DB_VERSION ) {
-				$wpdb->query( "DROP INDEX IF EXISTS `unique_object_and_status` on $table_name" ); // Cannot prepare table name. @codingStandardsIgnoreLine
-			}
-
 			set_transient( self::DB_VERSION_TRANSIENT, self::DB_VERSION, self::DB_VERSION_TRANSIENT_TTL );
 		} else {
 			trigger_error( esc_html( "VIP Search Queue index table ($table_name) not found after dbDelta()" ), \E_USER_WARNING );


### PR DESCRIPTION
## Description

DROP INDEX `IF EXISTS` is not supported on Vitess or mysql. Looking at it closer I think it is safe to remove those lines totally (as oppose to manually check for index existence before removal).

The idea there was that version 2 of vip-search DB queue used and created it, however the current version 3 no longer creates or uses this DB index (switched around a year ago).

As this code ultimately runs on every admin/CLI request it is reasonable to assume the old index is cleaned out already.  

@nickdaugherty could you please check if my assumptions make sense to you?

## Changelog Description

### Plugin Updated: Search

Removes legacy DB index cleanup that is no longer needed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

IF you want to execute this code:
1.  On `search/includes/classes/queue/class-schema.php:111` change `_prepare_table` to be public
2. Run `dev-env exec -- wp eval "(new \Automattic\VIP\Search\Queue\Schema())->_prepare_table();"`
