### PR TITLE
Enable Search Dev Tools for 25% of sites and ALL non-prod sites

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -159,6 +159,10 @@ if ( defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) && true === VIP_JETPACK_AUT
 
 define( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', $internal_cron_events );
 
+if ( ! defined( 'VIP_SEARCH_DEV_TOOLS' ) ) {
+	define( 'VIP_SEARCH_DEV_TOOLS', 'production' !== VIP_GO_APP_ENVIRONMENT || \Automattic\VIP\Feature::is_enabled( 'search-dev-tools' ) );
+}
+
 // Interaction with the filesystem will always be direct.
 // Avoids issues with `get_filesystem_method` which attempts to write to `WP_CONTENT_DIR` and fails.
 define( 'FS_METHOD', 'direct' );

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -216,9 +216,6 @@ if ( ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) || // legac
 	require_once( __DIR__ . '/search/search.php' );
 }
 
-
-
-
 // Set WordPress environment type
 // Map some VIP environments to 'production' and 'development', and use 'staging' for any other
 if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -159,10 +159,6 @@ if ( defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) && true === VIP_JETPACK_AUT
 
 define( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', $internal_cron_events );
 
-if ( ! defined( 'VIP_SEARCH_DEV_TOOLS' ) ) {
-	define( 'VIP_SEARCH_DEV_TOOLS', 'production' !== VIP_GO_APP_ENVIRONMENT || \Automattic\VIP\Feature::is_enabled( 'search-dev-tools' ) );
-}
-
 // Interaction with the filesystem will always be direct.
 // Avoids issues with `get_filesystem_method` which attempts to write to `WP_CONTENT_DIR` and fails.
 define( 'FS_METHOD', 'direct' );
@@ -208,6 +204,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once( __DIR__ . '/vip-helpers/class-vip-backup-user-role-cli.php' );
 }
 
+if ( ! defined( 'VIP_SEARCH_DEV_TOOLS' ) ) {
+	define( 'VIP_SEARCH_DEV_TOOLS', ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) || \Automattic\VIP\Feature::is_enabled( 'search-dev-tools' ) );
+}
+
 // Load elasticsearch helpers
 // Warning: Site Details depends on the existence of class Search.
 // If this changes in the future, please ensure that details for search are correctly extracted
@@ -215,6 +215,9 @@ if ( ( defined( 'USE_VIP_ELASTICSEARCH' ) && USE_VIP_ELASTICSEARCH ) || // legac
 	defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === VIP_ENABLE_VIP_SEARCH ) {
 	require_once( __DIR__ . '/search/search.php' );
 }
+
+
+
 
 // Set WordPress environment type
 // Map some VIP environments to 'production' and 'development', and use 'staging' for any other

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -16,7 +16,9 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = array();
+	public static $feature_percentages = array(
+		'search-dev-tools' => 0.25,
+	);
 
 	public static $site_id = false;
 

--- a/tests/search/test-search-dev-tools.php
+++ b/tests/search/test-search-dev-tools.php
@@ -17,10 +17,9 @@ class Search_Dev_Tools_Test extends \WP_UnitTestCase {
 	// phpcs:enable
 
 	public function setUp() {
-		define( 'VIP_SEARCH_DEV_TOOLS', true );
 		$this->search_instance = new \Automattic\VIP\Search\Search();
 
-		require_once __DIR__ . '/../../search/search-dev-tools/search-dev-tools.php'; 
+		require_once __DIR__ . '/../../search/search-dev-tools/search-dev-tools.php';
 	}
 
 	public function data_provider_endpoint_urls() {


### PR DESCRIPTION
## Description

This PR enables Search Dev Tools for 25% of sites and ALL non-prod sites.

## Changelog Description

### Plugin Updated: Search Dev Tools

We enabled Search Dev Tools on 25% of sites and all non-production sites.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
