### PR TITLE
Search move inconsistency alerts

### DIFF
--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -252,7 +252,7 @@ class HealthJob {
 					$result['diff']
 				);
 
-				$this->send_alert( '#vip-go-es-alerts', $message, 2, "{$result['entity']}:{$result['type']}" );
+				$this->send_alert( '#vip-go-es-inconsistencies', $message, 2, "{$result['entity']}:{$result['type']}" );
 			}
 		}
 	}

--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -124,13 +124,13 @@ class HealthJob_Test extends \WP_UnitTestCase {
 			->method( 'send_alert' )
 			->withConsecutive(
 				array(
-					'#vip-go-es-alerts',
+					'#vip-go-es-inconsistencies',
 					$this->getExpectedDiffMessage( $results[0] ),
 					2,
 					"{$results[0]['entity']}:{$results[0]['type']}",
 				),
 				array(
-					'#vip-go-es-alerts',
+					'#vip-go-es-inconsistencies',
 					$this->getExpectedDiffMessage( $results[1] ),
 					2,
 					"{$results[1]['entity']}:{$results[1]['type']}",


### PR DESCRIPTION

## Description

## Changelog Description


### Plugin Updated: Search

Moves search count inconsistencies to a separate channel. As there is an async aspect to indexing some level of inconsistencies is expected and therefore not actionable.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

This is not really testable as the only change is the IRC/Slack channel name and those messages are only pushed from the real environment.
