### PR TITLE
Hide Akismet admin notices

### DIFF
--- a/akismet.php
+++ b/akismet.php
@@ -68,7 +68,7 @@ add_action( 'admin_notices', 'vip_remove_akismet_admin_notices', 1 );
  * @return bool True if the Akismet key in the site is not existent or not valid
  */
 function is_akismet_key_invalid(): bool {
-	if ( class_exists('Akismet') ) {
+	if ( class_exists( 'Akismet' ) ) {
 		$key = Akismet::get_api_key();
 		$key_status = Akismet::check_key_status( $key );
 		return ! $key_status || ! $key_status[1] || 'invalid' === $key_status[1];

--- a/akismet.php
+++ b/akismet.php
@@ -50,13 +50,29 @@ function wpcom_vip_akismet_spam_count_incr( $val ) {
 }
 add_filter( 'akismet_spam_count_incr', 'wpcom_vip_akismet_spam_count_incr' );
 
-add_action( 'admin_menu', 'vip_remove_akismet_admin_menu', 999 );
-
 function vip_remove_akismet_admin_menu() {
-	$key = Akismet::get_api_key();
-	$key_status = Akismet::check_key_status( $key );
-
-	if ( ! $key_status || ! $key_status[1] || 'invalid' === $key_status[1] ) {
-		remove_submenu_page( 'jetpack', 'akismet-key-config' );
+	if ( is_akismet_key_invalid() ) {
+		remove_action( 'admin_menu', array( 'Akismet_Admin', 'admin_menu' ), 5 );
 	}
+}
+add_action( 'admin_menu', 'vip_remove_akismet_admin_menu', 1 );
+
+function vip_remove_akismet_admin_notices() {
+	if ( is_akismet_key_invalid() ) {
+		remove_action( 'admin_notices', array( 'Akismet_Admin', 'display_notice' ) );
+	}
+}
+add_action( 'admin_notices', 'vip_remove_akismet_admin_notices', 1 );
+
+/**
+ * @return bool True if the Akismet key in the site is not existent or not valid
+ */
+function is_akismet_key_invalid(): bool {
+	if ( class_exists('Akismet') ) {
+		$key = Akismet::get_api_key();
+		$key_status = Akismet::check_key_status( $key );
+		return ! $key_status || ! $key_status[1] || 'invalid' === $key_status[1];
+	}
+
+	return false;
 }


### PR DESCRIPTION
## Description

This PR removes some admin notices that Akismet would display when it was not activated. Given that we want to move towards activating Akismet automatically, we don't want to show the user buttons that are not actionable.

We are removing notices such as:

<img width="1731" alt="Screen Shot 2021-06-14 at 11 51 23 AM" src="https://user-images.githubusercontent.com/7188409/121873630-db704d00-cd06-11eb-89d6-a97a45a8672a.png">

The PR includes a small refactor to remove Akismet pages as well.

## Changelog Description

### Plugin Updated: Akismet

Removed Akismet notices.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Example:

1. Check out PR.
2. Go to `wp-admin` > `Plugins`
3. If Akismet is not active but Jetpack is, you shouldn't see the admin notice.