### PR TITLE
Tweaking Connection Pilot cron job schedules

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -90,7 +90,7 @@ class Connection_Pilot {
 
 	public function schedule_cron() {
 		if ( ! wp_next_scheduled( self::CRON_ACTION ) ) {
-			wp_schedule_event( strtotime( sprintf( '+%d minutes', mt_rand( 2, 60 ) ) ), self::CRON_SCHEDULE, self::CRON_ACTION );
+			wp_schedule_event( strtotime( sprintf( '+%d minutes', mt_rand( 2, 30 ) ) ), self::CRON_SCHEDULE, self::CRON_ACTION );
 		}
 	}
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -95,7 +95,7 @@ class Connection_Pilot {
 	}
 
 	public function schedule_immediate_cron() {
-		wp_schedule_single_event( strtotime( '+1 minutes' ), self::CRON_ACTION );
+		wp_schedule_single_event( time(), self::CRON_ACTION );
 	}
 
 	public static function do_cron() {

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -90,7 +90,7 @@ class Connection_Pilot {
 
 	public function schedule_cron() {
 		if ( ! wp_next_scheduled( self::CRON_ACTION ) ) {
-			wp_schedule_event( strtotime( sprintf( '+%d minutes', mt_rand( 1, 60 ) ) ), self::CRON_SCHEDULE, self::CRON_ACTION );
+			wp_schedule_event( strtotime( sprintf( '+%d minutes', mt_rand( 2, 60 ) ) ), self::CRON_SCHEDULE, self::CRON_ACTION );
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR tweaks how cron jobs are scheduled for Jetpack Connection Pilot so connections happen a bit quickly. Two modifications:

- First run goes down from ~1 minute after environment initialization to ~0 minutes after.
- Second run goes from between 1 and 60 minutes to 2 and 30 minutes. Note that subsequent runs are kept in an hourly schedule.

## Changelog Description

### Jetpack Connection Pilot schedules

Tweaked Jetpack Connection cron jobs schedules to improve auto connection times.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
