### PR TITLE
Removing redundant Connection Pilot connection checks

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -111,10 +111,6 @@ class Connection_Pilot {
 	 * Needs to be static due to how it is added to cron control.
 	 */
 	public function run_connection_pilot() {
-		if ( ! self::should_run_connection_pilot() ) {
-			return;
-		}
-
 		$is_connected = Connection_Pilot\Controls::jetpack_is_connected();
 
 		if ( true === $is_connected ) {

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -77,12 +77,8 @@ class Connection_Pilot {
 			add_action( 'admin_init', array( $this, 'schedule_cron' ) );
 		}
 
-		// Run CP shortly after site creation or update to try to connect automatically
-		if ( self::should_attempt_reconnection() ) {
-			add_action( 'wp_initialize_site', array( $this, 'schedule_immediate_cron' ) );
-			add_action( 'wp_update_site', array( $this, 'schedule_immediate_cron' ) );
-		}
-
+		add_action( 'wp_initialize_site', array( $this, 'schedule_immediate_cron' ) );
+		add_action( 'wp_update_site', array( $this, 'schedule_immediate_cron' ) );
 		add_action( self::CRON_ACTION, array( '\Automattic\VIP\Jetpack\Connection_Pilot', 'do_cron' ) );
 
 		add_filter( 'vip_jetpack_connection_pilot_should_reconnect', array( $this, 'filter_vip_jetpack_connection_pilot_should_reconnect' ), 10, 2 );
@@ -172,11 +168,6 @@ class Connection_Pilot {
 	}
 
 	public function filter_vip_jetpack_connection_pilot_should_reconnect( $should, $error = null ) {
-		// Attempting connection for fresh sites
-		if ( self::is_fresh_subsite() ) {
-			return true;
-		}
-
 		$error_code = null;
 
 		if ( $error && is_wp_error( $error ) ) {
@@ -299,28 +290,6 @@ class Connection_Pilot {
 		}
 
 		return apply_filters( 'vip_jetpack_connection_pilot_should_reconnect', false, $error );
-	}
-
-	/**
-	 * Checks if the site was created less than an hour before execution
-	 *
-	 * @return bool
-	 */
-	public static function is_fresh_subsite(): bool {
-		// Not applicable for single sites
-		if ( ! is_multisite() ) {
-			return false;
-		}
-
-		try {
-			$site_registered = new DateTime( get_site()->registered );
-		} catch ( \Exception $e ) {
-			return false;
-		}
-
-		$now = new DateTime("now");
-		$time_diff = $now->getTimestamp() - $site_registered->getTimestamp();
-		return $time_diff < 3600;
 	}
 }
 


### PR DESCRIPTION
## Description

This PR removes some additional checks that Connection Pilot has in place to check if it should reconnect. Given that the current behavior is to attempt a Jetpack reconnection to all sites that have CP enabled, those checks are not meaningful anymore and we can have simpler logic.

We are also removing the `is_fresh_site` check, used during the ramp-up process.

## Changelog Description

### Plugin Updated: Jetpack Connection Pilot

Removed some redundant checks.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.