### PR TITLE
Update renovatebot config to address the warnings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,32 +1,29 @@
 {
 	"extends": [
+		"github>whitesource/merge-confidence:beta",
 		"config:base",
 		"schedule:weekly"
 	],
-	"reviewers": [
-		"team:Automattic/vip-platform-cantina"
-	],
+	"reviewers": ["team:Automattic/vip-platform-cantina"],
 	"packageRules": [
 		{
-			"depTypeList": ["devDependencies"],
-			"minor": {
-				"groupName": "all non-major devDependencies",
-				"groupSlug": "all-minor-patch-devDependencies"
-			}
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor"],
+			"groupName": "all non-major devDependencies",
+			"groupSlug": "all-minor-patch-devDependencies"
 		},
 		{
-			"packagePatterns": ["eslint"],
-			"depTypeList": ["devDependencies"],
-			"minor": {
-				"groupName": "all non-major eslint",
-				"groupSlug": "all-minor-patch-eslint"
-			}
+			"matchPackagePatterns": ["eslint"],
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor"],
+			"groupName": "all non-major eslint",
+			"groupSlug": "all-minor-patch-eslint"
 		}
 	],
 	"ignorePaths": [
-		"akismet/",
-		"jetpack*/",
-		"vaultpress/",
-		"wp-parsely-*/"
+		"akismet/**",
+		"jetpack*/**",
+		"vaultpress/**",
+		"wp-parsely-*/**"
 	]
 }


### PR DESCRIPTION
## Description

Apparently, our renovatebot config was outdated and also had some warnings, this should address the issue. 

Additionally, use a more generic pattern for ignorePaths.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Merge and hope the ignored dependencies will be ignored this time.