### PR TITLE
Forcing VIP user to perform Akismet autoconnect

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -141,8 +141,8 @@ class Controls {
 		if ( class_exists( 'Akismet_Admin' ) ) {
 
 			if ( is_akismet_key_invalid() ) {
-				// Getting wpcomvip user, since it's the owner of the Jetpack connection
 				$current_user = wp_get_current_user();
+				// Getting wpcomvip user, since it's the owner of the Jetpack connection
 				$vip_user = get_user_by( 'login', 'wpcomvip' );
 				if ( ! $current_user || ! $vip_user ) {
 					return false;

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -138,17 +138,22 @@ class Controls {
 	 * @return bool True if connection worked, false otherwise
 	 */
 	public static function connect_akismet(): bool {
-		$current_user = wp_get_current_user();
-		$vip_user = get_user_by( 'login', 'wpcomvip' );
+		if ( class_exists( 'Akismet_Admin' ) ) {
 
-		if ( $current_user && $vip_user && class_exists( 'Akismet_Admin' ) ) {
 			if ( is_akismet_key_invalid() ) {
-				// Jetpack connection is owned by wpcomvip
+				// Getting wpcomvip user, since it's the owner of the connection
+				$current_user = wp_get_current_user();
+				$vip_user = get_user_by( 'login', 'wpcomvip' );
+				if ( ! $current_user || ! $vip_user) {
+					return false;
+				}
+
 				wp_set_current_user( $vip_user );
 				$result = \Akismet_Admin::connect_jetpack_user();
 				wp_set_current_user( $current_user );
 				return $result;
 			}
+
 			return true;
 		}
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -138,12 +138,20 @@ class Controls {
 	 * @return bool True if connection worked, false otherwise
 	 */
 	public static function connect_akismet(): bool {
-		if ( class_exists( 'Akismet_Admin' ) ) {
+		$current_user = wp_get_current_user();
+		$vip_user = get_user_by( 'login', 'wpcomvip' );
+
+		if ( $current_user && $vip_user && class_exists( 'Akismet_Admin' ) ) {
 			if ( is_akismet_key_invalid() ) {
-				return \Akismet_Admin::connect_jetpack_user();
+				// Jetpack connection is owned by wpcomvip
+				wp_set_current_user( $vip_user );
+				$result = \Akismet_Admin::connect_jetpack_user();
+				wp_set_current_user( $current_user );
+				return $result;
 			}
 			return true;
 		}
+
 		return false;
 	}
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -141,10 +141,10 @@ class Controls {
 		if ( class_exists( 'Akismet_Admin' ) ) {
 
 			if ( is_akismet_key_invalid() ) {
-				// Getting wpcomvip user, since it's the owner of the connection
+				// Getting wpcomvip user, since it's the owner of the Jetpack connection
 				$current_user = wp_get_current_user();
 				$vip_user = get_user_by( 'login', 'wpcomvip' );
-				if ( ! $current_user || ! $vip_user) {
+				if ( ! $current_user || ! $vip_user ) {
 					return false;
 				}
 


### PR DESCRIPTION
## Description

Akismet autoconnection would fail because the Jetpack connection would not be valid. That is because the Jetpack connection is owned by the WP VIP user. This PR forces that user when the connection attempt is performed.

## Changelog Description

### Jetpack Connection Pilot

Fix bug for Akismet autoconnection.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.