### PR TITLE
Checking Jetpack Connection owner after Jetpack site is connected

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -28,11 +28,6 @@ class Controls {
 			return new \WP_Error( 'jp-cxn-pilot-not-active', 'Jetpack is not currently active.' );
 		}
 
-		$is_vip_connection = WPCOM_VIP_MACHINE_USER_EMAIL === \Jetpack::get_master_user_email();
-		if ( ! $is_vip_connection ) {
-			return new \WP_Error( 'jp-cxn-pilot-not-vip-owned', sprintf( 'The connection is not owned by "%s".', WPCOM_VIP_MACHINE_USER_LOGIN ) );
-		}
-
 		$vip_machine_user = new \WP_User( \Jetpack_Options::get_option( 'master_user' ) );
 		if ( ! $vip_machine_user->exists() ) {
 			return new \WP_Error( 'jp-cxn-pilot-vip-user-missing', sprintf( 'The "%s" VIP user is missing.', WPCOM_VIP_MACHINE_USER_LOGIN ) );
@@ -43,6 +38,11 @@ class Controls {
 		$is_connected = self::test_jetpack_connection();
 		if ( is_wp_error( $is_connected ) ) {
 			return $is_connected;
+		}
+
+		$is_vip_connection = WPCOM_VIP_MACHINE_USER_EMAIL === \Jetpack::get_master_user_email();
+		if ( ! $is_vip_connection ) {
+			return new \WP_Error( 'jp-cxn-pilot-not-vip-owned', sprintf( 'The connection is not owned by "%s".', WPCOM_VIP_MACHINE_USER_LOGIN ) );
 		}
 
 		return true;


### PR DESCRIPTION
## Description

This PR tweaks Jetpack's Connection Pilot behavior to check if Jetpack is connected with the correct email *after* we check Jetpack is connected at all. This will allow us to have way cleaner error logs.

## Changelog Description

### Jetpack Connection Pilot Logging

Improving reliability of Jetpack Connection Pilot to check if the site is connected.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.