### PR TITLE
Removing else linter warnings on vip-dashboard

### DIFF
--- a/vip-dashboard/components/forms/sortable-list/index.jsx
+++ b/vip-dashboard/components/forms/sortable-list/index.jsx
@@ -63,9 +63,8 @@ module.exports = React.createClass( {
 			return -1;
 		} else if ( event.clientY > rect.bottom ) {
 			return 1;
-		} else {
-			return 0;
 		}
+		return 0;
 	},
 
 	isCursorBeyondElementThreshold: function( element, direction, permittedVertical, event ) {
@@ -98,9 +97,8 @@ module.exports = React.createClass( {
 		// their visible position index
 		if ( this.state.activeOrder ) {
 			return this.state.activeOrder[ index ];
-		} else {
-			return index;
 		}
+		return index;
 	},
 
 	getCursorElementIndex: function( event ) {
@@ -269,9 +267,8 @@ module.exports = React.createClass( {
 					<li ref={ 'wrap-shadow-' + index } key={ 'wrap-shadow-' + index } className="sortable-list__item is-shadow" style={ style }>{ child }</li>,
 					item
 				];
-			} else {
-				return item;
 			}
+			return item;
 		}, this );
 	},
 


### PR DESCRIPTION
## Description

This PR removes a couple of linter warnings that were flagged up when you compiled `vip-dashboard` using `gulp`.

Note that there's no need to deploy this PR since the generated code doesn't change.

## Changelog Description

### Plugin Updated: VIP Dashboard

Code cleanup for VIP Dashboard.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Go to `wp-admin` > `VIP Dashboard`.
3. Verify that the UI works as expected.