### PR TITLE
Block using 403 http code as 410 has unintended cache implications

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -87,7 +87,7 @@ class VIP_Request_Block {
 	 * @return void
 	 */
 	public static function block_and_log( string $value, string $criteria ) {
-		http_response_code( 410 );
+		http_response_code( 403 );
 		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
 		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 


### PR DESCRIPTION

## Description


## Changelog Description


### VIP_Request_Block block http code change

`VIP_Request_Block` used to block specific request uses now 403 instead of 410 http code. 410 code could lead to unintended caching.
 
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Add `VIP_Request_Block::ip( '13.37.13.37' );`
2. Run request with HTTP header  HTTP_TRUE_CLIENT_IP: 13.37.13.37
