### PR TITLE
Specify blocking only applies to origin requests

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Convenience class to quickly block unwanted clients based on user agent, IP or a header.
+ * Convenience class to quickly block unwanted clients from origin based on user agent, IP or a header.
  *
  * 🛑 THIS IS LOADED EARLY, PURE PHP ONLY, CORE IS NOT AVAILABLE YET!!! 🛑
  *

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Convenience class to quickly block unwanted clients from origin based on user agent, IP or a header.
+ * Convenience class to quickly block unwanted clients at origin (not edges) based on a user agent, IP, or a header.
  *
  * 🛑 THIS IS LOADED EARLY, PURE PHP ONLY, CORE IS NOT AVAILABLE YET!!! 🛑
  *


### PR DESCRIPTION
## Description

This PR clarifies the usage of VIP_Request_Block class by explicitly spelling out that it only applies to origin and not edge.

As I don't believe there's docs on this class (just yet), best to be as explicit as possible here that this blocking does not block edge requests

## Changelog Description

### Library updated: VIP_Request_Block

We've updated a code comment in VIP_Request_Block to clarify the fact that the library is meant to be used to block abusive clients at the origin and not edge locations.