### PR TITLE
Indexables::factory may return a boolean FALSE if an indexable is not  registered, which may result in Error: Uncaught exception 'Error'

### DIFF
--- a/search/includes/classes/class-cache.php
+++ b/search/includes/classes/class-cache.php
@@ -34,7 +34,9 @@ class Cache {
 			return;
 		}
 
-		if ( \ElasticPress\Indexables::factory()->get( 'post' )->elasticpress_enabled( $query ) && ! apply_filters( 'ep_skip_query_integration', false, $query ) ) {
+		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
+
+		if ( $indexable && $indexable->elasticpress_enabled( $query ) && ! apply_filters( 'ep_skip_query_integration', false, $query ) ) {
 			if ( true === $disabled_apc ) {
 				// Already disabled, don't try again.
 				return;


### PR DESCRIPTION
## Description

In a certain edge case related to the load order of userland code Automattic\VIP\Search::disable_apc_for_ep_enabled_requests with message 'Call to a member function elasticpress_enabled() on bool' in Search\Cache::disable_apc_for_ep_enabled_requests.

This PR addresses that by checking for truthiness before trying to call 'elasticpress_enabled' method.

## Changelog Description

### Plugin Updated: Search

We've addressed an edge case that could potentially result in a fatal error in `Automattic\VIP\Search::disable_apc_for_ep_enabled_requests` pre_get_posts callback

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
