### PR TITLE
Add a temporary feature flag for VIP_PHPMailer until unit tests are added

### DIFF
--- a/vip-mail.php
+++ b/vip-mail.php
@@ -33,7 +33,7 @@ class VIP_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 	}
 }
 
-if ( defined( 'USE_VIP_PHPMAILER' ) && USE_VIP_PHPMAILER ) {
+if ( defined( 'USE_VIP_PHPMAILER' ) && true === USE_VIP_PHPMAILER ) {
 	global $phpmailer;
 	$phpmailer = new VIP_PHPMailer( true ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 }

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -32,9 +32,11 @@ class VIP_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 		}
 	}
 }
-global $phpmailer;
-$phpmailer = new VIP_PHPMailer( true ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
+if ( defined( 'USE_VIP_PHPMAILER' ) && USE_VIP_PHPMAILER ) {
+	global $phpmailer;
+	$phpmailer = new VIP_PHPMailer( true ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+}
 class VIP_Noop_Mailer {
 	function __construct( $phpmailer ) {
 		$this->subject = $phpmailer->Subject ?? '[No Subject]';


### PR DESCRIPTION
## Description

Out of an abundance of caution and due to the fact the unit tests are missing for the feature we're gating it under `USE_VIP_PHPMAILER` constant.

## Changelog Description

### Component Updated: Mail 

We've released a compatibility fix for PHPMailer and VIP Filesystem so that VIP Filesystem attachments are allowed to be sent with an email.  

Currently, it requires `define( 'USE_VIP_PHPMAILER', true )` in vip-config.php

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Define the constant and follow the steps outlined in #2057
