### PR TITLE
Add WP 5.4-5.7 Circle CI jobs, reshuffle the order of the jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,16 @@ workflows:
       - php74-core-tests
       - php74-core-multisite-tests
       - php74-lint
-      - php74-build-multisite
-      - php74-build-multisite-no-jetpack
       - php74-build-singlesite
-      - php74-build-singlesite-no-jetpack
+      - php74-build-singlesite-57
+      - php74-build-singlesite-56
+      - php74-build-singlesite-55
+      - php74-build-singlesite-54
+      - php74-build-multisite
       - php74-build-multisite-nightly
       - php74-build-singlesite-nightly
+      - php74-build-singlesite-no-jetpack
+      - php74-build-multisite-no-jetpack
   changelog:
     jobs:
       - create-changelog-draft:
@@ -173,6 +177,42 @@ jobs:
       - WP_MULTISITE: "1"
       - WP_VERSION: "latest"
       - DISABLE_JETPACK: "1"
+    docker:
+      - image: circleci/php:7.4-node
+      - image: *db_image
+
+  php74-build-singlesite-54:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE: "0"
+      - WP_VERSION: "5.4.4"
+    docker:
+      - image: circleci/php:7.4-node
+      - image: *db_image
+
+  php74-build-singlesite-55:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE: "0"
+      - WP_VERSION: "5.5.5"
+    docker:
+      - image: circleci/php:7.4-node
+      - image: *db_image
+
+  php74-build-singlesite-56:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE: "0"
+      - WP_VERSION: "5.6.4"
+    docker:
+      - image: circleci/php:7.4-node
+      - image: *db_image
+
+  php74-build-singlesite-57:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE: "0"
+      - WP_VERSION: "5.7.2"
     docker:
       - image: circleci/php:7.4-node
       - image: *db_image


### PR DESCRIPTION
## Description

Add the Circle CI jobs for all currently used WP versions to avoid unpleasant surprises.

## Changelog Description

## Added test suites for older WP versions.



## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
