### PR TITLE
Don't include the VIP_PHPMailer on WordPress < 5.5, add test coverage

### DIFF
--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -14,7 +14,7 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 		}
 	}
 
-	protected function tearDown(): void {
+	public function tearDown(): void {
 		reset_phpmailer_instance();
 	}
 

--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -10,10 +10,6 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 		}
 	}
 
-	public function tearDown(): void {
-		reset_phpmailer_instance();
-	}
-
 	public function test__all_smtp_servers__not_array() {
 		$GLOBALS['all_smtp_servers'] = false;
 

--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -1,10 +1,6 @@
 <?php
 
 
-/**
- * @preserveGlobalState false
- * @runInSeparateProcess true
- */
 class VIP_Mail_Test extends \WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
@@ -71,8 +67,8 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Todo: remove this once we remove 5.4 stack
-	 *
+	 * @preserveGlobalState disabled
+	 * @runInSeparateProcess
 	 */
 	public function test_load_VIP_PHPMailer_gte_55() {
 		global $wp_version;
@@ -80,12 +76,12 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 			$this->markTestSkipped( 'Not testing WP < 5.5' );
 		}
 
-		$this->assertEquals( class_exists( 'VIP_PHPMailer' ), true, 'VIP_PHPMailer should be loaded on >= 5.5. Version: ' . $wp_version );
+		$this->assertEquals( true, class_exists( 'VIP_PHPMailer' ), 'VIP_PHPMailer should be loaded on >= 5.5. Version: ' . $wp_version );
 	}
 
 	/**
-	 * Todo: remove this once we remove 5.4 stack
-	 *
+	 * @preserveGlobalState disabled
+	 * @runInSeparateProcess
 	 */
 	public function test_dont_load_VIP_PHPMailer_lt_55() {
 		global $wp_version;
@@ -93,7 +89,7 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 			$this->markTestSkipped( 'Not testing WP < 5.5' );
 		}
 
-		$this->assertEquals( class_exists( 'VIP_PHPMailer' ), false, 'VIP_PHPMailer should not be loaded on < 5.5. Version: ' . $wp_version );
+		$this->assertEquals( false, class_exists( 'VIP_PHPMailer' ), 'VIP_PHPMailer should not be loaded on < 5.5. Version: ' . $wp_version );
 	}
 
 	/**

--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -57,4 +57,17 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 
 		$this->assertRegExp( '/X-Automattic-Tracking: 1:\d+:.+:\d+:\d+:\d+(\\r\\n|\\r|\\n)/', $header );
 	}
+
+	/**
+	 * Todo: remove this once we remove 5.4 stack
+	 *
+	 */
+	public function test__conditional_loading_of_VIP_PHPMailer() {
+		global $wp_version;
+		if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+			$this->assertEquals( class_exists( 'VIP_PHPMailer' ), true, 'VIP_PHPMailer should be loaded on >= 5.5' );
+		} else {
+			$this->assertEquals( class_exists( 'VIP_PHPMailer' ), false, 'VIP_PHPMailer should not be loaded on <= 5.4' );
+		}
+	}
 }

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -9,9 +9,14 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 */
 
 if ( ! class_exists( 'PHPMailer\PHPMailer\PHPMailer' ) ) {
-	require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
-	require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
-	require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
+	if ( version_compare( $wp_version, '5.5', '<' ) ) { 
+		require_once ABSPATH . WPINC . '/class-phpmailer.php';
+		require_once ABSPATH . WPINC . '/class-smtp.php';
+	} else {
+		require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+		require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
+		require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
+	}
 }
 class VIP_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 	/**

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -8,40 +8,38 @@ Version: 1.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-if ( ! class_exists( 'PHPMailer\PHPMailer\PHPMailer' ) ) {
-	if ( version_compare( $wp_version, '5.5', '<' ) ) { 
-		require_once ABSPATH . WPINC . '/class-phpmailer.php';
-		require_once ABSPATH . WPINC . '/class-smtp.php';
-	} else {
+if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+	if ( ! class_exists( 'PHPMailer\PHPMailer\PHPMailer' ) ) {
 		require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
 		require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
 		require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
 	}
-}
-class VIP_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {
-	/**
-	 * Check whether a file path is of a permitted type.
-	 *
-	 * Used to reject URLs and phar files from functions that access local file paths,
-	 * such as addAttachment. Allows VIP File System's `vip` protocol.
-	 *
-	 * @param string $path A relative or absolute path to a file
-	 *
-	 * @return bool
-	 */
-	protected static function isPermittedPath( $path ) {
-		if ( 0 === strpos( $path, 'vip://wp-content/uploads' ) ) {
-			return true;
-		} else {
-			return ! preg_match( '#^[a-z]+://#i', $path );
+	class VIP_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {
+		/**
+		 * Check whether a file path is of a permitted type.
+		 *
+		 * Used to reject URLs and phar files from functions that access local file paths,
+		 * such as addAttachment. Allows VIP File System's `vip` protocol.
+		 *
+		 * @param string $path A relative or absolute path to a file
+		 *
+		 * @return bool
+		 */
+		protected static function isPermittedPath( $path ) {
+			if ( 0 === strpos( $path, 'vip://wp-content/uploads' ) ) {
+				return true;
+			} else {
+				return ! preg_match( '#^[a-z]+://#i', $path );
+			}
 		}
+	}
+
+	if ( defined( 'USE_VIP_PHPMAILER' ) && true === USE_VIP_PHPMAILER ) {
+		global $phpmailer;
+		$phpmailer = new VIP_PHPMailer( true ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 }
 
-if ( defined( 'USE_VIP_PHPMAILER' ) && true === USE_VIP_PHPMAILER ) {
-	global $phpmailer;
-	$phpmailer = new VIP_PHPMailer( true ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-}
 class VIP_Noop_Mailer {
 	function __construct( $phpmailer ) {
 		$this->subject = $phpmailer->Subject ?? '[No Subject]';

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -7,13 +7,13 @@ Author: Automattic
 Version: 1.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-
 if ( version_compare( $wp_version, '5.5', '>=' ) ) {
 	if ( ! class_exists( 'PHPMailer\PHPMailer\PHPMailer' ) ) {
 		require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
 		require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
 		require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
 	}
+
 	class VIP_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 		/**
 		 * Check whether a file path is of a permitted type.


### PR DESCRIPTION
## Description

#2242 and #2057 introduced a regression on 5.4 due to the fact that PHPMailer paths were changed in 5.5, which we didn't catch because of not testing 5.4. 

This should address by checking the WP version and not requiring the new class if WordPress is older than 5.5

## Changelog Description

### Component updated: Mailer

We've disabled the new VIP_PHPMailer implementation on WordPress installs older than 5.5.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
