### PR TITLE
Safely update rewrite rule options

### DIFF
--- a/vip-helpers/vip-permastructs.php
+++ b/vip-helpers/vip-permastructs.php
@@ -164,7 +164,7 @@ function wpcom_vip_refresh_wp_rewrite() {
 
 /**
  * Filter option values to prevent WP Errors from being saved,
- * and generated permanant fatal errors after rewrite rules are flushed.
+ * and generating permanent fatal errors after rewrite rules are flushed.
  *
  * @param string|WP_Error $value The new option value about to be saved.
  * @param string $option The option key.


### PR DESCRIPTION
Long story short, replicating an error here requires a very specific set of events, and specific DB failures along the way with certain DB queries passing in between.

The easiest way to test would be to do a hack inside the patch area, and just trust me that it is possible to have such a WP Error at this point 🙃 :

```
// Safely save the precious
add_filter( "sanitize_option_{$option_key}", 'wpcom_vip_safeguard_rewrite_rule_updates', 999, 2 );

if ( $option_key === 'category_base' ) {
	$option_value = new WP_Error( 'wpdb_get_table_charset_failure' );
}

update_option( $option_key, $option_value );
remove_filter( "sanitize_option_{$option_key}", 'wpcom_vip_safeguard_rewrite_rule_updates', 999, 2 );
```

And if you want to see the bad-case, remove the filters and run again. Can use this to trigger the problem:

```
// Mimic what happens after a failed DB query.
add_action( 'init', function() {
	if ( ! isset( $_GET['viptestingrewrites'] ) || $_GET['viptestingrewrites'] !== 'flush' ) {
		return;
	}

	flush_rewrite_rules();
	do_action( 'rri_flush_rules' );
} );
```

Will also need something like the following in theme/plugin code beforehand to trigger all this:

```
wpcom_vip_load_permastruct( '/%category%/%post_id%/%postname%/' );
```

(Note: after running the failure case, you'll need to directly delete the `category_base` and `rewrite_rules` options from the database. Then comment out [this line](https://github.com/WordPress/WordPress/blob/94c655c89286fdf43e5bab82d4108fb679e46a7a/wp-includes/default-filters.php#L580) in WP core, followed by `wp cache flush`.)