### PR TITLE
Check if Jetpack Stats module is active when using VIP Stats

### DIFF
--- a/vip-helpers/vip-stats.php
+++ b/vip-helpers/vip-stats.php
@@ -25,7 +25,7 @@
  */
 function wpcom_vip_top_posts_array( $num_days = 30, $limit = 10, $end_date = false ) {
 	// Check Jetpack is present and active
-	if ( class_exists( 'Jetpack' ) && Jetpack::is_active() ) {
+	if ( class_exists( 'Jetpack' ) && Jetpack::is_active() && Jetpack::is_module_active( 'stats' ) ) {
 		
 		// WordPress.com stats defaults to current UTC date, default to site's local date instead
 		if ( ! $end_date ) {
@@ -40,8 +40,13 @@ function wpcom_vip_top_posts_array( $num_days = 30, $limit = 10, $end_date = fal
 
 		$posts = stats_get_csv( 'postviews', $args );
 	} else {
-		// If Jetpack is not present or not active, fake the data returned
+		// If Jetpack is present and active, but the Stats module has been disabled, add a notice
+		if ( class_exists( 'Jetpack' ) && Jetpack::is_active() && ! Jetpack::is_module_active( 'stats' ) ) {
 
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'The Jetpack Stats module is disabled but used by VIP Stats.' ), '0.1' );
+		}
+
+		// If Jetpack is not present or not active, fake the data returned
 		$posts = array();
 		$words = array( 'dessert', 'cotton', 'candy', 'caramels', 'tiramisu', 'muffin',  'wafer', 'toffee', 'gummi', 'lemon', 'drops', 'brownie', 'lollipop', 'bears', 'danish', 'chocolate', 'bar', 'topping', 'apple', 'pie', 'pastry', 'powder', 'pudding' );
 
@@ -77,7 +82,8 @@ function wpcom_vip_top_posts_array( $num_days = 30, $limit = 10, $end_date = fal
  */
 function wpcom_vip_get_post_pageviews( $post_id = null, $num_days = 1, $end_date = false ) {
 	// Check Jetpack is present and active
-	if ( class_exists( 'Jetpack' ) && Jetpack::is_active() ) {
+	if ( class_exists( 'Jetpack' ) && Jetpack::is_active() && Jetpack::is_module_active( 'stats' ) ) {
+
 		$args = array(
 			'post_id'  => $post_id,
 			'num_days' => $num_days,
@@ -106,6 +112,12 @@ function wpcom_vip_get_post_pageviews( $post_id = null, $num_days = 1, $end_date
 			wp_cache_set( $cache_key, $views, 'vip_stats', 3600 );
 		}
 	} else {
+		// If Jetpack is present and active, but the Stats module has been disabled, add a notice
+		if ( class_exists( 'Jetpack' ) && Jetpack::is_active() && ! Jetpack::is_module_active( 'stats' ) ) {
+
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'The Jetpack Stats module is disabled but used by VIP Stats.' ), '0.1' );
+		}
+
 		// If Jetpack is not present or not active, fake the data returned
 		$views = mt_rand( 0, 20000 );
 	}


### PR DESCRIPTION
## Description

The VIP Stats functions `wpcom_vip_top_posts_array()` and `wpcom_vip_get_post_pageviews()` produce the following PHP fatal error when the Jetpack Stats module has been programmatically disabled:

```
PHP Fatal error:  Uncaught Error: Call to undefined function stats_get_csv() in /var/www/wp-content/mu-plugins/vip-helpers/vip-stats.php:41
```

This PR resolves this error by checking if the Jetpack Stats module is active before using the Jetpack Stats function `stats_get_csv()` and supplies a [`_doing_it_wrong()`](https://developer.wordpress.org/reference/functions/_doing_it_wrong/) message to clarify that these functions expect the Jetpack Stats module to be active.

## Changelog Description
### Check if the Jetpack Stats module is active when using VIP Stats

Improves error handling in VIP Stats functions `wpcom_vip_top_posts_array()` and `wpcom_vip_get_post_pageviews()` by checking if the Jetpack Stats module is active.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- N/A - This change has relevant unit tests (if applicable).
- N/A - This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Before applying this patch,  programmatically disable the Jetpack Stats module and then use `wpcom_vip_top_posts_array()` or `wpcom_vip_get_post_pageviews()`. The following code snippet can be added to an MU plugin for testing:

```php
<?php
// Disable the Stats Jetpack Module
function disable_jetpack_modules( $modules ) {
	$disabled_modules = ['stats'];

	foreach ( $disabled_modules as $module_slug ) {
		$found = array_search( $module_slug, $modules, true );
		if ( false !== $found ) {
			unset( $modules[ $found ] );
		}
	}
	return $modules;
}
add_filter( 'jetpack_active_modules', 'disable_jetpack_modules', 99, 9 );

// Use wpcom_vip_get_post_pageviews() to show Post Views at the bottom of Single Posts content
function filter_the_content_in_the_main_loop( $content ) {
    if ( is_singular() && in_the_loop() && is_main_query() ) {
        return $content . esc_html__( 'Post Views: ' . wpcom_vip_get_post_pageviews( get_the_ID(), 1 ) );
    }

    return $content;
}
add_filter( 'the_content', 'filter_the_content_in_the_main_loop', 1 );
```
2. Verify that this PHP Fatal error is thrown when viewing a single post:
```
PHP Fatal error:  Uncaught Error: Call to undefined function stats_get_csv()
```
3. Apply the patch in this PR and verify that the error is no longer thrown (the functions silently fall back to using fake data as expected).