### PR TITLE
Removing Connection Pilot legacy constants

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -141,12 +141,7 @@ if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) && defined( 'VIP_GO_APP_ENVIRONMENT' 
 
 // Jetpack Connection Pilot is enabled by default
 if ( ! defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) ) {
-	// Keeping for historical reasons, we can remove this after clients are using the new constant
-	if ( defined( 'VIP_JETPACK_CONNECTION_PILOT_SHOULD_RUN' ) ) {
-		define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', VIP_JETPACK_CONNECTION_PILOT_SHOULD_RUN );
-	} else {
-		define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', true );
-	}
+	define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', true );
 }
 
 if ( defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) && true === VIP_JETPACK_AUTO_MANAGE_CONNECTION ) {

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -271,11 +271,6 @@ class Connection_Pilot {
 	 * @return bool True if a reconnect should be attempted
 	 */
 	public static function should_attempt_reconnection( \WP_Error $error = null ): bool {
-		// TODO: The constant is deprecated and should be removed. Keeping this check during the ramp-up
-		if ( defined( 'VIP_JETPACK_CONNECTION_PILOT_SHOULD_RECONNECT' ) ) {
-			return VIP_JETPACK_CONNECTION_PILOT_SHOULD_RECONNECT;
-		}
-
 		return apply_filters( 'vip_jetpack_connection_pilot_should_reconnect', true, $error );
 	}
 }


### PR DESCRIPTION
## Description

To wrap up the rollout of Connection Pilot, we are getting rid of some constants that were being used in earlier versions but are no longer relevant (CP is enabled by default on all sites and it always tries to reconnect Jetpack, VaultPress and Akismet).

## Changelog Description

### Removing Connection Pilot legacy constants

We are removing the usage of deprecated constants in Connection Pilot.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.