### PR TITLE
Use Logstash through the API

### DIFF
--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -550,7 +550,7 @@ class Logger {
 	/**
 	 * Sends data to `WP_DEBUG_LOG` when applicable.
 	 *
-	 * @since 2020-01-10
+	 * @since 2021-07-07
 	 *
 	 * @param array $entries.
 	 */
@@ -569,7 +569,7 @@ class Logger {
 	/**
 	 * Sends data to `WP_DEBUG_LOG` when applicable.
 	 *
-	 * @since 2020-01-10
+	 * @since 2021-07-07
 	 *
 	 * @param array $entry.
 	 */

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1953,6 +1953,6 @@ class Search {
 			);
 		}
 
-		$this->logger->log( 'warning', 'vip_search_query_failure', $message );
+		$this->logger->log( 'warning', 'search_query_failure', $message );
 	}
 }


### PR DESCRIPTION
## Description

The current approach to use a file to send logs to Logstash [doesn't work on Kubernetes](https://vipsyseng.wordpress.com/2021/07/01/active-fixes-and-rollouts-for-kubernetes/#comment-4047). The alternative is to use the Logstash public API.

This PR reuses [some code that was originally implemented for that purpose](https://github.com/Automattic/vip-go-mu-plugins/pull/1499/files#diff-018f88dd9fe487c8446ee053e5da08a7dff7bd3b033d6d8370b5f52d0420f8cdR349). We are also introducing a constant to allow each site to configure which method they want to use.

## Changelog Description

### Use Logstash through the API

Adding the possibility to send Logstash logs through its API so it works in K8s.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
