### PR TITLE
Remove duplicate prefix on failed Query Log

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1953,6 +1953,6 @@ class Search {
 			);
 		}
 
-		$this->logger->log( 'warning', 'vip_search_query_failure', $message );
+		$this->logger->log( 'warning', 'search_query_failure', $message );
 	}
 }


### PR DESCRIPTION
## Description

This PR removes the `vip` prefix from a log that doesn't need it (the prefix gets added by the logger class automatically).

## Changelog Description

### Remove duplicate prefix on failed Query Log

Improved internal logging for VIP Search.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
