### PR TITLE
Don't run Connection Pilot on local environments

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -139,9 +139,9 @@ if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) && defined( 'VIP_GO_APP_ENVIRONMENT' 
 	define( 'VIP_JETPACK_IS_PRIVATE', true );
 }
 
-// Jetpack Connection Pilot is enabled by default
+// Jetpack Connection Pilot is enabled by default on VIP Go environments
 if ( ! defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) ) {
-	define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', true );
+	define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', false !== VIP_GO_ENV );
 }
 
 if ( defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) && true === VIP_JETPACK_AUTO_MANAGE_CONNECTION ) {

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -141,7 +141,7 @@ if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) && defined( 'VIP_GO_APP_ENVIRONMENT' 
 
 // Jetpack Connection Pilot is enabled by default on VIP Go environments
 if ( ! defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) ) {
-	define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', false !== VIP_GO_ENV );
+	define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', WPCOM_IS_VIP_ENV );
 }
 
 if ( defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) && true === VIP_JETPACK_AUTO_MANAGE_CONNECTION ) {


### PR DESCRIPTION
## Description

Connection Pilot was enabled on _all_ environments. This PR enables it only on VIP Go environments, or what is the same, it disables Connection Pilot on local development environments (where connecting Jetpack does not make sense).

## Changelog Description

### Don't run Connection Pilot on local environments

Limits the execution of Jetpack Connection Pilot on development environments.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR on a Sandbox and see that CP autoconnects.
2. Check ot PR locally and see that CP is not instantiated.