### PR TITLE
Fix non-existent notify_pilot function in Connection Pilot

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -204,7 +204,7 @@ class Connection_Pilot {
 			}
 
 			// Not connected and current url doesn't match previous url, don't attempt reconnection
-			$this->notify_pilot( 'Jetpack is disconnected, and it appears the domain has changed.' );
+			$this->send_alert( 'Jetpack is disconnected, and it appears the domain has changed.' );
 
 			return false;
 		}


### PR DESCRIPTION
## Description

Jetpack Connection Pilot would fail to log an error because it was calling a function that did not exist, `notify_pilot`. This PR replaces that call with the `send_alert` function, that is used elsewhere and does the same thing.

## Changelog Description

### Fix non-existent notify_pilot function in Connection Pilot

Fixes an edge case in which a log would not be sent due to calling a non-existent method.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.