### PR TITLE
Allow check for single connected user in Jetpack Connection

### DIFF
--- a/jetpack-9.9/vendor/automattic/jetpack-connection/src/class-manager.php
+++ b/jetpack-9.9/vendor/automattic/jetpack-connection/src/class-manager.php
@@ -567,7 +567,7 @@ class Manager {
 	 * @return bool
 	 */
 	public function has_connected_user() {
-		return (bool) count( $this->get_connected_users() );
+		return (bool) count( $this->get_tokens()->get_connected_users( 'any', true ) );
 	}
 
 	/**

--- a/jetpack-9.9/vendor/automattic/jetpack-connection/src/class-tokens.php
+++ b/jetpack-9.9/vendor/automattic/jetpack-connection/src/class-tokens.php
@@ -499,9 +499,10 @@ class Tokens {
 	 * Able to select by specific capability.
 	 *
 	 * @param string $capability The capability of the user.
+	 * @param bool $is_any_user_connected Set to true to return when a single connected user is found
 	 * @return array Array of WP_User objects if found.
 	 */
-	public function get_connected_users( $capability = 'any' ) {
+	public function get_connected_users( $capability = 'any', $is_any_user_connected = false ) {
 		$connected_users = array();
 		$user_tokens     = Jetpack_Options::get_option( 'user_tokens' );
 
@@ -520,6 +521,9 @@ class Tokens {
 				$user_data = get_userdata( $id );
 				if ( $user_data instanceof \WP_User ) {
 					$connected_users[] = $user_data;
+					if ( $is_any_user_connected ) {
+						return $connected_users;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

Methods such as Manager->has_connected_user() doesn't need to loop through and check all connected Jetpack users from Tokens->get_connected_users().

By adding this second param, the $connected_users param will return once a single connected user was found and validated, allowing the foreach loop to close early.

When a larger site has over 100 users and has memcache enabled, this loop was causing an additional 200 memcache GET calls per request.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
### Fix Manager->has_connected_user() in Jetpack Connection

Fix an issue that was occurring at scale that was causing unnecessary Memcache GETs to happen on each request.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
