### PR TITLE
Disabling WebP images upload temporarily 

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -8,6 +8,9 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 */
 
 add_filter( 'upload_mimes', function( $mimes ) {
+	// TODO: Remove when WebP files are supported by VIP File System
+	unset( $mimes['webp'] );
+
 	unset( $mimes['flv'] );
 	return $mimes;
 }, 99999 );


### PR DESCRIPTION
## Description

WordPress 5.8 [adds support for WebP images](https://make.wordpress.org/core/2021/06/07/wordpress-5-8-adds-webp-support/). That file format is not yet supported on the VIP File System, therefore we're disabling the possibility to upload `webp` files.

## Changelog Description

### Disabling WebP images upload temporarily 

We are disabling WebP uploads for the WordPress 5.8 release until we can add proper support for webp transformation in the VIP Files Service. 

jpeg and png files will continue to be converted to and served as webp files to clients that request them. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Go to `wp-admin` > `Media Library`
3. Try to upload a webp image. You shouldn't be allowed.