### PR TITLE
Fix broken EP hook after EP upgrade

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -786,8 +786,11 @@ class Versioning {
 	 * since deletes are comparatively much less frequent, so the savings of preventing back-and-forth switching between
 	 * index versions is not as great. We also process the deletes immediately, b/c the queue system currently does not
 	 * support deletes (just indexing)
+	 *
+	 * NOTE 2 - we are passing 'post' as the default slug since EP 3.5 introduced `ep_delete_post` with only one
+	 * argument ($post_id)
 	 */
-	public function action__ep_delete_indexable( $object_id, $indexable_slug ) {
+	public function action__ep_delete_indexable( $object_id, $indexable_slug = 'post' ) {
 		// Prevent infinite loops :)
 		if ( $this->is_doing_object_delete ) {
 			return;


### PR DESCRIPTION
## Description

The last EP upgrade (https://github.com/Automattic/vip-go-mu-plugins/pull/2293) introduced a new hook, `ep_delete_post` with a single argument (instead of the two arguments the generic `ep_delete_ . $slug` had): https://github.com/Automattic/ElasticPress/blob/35a7c4a22158b460f55ef684e53a3cac318df66f/includes/classes/Indexable/Post/SyncManager.php#L389 

For this reason, our `action__ep_delete_indexable` would fail to execute, because sometimes the second argument would not be passed. Given that there is no such `ep_delete_term` or `ep_delete_user` with one argument, we can assume that the second argument is `post`. We are adding that as a default parameter to the function to avoid a fatal PHP error.

## Changelog Description

### Fix broken EP hook after EP upgrade

We upgraded our VIP Search integration with Elasticpress to fix a broken hook.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Try EP in general: perform an index, add, edit, remove, posts, etc.