### PR TITLE
Ignoring husky v7 files on deploy

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -18,6 +18,7 @@
 .github
 .gitignore
 .gitmodules
+.husky
 .huskyrc.json
 .jscsrc
 .jshintignore


### PR DESCRIPTION
## Description

Husky v7 uses a different structure for its hooks and we should ignore them for deploy as well.

## Changelog Description

### Ignoring husky v7 files on deploy

Upgrades around internal tooling and deploys.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.