### PR TITLE
Bumps Default JP to 10.0

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 9.9
+ * Version: 10.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -22,7 +22,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.7', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.8' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.9' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.0' );
 	}
 }
 


### PR DESCRIPTION
## Description

After the release of Jetpack 10.0, this PR makes that version default given that the WordPress version is compatible.

## Changelog Description

### Plugin Updated: Jetpack 10.0

We made Jetpack 10.0 the default version of Jetpack.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Go to the Jetpack admin panel.
3. Check that the version displayed is 10.0