### PR TITLE
Check if the SERVICES_AUTH_TOKEN is empty

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -202,7 +202,7 @@ class Site_Details_Index {
 	public function put_site_details() {
 		$site_details = $this->get_site_details();
 
-		if ( defined( 'SERVICES_API_URL' ) && defined( 'SERVICES_AUTH_TOKEN' ) ) {
+		if ( defined( 'SERVICES_API_URL' ) && defined( 'SERVICES_AUTH_TOKEN' ) && ! empty( SERVICES_AUTH_TOKEN ) ) {
 			$url = rtrim( SERVICES_API_URL, '/' ) . '/siteinfo/sites';
 
 			$args = array(


### PR DESCRIPTION
## Description

Check if the SERVICES_AUTH_TOKEN is empty before sending data to the site details service.

If the `services_auth_token` meta is not defined for a site, this define will be an empty string. In this case, we don't want to send data to the site details service, as it will fail for sure.

## Changelog Description

### Preparations for the site details service

We are about to release the site details service to production, and we need to ensure we can do it gradually, allowing to test some sites first. This PR allows that to happen

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
