### PR TITLE
Fix the url for the Site Details service

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -203,7 +203,7 @@ class Site_Details_Index {
 		$site_details = $this->get_site_details();
 
 		if ( defined( 'SERVICES_API_URL' ) && defined( 'SERVICES_AUTH_TOKEN' ) && ! empty( SERVICES_AUTH_TOKEN ) ) {
-			$url = rtrim( SERVICES_API_URL, '/' ) . '/siteinfo/sites';
+			$url = rtrim( SERVICES_API_URL, '/' ) . '/sitedetails/sites';
 
 			$args = array(
 				'method' => 'PUT',


### PR DESCRIPTION
## Description

The url for the site details service was wrong, pointing incorrectly to the site info service.

## Changelog Description

### Fixes for the site details service

As part of the preparation for the site details service, we keep adding small improvements and fixes for `vip-go-mu-plugins`

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
