### PR TITLE
Adding Stale bot to GitHub repository

### DIFF
--- a/.github/.stale
+++ b/.github/.stale
@@ -1,0 +1,13 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Label to use when marking an issue as stale
+staleLabel: [Status] Stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity in the past 60 days. It will be closed in 7 days if no
+  further activity occurs. Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: true

--- a/.github/.stale
+++ b/.github/.stale
@@ -1,13 +1,15 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 14
 # Label to use when marking an issue as stale
 staleLabel: [Status] Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity in the past 60 days. It will be closed in 7 days if no
-  further activity occurs. Thank you for your contributions.
+  recent activity in the past 90 days. It will be closed in 14 days if no
+  further activity occurs. Thank you for your contribution.
+  
+  Please feel free to re-open and address the feedback and we'll take another look.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: true


### PR DESCRIPTION
## Description

This PR adds the Stale bot to this repository. We are using the default configuration, which means that PRs will be marked as stale after 60 days of inactivity and will be closed 7 days after.

Following the [instructions of the bot](https://github.com/apps/stale), I have already enabled the app on the repository.

Note that this PR only affects the GitHub repository thus it doesn't need to be deployed.

## Changelog Description

### Adding Stale bot to GitHub repository

Internal tooling update to better track external contributions.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.