### PR TITLE
Adding WordPress 5.8 CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
       - php74-core-multisite-tests
       - php74-lint
       - php74-build-singlesite
+      - php74-build-singlesite-58
       - php74-build-singlesite-57
       - php74-build-singlesite-56
       - php74-build-singlesite-55
@@ -216,6 +217,15 @@ jobs:
     environment:
       - WP_MULTISITE: "0"
       - WP_VERSION: "5.7.2"
+    docker:
+      - image: circleci/php:7.4-node
+      - image: *db_image
+
+  php74-build-singlesite-58:
+    <<: *php_job
+    environment:
+      - WP_MULTISITE: "0"
+      - WP_VERSION: "5.8"
     docker:
       - image: circleci/php:7.4-node
       - image: *db_image


### PR DESCRIPTION
## Description

This PR adds an explicit CI test for WordPress 5.8 (we would have it already since it's the current `latest`, but when 5.9 is released we won't have it).

No need to deploy this change to production.

## Changelog Description

### Adding WordPress 5.8 CI tests

This PR adds internal tests for WordPress 5.8.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.