### PR TITLE
wp-parsley: Some loader improvements & maybe hide plugin UI

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -52,7 +52,7 @@ function maybe_load_plugin() {
 		$versions_to_try = array_unique( $versions_to_try );
 	} else {
 		trigger_error(
-			sprintf( 'Invalid value configured via wpvip_parsely_version filter: %s', $version ),
+			sprintf( 'Invalid value configured via wpvip_parsely_version filter: %s', esc_html( $version ) ),
 			E_USER_WARNING
 		);
 	}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -59,10 +59,21 @@ function maybe_load_plugin() {
 
 	foreach ( $versions_to_try as $version ) {
 		$entry_file = __DIR__ . '/wp-parsely-' . $version . '/wp-parsely.php';
-		if ( is_readable( $entry_file ) ) {
-			require $entry_file;
-			return;
+		if ( ! is_readable( $entry_file ) ) {
+			continue;
 		}
+
+		require $entry_file;
+
+		// If the plugin was loaded solely by the option, hide the UI (for now)
+		if ( apply_filters( 'wpvip_parsely_hide_ui_for_mu', ! has_filter( 'wpvip_parsely_load_mu' ) ) ) {
+			remove_action( 'admin_menu', array( $parsely, 'add_settings_sub_menu' ) );
+			remove_action( 'admin_footer', array( $parsely, 'display_admin_warning' ) );
+			remove_action( 'widgets_init', 'parsely_recommended_widget_register' );
+			remove_filter( 'page_row_actions', array( $parsely, 'row_actions_add_parsely_link' ) );
+			remove_filter( 'post_row_actions', array( $parsely, 'row_actions_add_parsely_link' ) );
+		}
+		return;
 	}
 }
 add_action( 'after_setup_theme', __NAMESPACE__ . '\maybe_load_plugin' );


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->

## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

We want to enable the plugin for some sites but not show the UI (settings menu / page, admin header warning, widget & controls). This change unhooks certain actions and filters when the plugin is loaded by this wrapper file _*unless*_ it was enabled via the `wpvip_parsely_load_mu` filter.

For future extensibility sake, we also check the return value of a new filter `wpvip_parsely_hide_ui_for_mu` which can be independently overridden.

A bit of refactoring is also included:
* namespace the wrapper file to `Automattic\VIP\WP_Parsely_Integration`
* simplify the function name since it's namespaced
* pull the list of `SUPPORTED_VERSIONS` out to a constant
* attempt to load versions in top-down order (the first element is the default, so no need to maintain the `WPVIP_PARSELY_DEFAULT_VERSION` constant.
* ensure the entry file is readable prior to `require`ing the path
* rename the `wpvip_parsely_major_version` filter to `wpvip_parsely_version` -- it's not used anywhere and the new format is more compact and correct

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->

Plugin Updated: VIP Parse.ly Integration -- Hide plugin UI in some cases

We made some behind-the-scenes changes that will help customers try Parse.ly on their sites more easily.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

1. Check out PR.
1. Ensure a proper value for the `apikey` in the `parsely` blog option (you can use the settings page in the plugin if it's active, otherwise, you can do something like `wp option patch insert parsely apikey example.com`)
1. Clear the activation option: `wp option delete _wpvip_parsely_mu`
1. Ensure you're not adding a filter to `wpvip_parsely_load_mu` in any plugin
  - The plugin should not be loaded at all -- no tracker, no meta, no admin UI
1. Set the activation option: `wp option set _wpvip_parsely_mu 1`
  - The plugin should be loaded (tracker & meta in the src), but no UI should be visible in WP-Admin > Settings > Parsely
1. Add the following to a sourced plugin file: `add_filter( 'wpvip_parsely_load_mu', '__return_true' );`
  - The plugin should be loaded & UI should be visible & fully functional in WP-Admin > Settings > Parsely
1. Clear the activation option: `wp option delete _wpvip_parsely_mu`
  - The plugin should be loaded & UI should be visible & fully functional in WP-Admin > Settings > Parsely
1. Add the following to a sourced plugin file: `add_filter( 'wpvip_parsely_hide_ui_for_mu', '__return_true' );`
  - The plugin should be loaded (tracker & meta in the src), but no UI should be visible in WP-Admin > Settings > Parsely
