### PR TITLE
wp-parsely: Only trigger warning when actually specifying a version via filter

### DIFF
--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -72,6 +72,7 @@ docker run \
 	--network $NETWORK_NAME \
 	-e WP_MULTISITE="$WP_MULTISITE" \
 	-e WPVIP_PARSELY_INTEGRATION_TEST_MODE="$WPVIP_PARSELY_INTEGRATION_TEST_MODE" \
+	-e WPVIP_PARSELY_INTEGRATION_PLUGIN_VERSION="$WPVIP_PARSELY_INTEGRATION_PLUGIN_VERSION" \
 	-v $(pwd):/app \
 	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
 	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \

--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -71,6 +71,7 @@ done
 docker run \
 	--network $NETWORK_NAME \
 	-e WP_MULTISITE="$WP_MULTISITE" \
+	-e WPVIP_PARSELY_INTEGRATION_TEST_MODE="$WPVIP_PARSELY_INTEGRATION_TEST_MODE" \
 	-v $(pwd):/app \
 	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
 	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -67,4 +67,34 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 tests_add_filter( 'muplugins_loaded', '_remove_init_hook_for_cache_manager' );
 tests_add_filter( 'muplugins_loaded', '_disable_core_legacy_widget_registration' );
 
+
+function _configure_wp_parsely_env_load_via_filter() {
+	echo "[WP_PARSELY_INTEGRATION] Enabling the plugin via filter\n";
+	add_filter( 'wpvip_parsely_load_mu', '__return_true' );
+}
+
+function _configure_wp_parsely_env_load_via_option() {
+	echo "[WP_PARSELY_INTEGRATION] Enabling the plugin via option\n";
+	update_option( '_wpvip_parsely_mu', '1' );
+}
+
+switch ( getenv( 'WPVIP_PARSELY_INTEGRATION_TEST_MODE' ) ) {
+	case 'filter_enabled':
+		echo "Expecting wp-parsely plugin to be enabled by the filter.\n";
+		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_env_load_via_filter' );
+		break;
+	case 'option_enabled':
+		echo "Expecting wp-parsely plugin to be enabled by the option.\n";
+		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_env_load_via_option' );
+		break;
+	case 'filter_and_option_enabled':
+		echo "Expecting wp-parsely plugin to be enabled by the filter and the option.\n";
+		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_env_load_via_filter' );
+		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_env_load_via_option' );
+		break;
+	default:
+		echo "Expecting wp-parsely plugin to be disabled.\n";
+		break;
+}
+
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -67,7 +67,7 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 tests_add_filter( 'muplugins_loaded', '_remove_init_hook_for_cache_manager' );
 tests_add_filter( 'muplugins_loaded', '_disable_core_legacy_widget_registration' );
 
-
+// Begin wp-parsely integration config
 function _configure_wp_parsely_env_load_via_filter() {
 	echo "[WP_PARSELY_INTEGRATION] Enabling the plugin via filter\n";
 	add_filter( 'wpvip_parsely_load_mu', '__return_true' );
@@ -78,19 +78,32 @@ function _configure_wp_parsely_env_load_via_option() {
 	update_option( '_wpvip_parsely_mu', '1' );
 }
 
+function _configure_wp_parsely_specified_version() {
+	$specified = getenv( 'WPVIP_PARSELY_INTEGRATION_PLUGIN_VERSION' );
+	if ( $specified ) {
+		echo '[WP_PARSELY_INTEGRATION] Specifying plugin version: ' . esc_html( $specified ) . "\n";
+		add_filter( 'wpvip_parsely_version', function ( $passed ) use ( $specified ) {
+			return $specified;
+		} );
+	}
+}
+
 switch ( getenv( 'WPVIP_PARSELY_INTEGRATION_TEST_MODE' ) ) {
 	case 'filter_enabled':
 		echo "Expecting wp-parsely plugin to be enabled by the filter.\n";
 		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_env_load_via_filter' );
+		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_specified_version' );
 		break;
 	case 'option_enabled':
 		echo "Expecting wp-parsely plugin to be enabled by the option.\n";
 		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_env_load_via_option' );
+		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_specified_version' );
 		break;
 	case 'filter_and_option_enabled':
 		echo "Expecting wp-parsely plugin to be enabled by the filter and the option.\n";
 		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_env_load_via_filter' );
 		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_env_load_via_option' );
+		tests_add_filter( 'muplugins_loaded', '_configure_wp_parsely_specified_version' );
 		break;
 	default:
 		echo "Expecting wp-parsely plugin to be disabled.\n";

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -8,7 +8,7 @@ function test_mode() {
 }
 
 class MU_Parsely_Integration_Test extends \WP_UnitTestCase {
-	static $test_mode;
+	protected static $test_mode;
 
 	public static function setUpBeforeClass() {
 		self::$test_mode = test_mode();
@@ -25,14 +25,14 @@ class MU_Parsely_Integration_Test extends \WP_UnitTestCase {
 	}
 
 	public function test_parsely_class_existance() {
-		$class_should_exist = self::$test_mode !== 'disabled';
+		$class_should_exist = 'disabled' !== self::$test_mode;
 		$this->assertSame( $class_should_exist, class_exists( 'Parsely' ) );
 	}
 
 	public function test_parsely_global() {
 		global $parsely;
 
-		$instance_should_exist = self::$test_mode !== 'disabled';
+		$instance_should_exist = 'disabled' !== self::$test_mode;
 		$this->assertSame( $instance_should_exist, isset( $parsely ) );
 	}
 

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Automattic\VIP\WP_Parsely_Integration;
+
+function test_mode() {
+	$mode = getenv( 'WPVIP_PARSELY_INTEGRATION_TEST_MODE' );
+	return $mode ? $mode : 'disabled';
+}
+
+class MU_Parsely_Integration_Test extends \WP_UnitTestCase {
+	static $test_mode;
+
+	public static function setUpBeforeClass() {
+		self::$test_mode = test_mode();
+		if ( 'disabled' !== self::$test_mode ) {
+			echo 'Running Parsely Integration Tests in mode: ' . esc_html( self::$test_mode ) . "\n";
+		}
+	}
+
+	public function test_has_maybe_load_plugin_action() {
+		$this->assertSame(
+			10,
+			has_action( 'after_setup_theme', __NAMESPACE__ . '\maybe_load_plugin' )
+		);
+	}
+
+	public function test_parsely_class_existance() {
+		$class_should_exist = self::$test_mode !== 'disabled';
+		$this->assertSame( $class_should_exist, class_exists( 'Parsely' ) );
+	}
+
+	public function test_parsely_global() {
+		global $parsely;
+
+		$instance_should_exist = self::$test_mode !== 'disabled';
+		$this->assertSame( $instance_should_exist, isset( $parsely ) );
+	}
+
+	public function test_bootstrap_modes() {
+		switch ( self::$test_mode ) {
+			case 'disabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'filter_enabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'option_enabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'filter_and_option_enabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
+				break;
+			default:
+				$this->fail( 'Invalid test mode specified: ' . self::$test_mode );
+		}
+	}
+
+	public function test_parsely_ui_hooks() {
+		global $parsely;
+
+		$expected = in_array( self::$test_mode, [ 'filter_enabled', 'filter_and_option_enabled' ] ) ? 10 : false;
+		$this->assertSame( $expected, has_action( 'admin_menu', array( $parsely, 'add_settings_sub_menu' ) ) );
+		$this->assertSame( $expected, has_action( 'admin_footer', array( $parsely, 'display_admin_warning' ) ) );
+		$this->assertSame( $expected, has_action( 'widgets_init', 'parsely_recommended_widget_register' ) );
+
+		/*
+			TODO: put these in when landing the quick links
+			$this->assertSame( $expected, has_filter( 'page_row_actions', array( $parsely, 'row_actions_add_parsely_link' ) ) );
+			$this->assertSame( $expected, has_filter( 'post_row_actions', array( $parsely, 'row_actions_add_parsely_link' ) ) );
+		*/
+	}
+}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -49,14 +49,16 @@ function maybe_load_plugin() {
 	 */
 	$specified_version = apply_filters( 'wpvip_parsely_version', false );
 
-	if ( in_array( $specified_version, SUPPORTED_VERSIONS ) ) {
-		array_unshift( $versions_to_try, $specified_version );
-		$versions_to_try = array_unique( $versions_to_try );
-	} else {
-		trigger_error(
-			sprintf( 'Invalid value configured via wpvip_parsely_version filter: %s', esc_html( $version ) ),
-			E_USER_WARNING
-		);
+	if ( $specified_version ) {
+		if ( in_array( $specified_version, SUPPORTED_VERSIONS ) ) {
+			array_unshift( $versions_to_try, $specified_version );
+			$versions_to_try = array_unique( $versions_to_try );
+		} else {
+			trigger_error(
+				sprintf( 'Invalid value configured via wpvip_parsely_version filter: %s', esc_html( $specified_version ) ),
+				E_USER_WARNING
+			);
+		}
 	}
 
 	foreach ( $versions_to_try as $version ) {


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

This is currently reporting an erroneous warning: "Invalid value configured via wpvip_parsely_version filter" even when a site is not overriding the filter.  This only performs the check when it is.

This also includes a first pass at integration tests for the plugin. Since WordPress is already mostly loaded and the plugin is sourced prior to running phpunit test cases, we have to hook into the phpunit bootstrap file to vary behavior. We do that by leveraging environment variables specified on the test runner host machine.

These will be hooked into CI in a follow up PR.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->

### Plugin Updated: VIP Parse.ly Integration -- Fix spurious PHP Warning

We made some behind-the-scenes changes that will help customers try Parse.ly on their sites more easily.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

1. Check out PR
2. Run docker
3. Execute each of the following. The tests should pass without visible PHP Warnings:
    - `WP_TESTS_DIR=/tmp/wordpress-tests-lib ./bin/phpunit-docker.sh --file tests/parsely/test-mu-parsely-integration.php` 
    - `WPVIP_PARSELY_INTEGRATION_TEST_MODE=option_enabled WP_TESTS_DIR=/tmp/wordpress-tests-lib ./bin/phpunit-docker.sh --file tests/parsely/test-mu-parsely-integration.php`
    - `WPVIP_PARSELY_INTEGRATION_TEST_MODE=filter_enabled WP_TESTS_DIR=/tmp/wordpress-tests-lib ./bin/phpunit-docker.sh --file tests/parsely/test-mu-parsely-integration.php`
    - `WPVIP_PARSELY_INTEGRATION_TEST_MODE=filter_and_option_enabled WP_TESTS_DIR=/tmp/wordpress-tests-lib ./bin/phpunit-docker.sh --file tests/parsely/test-mu-parsely-integration.php` 
    - `WPVIP_PARSELY_INTEGRATION_PLUGIN_VERSION=2.5 WPVIP_PARSELY_INTEGRATION_TEST_MODE=filter_enabled WP_TESTS_DIR=/tmp/wordpress-tests-lib ./bin/phpunit-docker.sh --file tests/parsely/test-mu-parsely-integration.php`
4. Execute the following:
    - `WPVIP_PARSELY_INTEGRATION_PLUGIN_VERSION=2.4 WPVIP_PARSELY_INTEGRATION_TEST_MODE=filter_enabled WP_TESTS_DIR=/tmp/wordpress-tests-lib ./bin/phpunit-docker.sh --file tests/parsely/test-mu-parsely-integration.php`
        - Tests should pass, but there should a PHP warning: `PHP Warning:  Invalid value configured via wpvip_parsely_version filter: 2.6 in /app/wp-parsely.php on line 59`: