### PR TITLE
Adding admin styles to VIP Search Widget

### DIFF
--- a/search/ui/class-vip-search-widget.php
+++ b/search/ui/class-vip-search-widget.php
@@ -40,7 +40,7 @@ class VIP_Search_Widget extends \WP_Widget {
 	 *
 	 */
 	public function widget_admin_setup() {
-		wp_enqueue_style( 'widget-vip-search-filters', plugins_url( 'css/search-widget-admin-ui.css', __FILE__ ) );
+		wp_enqueue_style( 'widget-vip-search-filters', plugins_url( 'css/search-widget-admin-ui.css', __FILE__ ), array(), 1.0 );
 	}
 
 	/**

--- a/search/ui/class-vip-search-widget.php
+++ b/search/ui/class-vip-search-widget.php
@@ -28,9 +28,19 @@ class VIP_Search_Widget extends \WP_Widget {
 			array( 'description' => 'Enterprise Search' )
 		);
 
-		if ( ! is_admin() ) {
+		if ( is_admin() ) {
+			add_action( 'sidebar_admin_setup', array( $this, 'widget_admin_setup' ) );
+		} else {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
 		}
+	}
+
+	/**
+	 * Enqueues the scripts and styles needed for the customizer.
+	 *
+	 */
+	public function widget_admin_setup() {
+		wp_enqueue_style( 'widget-vip-search-filters', plugins_url( 'css/search-widget-admin-ui.css', __FILE__ ) );
 	}
 
 	/**

--- a/search/ui/css/search-widget-admin-ui.css
+++ b/search/ui/css/search-widget-admin-ui.css
@@ -1,0 +1,87 @@
+.vip-search-filters-widget__filter {
+    background: #f6f7f7;
+    border: 1px solid #dcdcde;
+    padding: 0 12px;
+    margin-bottom: 12px;
+    cursor: move;
+}
+
+.vip-search-filters-widget__controls {
+    text-align: right;
+}
+
+.vip-search-filters-widget .vip-search-filters-widget__sort-controls-enabled {
+    margin-left: 24px;
+}
+
+.vip-search-filters-widget__controls .delete {
+    color: #d63638;
+}
+
+.vip-search-filters-widget.hide-filters .vip-search-filters-widget__filter {
+    display: none;
+}
+
+.button.vip-search-filters-widget__add-filter {
+    margin-bottom: 10px;
+}
+
+/* Assume that taxonomy select is the default selected. Other controls should be hidden here. */
+.vip-search-filters-widget__post-type-select {
+    display: none;
+}
+
+.vip-search-filters-widget__date-histogram-select {
+    display: none;
+}
+
+.vip-search-filters-widget__filter-placeholder {
+    border: 1px #555 dashed;
+    background-color: #f0f0f1;
+    height: 286px;
+    margin-bottom: 12px;
+}
+
+/* When post type is selected, remove the other controls */
+.vip-search-filters-widget__filter.is-post_type .vip-search-filters-widget__taxonomy-select {
+    display: none;
+}
+
+/* When date is selected, remove the other controls */
+.vip-search-filters-widget__filter.is-date_histogram .vip-search-filters-widget__date-histogram-select {
+    display: inline;
+}
+
+.vip-search-filters-widget__filter.is-date_histogram .vip-search-filters-widget__taxonomy-select {
+    display: none;
+}
+
+.vip-search-filters-widget.hide-post-types .vip-search-filters-widget__post-types-select {
+    display: none;
+}
+
+.vip-search-filters-help:before {
+    display: inline-block;
+    position: relative;
+    font-family: dashicons;
+    font-size: 20px;
+    top: 5px;
+    line-height: 1px;
+    content:"\f223";
+}
+.vip-search-filters-help {
+    padding: 5px 5px 15px 0;
+}
+
+.vip-search-filters-widget__post-types-select label {
+    display: block;
+    margin-bottom: 4px;
+}
+
+.vip-search-filters-widget__post-types-select input[type="checkbox"] {
+    margin-left: 24px;
+}
+
+body.no-js .vip-search-filters-widget__add-filter-wrapper {
+    display: none;
+}


### PR DESCRIPTION
## Description

We were missing some styles on the search widget admin panel, which made the options render in a sub-optimal way. This PR adds back those styles from Jetpack.

Before:

<img width="604" alt="Screen Shot 2021-08-11 at 12 02 45 PM" src="https://user-images.githubusercontent.com/7188409/129010454-85d5c928-d133-4fa1-b25c-51f72160fa56.png">

After:

<img width="603" alt="Screen Shot 2021-08-11 at 12 02 14 PM" src="https://user-images.githubusercontent.com/7188409/129010347-45286502-3d43-49c2-ad0d-bf0ec063533a.png">

## Changelog Description

### Adding admin styles to VIP Search Widget

Improving the visual layout of the admin UI of the Search widget.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.