### PR TITLE
Using id range instead of ids

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -759,7 +759,7 @@ class Queue {
 	/**
 	 * We can't re-queue jobs that are already waiting in queue. We should remove such jobs instead.
 	 */
-	private function delete_jobs_on_the_already_queued_object( $deadlocked_jobs ) {
+	public function delete_jobs_on_the_already_queued_object( $deadlocked_jobs ) {
 		global $wpdb;
 
 		$table_name = $this->schema->get_table_name();

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -614,7 +614,13 @@ class Queue {
 		$min_job_id_value = intval( $min_id );
 		$max_job_id_value = intval( $max_id );
 
-		$jobs = $wpdb->get_results( "SELECT * FROM {$table_name} WHERE `job_id` >= $min_job_id_value AND `job_id` <= $max_job_id_value" ); // Cannot prepare table name, ids already escaped. @codingStandardsIgnoreLine
+		$jobs = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$table_name} WHERE `job_id` >= %d AND `job_id` <= %d",  // Cannot prepare table name. @codingStandardsIgnoreLine
+				$min_job_id_value,
+				$max_job_id_value
+			)
+		);
 
 		return $jobs;
 	}

--- a/search/includes/classes/queue/class-cron.php
+++ b/search/includes/classes/queue/class-cron.php
@@ -144,10 +144,18 @@ class Cron {
 	 *
 	 * This is the cron hook for indexing a batch of objects
 	 *
-	 * @param {array} $job_ids Array of job ids to process
+	 * @param {array} $options Containing max_id and min_id keys
 	 */
-	public function process_jobs( $job_ids ) {
-		$jobs = $this->queue->get_jobs( $job_ids );
+	public function process_jobs( $options ) {
+
+		if ( ! array_key_exists( 'min_id', $options ) ) {
+			// This is a temporary fix to handle deployment correctly. To cover the case when
+			// the process job would be created with the full list of ids instead of min and max.
+			// It should be possible to remove within few minutes after deploy.
+			$jobs = $this->queue->get_jobs( $options );
+		} else {
+			$jobs = $this->queue->get_jobs_by_range( $options['min_id'], $options['max_id'] );
+		}
 
 		if ( empty( $jobs ) ) {
 			return;
@@ -285,7 +293,12 @@ class Cron {
 
 		$job_ids = wp_list_pluck( $jobs, 'job_id' );
 
-		return wp_schedule_single_event( time(), self::PROCESSOR_CRON_EVENT_NAME, array( $job_ids ) );
+		$options = [
+			'min_id' => min( $job_ids ),
+			'max_id' => max( $job_ids ),
+		];
+
+		return wp_schedule_single_event( time(), self::PROCESSOR_CRON_EVENT_NAME, [ $options ] );
 	}
 
 	public function schedule_queue_posts_for_term_taxonomy_id( $term_taxonomy_id ) {

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -196,7 +196,7 @@ class Cron_Test extends \WP_UnitTestCase {
 			[
 				'min_id' => 1,
 				'max_id' => 2,
-			]
+			],
 		];
 
 		// Should have scheduled 1 cron event to process the posts

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -69,7 +69,8 @@ class Cron_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $next, 'After Cron:disable_sweeper_job(), job was still found' );
 	}
 
-	public function test_process_jobs() {
+	// TODO Remove after change of args was deployed
+	public function test_process_jobs_legacy() {
 		$mock_queue = $this->getMockBuilder( Queue::class )
 			->setMethods( [ 'get_jobs', 'process_jobs' ] )
 			->getMock();
@@ -110,6 +111,52 @@ class Cron_Test extends \WP_UnitTestCase {
 		$this->cron->queue = $original_queue;
 	}
 
+	public function test_process_jobs() {
+		$mock_queue = $this->getMockBuilder( Queue::class )
+			->setMethods( [ 'get_jobs_by_range', 'process_jobs' ] )
+			->getMock();
+
+
+		$options = [
+			'min_id' => 1,
+			'max_id' => 2,
+		];
+
+		$mock_jobs = array(
+			(object) array(
+				'job_id' => 1,
+				'object_id' => 1,
+				'object_type' => 'post',
+			),
+			(object) array(
+				'job_id' => 2,
+				'object_id' => 2,
+				'object_type' => 'user',
+			),
+		);
+
+		// Should call Queue::get_jobs_by_range() with the right job_ids
+		$mock_queue->expects( $this->once() )
+			->method( 'get_jobs_by_range' )
+			->with( 1, 2 )
+			->will( $this->returnValue( $mock_jobs ) );
+
+		// Then it should process those jobs
+		$mock_queue->expects( $this->once() )
+			->method( 'process_jobs' )
+			->with( $mock_jobs )
+			->will( $this->returnValue( true ) );
+
+		$original_queue = $this->cron->queue;
+		$this->cron->queue = $mock_queue;
+
+		$this->cron->process_jobs( $options );
+
+		// Restore original Queue to not affect other tests
+		$this->cron->queue = $original_queue;
+	}
+
+
 	public function test_schedule_batch_job() {
 		$partially_mocked_cron = $this->getMockBuilder( Cron::class )
 			->setMethods( [ 'get_processor_job_count', 'get_max_concurrent_processor_job_count' ] )
@@ -117,8 +164,6 @@ class Cron_Test extends \WP_UnitTestCase {
 		$mock_queue = $this->getMockBuilder( Queue::class )
 			->setMethods( [ 'checkout_jobs', 'free_deadlocked_jobs' ] )
 			->getMock();
-
-		$mock_job_ids = array( 1, 2 );
 
 		$mock_jobs = array(
 			(object) array(
@@ -147,9 +192,12 @@ class Cron_Test extends \WP_UnitTestCase {
 
 		$partially_mocked_cron->sweep_jobs();
 
-		$expected_cron_event_args = array(
-			$mock_job_ids,
-		);
+		$expected_cron_event_args = [
+			[
+				'min_id' => 1,
+				'max_id' => 2,
+			]
+		];
 
 		// Should have scheduled 1 cron event to process the posts
 		$cron_event_time = wp_next_scheduled( Cron::PROCESSOR_CRON_EVENT_NAME, $expected_cron_event_args );

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -407,7 +407,7 @@ class Queue_Test extends \WP_UnitTestCase {
 	}
 
 	public function test_process_jobs() {
-		$job_ids = array(
+		$object_ids = array(
 			'12',
 			'45',
 			'89',
@@ -415,18 +415,18 @@ class Queue_Test extends \WP_UnitTestCase {
 		);
 
 		// Add some jobs to the queue
-		$this->queue->queue_objects( $job_ids );
+		$this->queue->queue_objects( $object_ids );
 
 		// Have to get by job id and not by object id
-		$jobs = $this->queue->get_jobs_by_range( 12, 246 );
+		$jobs = $this->queue->get_jobs_by_range( 1, 4 );
 
 		$job_count = $this->queue->count_jobs( 'all' );
 
-		$this->assertEquals( $job_count, count( $job_ids ), 'job count in database should match jobs added to queue' );
+		$this->assertEquals( $job_count, count( $object_ids ), 'job count in database should match jobs added to queue' );
 
 		$this->queue->process_jobs( $jobs );
 
-		$jobs = $this->queue->get_jobs_by_range( 12, 246 );
+		$jobs = $this->queue->get_jobs_by_range( 1, 4 );
 
 		$this->assertEmpty( $jobs, 'jobs should be gone after being processed' );
 	}

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -650,7 +650,8 @@ class Queue_Test extends \WP_UnitTestCase {
 
 		$partially_mocked_queue
 			->method( 'delete_jobs_on_the_already_queued_object' )
-			->willReturn( [ $first_job, $second_job, $third_job_on_other_object ] );
+			->with( [ $first_job, $third_job_on_other_object ] )
+			->willReturn( [ $first_job, $third_job_on_other_object ] );
 
 		$partially_mocked_queue->expects( $this->once() )
 			->method( 'update_jobs' )

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -466,7 +466,7 @@ class Queue_Test extends \WP_UnitTestCase {
 		$this->queue->queue_object( 1000, 'post' );
 		$this->queue->queue_object( 2000, 'post' );
 
-		$jobs = $this->queue->test_get_jobs_by_range( 1, 2 );
+		$jobs = $this->queue->get_jobs_by_range( 1, 2 );
 
 		$expected_object_ids = array( 1000, 2000 );
 		$actual_object_ids = wp_list_pluck( $jobs, 'object_id' );

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -418,7 +418,7 @@ class Queue_Test extends \WP_UnitTestCase {
 		$this->queue->queue_objects( $job_ids );
 
 		// Have to get by job id and not by object id
-		$jobs = $this->queue->get_jobs( array_keys( $job_ids ) );
+		$jobs = $this->queue->get_jobs_by_range( 12, 246 );
 
 		$job_count = $this->queue->count_jobs( 'all' );
 
@@ -426,7 +426,7 @@ class Queue_Test extends \WP_UnitTestCase {
 
 		$this->queue->process_jobs( $jobs );
 
-		$jobs = $this->queue->get_jobs( array_keys( $job_ids ) );
+		$jobs = $this->queue->get_jobs_by_range( 12, 246 );
 
 		$this->assertEmpty( $jobs, 'jobs should be gone after being processed' );
 	}
@@ -460,6 +460,18 @@ class Queue_Test extends \WP_UnitTestCase {
 		$jobs = $this->queue->get_jobs( array() );
 
 		$this->assertEquals( array(), $jobs );
+	}
+
+	public function test_get_jobs_by_range() {
+		$this->queue->queue_object( 1000, 'post' );
+		$this->queue->queue_object( 2000, 'post' );
+
+		$jobs = $this->queue->test_get_jobs_by_range( 1, 2 );
+
+		$expected_object_ids = array( 1000, 2000 );
+		$actual_object_ids = wp_list_pluck( $jobs, 'object_id' );
+
+		$this->assertEquals( $expected_object_ids, $actual_object_ids );
 	}
 
 	public function test_queue_objects_not_array() {


### PR DESCRIPTION
## Description

Currently, we store all the job_ids for the async search indexing queue as an argument for the cron instance. This is stored in autoloaded cron option. As this option is autoloaded on every request we would like to minimize the amount of data stored there.

Before the change, we would store an array of size up to 1000 per cron instance (up to 5). This change switches from using `[1,2,3,4,5]` to `1-5`.


## Changelog Description

### Plugin Updated: Search

This change optimizes the storage mechanism for cron processes in the async index queue.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

One of the ways to get items to the queue is having a second index version. Updates to post then will be queued in `wp_vip_search_index_queue` for the inactive version.
1) Watch the table in DB - wp_vip_search_index_queue
2) Run sweeping job - `dev-env exec -- wp cron event run vip_search_queue_sweeper` (this will change status of chosen jobs)
3) Run the processing job - `dev-env exec -- wp cron event run vip_search_queue_processor` (this will reindex documents and remove rows from db)

Alternatively you can check that the changes got into the ES document after the processor.