### PR TITLE
Adding enhanced logging for ElasticPress and changing error name

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -861,7 +861,7 @@ class Search {
 
 			$this->logger->log(
 				'error',
-				'vip_search_http_error',
+				'search_http_error',
 				implode( ';', $error_messages ),
 				[
 					'is_cli' => $is_cli,
@@ -880,7 +880,7 @@ class Search {
 			$error_message = $response_error['reason'] ?? 'Unknown Elasticsearch query error';
 			$this->logger->log(
 				'error',
-				'vip_search_query_error',
+				'search_query_error',
 				$error_message,
 				[
 					'error_type' => $response_error['type'] ?? 'Unknown error type',

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -845,7 +845,7 @@ class Search {
 	public function ep_handle_failed_request( $request, $response, $query, $statsd_prefix ) {
 		$is_cli = defined( 'WP_CLI' ) && WP_CLI;
 		$url = 'unknown';
-		if ( ! $is_cli ) {
+		if ( ! $is_cli && $request && ! is_wp_error( $request ) ) {
 			global $wp;
 			$url = add_query_arg( $wp->query_vars, home_url( $request ) );
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -845,9 +845,10 @@ class Search {
 		$is_cli = defined( 'WP_CLI' ) && WP_CLI;
 
 		if ( is_wp_error( $request ) ) {
-			$encoded_request = $request->get_error_message();
+			$encoded_request = $request->get_error_messages();
 		} else {
-			$encoded_request = wp_json_encode( $request );
+			// TODO: Report actual request, once we make sure all its fields are sanitized and publishable
+			$encoded_request = 'Not an error.';
 		}
 
 		if ( is_wp_error( $response ) ) {
@@ -889,6 +890,7 @@ class Search {
 					'backtrace' => wp_debug_backtrace_summary(),
 					'is_cli' => $is_cli,
 					'request' => $encoded_request,
+					'response' => $response_body,
 				]
 			);
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -843,10 +843,11 @@ class Search {
 
 	public function ep_handle_failed_request( $request, $response, $query, $statsd_prefix ) {
 		$is_cli = defined( 'WP_CLI' ) && WP_CLI;
-		$url = 'unknown';
-		if ( ! $is_cli && $request && ! is_wp_error( $request ) ) {
-			global $wp;
-			$url = add_query_arg( $wp->query_vars, home_url( $request ) );
+
+		if ( is_wp_error( $request ) ) {
+			$encoded_request = $request->get_error_message();
+		} else {
+			$encoded_request = wp_json_encode( $request );
 		}
 
 		if ( is_wp_error( $response ) ) {
@@ -864,7 +865,7 @@ class Search {
 				implode( ';', $error_messages ),
 				[
 					'is_cli' => $is_cli,
-					'url' => $url,
+					'request' => $encoded_request,
 				]
 			);
 		} else {
@@ -887,7 +888,7 @@ class Search {
 					'query' => $query_for_logging,
 					'backtrace' => wp_debug_backtrace_summary(),
 					'is_cli' => $is_cli,
-					'url' => $url,
+					'request' => $encoded_request,
 				]
 			);
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -520,7 +520,6 @@ class Search {
 		add_action( 'after_setup_theme', array( $this, 'apply_settings' ), PHP_INT_MAX ); // Try to apply Search settings after other actions in this hook.
 
 		// Log details of failed requests
-		// TODO: Deprecate
 		add_action( 'ep_invalid_response', [ $this, 'log_ep_invalid_response' ], PHP_INT_MAX, 2 );
 
 		// Lock search algorithm to 3.5

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2715,7 +2715,7 @@ class Search_Test extends \WP_UnitTestCase {
 				->method( 'log' )
 				->with(
 					$this->equalTo( 'error' ),
-					$this->equalTo( 'vip_search_query_error' ),
+					$this->equalTo( 'search_query_error' ),
 					$this->equalTo( $expected_message ),
 					$this->anything()
 				);

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2720,9 +2720,7 @@ class Search_Test extends \WP_UnitTestCase {
 					$this->anything()
 				);
 
-
-
-		$es->ep_handle_failed_request( $response, [], '' );
+		$es->ep_handle_failed_request( null, $response, [], '' );
 	}
 
 	public function get_sanitize_ep_query_for_logging_data() {


### PR DESCRIPTION
## Description

This PR adds three additional fields to ElasticPress's error logs: `is_cli` (whether the error comes from a CLI or not), `reponse` (whole body of the response) and `request` (if the request is an error or not).

We are also removing the `vip_` prefix from the errors, as it was duplicated (the `log2logstash` function would add it as well).

## Changelog Description

### Adding enhanced logging for ElasticPress

Adds some additional logs for when an ElasticPress request fails.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.