### PR TITLE
Enterprise Search: Add date relevancy default for weight

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -472,6 +472,8 @@ class Search {
 		add_filter( 'epwr_score_mode', array( $this, 'filter__epwr_score_mode' ), 0, 3 );
 		// Set to 'multiply'
 		add_filter( 'epwr_boost_mode', array( $this, 'filter__epwr_boost_mode' ), 0, 3 );
+		// Set to 0.001
+		add_filter( 'epwr_weight', array( $this, 'filter__epwr_weight' ), 0 , 3 );
 
 		//	Reduce existing filters based on post meta allow list and make sure the maximum field count is respected
 		add_filter( 'ep_prepare_meta_data', array( $this, 'filter__ep_prepare_meta_data' ), PHP_INT_MAX, 2 );
@@ -1532,6 +1534,13 @@ class Search {
 	 */
 	public function filter__epwr_boost_mode( $boost_mode, $formatted_args, $args ) {
 		return 'multiply';
+	}
+
+	/*
+	 * Filter for setting weight for date relevancy in ElasticPress
+	 */
+	public function filter__epwr_weight( $weight, $formatted_args, $args ) {
+		return 0.001;
 	}
 
 	/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -473,7 +473,7 @@ class Search {
 		// Set to 'multiply'
 		add_filter( 'epwr_boost_mode', array( $this, 'filter__epwr_boost_mode' ), 0, 3 );
 		// Set to 0.001
-		add_filter( 'epwr_weight', array( $this, 'filter__epwr_weight' ), 0 , 3 );
+		add_filter( 'epwr_weight', array( $this, 'filter__epwr_weight' ), 0, 3 );
 
 		//	Reduce existing filters based on post meta allow list and make sure the maximum field count is respected
 		add_filter( 'ep_prepare_meta_data', array( $this, 'filter__ep_prepare_meta_data' ), PHP_INT_MAX, 2 );


### PR DESCRIPTION
## Description
As of 3.5.6, the default search date weight changed from `1` to `0.001`: https://github.com/10up/ElasticPress/pull/2061.

Unfortunately, this can have unintended side effects if `min_score` is modified via `ep_formatted_args`, as the calculated scoring will end up as a different value to what is expected. For future-proofing, we will keep it at 0.001.

I didn't need to set `epwr_score_mode` or `epwr_boost_mode`, since that was already done via https://github.com/Automattic/vip-go-mu-plugins/pull/1537.

## Changelog Description
### Enterprise Search: Add date relevancy default for weight

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
