### PR TITLE
Enabling Search Dev Tools to all sites

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -200,10 +200,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once( __DIR__ . '/vip-helpers/class-vip-backup-user-role-cli.php' );
 }
 
-if ( ! defined( 'VIP_SEARCH_DEV_TOOLS' ) ) {
-	define( 'VIP_SEARCH_DEV_TOOLS', true );
-}
-
 // Load elasticsearch helpers
 // Warning: Site Details depends on the existence of class Search.
 // If this changes in the future, please ensure that details for search are correctly extracted

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -201,7 +201,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 if ( ! defined( 'VIP_SEARCH_DEV_TOOLS' ) ) {
-	define( 'VIP_SEARCH_DEV_TOOLS', ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) || \Automattic\VIP\Feature::is_enabled( 'search-dev-tools' ) );
+	define( 'VIP_SEARCH_DEV_TOOLS', true );
 }
 
 // Load elasticsearch helpers

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -16,9 +16,7 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = array(
-		'search-dev-tools' => 0.5,
-	);
+	public static $feature_percentages = array();
 
 	public static $site_id = false;
 

--- a/search/search.php
+++ b/search/search.php
@@ -23,10 +23,7 @@ require_once __DIR__ . '/includes/classes/class-search.php';
 if ( \Automattic\VIP\Search\Search::are_es_constants_defined() ) {
 	$search_plugin = \Automattic\VIP\Search\Search::instance();
 
-	// Temporarily hide it under a constant
-	if ( defined( '\VIP_SEARCH_DEV_TOOLS' ) && true === \VIP_SEARCH_DEV_TOOLS ) {
-		require_once __DIR__ . '/search-dev-tools/search-dev-tools.php';
-	}
+	require_once __DIR__ . '/search-dev-tools/search-dev-tools.php';
 
 	// If VIP Search query integration is enabled, disable Jetpack Search
 	if ( ! $search_plugin::ep_skip_query_integration( false ) ) {


### PR DESCRIPTION
## Description

This PR enables Search Dev Tools for all sites that are using Enterprise Search.

## Changelog Description

### Enabling Search Dev Tools to all sites

This PR enables Search Dev Tools for all sites that are using Enterprise Search.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Enable Enterprise Search
3. Check that the dev tools appear and work.