### PR TITLE
Temporarily disabling VIP Search UI

### DIFF
--- a/search/search.php
+++ b/search/search.php
@@ -35,10 +35,11 @@ if ( \Automattic\VIP\Search\Search::are_es_constants_defined() ) {
 		add_filter( 'jetpack_search_should_handle_query', '__return_false', PHP_INT_MAX );
 	}
 
-	add_action( 'widgets_init', function () {
-		require_once __DIR__ . '/ui/class-vip-search-widget.php';
-		register_widget( 'Automattic\VIP\Search\UI\VIP_Search_Widget' );
-	} );
+	// Temporarily disabling
+	// add_action( 'widgets_init', function () {
+	//	require_once __DIR__ . '/ui/class-vip-search-widget.php';
+	//	register_widget( 'Automattic\VIP\Search\UI\VIP_Search_Widget' );
+	// } );
 
 	do_action( 'vip_search_loaded' );
 }

--- a/search/search.php
+++ b/search/search.php
@@ -35,11 +35,5 @@ if ( \Automattic\VIP\Search\Search::are_es_constants_defined() ) {
 		add_filter( 'jetpack_search_should_handle_query', '__return_false', PHP_INT_MAX );
 	}
 
-	// Temporarily disabling
-	// add_action( 'widgets_init', function () {
-	//	require_once __DIR__ . '/ui/class-vip-search-widget.php';
-	//	register_widget( 'Automattic\VIP\Search\UI\VIP_Search_Widget' );
-	// } );
-
 	do_action( 'vip_search_loaded' );
 }


### PR DESCRIPTION
## Description

We have recently introduced a VIP Search UI Widget that consisted of a search box. Given that the widget currently only displays a search box, its functionality is already covered by WordPress' search widget.

We are temporarily disabling our widget to avoid confusion and duplication.

## Changelog Description

### Temporarily disabling VIP Search UI

Please use WordPress's Core Search widget instead.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.