### PR TITLE
Fix unit tests for WordPress nightly

### DIFF
--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -62,6 +62,12 @@ trap cleanup EXIT
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root "$MYSQL_ROOT_PASSWORD" "$DB_CONTAINER_NAME" "$WP_VERSION")
 
+if [ -f vendor/bin/phpunit ]; then
+	ENTRYPOINT="--entrypoint /app/vendor/bin/phpunit"
+else
+	ENTRYPOINT=""
+fi
+
 ## Ensure there's a database connection for the rest of the steps
 until docker exec -it $db mysql -u root -h $DB_CONTAINER_NAME --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do
 	echo "Waiting for database connection..."
@@ -76,5 +82,6 @@ docker run \
 	-v $(pwd):/app \
 	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
 	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \
+	$ENTRYPOINT \
 	--rm ghcr.io/automattic/phpunit-docker/phpunit:latest \
 	--bootstrap /app/tests/bootstrap.php ${EXTRA_ARGS} "${PATH_TO_TEST}"

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
         "automattic/vipwpcs": "2.3.2",
         "phpcompatibility/phpcompatibility-wp": "2.1.2",
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
-        "erusev/parsedown": "1.7.4"
+        "erusev/parsedown": "1.7.4",
+        "yoast/phpunit-polyfills": "^1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "868bd85bfbff4de8de90a14433f89011",
+    "content-hash": "9b75453a44a6e10cc6fa25c2a1b72b4e",
     "packages": [],
     "packages-dev": [
         {
@@ -2202,6 +2202,69 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "f014fb21c2b0038fd329515d59025af42fb98715"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/f014fb21c2b0038fd329515d59025af42fb98715",
+                "reference": "f014fb21c2b0038fd329515d59025af42fb98715",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-08-09T16:28:08+00:00"
         }
     ],
     "aliases": [],

--- a/tests/files/test-image.php
+++ b/tests/files/test-image.php
@@ -62,7 +62,7 @@ class A8C_Files_Image_Test extends \WP_UnitTestCase {
 	 *
 	 * @return ReflectionMethod
 	 */
-	protected static function getMethod( $name ) {
+	protected static function get_method( $name ) {
 		$class = new ReflectionClass( 'Automattic\\VIP\\Files\\Image' );
 		$method = $class->getMethod( $name );
 		$method->setAccessible(true);
@@ -76,7 +76,7 @@ class A8C_Files_Image_Test extends \WP_UnitTestCase {
 	 *
 	 * @return ReflectionProperty
 	 */
-	protected function getProperty( $name ) {
+	protected function get_property( $name ) {
 		$class = new ReflectionClass( 'Automattic\\VIP\\Files\\Image' );
 		$property = $class->getProperty( $name );
 		$property->setAccessible(true);
@@ -311,11 +311,11 @@ class A8C_Files_Image_Test extends \WP_UnitTestCase {
 		$postmeta = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
 
 		$image = new Automattic\VIP\Files\Image( $postmeta, $attachment_post_data['post_mime_type'] );
-		$width = $this->getProperty( 'width' );
+		$width = $this->get_property( 'width' );
 		$width->setValue( $image, 150 );
-		$height = $this->getProperty( 'height' );
+		$height = $this->get_property( 'height' );
 		$height->setValue( $image, 150 );
-		$get_resized_filename = $this->getMethod( 'get_resized_filename' );
+		$get_resized_filename = $this->get_method( 'get_resized_filename' );
 
 		$this->assertEquals( $this->test_image . '?resize=150,150', $get_resized_filename->invokeArgs( $image, [] ) );
 	}

--- a/tests/files/test-image.php
+++ b/tests/files/test-image.php
@@ -57,6 +57,8 @@ class A8C_Files_Image_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Helper function for accessing protected method.
+	 * 
+	 * Renamed from `getMethod` to `get_method` for consistency with `get_property` (see below)
 	 *
 	 * @param string $name Name of the method.
 	 *
@@ -71,6 +73,9 @@ class A8C_Files_Image_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Helper function for accessing protected property.
+	 * 
+	 * Renamed from `getProperty` `to `get_property` to avoid conflicts with PHPUnit Polyfill's `getProperty()` method
+	 * which is used by `assertAttributeXXX` assertions.
 	 *
 	 * @param string $name Name of the property.
 	 *


### PR DESCRIPTION
## Description

The nightly version of WordPress requires `yoast/phpunit-polyfills` to run unit tests.

Without the polyfills, it [throws an error](https://app.circleci.com/pipelines/github/Automattic/vip-go-mu-plugins/6933/workflows/92e8384c-31db-4547-afe6-ba550d8900a4/jobs/49746?invite=true#step-105-62)

> Error: The PHPUnit Polyfills library is a requirement for running the WP test suite.

This PR adds the missing polyfill.

## Changelog Description

### Fix unit tests in WordPress Nightly

Adds yoast/phpunit-polyfills to composer.{json,lock}

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

`php74-build-multisite-nightly` and `php74-build-singlesite-nightly` CI jobs should succeed.
