### PR TITLE
Handle unsupported calls to dirsize

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -100,6 +100,7 @@ class VIP_Filesystem {
 		add_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20, 2 );
 		add_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ], 10, 2 );
 		add_filter( 'wp_read_image_metadata', [ $this, 'filter_wp_read_image_metadata' ], 10, 2 );
+		add_filter( 'pre_recurse_dirsize', [ $this, 'filter_pre_recurse_dirsize' ] );
 	}
 
 	/**
@@ -117,6 +118,7 @@ class VIP_Filesystem {
 		remove_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20 );
 		remove_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ] );
 		remove_filter( 'wp_read_image_metadata', [ $this, 'filter_wp_read_image_metadata' ], 10, 2 );
+		remove_filter( 'pre_recurse_dirsize', [ $this, 'filter_pre_recurse_dirsize' ] );
 	}
 
 	/**
@@ -442,5 +444,15 @@ class VIP_Filesystem {
 		unlink( $temp_file );
 
 		return $meta;
+	}
+
+	/**
+	 * The core's function recurse_dirsize would call to opendir() which is not supproted by the
+	 * VIP File service and would always fail with Warning.
+	 *
+	 * To avoid this we will short-circuit the execution and return 0 as folder size.
+	 */
+	public function filter_pre_recurse_dirsize() {
+		return 0;
 	}
 }

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -447,7 +447,7 @@ class VIP_Filesystem {
 	}
 
 	/**
-	 * The core's function recurse_dirsize would call to opendir() which is not supproted by the
+	 * The core's function recurse_dirsize would call to opendir() which is not supported by the
 	 * VIP File service and would always fail with Warning.
 	 *
 	 * To avoid this we will short-circuit the execution and return 0 as folder size.


### PR DESCRIPTION
## Description


## Changelog Description

### Plugin Updated:  VIP File Service

Handle unsupported `dirsize` requests gracefully to avoid polluting error logs.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1) Clear dirsize cace: `wp --allow-root --path=/var/www eval 'delete_transient("dirsize_cache");'`
1) Run code that fetches dirsize: `wp --allow-root --path=/var/www eval '\Jetpack_Heartbeat::generate_stats_array();'`
