### PR TITLE
Use libgcc-10-dev instead of libgcc-8-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ job-references:
   install_dependencies: &install_dependencies
     name: "Install Dependencies"
     command: |
-      sudo apt-get update && sudo apt-get install subversion libgcc-8-dev default-mysql-client libpng-dev
+      sudo apt-get update && sudo apt-get install subversion libgcc-10-dev default-mysql-client libpng-dev
       sudo -E docker-php-ext-install mysqli gd
       npm ci
       composer install -n
@@ -76,7 +76,7 @@ job-references:
   install_core_tests_dependencies: &install_core_tests_dependencies
     name: "Install Dependencies"
     command: |
-      sudo apt-get update && sudo apt-get -y install subversion libgcc-8-dev default-mysql-client nodejs npm
+      sudo apt-get update && sudo apt-get -y install subversion libgcc-10-dev default-mysql-client nodejs npm
       sudo npm install npm@latest -g
       composer install -n
 


### PR DESCRIPTION
## Description

`libgcc-8-dev` is not available in Debian Bullseye; the suggested replacement is `libgcc-10-dev` to match the version of `gcc`.

This PR fixes [this issue](https://github.com/Automattic/vip-go-mu-plugins/pull/2367#issuecomment-903464648).

## Changelog Description

### CI: switch from libgcc-8-dev to libgcc-10-dev

Because the CI images switched to Debian Bullseye, libgcc-X-dev needs to be updated accordingly.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

If everything is good, CirceCI jobs should succeed (with the possible exception of `php74-build-multisite-nightly` and `php74-build-singlesite-nightly`, see #2367).
