### PR TITLE
FORNO-829: Decrease site details sync interval to 5 minutes

### DIFF
--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -62,6 +62,7 @@ class Sync {
 
 		return $schedule;
 	}
+
 	public function do_cron() {
 		$this->maybe_sync_jetpack_privacy_settings();
 		$this->put_site_details();

--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -7,7 +7,7 @@ class Sync {
 
 	const CRON_EVENT_NAME = 'vip_config_sync_cron';
 	const CRON_INTERVAL_NAME = 'vip_config_sync_cron_interval';
-	const CRON_INTERVAL = 30 * \MINUTE_IN_SECONDS;
+	const CRON_INTERVAL = 5 * \MINUTE_IN_SECONDS;
 	const LOG_FEATURE_NAME = 'vip_config_sync';
 
 	const JETPACK_PRIVACY_SETTINGS_SYNC_STATUS_OPTION_NAME = 'vip_config_jetpack_privacy_settings_synced_value';
@@ -57,7 +57,7 @@ class Sync {
 
 		$schedule[ self::CRON_INTERVAL_NAME ] = [
 			'interval' => self::CRON_INTERVAL,
-			'display' => __( 'VIP Config Sync cron interval' ),
+			'display' => __( 'Custom interval for VIP Config Sync. Currently set to 5 mins' ),
 		];
 
 		return $schedule;

--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -62,7 +62,6 @@ class Sync {
 
 		return $schedule;
 	}
-
 	public function do_cron() {
 		$this->maybe_sync_jetpack_privacy_settings();
 		$this->put_site_details();

--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -57,12 +57,12 @@ class Sync {
 
 		$schedule[ self::CRON_INTERVAL_NAME ] = [
 			'interval' => self::CRON_INTERVAL,
-			'display' => __( 'Custom interval for VIP Config Sync. Currently set to ' . self::CRON_INTERVAL . 'seconds' ),
+			'display' => __( 'Custom interval for VIP Config Sync. Currently set to 5 minutes' ),
 		];
 
 		return $schedule;
 	}
-	
+
 	public function do_cron() {
 		$this->maybe_sync_jetpack_privacy_settings();
 		$this->put_site_details();

--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -57,12 +57,12 @@ class Sync {
 
 		$schedule[ self::CRON_INTERVAL_NAME ] = [
 			'interval' => self::CRON_INTERVAL,
-			'display' => __( 'Custom interval for VIP Config Sync. Currently set to 5 mins' ),
+			'display' => __( 'Custom interval for VIP Config Sync. Currently set to ' . self::CRON_INTERVAL . 'seconds' ),
 		];
 
 		return $schedule;
 	}
-
+	
 	public function do_cron() {
 		$this->maybe_sync_jetpack_privacy_settings();
 		$this->put_site_details();


### PR DESCRIPTION
## Description
This PR reduces the site details sync interval, in order for site details service to have more up-to-date data for each site.

## Changelog Description

### Site details: Updated interval

We lowered the site details update interval from 30 to 5 minutes.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.