### PR TITLE
Fix the configuration option in phpcs.xml.dist

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -49,7 +49,7 @@
 	<!-- Limit to PHP files -->
 	<arg name="extensions" value="php"/>
 
-	<config name="ignore_warnings_on_exit">true</config>
+	<config name="ignore_warnings_on_exit" value="true"/>
 
 	<!-- Rules: Check PHP version compatibility - see
 		https://github.com/PHPCompatibility/PHPCompatibilityWP -->


### PR DESCRIPTION
## Description

Configuration values should be put into the `value` attribute, not as a text inside the tag.

## Changelog Description

### CI: fix phpcs configuration file

The value for the `ignore_warnings_on_exit` options was specified incorrectly.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Has already been tested by the CI jobs in #2367
