### PR TITLE
Search: add descriptions for the supported named arguments for the index command

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -173,6 +173,9 @@ class CoreCommand extends \ElasticPress\Command {
 	 * [--show-bulk-errors]
 	 * : displays the error message returned from Elasticsearch when a post fails to index (as opposed to just the title and ID of the post)
 	 *
+	 * [--skip-confirm]
+	 * : Skip Enterprise Search confirmation prompts for destructive operations.
+	 *
 	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--upper-limit-object-id] [--lower-limit-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--version] [--skip-confirm] [--using-versions]
 	 *
 	 * @param array $args Positional CLI args.

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -136,14 +136,44 @@ class CoreCommand extends \ElasticPress\Command {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--setup]
+	 * : Drop the index, send the new mappings to the server, and re-index the site.
+	 *
+	 * [--network-wide]
+	 * : Sequentially index every site in your multisite network.
+	 *
 	 * [--version]
-	 * : The index version to index into. Used to build up a new index in parallel with the currently active index version
+	 * : The index version to index into. Used to build up a new index in parallel with the currently active index version.
 	 *
 	 * [--using-versions]
 	 * : This switch will create a new version and reindex that version (while the current version will continue to serve content).
 	 * After the indexing is done the new version will be activated and old version removed.
 	 *
-	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--upper-limit-object-id] [--lower-limit-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--version] [--skip-confirm] [--using-versions]
+	 * [--per-page]
+	 * : Lets you determine the amount of posts to be indexed per bulk index (or cycle). Default: 500.
+	 *
+	 * [--include]
+	 * : Comma-separated list of object ID to index.
+	 *
+	 * [--post-ids]
+	 * : Alias of --include (deprecated).
+	 *
+	 * [--post-type]
+	 * : Comma-separated list of post types to index. By default all public post types are indexed.
+	 *
+	 * [--indexables]
+	 * : Comma-separated list of Indexables to index, default includes all registered Indexables.
+	 *
+	 * [--upper-limit-object-id]
+	 * : Upper limit of a range of IDs to be indexed. If indexing IDs from 30 to 45, this should be 45.
+	 *
+	 * [--lower-limit-object-id]
+	 * : Lower limit of a range of IDs to be indexed. If indexing IDs from 30 to 45, this should be 30.
+	 *
+	 * [--show-bulk-errors]
+	 * : displays the error message returned from Elasticsearch when a post fails to index (as opposed to just the title and ID of the post)
+	 *
+	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--upper-limit-object-id] [--lower-limit-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--version] [--skip-confirm] [--using-versions]
 	 *
 	 * @param array $args Positional CLI args.
 	 * @since 0.1.2

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -143,7 +143,7 @@ class CoreCommand extends \ElasticPress\Command {
 	 * : This switch will create a new version and reindex that version (while the current version will continue to serve content).
 	 * After the indexing is done the new version will be activated and old version removed.
 	 *
-	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--start-object-id] [--end-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--version] [--skip-confirm] [--using-versions]
+	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--upper-limit-object-id] [--lower-limit-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--version] [--skip-confirm] [--using-versions]
 	 *
 	 * @param array $args Positional CLI args.
 	 * @since 0.1.2


### PR DESCRIPTION
## Description

It started as fixing the discrepancy between the ElasticPress command and the Enterprise Search command. We had `start-object-id` and `end-object-id` arguments which was deemed confusing when the PR was merged to the upstream, so it was swapped for `upper-limit-object-id` and `lower-limit-object-id` which is less confusing.  Unfortunately we didn't catch that during the merge.

While fixing it we realized that the command doesn't really explain what do all of those arguments mean so we decided to address that as well.

## Changelog Description

### Plugin Updated: Enterprise Search

We've added detailed descriptions for each argument for the indexing command. 

Use `wp help vip-search index` to see them all.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out the PR
2. Run `wp help vip-search index`
3. Observe that arguments now have descriptions.

