### PR TITLE
Use __return_zero filter for files filter

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -100,7 +100,14 @@ class VIP_Filesystem {
 		add_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20, 2 );
 		add_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ], 10, 2 );
 		add_filter( 'wp_read_image_metadata', [ $this, 'filter_wp_read_image_metadata' ], 10, 2 );
-		add_filter( 'pre_recurse_dirsize', [ $this, 'filter_pre_recurse_dirsize' ] );
+
+		/**
+		 * The core's function recurse_dirsize would call to opendir() which is not supported by the
+		 * VIP File service and would always fail with Warning.
+		 *
+		 * To avoid this we will short-circuit the execution and return 0 as folder size.
+		 */
+		add_filter( 'pre_recurse_dirsize', '__return_zero' );
 	}
 
 	/**
@@ -118,7 +125,7 @@ class VIP_Filesystem {
 		remove_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20 );
 		remove_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ] );
 		remove_filter( 'wp_read_image_metadata', [ $this, 'filter_wp_read_image_metadata' ], 10, 2 );
-		remove_filter( 'pre_recurse_dirsize', [ $this, 'filter_pre_recurse_dirsize' ] );
+		remove_filter( 'pre_recurse_dirsize', '__return_zero' );
 	}
 
 	/**
@@ -444,15 +451,5 @@ class VIP_Filesystem {
 		unlink( $temp_file );
 
 		return $meta;
-	}
-
-	/**
-	 * The core's function recurse_dirsize would call to opendir() which is not supported by the
-	 * VIP File service and would always fail with Warning.
-	 *
-	 * To avoid this we will short-circuit the execution and return 0 as folder size.
-	 */
-	public function filter_pre_recurse_dirsize() {
-		return 0;
 	}
 }


### PR DESCRIPTION
## Description

Following @GaryJones comment on @pschoffer PR (https://github.com/Automattic/vip-go-mu-plugins/pull/2370), we are using the predefined `__return_zero` filter instead of a custom function.

## Changelog Description

### Use __return_zero filter for files filter

Internal code optimizations

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.