### PR TITLE
Removing Jetpack check for old WP versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ workflows:
       - php74-build-singlesite-57
       - php74-build-singlesite-56
       - php74-build-singlesite-55
-      - php74-build-singlesite-54
       - php74-build-multisite
       - php74-build-multisite-nightly
       - php74-build-singlesite-nightly
@@ -186,15 +185,6 @@ jobs:
       - WP_MULTISITE: "1"
       - WP_VERSION: "latest"
       - DISABLE_JETPACK: "1"
-    docker:
-      - image: circleci/php:7.4-node
-      - image: *db_image
-
-  php74-build-singlesite-54:
-    <<: *php_job
-    environment:
-      - WP_MULTISITE: "0"
-      - WP_VERSION: "5.4.4"
     docker:
       - image: circleci/php:7.4-node
       - image: *db_image

--- a/jetpack.php
+++ b/jetpack.php
@@ -15,9 +15,7 @@
 // Choose an appropriate default Jetpack version, ensuring that older WordPress versions
 // are not using a too modern Jetpack version that is not compatible with it
 if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
-	if ( version_compare( $wp_version, '5.5', '<' ) ) {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.1' );
-	} elseif ( version_compare( $wp_version, '5.6', '<' ) ) {
+	if ( version_compare( $wp_version, '5.6', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.4' );
 	} elseif ( version_compare( $wp_version, '5.7', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.8' );


### PR DESCRIPTION
## Description

Given that we no longer run WordPress 5.4 (or lower) sites on our platform, we are safe to drop the checks for those versions. This PR removes the checks on the Jetpack loading script and also drops the testing pipeline for 5.4.

## Changelog Description

### Removing Jetpack check for old WP versions

We are dropping support for WordPress 5.4 or lower in mu-plugins.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.