### PR TITLE
Making Jetpack 10.1 default version

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -1,15 +1,18 @@
 <?php
 
-/*
- * Plugin Name: Jetpack by WordPress.com
+/**
+ * Plugin Name: Jetpack
  * Plugin URI: https://jetpack.com
- * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
+ * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 10.0
+ * Version: 10.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
- * Domain Path: /languages/
+ * Requires at least: 5.7
+ * Requires PHP: 5.6
+ *
+ * @package automattic/jetpack
  */
 
 // Choose an appropriate default Jetpack version, ensuring that older WordPress versions
@@ -20,7 +23,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.7', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.8' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.0' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.1' );
 	}
 }
 


### PR DESCRIPTION
## Description

This PR makes Jetpack 10.1 the default version. We are also updating the plugin header from that same latest version.

## Changelog Description

### Plugin Updated: Jetpack 10.1

We are making Jetpack 10.1 the new default version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Make sure you have Jetpack enabled but no version pinned.
3. Check that you're running Jetpack 10.1.