### PR TITLE
Fix phpcs issues for admin-notice plugin

### DIFF
--- a/admin-notice.php
+++ b/admin-notice.php
@@ -9,4 +9,4 @@
  *
  * @package Automattic\VIP\AdminNotice
  */
-require_once( __DIR__ . '/admin-notice/admin-notice.php' );
+require_once __DIR__ . '/admin-notice/admin-notice.php';

--- a/admin-notice/class-admin-notice-controller.php
+++ b/admin-notice/class-admin-notice-controller.php
@@ -3,8 +3,8 @@
 namespace Automattic\VIP\Admin_Notice;
 
 class Admin_Notice_Controller {
-	const DISMISS_USER_META = 'dismissed_vip_notices';
-	const DISMISS_NONCE_ACTION = 'dismiss_notice';
+	const DISMISS_USER_META      = 'dismissed_vip_notices';
+	const DISMISS_NONCE_ACTION   = 'dismiss_notice';
 	const DISMISS_IDENTIFIER_KEY = 'identifier';
 
 	public static $stale_dismiss_cleanup_value = 1; // Value to compare <= against rand( 1, 100 ). 1 should result in roughly 1 in 100 chance.
@@ -31,9 +31,9 @@ class Admin_Notice_Controller {
 	}
 
 	public function enqueue_scripts() {
-		wp_enqueue_script( 'vip-admin-notice-script', plugins_url( '/js/script.js', __FILE__ ), [], '1.0' );
+		wp_enqueue_script( 'vip-admin-notice-script', plugins_url( '/js/script.js', __FILE__ ), [], '1.0', true );
 		wp_localize_script( 'vip-admin-notice-script', 'dismissal_data', [
-			'nonce' => wp_create_nonce( self::DISMISS_NONCE_ACTION ),
+			'nonce'          => wp_create_nonce( self::DISMISS_NONCE_ACTION ),
 			'data_attribute' => Admin_Notice::DISMISS_DATA_ATTRIBUTE,
 			'identifier_key' => self::DISMISS_IDENTIFIER_KEY,
 		] );
@@ -49,6 +49,7 @@ class Admin_Notice_Controller {
 	}
 
 	public function maybe_clean_stale_dismissed_notices() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand -- rand() is OK here, no need to use slower wp_rand()
 		if ( self::$stale_dismiss_cleanup_value >= rand( 1, 100 ) ) {
 			$this->clean_stale_dismissed_notices();
 		}

--- a/admin-notice/class-admin-notice.php
+++ b/admin-notice/class-admin-notice.php
@@ -28,10 +28,10 @@ class Admin_Notice {
 	 * @param string $dismiss_identifier if provided the dismiss will become dissmisible
 	 */
 	public function __construct( string $message, array $conditions = [], string $dismiss_identifier = '', string $notice_class = 'info' ) {
-		$this->message = $message;
-		$this->conditions = $conditions;
+		$this->message            = $message;
+		$this->conditions         = $conditions;
 		$this->dismiss_identifier = $dismiss_identifier;
-		$this->notice_class = in_array( $notice_class, self::ALLOWED_NOTICE_CLASSES, true ) ? $notice_class : 'info';
+		$this->notice_class       = in_array( $notice_class, self::ALLOWED_NOTICE_CLASSES, true ) ? $notice_class : 'info';
 	}
 
 	public function display() {

--- a/admin-notice/conditions/class-date-condition.php
+++ b/admin-notice/conditions/class-date-condition.php
@@ -9,8 +9,8 @@ class Date_Condition implements Condition {
 	private $decision_date;
 
 	public function __construct( string $start_date, string $end_date, string $decision_date = 'now' ) {
-		$this->start_date = new \DateTime( $start_date, new \DateTimeZone( 'UTC' ) );
-		$this->end_date = new \DateTime( $end_date, new \DateTimeZone( 'UTC' ) );
+		$this->start_date    = new \DateTime( $start_date, new \DateTimeZone( 'UTC' ) );
+		$this->end_date      = new \DateTime( $end_date, new \DateTimeZone( 'UTC' ) );
 		$this->decision_date = new \DateTime( $decision_date, new \DateTimeZone( 'UTC' ) );
 	}
 


### PR DESCRIPTION
## Description

This PR opens a series of code style fixes; in particular, it deals with the issues found by `phpcs` in `admin-notice` plugin. As a side note, these PRs give me a great opportunity to familiarize myself with the codebase.

I will annotate all found issues except for the whitespace-related ones.

## Changelog Description

### Code Style

Fix phpcs errors and warnings for admin-notice plugin

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Run `composer install`
2. Run `vendor/bin/phpcs -s admin-notice.php admin-notice` and observe the reported issues
3. Check out the PR
4. Re-run `vendor/bin/phpcs -s admin-notice.php admin-notice` and make sure that all previously reported issues are gone.