### PR TITLE
Fix "Class 'Automattic\VIP\Helpers\WP_Error' not found" in `User_Cleanup::revoke_roles_for_users()`

### DIFF
--- a/tests/vip-helpers/test-class-user-cleanup.php
+++ b/tests/vip-helpers/test-class-user-cleanup.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Helpers;
 
+use WP_Error;
+
 class User_Cleanup_Test extends \WP_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -323,6 +325,14 @@ class User_Cleanup_Test extends \WP_UnitTestCase {
 		if ( is_multisite() ) {
 			$this->assertFalse( is_user_member_of_blog( $user_1_id ), 'is_user_member_of_blog did not return false' );
 		}
+	}
+
+	public function test__revoke_roles_for_users_nonexisting() {
+		$user_id = -1;
+		$actual_results = User_Cleanup::revoke_roles_for_users( [ $user_id ] );
+		$this->assertIsArray( $actual_results );
+		$this->assertArrayHasKey( $user_id, $actual_results );
+		$this->assertInstanceOf( WP_Error::class, $actual_results[ $user_id ] );
 	}
 
 	private function _backup_super_admins() {

--- a/vip-helpers/class-user-cleanup.php
+++ b/vip-helpers/class-user-cleanup.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Helpers;
 
+use WP_Error;
+
 // If the constant is set, don't run the cleanup
 if ( defined( 'VIP_SKIP_USER_CLEANUP' ) && true === VIP_SKIP_USER_CLEANUP ) {
 	add_filter( 'vip_do_user_cleanup', '__return_false' );


### PR DESCRIPTION
## Description

If `User_Cleanup::revoke_roles_for_users()` is called with a non-existing user ID, it will try to return a `WP_Error`. However, because of the name resolution rules, PHP will try to use `\Automattic\VIP\Helpers\WP_Error` instead of `\WP_Error`,
which will cause a fatal error.

## Changelog Description

### VIP Init Plugin: bug fix

Fix a fatal error caused by the name resolution rules.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Comment out line 5 in `vip-helpers/class-user-cleanup.php`
3. Run `./bin/phpunit-docker.sh tests/vip-helpers/test-class-user-cleanup.php` and observe that it crashes with `Error: Class 'Automattic\VIP\Helpers\WP_Error' not found`
4. Revert the change to `vip-helpers/class-user-cleanup.php` and rerun the tests. Verify that the error is gone.


