### PR TITLE
Ignoring dev-env related file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 jetpack-private.php
 
 # dev-env related files
-dev-env-plugin.php
+/dev-env-plugin.php
 
 # Local PHPDoc configuration file
 # overrides phpdoc.dist.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Secret files
 jetpack-private.php
 
+# dev-env related files
+dev-env-plugin.php
+
 # Local PHPDoc configuration file
 # overrides phpdoc.dist.xml
 phpdoc.xml


### PR DESCRIPTION
## Description

If the `vip` CLI is used to spin up a local development environment, a file (`dev-env-plugin.php`) is created to make things work. We don't want that file to slip into production, hence we are ignoring it through `.gitignore`. 

## Changelog Description

### Ignoring dev-env related file

Internal code change to prevent conflicts with `vip dev-env`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.