### PR TITLE
Removed legacy code which broke comment counts.

### DIFF
--- a/performance/vip-tweaks.php
+++ b/performance/vip-tweaks.php
@@ -4,15 +4,6 @@
  * This is a list of performance tweaks that will become default for All VIP sites
  */
 function wpcom_vip_enable_performance_tweaks() {
-	/**
-	 * Improves performance of all the wp-admin pages that load comment counts in the menu.
-	 *
-	 * This caches them for 30 minutes. It does not impact the per page comment count, only
-	 * the total comment count that shows up in the admin menu.
-	 */
-	if ( function_exists( 'wpcom_vip_enable_cache_full_comment_counts' ) ) {
-		wpcom_vip_enable_cache_full_comment_counts();
-	}
 
 	// This disables the adjacent_post links in the header that are almost never beneficial and are very slow to compute.
 	remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -607,42 +607,6 @@ add_action( 'delete_attachment', function ( $post_id ) {
 	wp_cache_delete( $cache_key, 'default' );
 } );
 
-/**
- * Use this function to cache the comment counting in the wp menu that can be slow on sites with lots of comments
- * use like this:
- *
- * @param $post_id
- *
- * @see wp_count_comments()
- * @return bool|false|mixed|string
- */
-function wpcom_vip_cache_full_comment_counts( $counts = false, $post_id = 0 ) {
-	// We are only caching the global comment counts for now since those are often in the millions while the per page one is usually more reasonable.
-	if ( 0 !== $post_id ) {
-		return $counts;
-	}
-	$cache_key = "vip-comments-{$post_id}";
-	$stats_object = wp_cache_get( $cache_key );
-
-	// retrieve comments in the same way wp_count_comments() does
-	if ( false === $stats_object ) {
-		$stats = get_comment_count( $post_id );
-		$stats['moderated'] = $stats['awaiting_moderation'];
-		unset( $stats['awaiting_moderation'] );
-		$stats_object = (object) $stats;
-
-		wp_cache_set( $cache_key, $stats_object, 'default', 30 * MINUTE_IN_SECONDS );
-	}
-
-	return $stats_object;
-
-}
-
-function wpcom_vip_enable_cache_full_comment_counts() {
-	add_filter( 'wp_count_comments', 'wpcom_vip_cache_full_comment_counts', 10, 2 );
-}
-
-
 function wpcom_vip_enable_old_slug_redirect_caching() {
 	add_action( 'template_redirect', 'wpcom_vip_wp_old_slug_redirect', 8 );
 	// Hook the following actions to after the core's wp_check_for_changed_slugs - it's being hooke at prio 12


### PR DESCRIPTION
## Description

Removed legacy code from WordPress.com days that cached the comment counts. The `wp_comment_count` function in core now caches the values and this code is no longer used.

## Changelog Description

### Fixed comment counts on dashboard

Removed legacy code that caused sites with WooCommerce to show the wrong count for total comments in the WordPress Dashboard.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ x ] This change works and has been tested locally (or has an appropriate fallback).
- [ x ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ x ] I've created a changelog description that aligns with the provided examples.

Closes #1618 
