### PR TITLE
Re-work streamWrapper debug using log2logstash and more detailed debug backtrace

### DIFF
--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -419,7 +419,7 @@ class VIP_Filesystem_Stream_Wrapper {
 	 * @return  bool    True if success. False on failure
 	 */
 	public function unlink( $path ) {
-		$this->debug( sprintf( 'unlink =>  %s', $path ) );
+		$this->debug( sprintf( 'unlink =>  %s', $path ), true );
 
 		$path = $this->trim_path( $path );
 
@@ -854,9 +854,10 @@ class VIP_Filesystem_Stream_Wrapper {
 	 * @since   1.0.0
 	 * @access  protected
 	 * @param   string    $message  Debug message to be logged
+	 * @param   bool      $force Whether to force debug
 	 */
-	protected function debug( $message ) {
-		if ( ! $this->debug_mode ) {
+	protected function debug( $message, $force = false ) {
+		if ( ! ( $this->debug_mode || $force ) ) {
 			return;
 		}
 
@@ -880,14 +881,14 @@ class VIP_Filesystem_Stream_Wrapper {
 	 * @return array
 	 */
 	private function backtrace_fmt() {
-		$t = debug_backtrace( false, 30 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$trace = debug_backtrace( false, 30 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 		// Discard current frame.
-		unset( $t[0] );
-		foreach ( $t as &$frame ) {
+		unset( $trace[0] );
+		foreach ( $trace as &$frame ) {
 			$frame['file'] = str_replace( ABSPATH, '', $frame['file'] ) . ':' . $frame['line'];
 			unset( $frame['line'] );
 		}
 
-		return array_values( $t );
+		return array_values( $trace );
 	}
 }

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -881,11 +881,13 @@ class VIP_Filesystem_Stream_Wrapper {
 	 * @return array
 	 */
 	private function backtrace_fmt() {
-		$trace = debug_backtrace( false, 30 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$trace = debug_backtrace( 0, 30 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 		// Discard current frame.
 		unset( $trace[0] );
 		foreach ( $trace as &$frame ) {
-			$frame['file'] = str_replace( ABSPATH, '', $frame['file'] ) . ':' . $frame['line'];
+			if ( isset( $frame['file'] ) ) {
+				$frame['file'] = str_replace( ABSPATH, '', $frame['file'] ) . ':' . $frame['line'];
+			}
 			unset( $frame['line'] );
 		}
 

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -869,7 +869,7 @@ class VIP_Filesystem_Stream_Wrapper {
 				'feature'  => 'stream_wrapper_audit_' . $trace[1]['function'],
 				'message'  => "File op {$trace[1]['function']}: " . $message,
 				'extra'    => [
-					'trace' => $this->backtrace_fmt(),
+					'trace' => $trace,
 				],
 			]
 		);


### PR DESCRIPTION
## Description

The previous debug mode used `error_log` and `wp_debug_backtrace_summary`, both can be fairly limiting. 

So we're utilizing `debug_backtrace()` which provides more information and and log2logstash as a better logging mechanism.

## Changelog Description

<!-- intentionally blank -->

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
