### PR TITLE
Change default Parse.ly to 2.6

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -15,8 +15,8 @@ namespace Automattic\VIP\WP_Parsely_Integration;
 
 // The default version is the first entry in the SUPPORTED_VERSIONS list.
 const SUPPORTED_VERSIONS = [
-	'2.5',
 	'2.6',
+	'2.5',
 ];
 
 /**


### PR DESCRIPTION
## Description

This PR changes the default Parse.ly version from 2.5 to 2.6.

## Changelog Description

### Plugin Updated: Parse.ly 2.6

We upgraded Parsely from 2.5 to 2.6.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Go to the Parse.ly dashboard and check 2.6 is the enabled version.
