### PR TITLE
Fix the pre-push Git hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+cat > /dev/null
+
 npm run phpcs:changed:remote

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "phplint": "bin/php-lint.sh",
     "phpcs": "vendor/bin/phpcs",
     "phpcs:errors": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --processors enforce --quiet",
-    "phpcs:changed:remote": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet",
-    "phpcs:changed:local": "vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet -d index",
+    "phpcs:changed:remote": "vendor/bin/phpcs --cache --report=bin/phpcs-eslint-report.php | eslines --quiet",
+    "phpcs:changed:local": "vendor/bin/phpcs --cache --report=bin/phpcs-eslint-report.php | eslines --quiet -d index",
     "lint": "npm run phplint && npm run phpcs:changed:remote",
     "update-es-wp-query": "git subtree pull --prefix search/es-wp-query git@github.com:Automattic/es-wp-query master --squash",
     "prepare": "npx husky install"


### PR DESCRIPTION
## Description

This PR fixes the pre-push hook by reading the entire stdin before invoking `phpcs`.

The issue arose because the pre-push hook receives a list of to-be-updated refs through stdin. When our hook invoked `phcs` via `npm run phpcs:changed:remote`, `phpcs` saw that the stdin is not empty and tried to read the code to check from it *instead of* reading the files specified in its configuration file. I confirmed this with `vendor/bin/phpcs -vsp`:

```
+ vendor/bin/phpcs -vsp
Registering sniffs in the VIP-Go-mu-plugins standard... DONE (291 sniffs registered)
Changing into directory .
Processing STDIN [PHP => 1 tokens in 1 lines]... DONE in 6ms (0 errors, 0 warnings)
Time: 128ms; Memory: 14MB
```

The fix is to clear the stdin before invoking `phpcs`.

## Changelog Description

### Developer Tools

 * Fix the `pre-push` hook.
 * Improve performance of the `pre-push` hook by caching check results between runs.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Create a PHP file with the code that violates the code standard and commit it.
2. Try to push the changes. Observe that `vendor/bin/phpcs --report=bin/phpcs-eslint-report.php | eslines --quiet` terminates immediately and does not generate any errors or warnings.
3. Now check out the PR and repeat steps 1 and 2. Observe that `phpcs` needs more time to run and that it now reports violations.