### PR TITLE
Search: Health - Validate counts for terms and comments indexables

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -348,7 +348,7 @@ class Health {
 
 		$health = new self( $search );
 
-		foreach( $comment_types as $comment_type ) {
+		foreach ( $comment_types as $comment_type ) {
 
 			$query_args = [
 				'type' => $comment_type,

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -78,6 +78,42 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	}
 
 	/**
+	 * ## OPTIONS
+	 *
+	 * [--version=<int>]
+	 * : Index version to validate - defaults to all
+	 *
+	 * [--network-wide]
+	 * : Validate all sites in a multisite network
+	 *
+	 * ## EXAMPLES
+	 *     wp vip-es health validate-terms-count
+	 *
+	 * @subcommand validate-terms-count
+	 */
+	public function validate_terms_count( $args, $assoc_args ) {
+		$this->validate_indexable_count( 'term', $assoc_args );
+	}
+
+		/**
+	 * ## OPTIONS
+	 *
+	 * [--version=<int>]
+	 * : Index version to validate - defaults to all
+	 *
+	 * [--network-wide]
+	 * : Validate all sites in a multisite network
+	 *
+	 * ## EXAMPLES
+	 *     wp vip-es health validate-comments-count
+	 *
+	 * @subcommand validate-comments-count
+	 */
+	public function validate_comments_count( $args, $assoc_args ) {
+		$this->validate_indexable_count( 'comment', $assoc_args );
+	}
+
+	/**
 	 * Generic internal function to validate counts on any indexable,
 	 * supporting multisite installations
 	 *
@@ -175,6 +211,16 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 					break;
 				case 'user':
 					$results = \Automattic\VIP\Search\Health::validate_index_users_count( array(
+						'index_version' => $version_number,
+					) );
+					break;
+				case 'term':
+					$results = \Automattic\VIP\Search\Health::validate_index_terms_count( array(
+						'index_version' => $version_number,
+					) );
+					break;
+				case 'comment':
+					$results = \Automattic\VIP\Search\Health::validate_index_comments_count( array(
 						'index_version' => $version_number,
 					) );
 					break;


### PR DESCRIPTION
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

The current implementation of the `wp vip-search health validate-counts` command is only validating the `Post` and `User` indexables. The goal of this PR is to validate the remaining indexables - `Term` and `Comment`.

## Changelog Description

### Search Health: validate counts of Term and Comment indexables

Add the remaining missing indexables  - `Term` and `Comment` - to the ES health validation CLI command.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. If terms and comments are not yet indexed, they will need to be enabled, [per the Enterprise Search documentation](https://docs.wpvip.com/how-tos/vip-search/vip-search-features/#h-terms). If they are, skip this step.

For terms:

```bash
# Enable term feature
$ wp vip-search activate-feature terms
# Enable the mapping
$ wp vip-search put-mapping --indexables="term"
# Index the terms
$ wp vip-search index --indexables="term"
```

For comments:

```bash
# Enable comment feature
$ wp vip-search activate-feature comments
# Enable the mapping
$ wp vip-search put-mapping --indexables="comment"
# Index the comments
$ wp vip-search index --indexables="comment"
```
3. Run `wp vip-search health validate-counts`. You should see the validation results after a short while:

```
Validating post count

✅ no inconsistencies found when counting entity: post, type: post, index_version: 1 - (DB: 1, ES: 1, Diff: 0)
✅ no inconsistencies found when counting entity: post, type: page, index_version: 1 - (DB: 5, ES: 5, Diff: 0)
✅ no inconsistencies found when counting entity: post, type: product, index_version: 1 - (DB: 7857, ES: 7857, Diff: 0)

Validating comment count

✅ no inconsistencies found when counting entity: comment, type: comment, index_version: 1 - (DB: 2, ES: 2, Diff: 0)
✅ no inconsistencies found when counting entity: comment, type: review, index_version: 1 - (DB: 1, ES: 1, Diff: 0)

Validating term count

✅ no inconsistencies found when counting entity: term, type: N/A, index_version: 1 - (DB: 367, ES: 367, Diff: 0)
```