### PR TITLE
Hooking Parsely plugin tweaks to init

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -88,6 +88,10 @@ function maybe_load_plugin() {
 add_action( 'muplugins_loaded', __NAMESPACE__ . '\maybe_load_plugin' );
 
 function maybe_disable_some_features() {
+	if ( ! apply_filters( 'wpvip_parsely_load_mu', get_option( '_wpvip_parsely_mu' ) === '1' ) ) {
+		return;
+	}
+
 	global $parsely;
 
 	if ( null != $parsely ) {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -34,8 +34,6 @@ function alter_option_use_repeated_metas( $parsely_options = [] ) {
 }
 
 function maybe_load_plugin() {
-	global $parsely;
-
 	/**
 	 * Sourcing the wp-parsely plugin via mu-plugins is generally opt-in.
 	 * To enable it on your site, add this line:
@@ -84,6 +82,15 @@ function maybe_load_plugin() {
 
 		require $entry_file;
 
+		return;
+	}
+}
+add_action( 'muplugins_loaded', __NAMESPACE__ . '\maybe_load_plugin' );
+
+function maybe_disable_some_features() {
+	global $parsely;
+
+	if ( $parsely != null ) {
 		// If the plugin was loaded solely by the option, hide the UI (for now)
 		if ( apply_filters( 'wpvip_parsely_hide_ui_for_mu', ! has_filter( 'wpvip_parsely_load_mu' ) ) ) {
 			remove_action( 'admin_menu', array( $parsely, 'add_settings_sub_menu' ) );
@@ -95,8 +102,6 @@ function maybe_load_plugin() {
 			// ..& default to "repeated metas"
 			add_filter( 'option_parsely', __NAMESPACE__ . '\alter_option_use_repeated_metas' );
 		}
-
-		return;
 	}
 }
-add_action( 'muplugins_loaded', __NAMESPACE__ . '\maybe_load_plugin' );
+add_action( 'init', __NAMESPACE__ . '\maybe_disable_some_features' );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -90,7 +90,7 @@ add_action( 'muplugins_loaded', __NAMESPACE__ . '\maybe_load_plugin' );
 function maybe_disable_some_features() {
 	global $parsely;
 
-	if ( $parsely != null ) {
+	if ( null != $parsely ) {
 		// If the plugin was loaded solely by the option, hide the UI (for now)
 		if ( apply_filters( 'wpvip_parsely_hide_ui_for_mu', ! has_filter( 'wpvip_parsely_load_mu' ) ) ) {
 			remove_action( 'admin_menu', array( $parsely, 'add_settings_sub_menu' ) );


### PR DESCRIPTION
## Description

The code after the last conditional that removes some hooks doesn't work. That happens because `$parsely` is null. This is due to the fact that it has not yet been initialized (initialization of the wp-parsely plugin happens on the `plugins_loaded` hook, whereas this code happens on `muplugins_loaded`).

This PR moves this second part of the logic to the `init` hook, where wp-parsely is already initialized.

## Changelog Description

### Fix Parse.ly initialization

Some minor checks on the Parse.ly initialization were not being called.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
