### PR TITLE
Automatically fix code style issues in files

### DIFF
--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -10,21 +10,22 @@
 
 namespace Automattic\VIP\Files\Acl;
 
-const FILE_IS_PUBLIC = 'FILE_IS_PUBLIC';
+const FILE_IS_PUBLIC              = 'FILE_IS_PUBLIC';
 const FILE_IS_PRIVATE_AND_ALLOWED = 'FILE_IS_PRIVATE_AND_ALLOWED';
-const FILE_IS_PRIVATE_AND_DENIED = 'FILE_IS_PRIVATE_AND_DENIED';
+const FILE_IS_PRIVATE_AND_DENIED  = 'FILE_IS_PRIVATE_AND_DENIED';
 
 add_action( 'muplugins_loaded', __NAMESPACE__ . '\maybe_load_restrictions' );
 
 function maybe_load_restrictions() {
-	$is_files_acl_enabled = defined( 'VIP_FILES_ACL_ENABLED' ) && true === VIP_FILES_ACL_ENABLED;
-	$is_restrict_all_enabled = get_option_as_bool( 'vip_files_acl_restrict_all_enabled' );
+	$is_files_acl_enabled            = defined( 'VIP_FILES_ACL_ENABLED' ) && true === VIP_FILES_ACL_ENABLED;
+	$is_restrict_all_enabled         = get_option_as_bool( 'vip_files_acl_restrict_all_enabled' );
 	$is_restrict_unpublished_enabled = get_option_as_bool( 'vip_files_acl_restrict_unpublished_enabled' );
 
 	if ( ! $is_files_acl_enabled ) {
 		// Throw warning if restrictions are enabled but ACL constant is not set.
 		// This is probably a sign that options were copied between sites or someone missed a setup step.
 		if ( $is_restrict_all_enabled || $is_restrict_unpublished_enabled ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error( 'File ACL restrictions are enabled without server configs (missing `VIP_FILES_ACL_ENABLED` constant).', E_USER_WARNING );
 		}
 
@@ -32,11 +33,11 @@ function maybe_load_restrictions() {
 	}
 
 	if ( $is_restrict_all_enabled ) {
-		require_once( __DIR__ . '/restrict-all-files.php' );
+		require_once __DIR__ . '/restrict-all-files.php';
 
 		add_filter( 'vip_files_acl_file_visibility', __NAMESPACE__ . '\Restrict_All_Files\check_file_visibility', 10, 2 );
 	} elseif ( $is_restrict_unpublished_enabled ) {
-		require_once( __DIR__ . '/restrict-unpublished-files.php' );
+		require_once __DIR__ . '/restrict-unpublished-files.php';
 
 		add_filter( 'vip_files_acl_file_visibility', __NAMESPACE__ . '\Restrict_Unpublished_Files\check_file_visibility', 10, 2 );
 		// Purge attachments for posts for better cacheability
@@ -44,7 +45,7 @@ function maybe_load_restrictions() {
 	}
 }
 
-function get_option_as_bool( $option_name, $default = false ) {
+function get_option_as_bool( $option_name ) {
 	$value = get_option( $option_name, false );
 
 	return in_array( $value, [
@@ -96,27 +97,26 @@ function is_valid_path_for_site( $file_path ) {
 function send_visibility_headers( $file_visibility, $file_path ) {
 	// Default to throwing an error so we can catch unexpected problems more easily.
 	$status_code = 500;
-	$header = false;
-	$is_private = null;
+	$is_private  = null;
 
 	switch ( $file_visibility ) {
 		case FILE_IS_PUBLIC:
 			$status_code = 202;
-			$is_private = false;
+			$is_private  = false;
 			break;
 
 		case FILE_IS_PRIVATE_AND_ALLOWED:
 			$status_code = 202;
-			$is_private = true;
+			$is_private  = true;
 			break;
 
 		case FILE_IS_PRIVATE_AND_DENIED:
 			$status_code = 403;
-			$is_private = true;
+			$is_private  = true;
 			break;
 
 		default:
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error( sprintf( 'Invalid file visibility (%s) ACL set for %s', $file_visibility, $file_path ), E_USER_WARNING );
 			break;
 	}

--- a/files/acl/endpoint-check-file-acl.php
+++ b/files/acl/endpoint-check-file-acl.php
@@ -4,8 +4,8 @@ namespace Automattic\VIP\Files\Acl;
 
 require_once __DIR__ . '/pre-wp-utils.php';
 
-$vip_files_acl_original_uri = $_SERVER['HTTP_X_ORIGINAL_URI'] ?? null;
-$vip_files_acl_paths = Pre_WP_Utils\prepare_request( $vip_files_acl_original_uri );
+$vip_files_acl_original_uri = $_SERVER['HTTP_X_ORIGINAL_URI'] ?? null;                      // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+$vip_files_acl_paths        = Pre_WP_Utils\prepare_request( $vip_files_acl_original_uri );
 
 if ( ! $vip_files_acl_paths ) {
 	// Note: a 400 might be more appropriate but we're limited in terms of response codes.
@@ -18,7 +18,7 @@ if ( ! $vip_files_acl_paths ) {
 list( $vip_files_acl_subsite_path, $vip_files_acl_sanitized_file_path ) = $vip_files_acl_paths;
 
 if ( $vip_files_acl_subsite_path ) {
-	$_SERVER['REQUEST_URI'] = $vip_files_acl_subsite_path . ( $_SERVER['REQUEST_URI'] ?? '' );
+	$_SERVER['REQUEST_URI'] = $vip_files_acl_subsite_path . ( $_SERVER['REQUEST_URI'] ?? '' );  // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 }
 
 // Load WordPress
@@ -26,7 +26,7 @@ require __DIR__ . '/../../../../wp-load.php';
 
 $vip_files_acl_is_path_allowed = is_valid_path_for_site( $vip_files_acl_sanitized_file_path );
 if ( ! $vip_files_acl_is_path_allowed ) {
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- using htmlspecialchars, which PHPCS complains about
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped -- using htmlspecialchars, which PHPCS complains about
 	trigger_error( sprintf( 'Blocked request for file path that is not allowed (current site ID: %s | requested URI: %s)', (int) get_current_blog_id(), htmlspecialchars( $vip_files_acl_original_uri ) ), E_USER_WARNING );
 
 	http_response_code( 400 );

--- a/files/acl/pre-wp-utils.php
+++ b/files/acl/pre-wp-utils.php
@@ -19,12 +19,12 @@ namespace Automattic\VIP\Files\Acl\Pre_WP_Utils;
  */
 function prepare_request( $file_request_uri ) {
 	if ( ! $file_request_uri ) {
-		trigger_error( 'VIP Files ACL failed due to empty URI', E_USER_WARNING );
+		trigger_error( 'VIP Files ACL failed due to empty URI', E_USER_WARNING );   // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 
 		return false;
 	}
 
-	$file_path = parse_url( $file_request_uri, PHP_URL_PATH );
+	$file_path = parse_url( $file_request_uri, PHP_URL_PATH );  // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 
 	$is_valid_path = validate_path( $file_path );
 	if ( ! $is_valid_path ) {
@@ -44,14 +44,14 @@ function prepare_request( $file_request_uri ) {
  */
 function validate_path( $file_path ) {
 	if ( ! $file_path ) {
-		trigger_error( 'VIP Files ACL failed due to empty path', E_USER_WARNING );
+		trigger_error( 'VIP Files ACL failed due to empty path', E_USER_WARNING );  // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 
 		return false;
 	}
 
 	// Relative path not allowed
 	if ( '/' !== $file_path[0] ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		trigger_error( sprintf( 'VIP Files ACL failed due to relative path (for %s)', htmlspecialchars( $file_path ) ), E_USER_WARNING );
 
 		return false;
@@ -60,7 +60,7 @@ function validate_path( $file_path ) {
 	// Missing `/wp-content/uploads/`.
 	// Using `strpos` since we can have subsite / subdirectory paths.
 	if ( false === strpos( $file_path, '/wp-content/uploads/' ) ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		trigger_error( sprintf( 'VIP Files ACL failed due to invalid path (for %s)', htmlspecialchars( $file_path ) ), E_USER_WARNING );
 
 		return false;

--- a/files/acl/restrict-all-files.php
+++ b/files/acl/restrict-all-files.php
@@ -5,7 +5,6 @@
 
 namespace Automattic\VIP\Files\Acl\Restrict_All_Files;
 
-use const Automattic\VIP\Files\Acl\FILE_IS_PUBLIC;
 use const Automattic\VIP\Files\Acl\FILE_IS_PRIVATE_AND_DENIED;
 use const Automattic\VIP\Files\Acl\FILE_IS_PRIVATE_AND_ALLOWED;
 

--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -71,7 +71,7 @@ function check_file_visibility( $file_visibility, $file_path ) {
 function get_attachment_id_from_file_path( $path ) {
 	global $wpdb;
 
-	$cache_key = 'path_' . md5( $path );
+	$cache_key     = 'path_' . md5( $path );
 	$attachment_id = wp_cache_get( $cache_key, CACHE_GROUP );
 	if ( false !== $attachment_id ) {
 		return $attachment_id;
@@ -79,6 +79,7 @@ function get_attachment_id_from_file_path( $path ) {
 
 	$attachment_id = 0;
 
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 	$results = $wpdb->get_results(
 		$wpdb->prepare(
 			"SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = '_wp_attached_file' AND meta_value = %s",
@@ -125,12 +126,12 @@ function purge_attachments_for_post( $urls, $post_id ) {
 	}
 
 	$attachment_ids = get_posts( [
-		'post_parent'    => $post->ID,
-		'post_type'      => 'attachment',
-		'posts_per_page' => 250,            // Set a reasonably high limit (instead of -1 as default)
-		'orderby'        => 'ID',           // For performance (instead of `date` as default)
-		'order'          => 'ASC',
-		'fields'         => 'ids',
+		'post_parent'      => $post->ID,
+		'post_type'        => 'attachment',
+		'posts_per_page'   => 250,            // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- set a reasonably high limit (instead of -1 as default)
+		'orderby'          => 'ID',           // For performance (instead of date as default)
+		'order'            => 'ASC',
+		'fields'           => 'ids',
 		// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFiltersTrue
 		'suppress_filters' => true,
 	] );

--- a/files/class-api-cache.php
+++ b/files/class-api-cache.php
@@ -49,8 +49,8 @@ class API_Cache {
 			return;
 		}
 
-		foreach( $this->files as $name => $path ) {
-			unlink( $path );
+		foreach ( $this->files as $name => $path ) {
+			unlink( $path );                // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 			unset( $this->files[ $name ] );
 		}
 
@@ -97,6 +97,7 @@ class API_Cache {
 
 	public function remove_file( $filepath ) {
 		if ( isset( $this->files[ $filepath ] ) ) {
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 			unlink( $this->files[ $filepath ] );
 			unset( $this->files[ $filepath ] );
 		}
@@ -111,6 +112,7 @@ class API_Cache {
 	}
 
 	public function create_tmp_file() {
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_tempnam
 		return tempnam( $this->tmp_dir, 'vip' );
 	}
 }

--- a/files/class-curl-streamer.php
+++ b/files/class-curl-streamer.php
@@ -19,11 +19,12 @@ class Curl_Streamer {
 		remove_action( 'http_api_curl', [ $this, 'init_upload' ] );
 	}
 
-	public function enforce_curl_transport( $transports ) {
+	public function enforce_curl_transport() {
 		return [ 'curl' ];
 	}
 
-	public function init_upload( $curl_handle, $request_args, $url ) {
+	public function init_upload( $curl_handle ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- FP - the file is opened read-only
 		$file_stream = fopen( $this->file_path, 'r' );
 
 		if ( ! $file_stream ) {
@@ -32,15 +33,16 @@ class Curl_Streamer {
 
 		$file_size = filesize( $this->file_path );
 
+		// phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_setopt
 		curl_setopt( $curl_handle, CURLOPT_PUT, true ); // The Requests lib only sets `CURLOPT_CUSTOMREQUEST`; we need to explicitly set `CURLOPT_PUT` as well.
-
 		curl_setopt( $curl_handle, CURLOPT_INFILE, $file_stream );
 		curl_setopt( $curl_handle, CURLOPT_INFILESIZE, $file_size );
-
 		curl_setopt( $curl_handle, CURLOPT_READFUNCTION, [ $this, 'handle_upload' ] );
+		// phpcs:enable WordPress.WP.AlternativeFunctions.curl_curl_setopt
 	}
 
 	public function handle_upload( $curl_handle, $file_stream, $length ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fread
 		$data = fread( $file_stream, $length );
 		if ( ! $data ) {
 			return '';

--- a/files/class-image-sizes.php
+++ b/files/class-image-sizes.php
@@ -60,11 +60,15 @@ class ImageSizes {
 		 * to prevent creation of intermediate files, which are not really being used.
 		 */
 		remove_filter( 'intermediate_image_sizes', 'wpcom_intermediate_sizes' );
-		$intermediate_image_sizes = get_intermediate_image_sizes();
-		add_filter( 'intermediate_image_sizes', 'wpcom_intermediate_sizes' ); // Re-add the filter.
+		$intermediate_image_sizes = get_intermediate_image_sizes();             // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_intermediate_image_sizes_get_intermediate_image_sizes
+		add_filter( 'intermediate_image_sizes', 'wpcom_intermediate_sizes' );   // Re-add the filter.
 
 		foreach ( $intermediate_image_sizes as $s ) {
-			$sizes[ $s ] = [ 'width' => '', 'height' => '', 'crop' => false ];
+			$sizes[ $s ] = [
+				'width'  => '',
+				'height' => '',
+				'crop'   => false,
+			];
 			if ( isset( $_wp_additional_image_sizes[ $s ]['width'] ) ) {
 				// For theme-added sizes.
 				$sizes[ $s ]['width'] = intval( $_wp_additional_image_sizes[ $s ]['width'] );
@@ -125,9 +129,9 @@ class ImageSizes {
 		}
 
 		$defaults = [
-			'width' => null,
+			'width'  => null,
 			'height' => null,
-			'crop' => false,
+			'crop'   => false,
 		];
 
 		return array_merge( $defaults, $size_data );

--- a/files/class-image.php
+++ b/files/class-image.php
@@ -14,7 +14,7 @@ class Image {
 	/** @var string $filename Attachment's Filename. */
 	public $filename;
 
-	/** @var string/WP_Erorr $mime_type Attachment's mime-type, WP_Error on failure when recalculating the dimensions. */
+	/** @var string|\WP_Error $mime_type Attachment's mime-type, WP_Error on failure when recalculating the dimensions. */
 	private $mime_type;
 
 	/** @var int $original_width Image original width. */
@@ -44,10 +44,12 @@ class Image {
 	 * @param string|\WP_Error $mime_type Typically value returned from get_post_mime_type function.
 	 */
 	public function __construct( $data, $mime_type ) {
-		$this->filename = $data['file'];
-		$this->width = $this->original_width = $data['width'];
-		$this->height = $this->original_height = $data['height'];
-		$this->mime_type = $mime_type;
+		$this->filename        = $data['file'];
+		$this->original_width  = $data['width'];
+		$this->original_height = $data['height'];
+		$this->width           = $data['width'];
+		$this->height          = $data['height'];
+		$this->mime_type       = $mime_type;
 	}
 
 	/**
@@ -71,7 +73,8 @@ class Image {
 
 		$this->set_width_height( $dimensions );
 
-		return $this->is_resized = true;
+		$this->is_resized = true;
+		return true;
 	}
 
 	/**
@@ -90,9 +93,9 @@ class Image {
 		}
 
 		return [
-			'file' => $this->get_filename(),
-			'width' => $this->get_width(),
-			'height' => $this->get_height(),
+			'file'      => $this->get_filename(),
+			'width'     => $this->get_width(),
+			'height'    => $this->get_height(),
 			'mime-type' => $this->get_mime_type(),
 		];
 	}
@@ -103,8 +106,8 @@ class Image {
 	 * @return bool True on successful reset to original dimensions.
 	 */
 	public function reset_to_original() {
-		$this->width = $this->original_width;
-		$this->height = $this->original_height;
+		$this->width      = $this->original_width;
+		$this->height     = $this->original_height;
 		$this->is_resized = false;
 
 		return true;
@@ -173,7 +176,7 @@ class Image {
 			'resize' => join( ',', [
 				$this->get_width(),
 				$this->get_height(),
-			] )
+			] ),
 		];
 
 		return add_query_arg( $query_args, $this->filename );
@@ -206,7 +209,7 @@ class Image {
 			'dst_w',
 			'dst_h',
 			'src_w',
-			'src_h'
+			'src_h',
 		], $dimensions );
 	}
 
@@ -216,7 +219,7 @@ class Image {
 	 * @return void
 	 */
 	protected function set_width_height( $dimensions ) {
-		$this->width = (int) $dimensions['dst_w'];
+		$this->width  = (int) $dimensions['dst_w'];
 		$this->height = (int) $dimensions['dst_h'];
 	}
 

--- a/files/class-meta-updater.php
+++ b/files/class-meta-updater.php
@@ -43,10 +43,11 @@ class Meta_Updater {
 		$this->batch_size = $batch_size;
 
 		if ( $log_file ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
 			$this->log_file = fopen( $log_file, 'w' );
 		}
 
-		$this->count = array_sum( ( array ) wp_count_posts( 'attachment' ) );
+		$this->count = array_sum( (array) wp_count_posts( 'attachment' ) );
 	}
 
 	/**
@@ -82,7 +83,8 @@ class Meta_Updater {
 
 		global $wpdb;
 
-		$this->max_id = (int) $wpdb->get_var( 'SELECT ID FROM ' . $wpdb->posts . ' ORDER BY ID DESC LIMIT 1' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$this->max_id = (int) $wpdb->get_var( "SELECT MAX(ID) FROM {$wpdb->posts}" );
 
 		return $this->max_id;
 	}
@@ -98,9 +100,10 @@ class Meta_Updater {
 	public function get_attachments( int $start_index = 0, int $end_index = 0 ): array {
 		global $wpdb;
 
-		$sql = $wpdb->prepare( 'SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = "attachment" AND ID BETWEEN %d AND %d',
-			$start_index, $end_index );
-		$attachments = $wpdb->get_col( $sql );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$attachments = $wpdb->get_col(
+			$wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'attachment' AND ID BETWEEN %d AND %d", $start_index, $end_index )
+		);
 
 		// Only return attachments without filesize
 		$filtered = [];
@@ -134,8 +137,9 @@ class Meta_Updater {
 			$counts[ $result ]++;
 
 			if ( $this->log_file ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
 				fputcsv( $this->log_file, [
-					date( 'c' ),
+					gmdate( 'c' ),
 					$attachment_id,
 					$result,
 					$details,
@@ -197,7 +201,8 @@ class Meta_Updater {
 
 		$response = wp_remote_head( $attachment_url );
 		if ( is_wp_error( $response ) ) {
-			trigger_error( sprintf( '%s: failed to HEAD attachment %s because %s', __METHOD__, $attachment_url, $response->get_error_message() ), E_USER_WARNING );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error( sprintf( '%s: failed to HEAD attachment %s because %s', __METHOD__, esc_html( $attachment_url ), esc_html( $response->get_error_message() ) ), E_USER_WARNING );
 			return 0;
 		}
 

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -229,6 +229,7 @@ class VIP_Filesystem {
 
 		if ( is_wp_error( $result ) ) {
 			if ( 'invalid-file-type' !== $result->get_error_code() ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				trigger_error(
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					sprintf( '%s #vip-go-streams', $result->get_error_message() ),
@@ -280,6 +281,7 @@ class VIP_Filesystem {
 			return '';
 		}
 
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		if ( ! unlink( $file_path ) ) {
 			return '';
 		}
@@ -389,7 +391,7 @@ class VIP_Filesystem {
 		$invalidation_url = get_site_url() . $file_uri;
 
 		if ( ! \WPCOM_VIP_Cache_Manager::instance()->queue_purge_url( $invalidation_url ) ) {
-			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				/* translators: invalidation url */
 				sprintf( __( 'Error purging %s from the cache service #vip-go-streams' ), $invalidation_url ),
@@ -443,11 +445,13 @@ class VIP_Filesystem {
 
 		// Save a local copy and read metadata from that
 		$temp_file = wp_tempnam();
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents, WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		file_put_contents( $temp_file, file_get_contents( $file ) );
 		$meta = wp_read_image_metadata( $temp_file );
 
 		add_filter( 'wp_read_image_metadata', [ $this, 'filter_wp_read_image_metadata' ], 10, 2 );
 
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		unlink( $temp_file );
 
 		return $meta;

--- a/files/class-wp-filesystem-vip-uploads.php
+++ b/files/class-wp-filesystem-vip-uploads.php
@@ -2,9 +2,9 @@
 
 namespace Automattic\VIP\Files;
 
-require_once( ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php' );
+require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 
-require_once( __DIR__ . '/class-api-client.php' );
+require_once __DIR__ . '/class-api-client.php';
 
 class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 
@@ -26,7 +26,7 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 		$sanitized_path = $path;
 
 		$wp_content_dir = WP_CONTENT_DIR;
-		$upload_dir = wp_get_upload_dir();
+		$upload_dir     = wp_get_upload_dir();
 		$upload_basedir = $upload_dir['basedir'];
 
 		// WP_CONTENT_DIR and wp_get_upload_dir() may not be the same.
@@ -106,12 +106,13 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	public function put_contents( $file_path, $contents, $mode = false ) {
 		$uploads_path = $this->sanitize_uploads_path( $file_path );
 
-		$file_name = basename( $file_path );
-		$tmp_file_path = tempnam( get_temp_dir(), 'uploads-' . $file_name );
-		file_put_contents( $tmp_file_path, $contents );
+		$file_name     = basename( $file_path );
+		$tmp_file_path = tempnam( get_temp_dir(), 'uploads-' . $file_name );    // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_tempnam
+		file_put_contents( $tmp_file_path, $contents );                         // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
 
 		$response = $this->api->upload_file( $tmp_file_path, $uploads_path );
 
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		unlink( $tmp_file_path );
 
 		if ( is_wp_error( $response ) ) {
@@ -267,10 +268,12 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 * @return bool True if file copied successfully, False otherwise.
 	 */
 	public function copy( $source, $destination, $overwrite = false, $mode = false ) {
+		// translators: 1: method name
 		$error_msg = sprintf( __( 'The `%s` method cannot be called directly. Please use `WP_Filesystem_VIP::copy` instead' ), __METHOD__ );
 
 		$this->errors->add( 'incorrect-usage', $error_msg );
 
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped
 		trigger_error( $error_msg, E_USER_WARNING );
 
 		return false;
@@ -289,10 +292,12 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 * @return bool True if file copied successfully, False otherwise.
 	 */
 	public function move( $source, $destination, $overwrite = false ) {
+		// translators: 1 - method name
 		$error_msg = sprintf( __( 'The `%s` method cannot be called directly. Please use `WP_Filesystem_VIP::move` instead' ), __METHOD__ );
 
 		$this->errors->add( 'incorrect-usage', $error_msg );
 
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped
 		trigger_error( $error_msg, E_USER_WARNING );
 
 		return false;
@@ -479,6 +484,7 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 
 		$this->errors->add( 'unimplemented-method', $error_msg );
 
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped
 		trigger_error( $error_msg, E_USER_WARNING );
 
 		return $return_value;

--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -2,20 +2,18 @@
 
 namespace Automattic\VIP\Files;
 
-require_once( ABSPATH . 'wp-admin/includes/file.php' );
-require_once( ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php' );
-require_once( ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php' );
+require_once ABSPATH . 'wp-admin/includes/file.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 
-require_once( __DIR__ . '/class-wp-filesystem-vip-uploads.php' );
-require_once( __DIR__ . '/class-api-client.php' );
+require_once __DIR__ . '/class-wp-filesystem-vip-uploads.php';
+require_once __DIR__ . '/class-api-client.php';
 
 use WP_Error;
 use WP_Filesystem_Direct;
 
 class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 
-	/** @var WP_Filesystem_VIP_Uploads */
-	private $api;
 	/** @var WP_Filesystem_Direct */
 	private $direct;
 
@@ -79,7 +77,7 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 		}
 
 		$upload_dir = wp_get_upload_dir()['basedir'];
-		$temp_dir = get_temp_dir();
+		$temp_dir   = get_temp_dir();
 
 		/* Translators: 1) file name 2) class name 3) tmp dir path 4) uploads dir path */
 		$error_msg = sprintf( __( 'The `%1$s` file cannot be managed by the `%2$s` class. Writes are only allowed for the `%3$s` and `%4$s` directories and reads can be performed everywhere.' ), $filename, __CLASS__, $temp_dir, $upload_dir );
@@ -87,7 +85,8 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 		$this->errors->add( 'unsupported-filepath', $error_msg );
 
 		// TODO: Do we want to trigger_error in all environments? (Or just a small batch to start).
-		trigger_error( $error_msg, E_USER_WARNING );
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		trigger_error( esc_html( $error_msg ), E_USER_WARNING );
 
 		return false;
 	}
@@ -221,7 +220,7 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 
 		$destination_exists = $destination_transport->exists( $destination );
 		if ( ! $overwrite && $destination_exists ) {
-			/* translators 1: destination file path 2: overwrite param 3: `true` boolean value */
+			/* translators: 1: destination file path 2: overwrite param 3: `true` boolean value */
 			$this->errors->add( 'destination-exists', sprintf( __( 'The destination path (`%1$s`) already exists and `%2$s` was not not set to `%3$s`.' ), $destination, '$overwrite', 'true' ) );
 			return false;
 		}

--- a/files/init-filesystem.php
+++ b/files/init-filesystem.php
@@ -16,24 +16,24 @@
 
 define( 'VIP_FILESYSTEM_METHOD', 'VIP' );
 
-require_once( ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php' );
+require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 
-require_once( __DIR__ . '/class-wp-filesystem-vip.php' );
-require_once( __DIR__ . '/class-api-client.php' );
+require_once __DIR__ . '/class-wp-filesystem-vip.php';
+require_once __DIR__ . '/class-api-client.php';
 
 // Stub class to match the format that `WP_Filesystem()` expects.
 // it does a check for class_exists() of the filesystem method i.e. `WP_Filesystem_{type}`
 class WP_Filesystem_VIP extends Automattic\VIP\Files\WP_Filesystem_VIP {}
 
-add_filter( 'filesystem_method', function( $method, $args, $context, $allow_relaxed_file_ownership ) {
+add_filter( 'filesystem_method', function() {
 	return VIP_FILESYSTEM_METHOD; // The VIP base class transparently handles using the direct filesystem as well as the VIP Go File API
-}, PHP_INT_MAX, 4 );
+}, PHP_INT_MAX );
 
-add_filter( 'request_filesystem_credentials', function( $credentials, $form_post, $type, $error, $context, $extra_fields, $allow_relaxed_file_ownership ) {
+add_filter( 'request_filesystem_credentials', function( $credentials, $form_post, $type ) {
 	// Handle the default `''` case which we'll override thanks to the `filesystem_method` filter.
 	if ( '' === $type || VIP_FILESYSTEM_METHOD === $type ) {
-		if ( true === WPCOM_IS_VIP_ENV ){
-			$api_client = Automattic\VIP\Files\new_api_client();
+		if ( true === WPCOM_IS_VIP_ENV ) {
+			$api_client  = Automattic\VIP\Files\new_api_client();
 			$credentials = [
 				new Automattic\VIP\Files\WP_Filesystem_VIP_Uploads( $api_client ),
 				new WP_Filesystem_Direct( null ),
@@ -47,7 +47,7 @@ add_filter( 'request_filesystem_credentials', function( $credentials, $form_post
 		}
 	}
 	return $credentials;
-}, PHP_INT_MAX, 7 );
+}, PHP_INT_MAX, 3 );
 
 // Should't need this because we `require`-ed the class already.
 // But just in case :)


### PR DESCRIPTION
## Description

This PR fixes issues found by `phpcs` in `files`. Most of them were automatically corrected by `phpcbf`; for the others, I have added `phpcs:ignore` annotations as needed (or fixed, where this was required to pass the CI).

There are many `WordPress.Security.EscapeOutput.OutputNotEscaped` issues, but I am going to fix them in another PR to keep the size of the changeset small.

## Changelog Description

### VIP Filesystem

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Fix code standards compliance issues

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Make sure the CI passes.
