### PR TITLE
Conditionally loading init action on wp-parsely

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -54,6 +54,9 @@ function maybe_load_plugin() {
 		return;
 	}
 
+	// Enqueuing the disabling of Parse.ly features when the plugin is loaded (after the `plugins_loaded` hook)
+	add_action( 'init', __NAMESPACE__ . '\maybe_disable_some_features' );
+
 	$versions_to_try = SUPPORTED_VERSIONS;
 
 	/**
@@ -88,10 +91,6 @@ function maybe_load_plugin() {
 add_action( 'muplugins_loaded', __NAMESPACE__ . '\maybe_load_plugin' );
 
 function maybe_disable_some_features() {
-	if ( ! apply_filters( 'wpvip_parsely_load_mu', get_option( '_wpvip_parsely_mu' ) === '1' ) ) {
-		return;
-	}
-
 	global $parsely;
 
 	if ( null != $parsely ) {
@@ -108,4 +107,3 @@ function maybe_disable_some_features() {
 		}
 	}
 }
-add_action( 'init', __NAMESPACE__ . '\maybe_disable_some_features' );


### PR DESCRIPTION
## Description

This PR builds on top of https://github.com/Automattic/vip-go-mu-plugins/pull/2459. We keep the functionality, but we avoid doing a further conditional check by only enqueuing the `init` action once we're sure we loaded Parse.ly through mu-plugins.

## Changelog Description

### Conditionally loading init action on wp-parsely

Improving the way the wp-parsely plugin is loaded through mu-plugins.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Enable Parse.ly through the option. Check no Parse.ly UI is visible on wp-admin.
3. Enable Parse.ly through the filter. Check that the UI is visible now.