### PR TITLE
Don't use global declaration on Parse.ly

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -91,16 +91,14 @@ function maybe_load_plugin() {
 add_action( 'muplugins_loaded', __NAMESPACE__ . '\maybe_load_plugin' );
 
 function maybe_disable_some_features() {
-	global $parsely;
-
-	if ( null != $parsely ) {
+	if ( $GLOBALS['parsely'] && is_a( $GLOBALS['parsely'], 'Parsely' ) ) {
 		// If the plugin was loaded solely by the option, hide the UI (for now)
 		if ( apply_filters( 'wpvip_parsely_hide_ui_for_mu', ! has_filter( 'wpvip_parsely_load_mu' ) ) ) {
-			remove_action( 'admin_menu', array( $parsely, 'add_settings_sub_menu' ) );
-			remove_action( 'admin_footer', array( $parsely, 'display_admin_warning' ) );
+			remove_action( 'admin_menu', array( $GLOBALS['parsely'], 'add_settings_sub_menu' ) );
+			remove_action( 'admin_footer', array( $GLOBALS['parsely'], 'display_admin_warning' ) );
 			remove_action( 'widgets_init', 'parsely_recommended_widget_register' );
-			remove_filter( 'page_row_actions', array( $parsely, 'row_actions_add_parsely_link' ) );
-			remove_filter( 'post_row_actions', array( $parsely, 'row_actions_add_parsely_link' ) );
+			remove_filter( 'page_row_actions', array( $GLOBALS['parsely'], 'row_actions_add_parsely_link' ) );
+			remove_filter( 'post_row_actions', array( $GLOBALS['parsely'], 'row_actions_add_parsely_link' ) );
 
 			// ..& default to "repeated metas"
 			add_filter( 'option_parsely', __NAMESPACE__ . '\alter_option_use_repeated_metas' );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -91,7 +91,7 @@ function maybe_load_plugin() {
 add_action( 'muplugins_loaded', __NAMESPACE__ . '\maybe_load_plugin' );
 
 function maybe_disable_some_features() {
-	if ( $GLOBALS['parsely'] && is_a( $GLOBALS['parsely'], 'Parsely' ) ) {
+	if ( isset( $GLOBALS['parsely'] ) && is_a( $GLOBALS['parsely'], 'Parsely' ) ) {
 		// If the plugin was loaded solely by the option, hide the UI (for now)
 		if ( apply_filters( 'wpvip_parsely_hide_ui_for_mu', ! has_filter( 'wpvip_parsely_load_mu' ) ) ) {
 			remove_action( 'admin_menu', array( $GLOBALS['parsely'], 'add_settings_sub_menu' ) );


### PR DESCRIPTION
## Description

Instead of using potentially problematic `global $parsely`, we're moving to the use of safer `$GLOBALS['parsely']`.

## Changelog Description

### Don't use global declaration on Parse.ly

We are implementing a safer way of loading the Parse.ly plugin.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.