### PR TITLE
Fix code style issues and code smells in `000-debug`

### DIFF
--- a/000-debug/0-load.php
+++ b/000-debug/0-load.php
@@ -2,6 +2,6 @@
 
 namespace Automattic\VIP\Debug;
 
-require_once( __DIR__ . '/logger.php' );
-require_once( __DIR__ . '/debug-mode.php' );
-require_once( __DIR__ . '/not-proxied-flag.php' );
+require_once __DIR__ . '/logger.php';
+require_once __DIR__ . '/debug-mode.php';
+require_once __DIR__ . '/not-proxied-flag.php';

--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -25,6 +25,7 @@ const COOKIE_TTL = 2 * HOUR_IN_SECONDS;
 add_action( 'muplugins_loaded', __NAMESPACE__ . '\init_debug_mode' );
 
 function init_debug_mode() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['a8c-debug'] ) ) {
 		toggle_debug_mode();
 		return;
@@ -36,10 +37,10 @@ function init_debug_mode() {
 }
 
 function is_debug_mode_enabled() {
-	$is_nocache = isset( $_COOKIE['vip-go-cb'] ) && '1' === $_COOKIE['vip-go-cb'];
-	$is_debug = isset( $_COOKIE['a8c-debug'] ) && '1' === $_COOKIE['a8c-debug'];
+	$is_nocache = isset( $_COOKIE['vip-go-cb'] ) && '1' === $_COOKIE['vip-go-cb'];  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+	$is_debug   = isset( $_COOKIE['a8c-debug'] ) && '1' === $_COOKIE['a8c-debug'];  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	$is_proxied = \is_proxied_request();
-	$is_local = defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === WP_ENVIRONMENT_TYPE;
+	$is_local   = defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === WP_ENVIRONMENT_TYPE;
 
 	if ( ( $is_nocache && $is_debug && $is_proxied ) || $is_local ) {
 		return true;
@@ -51,7 +52,7 @@ function is_debug_mode_enabled() {
 function redirect_back() {
 	$redirect_to = add_query_arg( [
 		// Redirect to the same page without the activation handler.
-		'a8c-debug' => false,
+		'a8c-debug'    => false,
 
 		// Redirect with a cache buster on the URL to avoid browser-based caches.
 		'_cachebuster' => time(),
@@ -72,8 +73,8 @@ function enable_debug_mode() {
 	}
 
 	$ttl = time() + COOKIE_TTL;
-	setcookie( 'vip-go-cb', '1', $ttl );
-	setcookie( 'a8c-debug', '1', $ttl );
+	setcookie( 'vip-go-cb', '1', $ttl );    // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+	setcookie( 'a8c-debug', '1', $ttl );    // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 
 	send_pixel( [ 'vip-go-a8c-debug' => 'enable' ] );
 
@@ -84,8 +85,8 @@ function disable_debug_mode() {
 	nocache_headers();
 
 	$ttl = time() - COOKIE_TTL;
-	setcookie( 'vip-go-cb', '', $ttl );
-	setcookie( 'a8c-debug', '', $ttl );
+	setcookie( 'vip-go-cb', '', $ttl );     // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+	setcookie( 'a8c-debug', '', $ttl );     // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 
 	send_pixel( [ 'vip-go-a8c-debug' => 'disable' ] );
 
@@ -93,23 +94,24 @@ function disable_debug_mode() {
 }
 
 function toggle_debug_mode() {
+	// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated -- we check if `a8c-debug` exists in `init_debug_mode`
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( 'true' === $_GET['a8c-debug'] ) {
 		enable_debug_mode();
-		return;
-    } elseif ( 'false' === $_GET['a8c-debug'] ) {
+	} elseif ( 'false' === $_GET['a8c-debug'] ) {
 		disable_debug_mode();
-		return;
 	}
+	// phpcs:enable
 }
 
 function enable_debug_tools() {
-	add_filter( 'user_has_cap', function( $user_caps, $caps, $args, $user ) {
-		if ( 'view_query_monitor' === $args[ 0 ] ) {
+	add_filter( 'user_has_cap', function( $user_caps, $caps, $args ) {
+		if ( 'view_query_monitor' === $args[0] ) {
 			$user_caps['view_query_monitor'] = true;
 		}
 
 		return $user_caps;
-	}, 10, 4 );
+	}, 10, 3 );
 
 	add_action( 'wp_footer', __NAMESPACE__ . '\show_debug_flag', 9999 ); // output later in the page
 	add_action( 'login_footer', __NAMESPACE__ . '\show_debug_flag', 9999 ); // output later in the page
@@ -119,7 +121,7 @@ function show_debug_flag() {
 	$disable_url = add_query_arg( [
 		'a8c-debug' => 'false',
 		// Remove the cache-buster, if set.
-		'random' => false,
+		'random'    => false,
 	] );
 
 	?>

--- a/000-debug/logger.php
+++ b/000-debug/logger.php
@@ -50,10 +50,12 @@ function l( $stuff = null, ...$rest ) {
 		return $stuff;
 	}
 	if ( ! isset( $pageload ) ) {
-		$pageload = substr( md5( mt_rand() ), 0, 4 );
+		$pageload = substr( md5( wp_rand() ), 0, 4 );
 		if ( ! empty( $_SERVER['argv'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$hint = implode( ' ', $_SERVER['argv'] );
 		} elseif ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$hint = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		} else {
 			$hint = php_sapi_name();
@@ -65,8 +67,8 @@ function l( $stuff = null, ...$rest ) {
 	$pid = $pageload . '-' . getmypid();
 	if ( is_null( $stuff ) ) {
 		// Log the file and line number
-		// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
-		$backtrace = debug_backtrace( false );
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 		while ( isset( $backtrace[1]['function'] ) && __FUNCTION__ == $backtrace[1]['function'] ) {
 			array_shift( $backtrace );
 		}
@@ -94,8 +96,8 @@ function l( $stuff = null, ...$rest ) {
 			if ( array( 'default output handler' ) == $obs ) {
 				break;
 			}
-			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
-			$backtrace = debug_backtrace( false );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+			$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 			foreach ( $backtrace as $level ) {
 				$caller = '';
 				if ( isset( $level['class'] ) ) {
@@ -111,6 +113,7 @@ function l( $stuff = null, ...$rest ) {
 		if ( $in_ob_handler ) {
 			$log = l_json_encode_pretty( $stuff );
 		} else {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			$log = print_r( $stuff, true );
 		}
 	}
@@ -123,7 +126,7 @@ function l( $stuff = null, ...$rest ) {
 // Log only once (suppresses logging on subsequent calls from the same file+line)
 function lo( $stuff, ...$rest ) {
 	static $callers = array();
-	$backtrace      = debug_backtrace( false );
+	$backtrace      = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );       // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 	$caller         = md5( $backtrace[0]['file'] . $backtrace[0]['line'] );
 	if ( isset( $callers[ $caller ] ) ) {
 		return $stuff;
@@ -137,11 +140,11 @@ function lo( $stuff, ...$rest ) {
 function l_json_encode_pretty( $data ) {
 	if ( defined( 'JSON_PRETTY_PRINT' ) ) {
 		// Added in PHP 5.4.0
-		return json_encode( $data, JSON_PRETTY_PRINT );
+		return wp_json_encode( $data, JSON_PRETTY_PRINT );
 	}
 
 	// Adapted from http://us3.php.net/manual/en/function.json-encode.php#80339
-	$json = json_encode( $data );
+	$json = wp_json_encode( $data );
 	$len  = strlen( $json );
 
 	$tab          = "\t";
@@ -205,7 +208,7 @@ function vip_timer( $name = '' ) {
 	static $times = array();
 	if ( ! array_key_exists( $name, $times ) ) {
 		$times[ $name ] = microtime( true );
-		return;
+		return null;
 	}
 	$elapsed = microtime( true ) - $times[ $name ];
 	unset( $times[ $name ] );
@@ -240,7 +243,8 @@ function t() {
 		$start = $now;
 	}
 
-	$backtrace = debug_backtrace( false );
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+	$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 	while ( isset( $backtrace[1]['function'] ) && __FUNCTION__ == $backtrace[1]['function'] ) {
 		array_shift( $backtrace );
 	}


### PR DESCRIPTION
## Description

This PR fixes code style compliance issues found by `phpcs` and a couple of code smells found by `sonarlint`.

## Changelog Description

### Fix code style compliance issues in `000-debug` directory
  * Fix issues found by phpcs;
  * Add phpcs:ignore where appropriate to suppress false positives or known good code;
  * Fix code smells detected by `sonarlint`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Make sure that CI passes successfully
