### PR TITLE
Search: Fix `get-indexes` command to return accurate results

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -324,4 +324,33 @@ class CoreCommand extends \ElasticPress\Command {
 
 		WP_CLI::confirm( '⚠️  You are about to run ' . WP_CLI::colorize( '%ra destructive operation%n' ) . '. Are you sure?' );
 	}
+
+	/**
+	 * Return all index names as a JSON object.
+	 * 
+	 * @subcommand get-indexes
+	 * 
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get_indexes( $args, $assoc_args ) {
+		$path = '_cat/indices?format=json';
+
+		$response = \ElasticPress\Elasticsearch::factory()->remote_request( $path );
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( ! is_array( $body ) ) {
+			if ( property_exists( $body, 'error' ) ) {
+				WP_CLI::error( $body->error );
+			} else {
+				WP_CLI::error( 'Ohnoes! Something went wrong.' );
+			}
+		}
+
+		$indexes = array_column( $body, 'index' );
+		sort( $indexes );
+
+		WP_CLI::line( wp_json_encode( $indexes ) );
+	}
 }


### PR DESCRIPTION
## Description
If you delete an index, it will still show up as existing with the current `wp vip-search get-indexes` command. This is not an accurate representation, as it uses `get_index_name()`, which does not take into account the current index state or versioning. 

I've replaced the command with our own version to directly query for the indexes directly. This will be beneficial in assisting with debugging.

## Changelog Description

### Search: Fix `get-indexes` command to return accurate results
Results were not accurate because get-indexes was not taking into account index state or version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Use any site with VIP Search enabled
2) Delete the index `wp vip-search delete-index`
3) Run `wp vip-search get-indexes` and see the index still unexpectedly being returned
4) Check out PR
5) Repeat step 3) and see the index not returned