### PR TITLE
Update phpcs.xml.dist

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -65,7 +65,7 @@
 	<rule ref="WordPress-Extra"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.3"/>
+	<config name="minimum_supported_wp_version" value="5.5"/>
 
 	<!-- Rules: Check VIP Coding Standards - see
 		https://github.com/Automattic/VIP-Coding-Standards/ -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -38,7 +38,7 @@
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>wordpress-importer/*</exclude-pattern>
 	<exclude-pattern>wp-cron-control/*</exclude-pattern>
-	<exclude-pattern>wp-parsely-2.5/*</exclude-pattern>
+	<exclude-pattern>wp-parsely-*/*</exclude-pattern>
 	<exclude-pattern>test-jquery-updates/*</exclude-pattern>
 	<exclude-pattern>*/build/*.asset.php</exclude-pattern>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -57,7 +57,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="7.3-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->


### PR DESCRIPTION
## Description

This PR adds all `wp-parsely` directories to the phpcs's `exclude-pattern`, bumps minimum supported WP version to 5.5, and minimum supported PHP version to 7.4.

## Changelog Description

### Developer Tools

  * Exclude `wp-parsely` directories from `phpcs` checks

### MU Plugins

  * Bump minimum supported WordPress version to 5.5;
  * Bump minimum supported PHP version to 7.4.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Make sure the CI passes.
