### PR TITLE
Replace `phpversion()` with `PHP_VERSION`

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -70,7 +70,7 @@ class Site_Details_Index {
 		$site_details['client_site_id']       = $site_id;
 		$site_details['environment_name']     = $environment_name;
 		$site_details['core']['wp_version']   = strval( $wp_version );
-		$site_details['core']['php_version']  = phpversion();
+		$site_details['core']['php_version']  = PHP_VERSION;
 		$site_details['core']['blog_id']      = get_current_blog_id();
 		$site_details['core']['site_url']     = get_site_url();
 		$site_details['core']['is_multisite'] = is_multisite();


### PR DESCRIPTION
## Description

Split from #2470 — this PR replaces the call to `phpversion()` with the `PHP_VERSION` constant as requested [here](https://github.com/Automattic/vip-go-mu-plugins/pull/2470#issuecomment-936270758).

## Changelog Description

### VIP Init Plugin

  * replace `phpversion()` call with the `PHP_VERSION` constant.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should succeed.