### PR TITLE
Remove legacy JSON prettification

### DIFF
--- a/000-debug/logger.php
+++ b/000-debug/logger.php
@@ -136,64 +136,14 @@ function lo( $stuff, ...$rest ) {
 	return call_user_func_array( 'l', $args );
 }
 
-// Pretty print for JSON (stolen from public.api)
+/**
+ * Pretty print for JSON
+ * 
+ * @param mixed $data       Variable to encode as JSON.
+ * @return string|false     The JSON-encoded string, or false if it cannot be encoded.
+ */
 function l_json_encode_pretty( $data ) {
-	if ( defined( 'JSON_PRETTY_PRINT' ) ) {
-		// Added in PHP 5.4.0
-		return wp_json_encode( $data, JSON_PRETTY_PRINT );
-	}
-
-	// Adapted from http://us3.php.net/manual/en/function.json-encode.php#80339
-	$json = wp_json_encode( $data );
-	$len  = strlen( $json );
-
-	$tab          = "\t";
-	$new_json     = '';
-	$indent_level = 0;
-	$in_string    = false;
-
-	$slashed = false;
-	for ( $c = 0; $c < $len; $c++ ) {
-		$char = $json[ $c ];
-		if ( $in_string ) {
-			if ( '"' === $char && $c > 0 && ! $slashed ) {
-				$in_string = false;
-			}
-			$new_json .= $char;
-		} else {
-			switch ( $char ) {
-				case '{':
-				case '[':
-					$new_json .= $char . "\n" . str_repeat( $tab, ++$indent_level );
-					break;
-				case '}':
-				case ']':
-					$new_json .= "\n" . str_repeat( $tab, --$indent_level ) . $char;
-					break;
-				case ',':
-					$new_json .= ",\n" . str_repeat( $tab, $indent_level );
-					break;
-				case ':':
-					$new_json .= ': ';
-					break;
-				case '"':
-					if ( $c > 0 && ! $slashed ) {
-						$in_string = true;
-					}
-					// no break
-				default:
-					$new_json .= $char;
-					break;
-			}
-		}
-		if ( '\\' == $char ) {
-			$slashed = ! $slashed;
-		} else {
-			$slashed = false;
-		}
-	}
-
-	return $new_json;
+	return wp_json_encode( $data, JSON_PRETTY_PRINT );
 }
 
 /**


### PR DESCRIPTION
## Description

This PR removes the legacy (pre-PHP 5.4) code from the `l_json_encode_pretty()` funciton

## Changelog Description

### Developer Tools

  * Remove legacy code

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Make sure the CI passes.
