### PR TITLE
Fix 'Call to undefined function wp_kses_normalize_entities()'

### DIFF
--- a/lib/sunrise/sunrise.php
+++ b/lib/sunrise/sunrise.php
@@ -26,8 +26,8 @@ function network_not_found( $domain, $path ) {
 	];
 	$data = wp_json_encode( $data );
 
-	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-	trigger_error( 'ms_network_not_found: ' . esc_html( $data ), E_USER_WARNING );
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped
+	trigger_error( 'ms_network_not_found: ' . htmlspecialchars( $data ), E_USER_WARNING );
 
 	handle_not_found_error( 'network' );
 }
@@ -48,8 +48,8 @@ function site_not_found( $network, $domain, $path ) {
 	];
 	$data = wp_json_encode( $data );
 
-	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-	trigger_error( 'ms_site_not_found: ' . esc_html( $data ), E_USER_WARNING );
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped
+	trigger_error( 'ms_site_not_found: ' . htmlspecialchars( $data ), E_USER_WARNING );
 
 	handle_not_found_error( 'site' );
 }


### PR DESCRIPTION
## Description

This PR fixes the `Call to undefined function wp_kses_normalize_entities()` fatal error:

```
PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function wp_kses_normalize_entities() in /var/www/wp-includes/formatting.php:981
Stack trace:
#0 /var/www/wp-includes/formatting.php(4480): _wp_specialchars('{"network_id":1...', 3)
#1 /var/www/wp-content/mu-plugins/lib/sunrise/sunrise.php(52): esc_html('{"network_id":1...')
#2 /var/www/wp-includes/class-wp-hook.php(303): Automattic\VIP\Sunrise\site_not_found(Object(stdClass), 'staging.consequ...', '/2017/07/jack-w...')
#3 /var/www/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters('', Array)
#4 /var/www/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#5 /var/www/wp-includes/ms-load.php(414): do_action('ms_site_not_fou...', Object(stdClass), 'staging.consequ...', '/2017/07/jack-w...')
#6 /var/www/wp-includes/ms-settings.php(72): ms_load_current_site_and_network('staging.consequ...', '/2017/07/jack-w...', 0)
#7 /var/www/wp-settings.php(141): require('/var/www/wp-inc...')
#8 /var/www/wp-config.php(43): require_once('/var/www/wp-set...')
#9 /var/www/wp-...
```

## Changelog Description

### VIP Init

  * Fix 'Call to undefined function wp_kses_normalize_entities()' when a site or a network cannot be found

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

N/A
