### PR TITLE
Jetpack Connection Pilot: Ignore specific error messages

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -329,7 +329,7 @@ class Connection_Pilot {
 
 		// Bypass alerting on specific set messages, that can be false positives
 		// Array of regexps to match the message that should be ignored
-		$alerts_to_be_silenced = apply_filters( 'vip_jetpack_connection_pilot_silenced_alerts', array( ) );
+		$alerts_to_be_silenced = apply_filters( 'vip_jetpack_connection_pilot_silenced_alerts', [] );
 		foreach ( $alerts_to_be_silenced as $alert_regex ) {
 			if ( preg_match( $alert_regex, $message ) ) {
 				return $message;


### PR DESCRIPTION

## Description

The goal of this PR is to implement a list of alerts that can be ignored and silenced, to prevent a flood of unactionable alerts. This works with the `vip_jetpack_connection_pilot_silenced_alerts` filter that allows to silence specific errors.

By default, I have included a single error on the list:

```VaultPress connection error: [-6] A registration key can only be used on one site. You can access all of your registration keys in the <a href="https://dashboard.vaultpress.com/account/">Account section</a> of the VaultPress dashboard. (code: VPR06) Site: https://somesite.com (ID 12345). The last known connection was on October 08, 12:00 UTC to Cache Site ID 7654321 (https://somesite.com).```

The array, that can be filtered through `vip_jetpack_connection_pilot_silenced_alerts`, is composed of regex expressions that should match the error message that we want to be ignored.

```php
$alerts = array( 
		'/VaultPress connection error.*A registration key can only be used on one site/',
);
```

If one wants to extend the list of ignorable errors, they can use the filter, or add elements to the array defined in the `filter_vip_jetpack_connection_pilot_silenced_alerts` method ([code here](https://github.com/Automattic/vip-go-mu-plugins/commit/06283389f7be00fe668a3254bf5c7bad0385684b#diff-2e8afd16cc8ce020a84de51d55e31b1d1e79d096ec093ea17ed73de79f2ddeedR282-R288)).


## Changelog Description


### Jetpack Connection Pilot: Allow ignoring specific error messages

Implements the `vip_jetpack_connection_pilot_silenced_alerts` filter that allows to specifiy, with regex, specific errors that should be ignored/silenced. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Not the easiest code to test, give the async nature of this module, but it was something along these lines: 

1. Check out PR.
2. Sandbox a site that is throwing the `VaultPress connection error: [-6] (...)` error message.
3. Run `wp shell --url=https://somesite.com`
4. Run `\Automattic\VIP\Jetpack\Connection_Pilot\Controls::jetpack_is_connected();`. Should return `true`, as the VaultPress error that we're ignoring can only be triggered when Jetpack is connected. 
4. On the interpreter, run `\Automattic\VIP\Jetpack\Connection_Pilot::instance()->run_connection_pilot();`
5. Should be visible that the message wasn't sent to Slack/IRC. 
