### PR TITLE
Replace deprecated get_page() with get_post()

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -168,7 +168,7 @@ function wpcom_vip_get_page_by_title( $title, $output = OBJECT, $post_type = 'pa
 	}
 
 	if ( $page_id ) {
-		return get_page( $page_id, $output );
+		return get_post( $page_id, $output );
 	}
 
 	return null;
@@ -203,7 +203,7 @@ function wpcom_vip_get_page_by_path( $page_path, $output = OBJECT, $post_type = 
 	}
 
 	if ( $page_id ) {
-		return get_page( $page_id, $output );
+		return get_post( $page_id, $output );
 	}
 
 	return null;


### PR DESCRIPTION
## Description

`get_page()` is deprecated since WP 3.5.0, it is recommended to use `get_post()` instead.

## Changelog Description

### VIP Helpers

  * Replace `get_page()` with `get_post()`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

N/A — there are no noticable changes because WordPress does not use `_doing_it_wrong()` on `get_page()` yet.
