### PR TITLE
Allow short ternary statement

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -82,6 +82,9 @@
 
 		<!-- Do not enforce 'class-' prefix -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+
+		<!-- Allow short ternaries -->
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
 	</rule>
 
 </ruleset>


### PR DESCRIPTION
## Description

This PR adds a rule to allow short ternary statements (`?:`).

## Changelog Description

### Code Style Check Configuration

  * Allow short ternary statement

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out this PR
2. Add a line to a PHP file with a short ternary statement
3. Make sure that `phpcs` no longer complains
