### PR TITLE
Fix exclude-patterns in phpcs.xml.dist

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,9 +18,7 @@
 	<exclude-pattern>/debug-bar-cron/*</exclude-pattern>
 	<exclude-pattern>/http-concat/*</exclude-pattern>
 	<exclude-pattern>/jetpack/*</exclude-pattern>
-	<exclude-pattern>/jetpack-[\d.]+/</exclude-pattern>
 	<exclude-pattern>/lightweight-term-count-update/*</exclude-pattern>
-	<exclude-pattern>/query-monitor/*</exclude-pattern>
 	<exclude-pattern>/rewrite-rules-inspector/*</exclude-pattern>
 	<exclude-pattern>/vip-support/*</exclude-pattern>
 
@@ -30,6 +28,8 @@
 	<exclude-pattern>/bin/*</exclude-pattern>
 	<exclude-pattern>/debug-bar/*</exclude-pattern>
 	<exclude-pattern>/drop-ins/*</exclude-pattern>
+	<exclude-pattern>/jetpack-[\d.]+/</exclude-pattern>
+	<exclude-pattern>/query-monitor/*</exclude-pattern>
 	<exclude-pattern>/search/elasticpress/*</exclude-pattern>
 	<exclude-pattern>/search/debug-bar-elasticpress/*</exclude-pattern>
 	<exclude-pattern>/search/es-wp-query/*</exclude-pattern>


### PR DESCRIPTION
## Description

This PR fixes a bug introduced in #2501 and #2502 ([link 1](https://github.com/Automattic/vip-go-mu-plugins/pull/2502/files#diff-05ae9cddcaec1e845771a7db224961439f83ef5939ec67d3a48744cb34d7e58bR20-R21), [link 2](https://github.com/Automattic/vip-go-mu-plugins/pull/2501/files#diff-05ae9cddcaec1e845771a7db224961439f83ef5939ec67d3a48744cb34d7e58bR45)).

1. It looks like PHPCS does not support anchoring; a directory separator should be used instead.
2. `<include-pattern>` is not allowed inside `<ruleset>`

## Changelog Description

### Developer Tools

  * Fix PHPCS config

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Run `vendor/bin/phpcs -v` and observe that PHPCS checks `jetpack-*` directories
2. Check out this PR
3. Run `vendor/bin/phpcs -v` again; `jetpack-*` directories should not be checked now

Alternatively,

The output of `vendor/bin/phpcs -v jetpack-*/` after checking out this PR should mention

> Creating file list... DONE (3 files in queue)
