### PR TITLE
Remove `type` of request as we don't use it

### DIFF
--- a/vip-dashboard/components/widget-contact.php
+++ b/vip-dashboard/components/widget-contact.php
@@ -41,18 +41,6 @@ function render_vip_dashboard_widget_contact() {
 			</div>
 			<div class="contact-form__row">
 				<div class="contact-form__label">
-					<label for="contact-form__type">Type</label>
-				</div>
-				<div class="contact-form__input">
-					<select id="contact-form__type">
-						<option value="Technical">Technical</option>
-						<option value="Business">Business/Project Management</option>
-						<option value="Review">Theme/Plugin Review</option>
-					</select>
-				</div>
-			</div>
-			<div class="contact-form__row">
-				<div class="contact-form__label">
 					<label for="contact-form__details">Details</label>
 				</div>
 				<div class="contact-form__input">


### PR DESCRIPTION
## Description
Removed the HTML from the contact us form, since we don't use it when sending information through - see: https://github.com/Automattic/vip-go-mu-plugins/blob/master/vip-dashboard/vip-dashboard.php#L79

It also is an old way of engaging with us - more work should be done on this in the future.
