### PR TITLE
Search: remove "vip_" duplicate prefix from vip_search_indexing_rate_limiting metric

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -1015,7 +1015,7 @@ class Queue {
 		\Automattic\VIP\Logstash\log2logstash(
 			array(
 				'severity' => 'warning',
-				'feature' => 'vip_search_indexing_rate_limiting',
+				'feature' => 'search_indexing_rate_limiting',
 				'message' => $message,
 			)
 		);
@@ -1185,7 +1185,7 @@ class Queue {
 
 		$this->logger->log(
 			'warning',
-			'vip_search_indexing_rate_limiting',
+			'search_indexing_rate_limiting',
 			$message
 		);
 	}

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -801,7 +801,7 @@ class Queue_Test extends \WP_UnitTestCase {
 				->method( 'log' )
 				->with(
 					$this->equalTo( 'warning' ),
-					$this->equalTo( 'vip_search_indexing_rate_limiting' ),
+					$this->equalTo( 'search_indexing_rate_limiting' ),
 					$this->equalTo(
 						'Application 123 - http://example.org has triggered Elasticsearch indexing rate limiting, which will last for 300 seconds. Large batch indexing operations are being queued for indexing in batches over time.'
 					),
@@ -1337,7 +1337,7 @@ class Queue_Test extends \WP_UnitTestCase {
 				->method( 'log' )
 				->with(
 					$this->equalTo( 'warning' ),
-					$this->equalTo( 'vip_search_indexing_rate_limiting' ),
+					$this->equalTo( 'search_indexing_rate_limiting' ),
 					$this->equalTo(
 						'Application 123 - http://example.org has triggered Elasticsearch indexing rate limiting, which will last for 300 seconds. Large batch indexing operations are being queued for indexing in batches over time.'
 					),


### PR DESCRIPTION
## Description
Similar to #2379. Currently the metric is `a8c_vip_vip_search_indexing_rate_limiting`, so let's change it to `a8c_vip_search_indexing_rate_limiting` for consistency. 

## Changelog Description

### Search: remove "vip_" duplicate prefix from vip_search_indexing_rate_limiting metric

The metric will be changed from a8c_vip_vip_search_indexing_rate_limiting to a8c_vip_search_indexing_rate_limiting.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

