### PR TITLE
Deduplicate code in wpcom_vip_file_get_contents()

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -499,12 +499,15 @@ function vip_regex_redirects( $vip_redirects_array = array(), $with_querystring 
 function _wpcom_log_failed_request( $url, $response ): void {
 	global $blog_id;
 
-	if ( ! defined( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING' ) || ! WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING ) {
-		if ( $response && ! is_wp_error( $response ) ) {
-			trigger_error( "wpcom_vip_file_get_contents: Blog ID {$blog_id}: Failure for {$url} and the result was: " . $response['response']['code'] . ' ' . $response['response']['message'], E_USER_NOTICE );
-		} elseif ( $response ) { // is WP_Error object
-			trigger_error( "wpcom_vip_file_get_contents: Blog ID {$blog_id}: Failure for {$url} and the result was: " . $response->get_error_message(), E_USER_NOTICE );
-		}
+	if ( $response && ( ! defined( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING' ) || ! WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING ) ) {
+		$message = sprintf(
+			'wpcom_vip_file_get_contents: Blog ID %d: Failure for %s and the result was: %s',
+			$blog_id,
+			$url,
+			is_wp_error( $response ) ? $response->get_error_message() : $response['response']['code'] . ' ' . $response['response']['message']
+		);
+
+		trigger_error( esc_html( $message ), E_USER_NOTICE );
 	}
 }
 


### PR DESCRIPTION
## Description

This PR is split from #2518. It refactors the `wpcom_vip_file_get_contents()` function by moving duplicate blocks of code into a separate helper function.

## Changelog Description

### Plugin Updated: VIP Helpers

Refactor the `wpcom_vip_file_get_contents()` function by moving duplicate blocks of code into a separate helper function.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
