### PR TITLE
Search: max out batch-size option at 5000 for validate-contents

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -399,7 +399,7 @@ class Health {
 	 * : Optional last post id to check
 	 *
 	 * [batch_size=<int>]
-	 * : Optional batch size
+	 * : Optional batch size (max is 5000)
 	 *
 	 * [max_diff_size=<int>]
 	 * : Optional max count of diff before exiting
@@ -446,7 +446,7 @@ class Health {
 		if ( ! is_numeric( $batch_size ) || 0 >= $batch_size || $batch_size > PHP_INT_MAX ) {
 			$batch_size = self::CONTENT_VALIDATION_BATCH_SIZE;
 		} else {
-			$batch_size = intval( $batch_size );
+			$batch_size = min( 5000, intval( $batch_size ) );
 		}
 
 		// If max diff size NOT an int over 0, reset to default


### PR DESCRIPTION
## Description
Similar to the limit enforced in https://github.com/Automattic/ElasticPress/pull/109, we should ensure that batch sizes are at a reasonable limit.

## Changelog Description
### Search: Add maximum to batch_size option for validate-contents command

To ensure that batch sizes are a reasonable limit. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Use a site with over 10000 posts
2. Pass in `wp vip-search health validate-contents --batch_size=9999999999999`
3. Notice that it only does 5000 at once per cycle.