### PR TITLE
Disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error rule

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -88,6 +88,8 @@
 
 		<!-- Generates too many false positives -->
 		<exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+		<!-- We use trigger_error extensively -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
 	</rule>
 
 </ruleset>


### PR DESCRIPTION
## Description

This PR disables the `WordPress.PHP.DevelopmentFunctions.error_log_trigger_error` because we use `trigger_error()` very often.

## Changelog Description

### Code Sttyle Guide

  * Disable the `WordPress.PHP.DevelopmentFunctions.error_log_trigger_error` rule

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.