### PR TITLE
Fix SVN parsing error on Parse.ly

### DIFF
--- a/vip-parsely/Telemetry/Tracks/class-tracks.php
+++ b/vip-parsely/Telemetry/Tracks/class-tracks.php
@@ -18,7 +18,7 @@ class Tracks implements Telemetry_System {
 	 *
 	 * @var array
 	 */
-	private array $queue = array();
+	private $queue = array();
 
 	const EVENT_NAME_PREFIX = 'wpparsely_';
 	const TRACKS_RECORD_URL = 'https://public-api.wordpress.com/rest/v1.1/tracks/record';


### PR DESCRIPTION
## Description

When deploying #2500 to staging, we got the following error:

```
Parse error: syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in staging/vip-parsely/Telemetry/Tracks/class-tracks.php on line 21
xargs: php: exited with status 255; aborting
```

This is due to the usage of the `array` keyword. This PR removes it so we can merge it correctly.

## Changelog Description

### Fix SVN parsing error on Parse.ly

We fixed an error that prevented us from merging code.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.