### PR TITLE
Using WPError on Parse.ly Tracks

### DIFF
--- a/vip-parsely/Telemetry/Tracks/class-tracks-event.php
+++ b/vip-parsely/Telemetry/Tracks/class-tracks-event.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Automattic\VIP\Parsely\Telemetry;
 
+use WP_Error;
+
 /**
  * Instances of this class are fit for recording to the Automattic Tracks system (unless an error occurs during instantiation).
  */


### PR DESCRIPTION
## Description

This PR fixes an issue that prevented us from constructing a `WP_Error` when something went wrong in a Tracks event. The `WP_Error` class was not being imported properly, hence the error construction would fail. This PR imports the class by doing `use WP_Error`.

## Changelog Description

### Using WPError on Parse.ly Tracks

Fixing an issue that prevented errors from being properly handled on Parse.ly Tracks.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR, then on a `wp cli`.
```
$telemetry_system = new Automattic\VIP\Parsely\Telemetry\Tracks();
$telemetry_system->record_event( 'invalid_name' );
```
2. This should raise an exception with the old code and none with the new one.