### PR TITLE
Adding status code check on Parse.ly Tracks

### DIFF
--- a/vip-parsely/Telemetry/Tracks/class-tracks.php
+++ b/vip-parsely/Telemetry/Tracks/class-tracks.php
@@ -72,7 +72,7 @@ class Tracks implements Telemetry_System {
 			}
 
 			$status_code = wp_remote_retrieve_response_code( $response );
-			if ( ! is_int( $status_code ) || $status_code > 300 ) {
+			if ( ! is_int( $status_code ) || $status_code >= 300 || $status_code < 200 ) {
 				return new WP_Error( 'request_error', 'The request to the tracks service was invalid', $status_code );
 			}
 


### PR DESCRIPTION
## Description

Some requests to the A8c Tracks back-end on the Parse.ly Telemetry module might fail. That is partially covered by `is_wp_error`, but a request might not be a WP Error but have a 4xx response code. 

This PR adds this additional check and raises an error if a request fails that way.

## Changelog Description

### Adding status code check on Parse.ly Tracks

Detecting failed requests to the Tracks back-end.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. On the CLI, perform an invalid request (for instance, an event without body).
3. You now should get a `WP_Error` instead of `true`.