### PR TITLE
Fix sending empty event on Parse.ly Tracks

### DIFF
--- a/vip-parsely/Telemetry/Tracks/class-tracks-event.php
+++ b/vip-parsely/Telemetry/Tracks/class-tracks-event.php
@@ -20,7 +20,7 @@ class Tracks_Event {
 	 *
 	 * @var object|WP_Error Event.
 	 */
-	public $_event;
+	public $data;
 
 	/**
 	 * Jetpack_Tracks_Event constructor.
@@ -28,7 +28,7 @@ class Tracks_Event {
 	 * @param array $event Tracks event.
 	 */
 	public function __construct( array $event ) {
-		$this->_event = self::validate_and_sanitize( $event );
+		$this->data = self::validate_and_sanitize( $event );
 	}
 
 	/**

--- a/vip-parsely/Telemetry/Tracks/class-tracks.php
+++ b/vip-parsely/Telemetry/Tracks/class-tracks.php
@@ -60,7 +60,7 @@ class Tracks implements Telemetry_System {
 	 */
 	public function record_event( string $event_name, array $event_props = array(), bool $send_immediately = false ) {
 		$event_object = self::normalize_event( $event_name, $event_props );
-		$event = $event_object->_event;
+		$event        = $event_object->data;
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}


### PR DESCRIPTION
## Description

Empty events would be sent to the A8c Tracks endpoint because while normalizing the event, the fields of the object would not be exposed. This PR fixes it by creating an internal `$_event` property which is then sent over the wire.

## Changelog Description

### Fix sending empty event on Parse.ly Tracks

Tracking would not work on Parse.ly events because empty bodies would be sent.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.