### PR TITLE
Search: Modify validate-contents output message to be dependent on do_not_heal option

### DIFF
--- a/vip-parsely/Telemetry/Tracks/class-tracks-event.php
+++ b/vip-parsely/Telemetry/Tracks/class-tracks-event.php
@@ -16,14 +16,11 @@ use WP_Error;
  */
 class Tracks_Event {
 	/**
-	 * Tracks Event Error.
-	 * If this is set to a `WP_Error` instance, the event will not be tracked.
+	 * The object containing the event itself.
 	 *
-	 * @see Tracks::record_event
-	 *
-	 * @var WP_Error Error.
+	 * @var object|WP_Error Event.
 	 */
-	public $error;
+	public $data;
 
 	/**
 	 * Jetpack_Tracks_Event constructor.
@@ -31,12 +28,7 @@ class Tracks_Event {
 	 * @param array $event Tracks event.
 	 */
 	public function __construct( array $event ) {
-		$_event = self::validate_and_sanitize( $event );
-		if ( is_wp_error( $_event ) ) {
-			// Execution should be aborted if an error is found. We don't have an explicit return
-			// since there is no more code after this statement.
-			$this->error = $_event;
-		}
+		$this->data = self::validate_and_sanitize( $event );
 	}
 
 	/**

--- a/vip-parsely/Telemetry/Tracks/class-tracks.php
+++ b/vip-parsely/Telemetry/Tracks/class-tracks.php
@@ -59,9 +59,10 @@ class Tracks implements Telemetry_System {
 	 * @return bool|WP_Error True if the event could be enqueued or send correctly. WP_Error otherwise
 	 */
 	public function record_event( string $event_name, array $event_props = array(), bool $send_immediately = false ) {
-		$event = self::normalize_event( $event_name, $event_props );
-		if ( is_wp_error( $event->error ) ) {
-			return $event->error;
+		$event_object = self::normalize_event( $event_name, $event_props );
+		$event        = $event_object->data;
+		if ( is_wp_error( $event ) ) {
+			return $event;
 		}
 
 		if ( $send_immediately ) {


### PR DESCRIPTION
## Description

Since `wp vip-search health validate-contents` simultaneously checks AND fixes inconsistencies (if `--do_not_heal` option is not passed), we should be explicit about that to the user.

Props @yolih for the idea while we were working on docs.

## Changelog Description

### Search: Update message for validate-contents to reflect do_not_heal option

Accounts for fixing if do_not_heal option is not passed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Check out PR
2) Run `wp vip-search health validate-contents`
3) Expect to see "Inconsistencies fixed:" before output if inconsistencies
4) Run `wp vip-search health validate-contents --do_not_heal`
5)  Expect to see "Inconsistencies found:" before output if inconsistencies