### PR TITLE
Parsely: Ensure vip-parsely folder exists

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -89,7 +89,10 @@ function maybe_load_plugin() {
 		require_once $entry_file;
 
 		// Requiring VIP's customizations over Parse.ly
-		require_once __DIR__ . '/vip-parsely/vip-parsely.php';
+		$vip_parsely_plugin = __DIR__ . '/vip-parsely/vip-parsely.php';
+		if ( is_readable( $vip_parsely_plugin ) ) {
+			require_once $vip_parsely_plugin;
+		}
 
 		return;
 	}


### PR DESCRIPTION
Ensure there isn't a second or two of fatals during a deploy, where the root mu-plugin exists and is loaded but the `vip-parsely/` folder has not completed copying over yet.