### PR TITLE
Allow nullable instances on tracking updated Parse.ly widget

### DIFF
--- a/vip-parsely/Telemetry/Events/track-widget-updated.php
+++ b/vip-parsely/Telemetry/Events/track-widget-updated.php
@@ -40,7 +40,7 @@ function track_widget_updated( array $instance, ?array $new_instance, ?array $ol
 		return $instance;
 	}
 
-	if ( $old_instance == null ) {
+	if ( null == $old_instance ) {
 		// If there is no old instance, all keys are updated. We have this shortcut so we don't have to do
 		// `array_keys` of null, thus raising a warning.
 		$updated_keys = array_keys( $instance );


### PR DESCRIPTION
## Description

In some situations, the `$new_instance` and `$old_instance` parameters on the tracking function for the Parse.ly recommended widget might be null. Since we're using `strict_types`, we now mark those parameters as nullable.

## Changelog Description

### Allow nullable instances on tracking updated Parse.ly widget

We fixed a case in which the tracking would not be correctly send on the Parse.ly Recommended Widget.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.