### PR TITLE
Returning result of tracking functions

### DIFF
--- a/vip-parsely/Telemetry/class-telemetry.php
+++ b/vip-parsely/Telemetry/class-telemetry.php
@@ -73,7 +73,7 @@ class Telemetry {
 					} else {
 						$args = array( $this->telemetry_system );
 					}
-					call_user_func_array( $event['callable'], $args );
+					return call_user_func_array( $event['callable'], $args );
 				};
 				add_filter( $event['action_hook'], $func, 10, $accepted_args );
 			}


### PR DESCRIPTION
## Description

This fixes an issue in which some filters that require a return value would not get that value back, even if the called function was returning it.

## Changelog Description

### Returning result of tracking functions

Fix an issue when tracking would not work for filters that require a return value.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.