### PR TITLE
Fix 2FA error during Lando: wp install

### DIFF
--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -68,4 +68,14 @@ class Environment {
 
 		return false;
 	}
+
+	public static function is_dev_env_container( ) {
+		if ( isset( $_ENV['LANDO_APP_ROOT'] ) ) {
+			if ( preg_match( '/^[\w\-. \/\-_]+vip\/dev-environment\/[\w\-. \-_]+$/',  $_ENV['LANDO_APP_ROOT'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -69,9 +69,9 @@ class Environment {
 		return false;
 	}
 
-	public static function is_dev_env_container( ) {
+	public static function is_dev_env_container() {
 		if ( isset( $_ENV['LANDO_APP_ROOT'] ) ) {
-			if ( preg_match( '/^[\w\-. \/\-_]+vip\/dev-environment\/[\w\-. \-_]+$/',  $_ENV['LANDO_APP_ROOT'] ) ) {
+			if ( preg_match( '/^[\w\-. \/\-_]+vip\/dev-environment\/[\w\-. \-_]+$/', $_ENV['LANDO_APP_ROOT'] ) ) {
 				return true;
 			}
 		}

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -221,8 +221,8 @@ class Environment_Test extends TestCase {
 		return array(
 			array(
 				// path -- directory where a dev-env lando root is
-				'/Users/username/.local/share/vip/dev-environment/username'
-			)
+				'/Users/username/.local/share/vip/dev-environment/username',
+			),
 		);
 	}
 
@@ -233,6 +233,6 @@ class Environment_Test extends TestCase {
 	 */
 	public function test_is_dev_env_container( $path ) {
 		$_ENV['LANDO_APP_ROOT'] = $path;
-		$this->assertTrue( Environment::is_dev_env_container( ) );
+		$this->assertTrue( Environment::is_dev_env_container() );
 	}
 }

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -216,4 +216,23 @@ class Environment_Test extends TestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	public function is_dev_env_container_data() {
+		return array(
+			array(
+				// path -- directory where a dev-env lando root is
+				'/Users/username/.local/share/vip/dev-environment/username'
+			)
+		);
+	}
+
+	/**
+	 * Tests the functionality of Environment::is_dev_env_container
+	 * Really only testing the regex because it would be impossible to have a valid test in non-dev-env containers
+	 * @dataProvider is_dev_env_container_data
+	 */
+	public function test_is_dev_env_container( $path ) {
+		$_ENV['LANDO_APP_ROOT'] = $path;
+		$this->assertTrue( Environment::is_dev_env_container( ) );
+	}
 }

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,6 +12,9 @@ require_once __DIR__ . '/wpcom-vip-two-factor/set-providers.php';
 // Detect if the current user is logged in via Jetpack SSO
 require_once __DIR__ . '/wpcom-vip-two-factor/is-jetpack-sso.php';
 
+// Environment tools
+use Automattic\VIP\Environment;
+
 // Do not allow API requests from 2fa users.
 add_filter( 'two_factor_user_api_login_enable', '__return_false', 1 ); // Hook in early to allow overrides
 
@@ -155,7 +158,10 @@ function wpcom_vip_enforce_two_factor_plugin() {
 	}
 }
 
-add_action( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
+// Do not enable 2FA plugin if WordPress is executed in the context of the CLI
+if ( defined( 'WP_CLI' ) && ! Environment::is_dev_env_container() ) {
+	add_action( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
+}
 function wpcom_enable_two_factor_plugin() {
 	$enable_two_factor = apply_filters( 'wpcom_vip_enable_two_factor', true );
 	if ( true !== $enable_two_factor ) {


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->
The dev-env start routine will do a WordPress install if the dev-env containers have not yet been created. When this happens, the Lando init routine will run the WP CLI to install the Wordpress Instance. This causes a benign but annoying PHP error notice because: in the 2FA plugin, `wp_parse_url` is called with a url parameter value of: "". When the plugin tries to use the parts['host'] from that parse, it doesn't exist in the dictionary and causes that annoying notice.

This PR addresses that notice with the following change:

  * Adds Automattic\VIP\Environment::is_dev_env_container method
  * Prevents loading the 2FA plugin in the context of WP CLI and vip dev-env
  * Unit test for Environment::is_dev_env_container

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->

The command: `vip dev-env start` will no longer show a PHP Notice error when the WordPress environment container is first instantiated.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

1. Check out PR.
1. Create a new dev-env container with the command: `vip dev-env create --slug=test-2fa-bug`
1. Run the container with `vip dev-env start --slug=test-2fa-bug`
1. Verify that there is no longer a PHP Notice error about the 2FA plugin.
