### PR TITLE
Create a new folder 000-pre-vip-config and move all the requires that happen before vip-config.php there for better visibility

### DIFF
--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file contains everything that's loaded before vip-config.php
+ *
+ * You should make sure to include this file locally in case you're not using VIP Local Development Environment
+ * @see https://docs.wpvip.com/how-tos/local-development/use-the-vip-local-development-environment/
+ */
+
+$mu_plugins_base = dirname( __DIR__ );
+
+// Load custom error logging functions, if available
+if ( file_exists( $mu_plugins_base . '/lib/wpcom-error-handler/wpcom-error-handler.php' ) ) {
+	require_once $mu_plugins_base . '/lib/wpcom-error-handler/wpcom-error-handler.php';
+}
+
+// Load VIP_Request_Block utility class, if available
+if ( file_exists( $mu_plugins_base . '/lib/class-vip-request-block.php' ) ) {
+	require_once $mu_plugins_base . '/lib/class-vip-request-block.php';
+}
+
+// Load Environment utility class and its helpers, if available
+if ( file_exists( $mu_plugins_base . '/lib/environment/class-environment.php' ) ) {
+	require_once $mu_plugins_base . '/lib/environment/class-environment.php';
+	// TODO: add the env helpers once implemented
+}


### PR DESCRIPTION
## Description

We have a bunch of "secret sauce" that was loaded prior to vip-config.php but wasn't exposed anywhere, there's no particularly good reason to do so. Furthermore, it's a bit annoying because it's opaque and in case customers don't use our Local Dev Env they'll no doubt will be tripped up by that. 

This PR aims to address the issue by introducing a new folder, which is very explicitly named `000-pre-vip-config`. This needs to be accompanied with:

- [ ] Docs updates
- [ ] Dev Env bootstrap update
- [ ] Removal of the secret sauce from the secret place(s).

## Changelog Description

### WordPress dependency load order update

Previously we included a few classes, notably VIP_Request_Block and our custom error handler very early in the bootstrap, prior to loading the `vip-config.php`. Although those files are located in mu-plugins we didn't load them from there. 

We've made a change to include `000-pre-vip-config/requires.php` that will now contain those early dependencies so that it's more apparent.  

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

