### PR TITLE
Use the latest available WordPress versions for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
     <<: *php_job
     environment:
       - WP_MULTISITE: "0"
-      - WP_VERSION: "5.5.5"
+      - WP_VERSION: "5.5.6"
     docker:
       - image: cimg/php:7.4-node
       - image: *db_image
@@ -238,7 +238,7 @@ jobs:
     <<: *php_job
     environment:
       - WP_MULTISITE: "0"
-      - WP_VERSION: "5.6.4"
+      - WP_VERSION: "5.6.5"
     docker:
       - image: cimg/php:7.4-node
       - image: *db_image
@@ -247,7 +247,7 @@ jobs:
     <<: *php_job
     environment:
       - WP_MULTISITE: "0"
-      - WP_VERSION: "5.7.2"
+      - WP_VERSION: "5.7.3"
     docker:
       - image: cimg/php:7.4-node
       - image: *db_image
@@ -256,7 +256,7 @@ jobs:
     <<: *php_job
     environment:
       - WP_MULTISITE: "0"
-      - WP_VERSION: "5.8"
+      - WP_VERSION: "5.8.1"
     docker:
       - image: cimg/php:7.4-node
       - image: *db_image


### PR DESCRIPTION
## Description

WordPress versions we use in our tests lag behind the latest releases. This PR fixes that.

## Changelog Description

### Unit Tests

Use the latest versions of WordPress to run tests.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
