### PR TITLE
Search: create index no matter what request method

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -782,13 +782,6 @@ class Search {
 	 * This method avoids this issue by creating the index with correct mapping if the index doesn't exist yet.
 	 */
 	public function ensure_index_existence( $url, $args ) {
-		$method                  = strtoupper( $args['method'] ?? '' );
-		$methods_that_need_index = [ 'POST', 'PUT' ];
-		if ( ! in_array( $method, $methods_that_need_index, true ) ) {
-			// bailing out on methods that would not create index with incorrect mapping
-			return true;
-		}
-
 		$index_name = $this->get_index_name_for_url( $url );
 		if ( ! $index_name ) {
 			return true;

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -782,6 +782,13 @@ class Search {
 	 * This method avoids this issue by creating the index with correct mapping if the index doesn't exist yet.
 	 */
 	public function ensure_index_existence( $url, $args ) {
+		$method                  = strtoupper( $args['method'] ?? '' );
+		$methods_that_need_index = [ 'POST', 'PUT' ];
+		if ( ! in_array( $method, $methods_that_need_index, true ) ) {
+			// bailing out on methods that would not create index with incorrect mapping
+			return true;
+		}
+
 		$index_name = $this->get_index_name_for_url( $url );
 		if ( ! $index_name ) {
 			return true;

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -786,7 +786,7 @@ class Search {
 		$methods_that_need_index = [ 'POST', 'PUT' ];
 		if ( ! in_array( $method, $methods_that_need_index, true ) ) {
 			// bailing out on methods that would not create index with incorrect mapping
-			return true;
+			return false;
 		}
 
 		$index_name = $this->get_index_name_for_url( $url );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1411,6 +1411,10 @@ class Search {
 	public function get_index_name_for_url( $url ) {
 		$parsed = wp_parse_url( trim( $url ) );
 
+		if ( ! isset( $parsed['path'] ) ) {
+			return null;
+		}
+
 		$path = explode( '/', trim( $parsed['path'], '/' ) );
 
 		// Index name is _usually_ the first part of the path


### PR DESCRIPTION
## Description
We automagically create a new index if during a POST/PUT request it does not exist. However, we should extend this to all request methods. Looking at our logs, we have a lot of `index_not_found` errors generated by GET requests.

## Changelog Description

### Search: Create index on non-existence no matter what

Removed safelist for only PUT/POST requests.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Use a site on Enterprise Search
2) See if it has a post index `wp vip-search get-indexes`
3) If it does, delete it with `wp vip-search delete-index` - if not, skip this step
4) Shell in and run `\Automattic\VIP\Search\Search::instance()->maybe_alert_for_field_count();` which does a GET request and usually throws an index_not_found exception error 
5) Check if a new post index has been created with `wp vip-search get-indexes`