### PR TITLE
Search: Do not perform current field count if no index exists

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1165,7 +1165,7 @@ class Search {
 	 * @return null|int The current field count
 	 */
 	public function get_current_field_count( \ElasticPress\Indexable $indexable ) {
-		if ( ! $indexable ) {
+		if ( ! $indexable || ! $indexable->index_exists() ) {
 			return null;
 		}
 


### PR DESCRIPTION
## Description
There seems to be a lot of index_not_found_exception errors in our logs stemming from the cron `maybe_alert_for_field_count` which calls `get_current_field_count()` — it attempts to do a GET request on an index that doesn't exist. We should return early if index does not exist.

## Changelog Description

### Search: Return early if no index on get_current_field_count()

No need to perform a remote request since it will throw an index_not_found_exception.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Check out PR
2) Spin up search site
3) If index exists, delete it `wp vip-search delete-index`
4) Use `Automattic\VIP\Search\Search::instance()->maybe_alert_for_field_count();` to see if `$current_field_count` returns NULL.