### PR TITLE
Making Jetpack 10.3 default version

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 10.2.1
+ * Version: 10.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -23,7 +23,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.7', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.8' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.2' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.3' );
 	}
 }
 


### PR DESCRIPTION
## Description

This PR makes Jetpack 10.3 the default version. We are also updating the plugin header from that same latest version.

## Changelog Description

### Plugin Updated: Jetpack 10.3

We are making Jetpack 10.3 the new default version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Make sure you have Jetpack enabled but no version pinned.
3. Check that you're running Jetpack 10.3.