### PR TITLE
Change local Maria testing image

### DIFF
--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -51,7 +51,7 @@ MYSQL_ROOT_PASSWORD='wordpress'
 
 docker network create $NETWORK_NAME
 
-db=$(docker run --network $NETWORK_NAME --name $DB_CONTAINER_NAME -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb/server:$MARIADB_VERSION)
+db=$(docker run --network $NETWORK_NAME --name $DB_CONTAINER_NAME -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb:$MARIADB_VERSION)
 function cleanup() {
 	echo "cleanup!"
 	docker rm -f $db


### PR DESCRIPTION
## Description

This PR changes the MariaDB image used to run local tests from `mariadb/server` to `mariadb`. The first one is deprecated and it is not compatible with ARM architectures (like the M1 Mac series).

## Changelog Description

### Change local Maria testing image

Improving tooling for local development and testing.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out this PR.
2. Run `composer install`
3. Run the tests (make sure Docker is running): `bin/phpunit-docker.sh`
