### PR TITLE
CLI: Add success messages after data cleanup CLIs

### DIFF
--- a/wp-cli/vip-data-cleanup.php
+++ b/wp-cli/vip-data-cleanup.php
@@ -11,6 +11,7 @@ class VIP_Data_Cleanup_Command extends WPCOM_VIP_CLI_Command {
 	 */
 	public function datasync() {
 		$this->cleanup_all_sites( 'datasync' );
+		WP_CLI::success( 'Datasync cleanup completed.' );
 	}
 
 	/**
@@ -21,6 +22,7 @@ class VIP_Data_Cleanup_Command extends WPCOM_VIP_CLI_Command {
 	public function sql_import() {
 		// TODO: Would be ideal if we could pinpoint if just a specific subsite's blog tables were imported.
 		$this->cleanup_all_sites( 'sqlimport' );
+		WP_CLI::success( 'SQL Import cleanup completed.' );
 	}
 
 	private function cleanup_all_sites( $operation ) {


### PR DESCRIPTION
## Description

Show success messages after data cleanup CLIs are completed. Helps make the job logs a bit more tidy and clear when the CLIs have finished successfully.

## Changelog Description
n/a (can skip this from changelog)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

- `wp vip data-cleanup datasync`
- `wp vip data-cleanup sql-import`
