### PR TITLE
Search: Implement delay between content validation batches

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -543,6 +543,8 @@ class Health {
 			if ( $is_cli && ! $silent ) {
 				echo sprintf( "...%s %s\n", empty( $result ) ? '✓' : '✘', $do_not_heal || empty( $result ) ? '' : '(attempted to reconcile)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
+			// To prevent continuous hammering of clusters.
+			sleep( mt_rand( 2, 5 ) );
 		} while ( $start_post_id <= $last_post_id );
 
 		if ( $process_parallel_execution_lock ) {

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -543,8 +543,10 @@ class Health {
 			if ( $is_cli && ! $silent ) {
 				echo sprintf( "...%s %s\n", empty( $result ) ? '✓' : '✘', $do_not_heal || empty( $result ) ? '' : '(attempted to reconcile)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
-			// To prevent continuous hammering of clusters.
-			sleep( mt_rand( 2, 5 ) );
+			if ( $is_cli && $silent ) {
+				// To prevent continuous hammering of clusters.
+				sleep( mt_rand( 2, 5 ) );
+			}
 		} while ( $start_post_id <= $last_post_id );
 
 		if ( $process_parallel_execution_lock ) {


### PR DESCRIPTION
## Description

Implement a randomized delay between batches to give ES clusters a bit of breathing space because large content validations can put a strain on them.

This will only run if it's in the CLI context and the `silent` flag is passed. 

## Changelog Description

### Plugin Updated: Enterprise Search

We've implemented a delay between validation batches to minimize the chances of causing a resource strain during periodic content validation.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
