### PR TITLE
CLI: Add extra cache flush at the start of cleanup CLIs

### DIFF
--- a/wp-cli/vip-data-cleanup.php
+++ b/wp-cli/vip-data-cleanup.php
@@ -45,6 +45,9 @@ class VIP_Data_Cleanup_Command extends WPCOM_VIP_CLI_Command {
 	private function cleanup_site( $operation ) {
 		$this->ensure_correct_site_schema();
 
+		// Flush cache before customization hooks are run, else can easily run into cache/db discrepancies.
+		wp_cache_flush();
+
 		if ( 'datasync' === $operation ) {
 			/**
 			 * Runs on a child environment after recieving a data sync from production.
@@ -66,6 +69,7 @@ class VIP_Data_Cleanup_Command extends WPCOM_VIP_CLI_Command {
 
 		$this->delete_db_transients();
 
+		// Flush cache again. After DB transient removal, and prevents the need for flushing on the individiual hooks above.
 		wp_cache_flush();
 
 		if ( ! defined( 'VIP_JETPACK_SKIP_LOAD' ) || ! VIP_JETPACK_SKIP_LOAD ) {


### PR DESCRIPTION
## Description

This was a fun one to track down. As an example of why this is needed for future readers, if there is an `update_option()` performed on the cleanup hooks it's possible the update either doesn't take place or the DB query fails. Why you ask?

1) This happens on a cleanup hook somewhere `update_option( 'example', 'child site value' )`
2) If `child site value` was already the value, WP likely has this in the alloptions cache still and will decide it doesn't need updating (even though the actual DB has `production site value`.
3) Or if the `example` option doesn't exist on the production site but exist(ed) on the child site, WP will perform an UPDATE query which will fail because it actually needed to do an INSERT.

tl;dr - Just flush out the cache after we've imported a bunch of SQL :)

Double flushing isn't really hurtful, since it's just a key swap. Also helps to continue cover customer code in case direct SQL is performed during the cleanup hooks as well.

## Changelog Description
n/a (can skip on this one, the overall CLI/Sync/Import changelog post is about to go up)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
- `wp vip data-cleanup datasync`
- `wp vip data-cleanup sql-import`
