### PR TITLE
jetpack-start: Update to use modern function

### DIFF
--- a/jetpack-start/wp-cli-provision.php
+++ b/jetpack-start/wp-cli-provision.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Tokens;
+
 /**
  * These are extracted commands from Jetpack CLI.
  *
@@ -230,7 +232,7 @@ class Jetpack_Start_Provision_CLI_Command extends WPCOM_VIP_CLI_Command {
 
 		if ( isset( $body_json->access_token ) ) {
 			// authorize user and enable SSO
-			Jetpack::update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
+			( new Tokens )->update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
 
 			$active_modules = Jetpack_Options::get_option( 'active_modules' );
 			if ( $active_modules ) {

--- a/jetpack-start/wp-cli-provision.php
+++ b/jetpack-start/wp-cli-provision.php
@@ -233,8 +233,10 @@ class Jetpack_Start_Provision_CLI_Command extends WPCOM_VIP_CLI_Command {
 		if ( isset( $body_json->access_token ) ) {
 			// authorize user and enable SSO
 			if ( method_exists( 'Jetpack', 'update_user_token' ) ) {
+				// Removed in JP 10.3
 				Jetpack::update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
 			} else {
+				// Available since JP 9.5
 				( new Tokens() )->update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
 			}
 

--- a/jetpack-start/wp-cli-provision.php
+++ b/jetpack-start/wp-cli-provision.php
@@ -232,7 +232,12 @@ class Jetpack_Start_Provision_CLI_Command extends WPCOM_VIP_CLI_Command {
 
 		if ( isset( $body_json->access_token ) ) {
 			// authorize user and enable SSO
-			( new Tokens )->update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
+			if ( method_exists( 'Jetpack', 'update_user_token' ) ) {
+				Jetpack::update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
+			} else {
+				( new Tokens() )->update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
+			}
+
 
 			$active_modules = Jetpack_Options::get_option( 'active_modules' );
 			if ( $active_modules ) {


### PR DESCRIPTION
This function has been deprecated since 9.5 and removed in 10.3. See https://github.com/Automattic/jetpack/pull/16434


## Changelog Description
Update `jetpack-start` to use modern function.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Unsure personally. Reported in vip-jetpack via p1636058453047900-slack-CDD9LQRSN