### PR TITLE
Search Dev Tools: do not bust assets cache for every request

### DIFF
--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -138,8 +138,11 @@ function enqueue_assets() {
 		return;
 	}
 
-	wp_enqueue_script( 'vip-search-dev-tools', plugin_dir_url( __FILE__ ) . 'build/bundle.js', [], time(), true );
-	wp_enqueue_style( 'vip-search-dev-tools', plugin_dir_url( __FILE__ ) . 'build/bundle.css', [], time() );
+	$assets_dir = __DIR__ . '/build';
+	$assets_url = plugin_dir_url( __FILE__ ) . 'build';
+
+	wp_enqueue_script( 'vip-search-dev-tools', $assets_url . '/bundle.js', [], filemtime( $assets_dir . '/bundle.js' ), true );
+	wp_enqueue_style( 'vip-search-dev-tools', $assets_url . '/bundle.css', [], filemtime( $assets_dir . '/bundle.css' ) );
 }
 
 /**


### PR DESCRIPTION
## Description

This PR improves the cacheability of Search Dev Tools' static assets.

Currently, the plugin enqueues its static assets so that the browser has to re-download them on every request, even if the assets haven't changed. This PR changes that by using the file modification time as the version string (vs the current time).

## Changelog Description

### Plugin Updated: Search Dev Tools

Improve cacheability of the static assets.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

N/A
