### PR TITLE
Fix 'Invalid value supplied for foreach' warning

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -774,7 +774,7 @@ class Health {
 		}
 
 		// Check that there is no missing key that would only be on $prepared_document
-		foreach ( $prepared_document as $key => $value ) {
+		foreach ( (array) $prepared_document as $key => $value ) {
 			if ( ! array_key_exists( $key, $checked_keys ) ) {
 				$diff[ $key ] = array(
 					'expected' => $value,

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -760,7 +760,7 @@ class Health {
 			}
 
 			if ( is_array( $value ) ) {
-				$recursive_diff = self::diff_document_and_prepared_document( $value, $prepared_document[ $key ] );
+				$recursive_diff = self::diff_document_and_prepared_document( $value, $prepared_document[ $key ] ?? [] );
 
 				if ( ! empty( $recursive_diff ) ) {
 					$diff[ $key ] = $recursive_diff;
@@ -774,7 +774,7 @@ class Health {
 		}
 
 		// Check that there is no missing key that would only be on $prepared_document
-		foreach ( (array) $prepared_document as $key => $value ) {
+		foreach ( $prepared_document as $key => $value ) {
 			if ( ! array_key_exists( $key, $checked_keys ) ) {
 				$diff[ $key ] = array(
 					'expected' => $value,

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -225,6 +225,29 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_diff, $diff );
 	}
 
+	public function test_diff_document_and_prepared_document_does_not_generate_notices(): void {
+		$document = [
+			'meta' => [
+				'_dt_aop_include_in_feed' => [
+					[
+						'value'    => '',
+						'raw'      => '',
+						'boolean'  => false,
+						'date'     => '1971-01-01',
+						'datetime' => '1971-01-01 00:00:01',
+						'time'     => '00:00:01', 
+					],
+				],
+			],
+		];
+		
+		$prepared_document = [
+			'meta' => [],
+		];
+
+		self::assertNull( \Automattic\VIP\Search\Health::diff_document_and_prepared_document( $document, $prepared_document ) );
+	}
+
 	public function test_get_document_ids_for_batch() {
 		$ids = \Automattic\VIP\Search\Health::get_document_ids_for_batch( 1, 5 );
 


### PR DESCRIPTION
## Description

This PR fixes the `Invalid argument supplied for foreach() in /wp-content/mu-plugins/search/includes/classes/class-health.php on line 777` warning, which happens when one of the keys contains a `null` value.

## Changelog Description

### Plugin Updated: VIP Search

Fix PHP warning in `Health::diff_document_and_prepared_document()`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Added a unit test for this case — the CI should pass.
