### PR TITLE
Enabling Parse.ly telemetry by default

### DIFF
--- a/vip-parsely/vip-parsely.php
+++ b/vip-parsely/vip-parsely.php
@@ -25,7 +25,7 @@ use Automattic\VIP\Parsely\Telemetry\Tracks;
 const WP_PARSELY_RECOMMENDED_WIDGET_BASE_ID = 'parsely_recommended_widget';
 
 // Telemetry is enabled by default on non-production sites.
-if ( apply_filters( 'wp_parsely_enable_telemetry_backend', defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) ) {
+if ( apply_filters( 'wp_parsely_enable_telemetry_backend', true ) ) {
 	require __DIR__ . '/Telemetry/class-telemetry.php';
 	require __DIR__ . '/Telemetry/class-telemetry-system.php';
 	require __DIR__ . '/Telemetry/Tracks/class-tracks.php';


### PR DESCRIPTION
## Description

We've been running the Parse.ly telemetry option for some time now on staging sites without any issues. We can now enable it by default to all sites.

## Changelog Description

### Enabling Parse.ly telemetry by default

We enabled Parse.ly telemetry for all sites that have Parse.ly enabled.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.