### PR TITLE
Removing custom Akismet filters

### DIFF
--- a/akismet.php
+++ b/akismet.php
@@ -50,20 +50,6 @@ function wpcom_vip_akismet_spam_count_incr( $val ) {
 }
 add_filter( 'akismet_spam_count_incr', 'wpcom_vip_akismet_spam_count_incr' );
 
-function vip_remove_akismet_admin_menu() {
-	if ( is_akismet_key_invalid() ) {
-		remove_action( 'admin_menu', array( 'Akismet_Admin', 'admin_menu' ), 5 );
-	}
-}
-add_action( 'admin_menu', 'vip_remove_akismet_admin_menu', 1 );
-
-function vip_remove_akismet_admin_notices() {
-	if ( is_akismet_key_invalid() ) {
-		remove_action( 'admin_notices', array( 'Akismet_Admin', 'display_notice' ) );
-	}
-}
-add_action( 'admin_notices', 'vip_remove_akismet_admin_notices', 1 );
-
 /**
  * @return bool True if the Akismet key in the site is not existent or not valid
  */


### PR DESCRIPTION
## Description

We introduced a couple of filters that checked if Akismet was correctly installed and active, and if that wasn't the case, it would hide some elements from `wp-admin`. This comes at the cost of an additional HTTP request, that might impact the server's performance. 

Given the fact that Akismet is always enabled (unless Jetpack is not) and VIP's Connection Pilot should connect it automatically, we no longer need to hide those messages. The only situation in which they would show up and they would redirect to a non-connected site is when CP fails, in which case is fine that the user sees that something is wrong.

## Changelog Description

### Removing custom Akismet filters

Getting rid of some custom code regarding Akismet messaging.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR on a Sandbox.
2. Disconnect Akismet manually through it's wp-admin page.
3. Expect to see normal messaging about Akismet not being active.
4. Let Connection Pilot reconnect Akismet.