### PR TITLE
Fix overescaping when displaying "Bulk actions disabled" notice

### DIFF
--- a/performance/bulk-edit.php
+++ b/performance/bulk-edit.php
@@ -97,7 +97,16 @@ function bulk_edit_admin_notice() {
 	$mailto        = 'mailto:vip-support@wordpress.com?subject=' . urlencode( $email_subject );
 	?>
 	<div id="<?php echo esc_attr( $id ); ?>" class="notice notice-error is-dismissible">
-		<p><?php /* translators: 1: number of items, 2: email address */ printf( esc_html__( 'Bulk actions are disabled because more than %1$s items were requested. To re-enable bulk edit, please adjust the "Number of items" setting under <em>Screen Options</em>. If you have a large number of posts to update, please <a href="%2$s">get in touch</a> as we may be able to help.', 'wpcom-vip' ), esc_html( number_format_i18n( BULK_EDIT_LIMIT ) ), esc_url( $mailto ) ); ?></p>
+		<p>
+		<?php
+		printf(
+			/* translators: 1: number of items, 2: email address */
+			__( 'Bulk actions are disabled because more than %1$s items were requested. To re-enable bulk edit, please adjust the "Number of items" setting under <em>Screen Options</em>. If you have a large number of posts to update, please <a href="%2$s">get in touch</a> as we may be able to help.', 'wpcom-vip' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML string
+			esc_html( number_format_i18n( BULK_EDIT_LIMIT ) ),
+			esc_url( $mailto )
+		);
+		?>
+		</p>
 
 		<script>jQuery(document).ready( function($) { $( '#<?php echo esc_js( $id ); ?>' ).on( 'remove', function() {
 			$.ajax( {


### PR DESCRIPTION
## Description

`esc_html__` was used on a HTML string. This PR removes it.

## Changelog Description

### Plugin Updated: VIP Performance Tweaks

Fix overescaping of a notification message.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
