### PR TITLE
Search: Bail and do not log when request is index_exists

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1990,7 +1990,7 @@ class Search {
 		}
 
 		$this->logger->log( 'warning', 'search_query_failure', $message, [
-			'request' => $request,
+			'request'    => $request,
 			'query_args' => $query_args,
 		] );
 	}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -690,7 +690,16 @@ class Search {
 		return 500;
 	}
 
-	public function filter__ep_do_intercept_request( $request, $query, $args, $type ) {
+	/**
+	 * Filter to intercept EP remote requests.
+	 * 
+	 * @param  array  $request New remote request response
+	 * @param  array  $query   Remote request arguments
+	 * @param  array  $args    Request arguments
+	 * @param  string $type    Type of request
+	 * @return array  $request New request
+	 */
+	public function filter__ep_do_intercept_request( $request, $query, $args, $type = null ) {
 		// Add custom headers to identify authorized traffic
 		if ( ! isset( $args['headers'] ) || ! is_array( $args['headers'] ) ) {
 			$args['headers'] = [];

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -413,7 +413,7 @@ class Search {
 
 		// Network layer replacement to use VIP helpers (that handle slow/down upstream server)
 		add_filter( 'ep_intercept_remote_request', '__return_true', 9999 );
-		add_filter( 'ep_do_intercept_request', [ $this, 'filter__ep_do_intercept_request' ], 9999, 3 );
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter__ep_do_intercept_request' ], 9999, 4 );
 
 		// Disable query integration by default
 		add_filter( 'ep_skip_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5, 2 );
@@ -690,7 +690,7 @@ class Search {
 		return 500;
 	}
 
-	public function filter__ep_do_intercept_request( $request, $query, $args ) {
+	public function filter__ep_do_intercept_request( $request, $query, $args, $type ) {
 		// Add custom headers to identify authorized traffic
 		if ( ! isset( $args['headers'] ) || ! is_array( $args['headers'] ) ) {
 			$args['headers'] = [];
@@ -727,7 +727,7 @@ class Search {
 		$response_code = (int) wp_remote_retrieve_response_code( $response );
 
 		if ( is_wp_error( $response ) || $response_code >= 400 ) {
-			$this->ep_handle_failed_request( $request, $response, $query, $statsd_prefix );
+			$this->ep_handle_failed_request( $request, $response, $query, $statsd_prefix, $type );
 		} else {
 			// Record engine time (have to parse JSON to get it)
 			$response_body_json = wp_remote_retrieve_body( $response );
@@ -832,7 +832,10 @@ class Search {
 		return true;
 	}
 
-	public function ep_handle_failed_request( $request, $response, $query, $statsd_prefix ) {
+	public function ep_handle_failed_request( $request, $response, $query, $statsd_prefix, $type ) {
+		if ( 'index_exists' === $type ) {
+			return; // Not a failed request, it is just doing a check if the index exists or not.
+		}
 		$is_cli = defined( 'WP_CLI' ) && WP_CLI;
 
 		if ( is_wp_error( $request ) ) {
@@ -1987,7 +1990,7 @@ class Search {
 		}
 
 		$this->logger->log( 'warning', 'search_query_failure', $message, [
-			'request'    => $request,
+			'request' => $request,
 			'query_args' => $query_args,
 		] );
 	}

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2738,7 +2738,20 @@ class Search_Test extends WP_UnitTestCase {
 					$this->anything()
 				);
 
-		$es->ep_handle_failed_request( null, $response, [], '' );
+		$es->ep_handle_failed_request( null, $response, [], '', null );
+	}
+
+	public function test__ep_handle_failed_request__index_exists() {
+		$es = new \Automattic\VIP\Search\Search();
+		$es->init();
+
+		$es->logger = $this->getMockBuilder( \Automattic\VIP\Logstash\Logger::class )
+				->setMethods( [ 'log' ] )
+				->getMock();
+
+		$es->logger->expects( $this->never() )->method( 'log' );
+
+		$es->ep_handle_failed_request( null, 404, [], '', 'index_exists' );
 	}
 
 	public function get_sanitize_ep_query_for_logging_data() {

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2741,6 +2741,9 @@ class Search_Test extends WP_UnitTestCase {
 		$es->ep_handle_failed_request( null, $response, [], '', null );
 	}
 
+	/**
+	 * Ensure when index_exists() is called and there is no index, it does not get logged as a failed request.
+	 */
 	public function test__ep_handle_failed_request__index_exists() {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();


### PR DESCRIPTION
## Description
We should not be logging any remote calls to `index_exists` as a failed request. 

`index_exists()` [does a remote request to determine if a 200 or a 404 is being returned](https://github.com/Automattic/ElasticPress/blob/fef833793a85e0229bf6fa3f66ba75333f00d8c8/includes/classes/Elasticsearch.php#L1001-L1023), but if there's no index, it gets logged as a failed request: https://github.com/Automattic/vip-go-mu-plugins/blob/3ee96e7db66a9345858f66eb0f28bd23c0172280/search/includes/classes/class-search.php#L729-L730

** DEPLOY NOTE: THIS MUST GO OUT AFTER (or in tandem with) https://github.com/Automattic/vip-go-mu-plugins/pull/2621 **

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.
