### PR TITLE
Fix incorrect invocation of get_error_message()

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -104,7 +104,7 @@ class Health {
 
 			$db_total = (int) $db_result['total_objects'];
 		} catch ( \Exception $e ) {
-			return new WP_Error( 'db_query_error', sprintf( 'failure querying the DB: %s #vip-search', $e->get_error_message() ) );
+			return new WP_Error( 'db_query_error', sprintf( 'failure querying the DB: %s #vip-search', $e->getMessage() ) );
 		}
 
 		$diff = 0;
@@ -147,8 +147,7 @@ class Health {
 
 			$es_result = $indexable->query_es( $formatted_args, $query->query_vars );
 		} catch ( \Exception $e ) {
-			$source = method_exists( $e, 'get_error_message' ) ? $e->get_error_message() : $e->getMessage();
-			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-search', $source ) );
+			return new WP_Error( 'es_query_error', sprintf( 'failure querying ES: %s #vip-search', $e->getMessage() ) );
 		}
 
 		// There is not other useful information out of query_es(): it just returns false in case of failure.

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -205,7 +205,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 				restore_current_blog();
 
 				if ( is_wp_error( $site_versions ) ) {
-					return WP_CLI::error( $result->get_error_message() );
+					return WP_CLI::error( $site_versions->get_error_message() );
 				}
 
 				foreach ( $site_versions as &$version ) {
@@ -221,7 +221,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			$versions = $search->versioning->get_versions( $indexable );
 
 			if ( is_wp_error( $versions ) ) {
-				return WP_CLI::error( $result->get_error_message() );
+				return WP_CLI::error( $versions->get_error_message() );
 			}
 
 			\WP_CLI\Utils\format_items( $assoc_args['format'] ?? 'table', $versions, array( 'number', 'active', 'created_time', 'activated_time' ) );


### PR DESCRIPTION
## Description

This PR fixes two issues:
* `get_error_message()` called on `Exception` object instead of `getMessage()`;
* `get_error_message()` on a wrong/uninitialized variable.

## Changelog Description

### Plugin Updated: VIP Search

  * Bug fix: `get_error_message()` called on `Exception` object instead of `getMessage()`
  * Bug fix: when `get_error_message()` was called on a uninitialized variable in wp-cli commands

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

N/A — we don't have tests (yet) that could have caught this bug.