### PR TITLE
Make sure that *diff_document_and_prepared_document receives an array

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -730,12 +730,13 @@ class Health {
 				continue;
 			}
 
+			$prepared_value = $prepared_document[ $key ] ?? null;
 			if ( is_array( $value ) ) {
-				$recursive_diff = self::simplified_diff_document_and_prepared_document( $value, $prepared_document[ $key ] );
+				$recursive_diff = self::simplified_diff_document_and_prepared_document( $value, is_array( $prepared_value ) ? $prepared_value : [] );
 				if ( $recursive_diff ) {
 					return true;
 				}
-			} elseif ( ( $prepared_document[ $key ] ?? null ) != $value ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
+			} elseif ( $prepared_value != $value ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
 				return true;
 			}
 		}
@@ -760,13 +761,14 @@ class Health {
 				continue;
 			}
 
+			$prepared_value = $prepared_document[ $key ] ?? null;
 			if ( is_array( $value ) ) {
-				$recursive_diff = self::diff_document_and_prepared_document( $value, $prepared_document[ $key ] ?? [] );
+				$recursive_diff = self::diff_document_and_prepared_document( $value, is_array( $prepared_value ) ? $prepared_value : [] );
 
 				if ( ! empty( $recursive_diff ) ) {
 					$diff[ $key ] = $recursive_diff;
 				}
-			} elseif ( ( $prepared_document[ $key ] ?? null ) != $value ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
+			} elseif ( $prepared_value != $value ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
 				$diff[ $key ] = array(
 					'expected' => $prepared_document[ $key ] ?? null,
 					'actual'   => $value,

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -2,7 +2,9 @@
 
 namespace Automattic\VIP\Search;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\MockObject;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use WP_UnitTestCase;
 
 class Health_Test extends WP_UnitTestCase {
@@ -226,27 +228,54 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_diff, $diff );
 	}
 
-	public function test_diff_document_and_prepared_document_does_not_generate_notices(): void {
-		$document = [
-			'meta' => [
-				'_dt_aop_include_in_feed' => [
-					[
-						'value'    => '',
-						'raw'      => '',
-						'boolean'  => false,
-						'date'     => '1971-01-01',
-						'datetime' => '1971-01-01 00:00:01',
-						'time'     => '00:00:01', 
+	/**
+	 * @dataProvider data_diff_document_and_prepared_document_does_not_generate_notices
+	 */
+	public function test_diff_document_and_prepared_document_does_not_generate_notices( array $document, array $prepared_document ): void {
+		self::assertNull( \Automattic\VIP\Search\Health::diff_document_and_prepared_document( $document, $prepared_document ) );
+	}
+
+	/**
+	 * @dataProvider data_diff_document_and_prepared_document_does_not_generate_notices
+	 */
+	public function test_simplified_diff_document_and_prepared_document_does_not_generate_notices( array $document, array $prepared_document ): void {
+		self::assertFalse( \Automattic\VIP\Search\Health::simplified_diff_document_and_prepared_document( $document, $prepared_document ) );
+	}
+
+	public function data_diff_document_and_prepared_document_does_not_generate_notices(): iterable {
+		return [
+			[
+				[
+					'meta' => [
+						'_dt_aop_include_in_feed' => [
+							[
+								'value'    => '',
+								'raw'      => '',
+								'boolean'  => false,
+								'date'     => '1971-01-01',
+								'datetime' => '1971-01-01 00:00:01',
+								'time'     => '00:00:01', 
+							],
+						],
 					],
+				],
+				[
+					'meta' => [],
+				],
+			],
+			[
+				[
+					'meta' => [
+						[
+							'value' => '',
+						],
+					],
+				],
+				[
+					'meta' => 'value',
 				],
 			],
 		];
-		
-		$prepared_document = [
-			'meta' => [],
-		];
-
-		self::assertNull( \Automattic\VIP\Search\Health::diff_document_and_prepared_document( $document, $prepared_document ) );
 	}
 
 	public function test_get_document_ids_for_batch() {


### PR DESCRIPTION
## Description

Related to #2603 and fixes more cases that could generate the warning.

## Changelog Description

### Plugin Updated: VIP Search

Fix PHP warning in Health::diff_document_and_prepared_document()

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Added a unit test for this case — the CI should pass.