### PR TITLE
Add more powerful test runner for local development

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --wp)
+            shift
+            WP_VERSION="$1"
+        ;;
+
+        --multisite)
+            shift
+            WP_MULTISITE="$1"
+        ;;
+
+        --php)
+            shift
+            PHP_VERSION="$1"
+        ;;
+
+        --php-options)
+            shift
+            PHP_OPTIONS="$1"
+        ;;
+
+        --phpunit)
+            shift
+            PHPUNIT_VERSION="$1"
+        ;;
+
+        --network)
+            shift
+            NETWORK_NAME_OVERRIDE="$1"
+        ;;
+
+        --dbhost)
+            shift
+            MYSQL_HOST_OVERRIDE="$1"
+        ;;
+
+        *)
+            ARGS="${ARGS} $1"
+        ;;
+    esac
+
+    shift
+done
+
+: "${WP_VERSION:=latest}"
+: "${WP_MULTISITE:=0}"
+: "${PHP_VERSION:=""}"
+: "${PHP_OPTIONS:=""}"
+: "${PHPUNIT_VERSION:=""}"
+
+export WP_VERSION
+export WP_MULTISITE
+export PHP_VERSION
+export PHP_OPTIONS
+export PHPUNIT_VERSION
+
+echo "--------------"
+echo "Will test with WP_VERSION=${WP_VERSION} and WP_MULTISITE=${WP_MULTISITE}"
+echo "--------------"
+echo
+
+MARIADB_VERSION="10.3"
+
+UUID=$(date +%s000)
+if [ -z "${NETWORK_NAME_OVERRIDE}" ]; then
+    NETWORK_NAME="tests-${UUID}"
+    docker network create "${NETWORK_NAME}"
+else
+    NETWORK_NAME="${NETWORK_NAME_OVERRIDE}"
+fi
+
+export MYSQL_USER=wordpress
+export MYSQL_PASSWORD=wordpress
+export MYSQL_DATABASE=wordpress_test
+
+db=""
+if [ -z "${MYSQL_HOST_OVERRIDE}" ]; then
+    MYSQL_HOST="db-${UUID}"
+    db=$(docker run --rm --network "${NETWORK_NAME}" --name "${MYSQL_HOST}" -e MYSQL_ROOT_PASSWORD="wordpress" -e MARIADB_INITDB_SKIP_TZINFO=1 -e MYSQL_USER -e MYSQL_PASSWORD -e MYSQL_DATABASE -d "mariadb:${MARIADB_VERSION}")
+else
+    MYSQL_HOST="${MYSQL_HOST_OVERRIDE}"
+fi
+
+export MYSQL_HOST
+
+cleanup() {
+    if [ -n "${db}" ]; then
+        docker rm -f "${db}"
+    fi
+
+    if [ -z "${NETWORK_NAME_OVERRIDE}" ]; then
+        docker network rm "${NETWORK_NAME}"
+    fi
+}
+
+trap cleanup EXIT
+
+# shellcheck disable=SC2086 # ARGS must not be quoted
+docker run \
+    -it \
+    --rm \
+    --network "${NETWORK_NAME}" \
+    -e WP_VERSION \
+    -e WP_MULTISITE \
+    -e PHP_VERSION \
+    -e PHP_OPTIONS \
+    -e PHPUNIT_VERSION \
+    -e MYSQL_USER \
+    -e MYSQL_PASSWORD \
+    -e MYSQL_DATABASE \
+    -e MYSQL_HOST \
+    -v "$(pwd):/home/circleci/project" \
+    ghcr.io/automattic/vip-container-images/wp-test-runner:latest \
+    ${ARGS}


### PR DESCRIPTION
This PR adds a more powerful alternative to `bin/phpunit-docker.sh`.

Its features:
* supports multiple PHP versions (7.4, 8.0, 8.1), available via `--php` parameter (7.4 is the default one);
* supports multiple PHPUnit versions (7, 8, 9), available via `--phpunit` parameter (the default is the one bundled with the application);
* supports passing extra command-line arguments to PHP (`--php-options` parameter); this can be useful to profile slow tests; this feature depends on Automattic/vip-container-images#46;
* can use the existing MySQL database server for tests (`--network` and `--dbhost` parameters), which eliminates the need to create, start, and stop MySQL for every invocation.

Among other things, it is faster than the old `phpunit-docker.sh`.

This runner:
```
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Test 'Automattic\VIP\Search\Queue_Test::test_job_priorities' started
Test 'Automattic\VIP\Search\Queue_Test::test_job_priorities' ended


Time: 5.94 seconds, Memory: 46.50 MB

OK (1 test, 3 assertions)
```

The old runner:
```
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Test 'Automattic\VIP\Search\Queue_Test::test_job_priorities' started
Test 'Automattic\VIP\Search\Queue_Test::test_job_priorities' ended


Time: 27.86 seconds, Memory: 52.50 MB

OK (1 test, 3 assertions)
```

**Speeding up test runs with the preloaded MySQL server:**

First, you need to create a new network and run a MySQL server in that network:
```bash
docker network create wptest
docker run --rm --network wptest --name mysql -e MYSQL_ROOT_PASSWORD=wordpress -e MARIADB_INITDB_SKIP_TZINFO=1 -e MYSQL_USER=wordpress -e MYSQL_PASSWORD=wordpress -e MYSQL_DATABASE=wordpress_test -d mariadb:10.3
```

Then, whenever you need to run tests, just pass the proper `--network` and `--dbhost` parameters to the test runner:
```bash
bin/test.sh --network wptest --dbhost mysql
```
