### PR TITLE
Search: filter__ep_do_intercept_request: Account for $failures parameter

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -416,7 +416,7 @@ class Search {
 
 		// Network layer replacement to use VIP helpers (that handle slow/down upstream server)
 		add_filter( 'ep_intercept_remote_request', '__return_true', 9999 );
-		add_filter( 'ep_do_intercept_request', [ $this, 'filter__ep_do_intercept_request' ], 9999, 4 );
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter__ep_do_intercept_request' ], 9999, 5 );
 
 		// Disable query integration by default
 		add_filter( 'ep_skip_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5, 2 );
@@ -690,13 +690,14 @@ class Search {
 	/**
 	 * Filter to intercept EP remote requests.
 	 * 
-	 * @param  array  $request New remote request response
-	 * @param  array  $query   Remote request arguments
-	 * @param  array  $args    Request arguments
-	 * @param  string $type    Type of request
-	 * @return array  $request New request
+	 * @param  array  $request  New remote request response
+	 * @param  array  $query    Remote request arguments
+	 * @param  array  $args     Request arguments
+	 * @param  array  $failures Number of failures
+	 * @param  string $type     Type of request
+	 * @return array  $request  New request
 	 */
-	public function filter__ep_do_intercept_request( $request, $query, $args, $type = null ) {
+	public function filter__ep_do_intercept_request( $request, $query, $args, $failures = 0, $type = null ) {
 		// Add custom headers to identify authorized traffic
 		if ( ! isset( $args['headers'] ) || ! is_array( $args['headers'] ) ) {
 			$args['headers'] = [];

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2189,7 +2189,7 @@ class Search_Test extends WP_UnitTestCase {
 				[ "$stats_prefix.total", $this->greaterThan( 0 ) ]
 			);
 
-		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, null );
+		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, 0, null );
 	}
 
 	public function test__filter__ep_do_intercept_request__records_statsd_per_doc() {
@@ -2223,7 +2223,7 @@ class Search_Test extends WP_UnitTestCase {
 				[ "$stats_prefix.per_doc", $this->greaterThan( 0 ) ]
 			);
 
-		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, null );
+		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, 0, null );
 	}
 
 	public function test__filter__ep_do_intercept_request__records_statsd_on_non_200_response() {
@@ -2254,7 +2254,7 @@ class Search_Test extends WP_UnitTestCase {
 			->method( 'maybe_increment_stat' )
 			->withConsecutive( [ "$stats_prefix.total" ], [ "$stats_prefix.error" ] );
 
-		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, null );
+		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, 0, null );
 	}
 
 	public function test__filter__ep_do_intercept_request__records_statsd_on_wp_error_per_msg() {
@@ -2285,7 +2285,7 @@ class Search_Test extends WP_UnitTestCase {
 			->method( 'maybe_increment_stat' )
 			->withConsecutive( [ "$stats_prefix.total" ], [ "$stats_prefix.error" ], [ "$stats_prefix.error" ] );
 
-		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, null );
+		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, 0, null );
 	}
 
 	public function test__filter__ep_do_intercept_request__records_statsd_on_wp_error_timeout() {
@@ -2311,7 +2311,7 @@ class Search_Test extends WP_UnitTestCase {
 			->method( 'maybe_increment_stat' )
 			->withConsecutive( [ "$stats_prefix.total" ], [ "$stats_prefix.timeout" ] );
 
-		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, null );
+		$partially_mocked_search->filter__ep_do_intercept_request( null, $query, $args, 0, null );
 	}
 
 	public function test__maybe_alert_for_average_queue_time__sends_notification() {
@@ -2759,7 +2759,7 @@ class Search_Test extends WP_UnitTestCase {
 
 		$es->logger->expects( $this->never() )->method( 'log' );
 
-		$es->ep_handle_failed_request( null, 404, [], '', 'index_exists' );
+		$es->ep_handle_failed_request( null, 404, [], 0, 'index_exists' );
 	}
 
 	public function get_sanitize_ep_query_for_logging_data() {


### PR DESCRIPTION
## Description

My lizard brain forgot that it's the order you pass in, not by parameter name 🥇 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.