### PR TITLE
Search: Check object exists before attempting to delete object

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -816,8 +816,10 @@ class Versioning {
 		foreach ( $inactive_versions as $version ) {
 			$this->set_current_version_number( $indexable, $version['number'] );
 
-			$indexable->delete( $object_id );
-
+			if ( $indexable->get( $object_id ) ) {
+				$indexable->delete( $object_id );
+			}
+			
 			$this->reset_current_version_number( $indexable );
 		}
 

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -1209,10 +1209,15 @@ class Versioning_Test extends WP_UnitTestCase {
 
 		// Add a filter that we can use to count how many deletes are actually sent to ES
 		$delete_count = 0;
+		$get_count = 0;
 
-		add_filter( 'ep_do_intercept_request', function( $request, $query, $args ) use ( &$delete_count ) {
+		add_filter( 'ep_do_intercept_request', function( $request, $query, $args ) use ( &$delete_count, &$get_count ) {
 			if ( 'DELETE' === $args['method'] ) {
 				$delete_count++;
+			}
+
+			if ( 'GET' === $args['method'] ) {
+				$get_count++;
 			}
 
 			// For linting, always have to return something
@@ -1221,7 +1226,8 @@ class Versioning_Test extends WP_UnitTestCase {
 
 		$indexable->delete( 1 );
 
-		$this->assertEquals( $delete_count, 2 );
+		$this->assertEquals( $delete_count, 1 );
+		$this->assertEquals( $get_count, 1 );
 	}
 
 	public function normalize_version_data() {


### PR DESCRIPTION
## Description

When a new index version is created but it hasn't been indexed yet, it will have no posts in it. If you attempt to delete a post, it will attempt to delete the post from the inactive index as well. We should check that the post exists before attempting to delete it.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Reproduction Steps:
1) Create some posts
2) Index: `wp vip-search index`
3) Add new index version `wp vip-search index-versions add post`
4) Delete a post
5) See logging:

```
wp_trash_post, wp_update_post, wp_insert_post, do_action('wp_insert_post'), WP_Hook->do_action, WP_Hook->apply_filters, ElasticPress\\\\Indexable\\\\Post\\\\SyncManager->action_sync_on_update, ElasticPress\\\\Indexable\\\\Post\\\\SyncManager->action_delete_post, ElasticPress\\\\Indexable->delete, do_action('ep_delete_post'), WP_Hook->do_action, WP_Hook->apply_filters, Automattic\\\\VIP\\\\Search\\\\Versioning->action__ep_delete_indexable, ElasticPress\\\\Indexable->delete, ElasticPress\\\\Elasticsearch->delete_document, ElasticPress\\\\Elasticsearch->remote_request, apply_filters('ep_do_intercept_request'), WP_Hook->apply_filters, Automattic\\\\VIP\\\\Search\\\\Search->filter__ep_do_intercept_request, Automattic\\\\VIP\\\\Search\\\\Search->ep_handle_failed_request
```
