### PR TITLE
Remove XDebug and Speed Up CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ job-references:
       MYSQL_USER: << pipeline.parameters.db_user >>
       MYSQL_PASSWORD: << pipeline.parameters.db_pass >>
       MYSQL_DB: << pipeline.parameters.db_name >>
+      DISABLE_XDEBUG: "1"
 
   php_job: &php_job
     steps:

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -112,6 +112,7 @@ docker run \
     -e MYSQL_PASSWORD \
     -e MYSQL_DATABASE \
     -e MYSQL_HOST \
+    -e DISABLE_XDEBUG=1 \
     -v "$(pwd):/home/circleci/project" \
     ghcr.io/automattic/vip-container-images/wp-test-runner:latest \
     ${ARGS}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -112,4 +112,6 @@ switch ( getenv( 'WPVIP_PARSELY_INTEGRATION_TEST_MODE' ) ) {
 		break;
 }
 
+require_once __DIR__ . '/mock-header.php';
+
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/cache/mock-header.php
+++ b/tests/cache/mock-header.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Automattic\VIP\Cache;
+
+function header_remove( ?string $name = null ): void {
+	\Automattic\Test\header_remove( $name );
+}
+
+function headers_list(): array {
+	return \Automattic\Test\headers_list();
+}
+
+function headers_sent(): bool {
+	return \Automattic\Test\headers_sent();
+}
+
+function header( string $header, bool $replace = true ) {
+	\Automattic\Test\header( $header, $replace );
+}
+
+function setcookie() {
+	// Do nothing
+}
+
+function setrawcookie() {
+	// Do nothing
+}

--- a/tests/files/acl/mock-header.php
+++ b/tests/files/acl/mock-header.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Automattic\VIP\Files\Acl;
+
+function header_remove( ?string $name = null ): void {
+	\Automattic\Test\header_remove( $name );
+}
+
+function headers_list(): array {
+	return \Automattic\Test\headers_list();
+}
+
+function headers_sent(): bool {
+	return \Automattic\Test\headers_sent();
+}
+
+function header( string $header, bool $replace = true ) {
+	\Automattic\Test\header( $header, $replace );
+}

--- a/tests/mock-header.php
+++ b/tests/mock-header.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Automattic\Test;
+
+$headers = [];
+
+function header_remove( ?string $name = null ): void {
+	global $headers;
+	if ( null === $name ) {
+		$headers = [];
+	} else {
+		foreach ( $headers as $index => $header ) {
+			$parts = explode( ':', $header, 2 );
+			$hname = strtolower( trim( $parts[0] ) );
+			if ( ! strcasecmp( $hname, $name ) ) {
+				unset( $headers[ $index ] );
+			}
+		}
+	}
+}
+
+function headers_list(): array {
+	global $headers;
+	return array_values( $headers );
+}
+
+function headers_sent(): bool {
+	global $headers;
+	return ! empty( $headers );
+}
+
+function header( string $header, bool $replace = true ) {
+	global $headers;
+
+	if ( $replace ) {
+		$parts = explode( ':', $header, 2 );
+		$name  = trim( $parts[0] );
+		namespace\header_remove( $name );
+	}
+
+	$headers[] = $header;
+}

--- a/tests/search/includes/classes/mock-header.php
+++ b/tests/search/includes/classes/mock-header.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+function header_remove( ?string $name = null ): void {
+	\Automattic\Test\header_remove( $name );
+}
+
+function headers_list(): array {
+	return \Automattic\Test\headers_list();
+}
+
+function headers_sent(): bool {
+	return \Automattic\Test\headers_sent();
+}
+
+function header( string $header, bool $replace = true ) {
+	\Automattic\Test\header( $header, $replace );
+}

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
+require_once __DIR__ . '/mock-header.php';
 require_once __DIR__ . '/../../../../search/search.php';
 require_once __DIR__ . '/../../../../search/includes/classes/class-versioning.php';
 require_once __DIR__ . '/../../../../search/elasticpress/elasticpress.php';
@@ -29,6 +30,8 @@ class Search_Test extends WP_UnitTestCase {
 
 		$cache_key = \Automattic\VIP\Search\Search::INDEX_EXISTENCE_CACHE_KEY_PREFIX . $this->test_index_name;
 		wp_cache_delete( $cache_key, \Automattic\VIP\Search\Search::SEARCH_CACHE_GROUP );
+
+		header_remove();
 	}
 
 	public function test_query_es_with_invalid_type() {
@@ -656,11 +659,6 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertContains( $es->get_random_host( $hosts ), $hosts );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 * @requires function xdebug_get_headers
-	 */
 	public function test__send_vary_headers__sent_for_group() {
 
 		$es = new \Automattic\VIP\Search\Search();
@@ -675,7 +673,8 @@ class Search_Test extends WP_UnitTestCase {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		unset( $_GET['ep_debug'] );
 
-		$this->assertContains( 'X-ElasticPress-Search-Valid-Response: true', xdebug_get_headers() );
+		$headers = headers_list();
+		$this->assertContains( 'X-ElasticPress-Search-Valid-Response: true', $headers, '', true );
 	}
 
 	public function test__vip_search_filter__ep_facet_taxonomies_size() {


### PR DESCRIPTION
This PR tries to speed up our CI by eliminating the dependency on XDebug and mocking `header()` and related functions for tests that use it. In many cases, this also allowed us to get rid of the `@runInSeparateProcess` annotation, which also positively affected performance.

On averages, the builds are now 1 to 2 minutes faster (I guess that depends on CircleCI's workload, need to test this in a more quiet time). Well, it ain't much but it's honest work :grinning: 
