### PR TITLE
Search: Do not log on $indexable->get() for non-existent posts

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -840,9 +840,15 @@ class Search {
 	}
 
 	public function ep_handle_failed_request( $request, $response, $query, $statsd_prefix, $type ) {
-		if ( 'index_exists' === $type ) {
-			return; // Not a failed request, it is just doing a check if the index exists or not.
+		// Not real failed requests, we should not be logging.
+		$skiplist = [
+			'index_exists',
+			'get',
+		];
+		if ( in_array( $type, $skiplist, true ) ) {
+			return;
 		}
+
 		$is_cli = defined( 'WP_CLI' ) && WP_CLI;
 
 		if ( is_wp_error( $request ) ) {

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2747,9 +2747,9 @@ class Search_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure when index_exists() is called and there is no index, it does not get logged as a failed request.
+	 * Ensure when actions from the skiplist are called, they do not get logged as a failed request.
 	 */
-	public function test__ep_handle_failed_request__index_exists() {
+	public function test__ep_handle_failed_request__skiplist() {
 		$es = new \Automattic\VIP\Search\Search();
 		$es->init();
 
@@ -2759,7 +2759,14 @@ class Search_Test extends WP_UnitTestCase {
 
 		$es->logger->expects( $this->never() )->method( 'log' );
 
-		$es->ep_handle_failed_request( null, 404, [], 0, 'index_exists' );
+		$skiplist = [
+			'index_exists',
+			'get',
+		];
+
+		foreach ( $skiplist as $item ) {
+			$es->ep_handle_failed_request( null, 404, [], 0, $item );
+		}
 	}
 
 	public function get_sanitize_ep_query_for_logging_data() {


### PR DESCRIPTION
## Description
Kind of a part 2 to https://github.com/Automattic/vip-go-mu-plugins/pull/2629.

Similar to what we did in https://github.com/Automattic/vip-go-mu-plugins/pull/2620. We should not be logging if we call `$indexable->get()` on a non-existent post (object) since I wouldn't exactly call that a failed request either. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Pull down PR
2) Open wp shell
3) `$indexable = \ElasticPress\Indexables::factory()->get( 'post' );`
4) `$indexable->get( 1821312123123123123123 );`
5) Notice no `search_query_error` being logged