### PR TITLE
ES-WP-Query: Reset array keys after applying array_unique to terms

### DIFF
--- a/search/es-wp-query/class-es-wp-tax-query.php
+++ b/search/es-wp-query/class-es-wp-tax-query.php
@@ -264,7 +264,7 @@ class ES_WP_Tax_Query extends WP_Tax_Query {
 			return;
 		}
 
-		$query['terms'] = array_unique( (array) $query['terms'] );
+		$query['terms'] = array_values( array_unique( (array) $query['terms'] ) );
 
 		if ( is_taxonomy_hierarchical( $query['taxonomy'] ) && $query['include_children'] ) {
 			$this->transform_query( $query, 'term_id' );


### PR DESCRIPTION
## Description

There could be a situation where having duplicate values in the array of terms will lead to holes in the array after using `array_unique`, this would break JSON for the query.

## Changelog Description

### Plugin Updated: Enterprise Search

We addressed an issue that may result in a broken ES-WP-Query query if terms parameter contained duplicate terms.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
