### PR TITLE
Cleanup JP connection pilot cron registration & run conditions

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -139,6 +139,8 @@ $internal_cron_events = array(
 	),
 );
 
+define( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', $internal_cron_events );
+
 // Enable Jetpack private connection by default on non production sites
 if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) && defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) {
 	define( 'VIP_JETPACK_IS_PRIVATE', true );
@@ -148,16 +150,6 @@ if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) && defined( 'VIP_GO_APP_ENVIRONMENT' 
 if ( ! defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) ) {
 	define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', WPCOM_IS_VIP_ENV );
 }
-
-if ( defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) && true === VIP_JETPACK_AUTO_MANAGE_CONNECTION ) {
-	$internal_cron_events[] = array(
-		'schedule' => 'hourly',
-		'action'   => 'wpcom_vip_run_jetpack_connection_pilot',
-		'callback' => array( '\Automattic\VIP\Jetpack\Connection_Pilot', 'do_cron' ),
-	);
-}
-
-define( 'CRON_CONTROL_ADDITIONAL_INTERNAL_EVENTS', $internal_cron_events );
 
 // Interaction with the filesystem will always be direct.
 // Avoids issues with `get_filesystem_method` which attempts to write to `WP_CONTENT_DIR` and fails.

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -32,7 +32,7 @@ class Connection_Pilot {
 	/**
 	 * Maximum number of hours that the system will wait to try to reconnect.
 	 */
-	const MAX_BACKOFF_FACTOR = 2048;
+	const MAX_BACKOFF_FACTOR = 7 * 24;
 
 	/**
 	 * The healtcheck option's current data.
@@ -187,6 +187,13 @@ class Connection_Pilot {
 	private function should_back_off(): bool {
 		if ( ! empty( $this->last_heartbeat['backoff_factor'] ) && ! empty( $this->last_heartbeat['timestamp'] ) ) {
 			$backoff_factor = $this->last_heartbeat['backoff_factor'];
+
+			// Ensure we don't go past the max, and support future decreases should they occur.
+			if ( $backoff_factor > self::MAX_BACKOFF_FACTOR ) {
+				$backoff_factor = self::MAX_BACKOFF_FACTOR;
+				$this->update_heartbeat( $backoff_factor );
+			}
+
 			if ( $backoff_factor > 0 ) {
 				$dt_heartbeat = ( new DateTime() )->setTimestamp( $this->last_heartbeat['timestamp'] );
 				$dt_now       = new DateTime();


### PR DESCRIPTION
## Description

- Lower the max backoff for connection attempts to once a week.
- Cleanup cron registration:
  - Remove the internal job
  - Unregister the job when auto-connections are disabled
  - Limit conditions when it is registered
 - Expose CLI command regardless of `VIP_JETPACK_AUTO_MANAGE_CONNECTION` 

## Changelog Description
### Jetpack Connections: Cron job cleanup

Lower the max backoff time for connection attempts, and unregister the cron job when it's not needed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Not much to test here, but could disable `VIP_JETPACK_AUTO_MANAGE_CONNECTION` and ensure the job is gone (keep batch containers in mind).

And then manually set a backoff factor to something more than 24 * 7 and set an old timestamp, then ensure the event still runs. Unit tests cover this already though :)
