### PR TITLE
Make Alerts more testable

### DIFF
--- a/tests/lib/utils/class-testable-alerts.php
+++ b/tests/lib/utils/class-testable-alerts.php
@@ -1,0 +1,39 @@
+<?php
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found -- "useless overrides" override method visibility
+
+namespace Automattic\VIP\Utils;
+
+require_once __DIR__ . '/../../../lib/utils/class-alerts.php';
+
+class Testable_Alerts extends Alerts {
+	public static $svc_address = 'test.host';
+	public static $svc_port    = 9999;
+
+	protected static function get_service_address() {
+		return self::$svc_address;
+	}
+
+	protected static function get_service_port() {
+		return self::$svc_port;
+	}
+
+	public static function clear_instance() {
+		parent::clear_instance();
+	}
+
+	public function send( array $body ) {
+		return parent::send( $body );
+	}
+
+	public function validate_channel_or_user( $channel_or_user ) {
+		return parent::validate_channel_or_user( $channel_or_user );
+	}
+
+	public function validate_message( $message ) {
+		return parent::validate_message( $message );
+	}
+
+	public function validate_opsgenie_details( $details ) {
+		return parent::validate_opsgenie_details( $details );
+	}
+}


### PR DESCRIPTION
I have refactored Alerts tests so that they don't have to be run in a separate process.

The main changes are:
* the testable methods are now `protected`, not `private`. This allows us not to use the Reflection API and makes tests more readable;
* I have introduced two `protected static` helper methods: `get_service_address()` and `get_service_port`. They can be overridden by a descendant; their raison d'être is to allow us not to use PHP constants and, as a consequence, to be able to run all tests in a single process;
* another helper method is `clear_instance()`: because Singletons are hard to test :-( 

With these changes, it takes 2.68 seconds to complete the tests (vs 1.08 minutes).