### PR TITLE
Refactor Logger tests

### DIFF
--- a/tests/logstash/class-testable-logger.php
+++ b/tests/logstash/class-testable-logger.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Automattic\VIP\Logstash;
+
+class Testable_Logger extends Logger {
+	public static $logged_entries = [];
+
+	public static function set_entries( array $entries ): void {
+		self::$entries             = $entries;
+		static::$processed_entries = false;
+		static::$logged_entries    = [];
+	}
+
+	public static function wp_debug_log( array $entry ) : void {
+		self::$logged_entries[] = $entry;
+	}
+
+	public static function get_entries(): array {
+		return static::$entries;
+	}
+}


### PR DESCRIPTION
Refactor Logger tests:
* do not use Reflection API;
* run tests in the same process.
