### PR TITLE
Refactor password tests

### DIFF
--- a/tests/security/test-password.php
+++ b/tests/security/test-password.php
@@ -18,10 +18,11 @@ class Current_Password_Change_Test extends WP_UnitTestCase {
 		] );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
+	public function clean_up_global_scope() {
+		parent::clean_up_global_scope();
+		$_REQUEST = [];
+	}
+
 	public function test__should_return_if_creating_user() {
 		$errors = new WP_Error();
 		$user   = get_user_by( 'login', 'john' );
@@ -30,10 +31,6 @@ class Current_Password_Change_Test extends WP_UnitTestCase {
 		$this->assertFalse( $errors->has_errors() );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__should_return_in_user_edit() {
 		$errors = new WP_Error();
 		$user   = get_user_by( 'login', 'john' );
@@ -43,10 +40,6 @@ class Current_Password_Change_Test extends WP_UnitTestCase {
 		$this->assertFalse( $errors->has_errors() );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__should_return_if_no_pass_update() {
 		$errors               = new WP_Error();
 		$user                 = get_user_by( 'login', 'john' );
@@ -57,10 +50,6 @@ class Current_Password_Change_Test extends WP_UnitTestCase {
 		$this->assertFalse( $errors->has_errors() );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__should_return_error_if_no_current_pass() {
 		$_POST                = [
 			'pass1' => 'somepassword',
@@ -77,10 +66,6 @@ class Current_Password_Change_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_error, $errors->get_error_message( 0 ) );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__should_return_error_if_current_pass_incorrect() {
 		$_POST                = [
 			'pass1'        => 'somepassword',
@@ -98,10 +83,6 @@ class Current_Password_Change_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_error, $errors->get_error_message( 0 ) );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__should_succeed_with_correct_password() {
 		$_POST                = [
 			'pass1'        => 'somepassword',


### PR DESCRIPTION
Refactor password tests to allow them to run in a single process.

This PR adds the necessary clean-up logic, and drops `@runInSeparateProcess` declarations for `test-password.php`.

Timings (for my local environment, it is *slower* than CircleCI):
* before: 21.34 seconds
* after: 3.95 seconds
