### PR TITLE
Refactor tests for private sites and Lockout component

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -43,9 +43,9 @@ class Lockout {
 		if ( defined( 'VIP_LOCKOUT_STATE' ) ) {
 			$user = wp_get_current_user();
 
-			switch ( VIP_LOCKOUT_STATE ) {
+			switch ( constant( 'VIP_LOCKOUT_STATE' ) ) {
 				case 'warning':
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'manage_options' ), VIP_LOCKOUT_STATE, $user );
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'manage_options' ), constant( 'VIP_LOCKOUT_STATE' ), $user );
 					if ( $show_notice ) {
 						$this->render_warning_notice();
 
@@ -55,7 +55,7 @@ class Lockout {
 					break;
 
 				case 'locked':
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'edit_posts' ), VIP_LOCKOUT_STATE, $user );
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'edit_posts' ), constant( 'VIP_LOCKOUT_STATE' ), $user );
 					if ( $show_notice ) {
 						$this->render_locked_notice();
 
@@ -76,7 +76,7 @@ class Lockout {
 		$seen_warning = get_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, true );
 
 		if ( ! $seen_warning ) {
-			add_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, VIP_LOCKOUT_STATE, true );
+			add_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, constant( 'VIP_LOCKOUT_STATE' ), true );
 			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- not sure if it is safe to replace with gmdate()
 			add_user_meta( $user->ID, self::USER_SEEN_WARNING_TIME_KEY, date( 'Y-m-d H:i:s' ), true );
 		}
@@ -87,7 +87,7 @@ class Lockout {
 		<div id="lockout-warning" class="notice-warning wrap clearfix" style="align-items: center;background: #ffffff;border-left-width:4px;border-left-style:solid;border-radius: 6px;display: flex;margin-top: 30px;padding: 30px;line-height: 2em;">
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#ffb900;"></div>
 			<div style="display: flex;align-items: center;" >
-				<h3><?php echo wp_kses_post( VIP_LOCKOUT_MESSAGE ); ?></h3>
+				<h3><?php echo wp_kses_post( constant( 'VIP_LOCKOUT_MESSAGE' ) ); ?></h3>
 			</div>
 		</div>
 		<?php
@@ -98,7 +98,7 @@ class Lockout {
 		<div id="lockout-warning" class="notice-error wrap clearfix" style="align-items: center;background: #ffffff;border-left-width:4px;border-left-style:solid;border-radius: 6px;display: flex;margin-top: 30px;padding: 30px;line-height: 2em;">
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#dc3232;"></div>
 			<div style="display: flex;align-items: center;" >
-				<h3><?php echo wp_kses_post( VIP_LOCKOUT_MESSAGE ); ?></h3>
+				<h3><?php echo wp_kses_post( constant( 'VIP_LOCKOUT_MESSAGE' ) ); ?></h3>
 			</div>
 		</div>
 		<?php
@@ -117,7 +117,7 @@ class Lockout {
 	 * @return array
 	 */
 	public function filter_user_has_cap( $user_caps, $caps, $args, $user ) {
-		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === VIP_LOCKOUT_STATE ) {
+		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === constant( 'VIP_LOCKOUT_STATE' ) ) {
 			if ( is_automattician( $user->ID ) ) {
 				return $user_caps;
 			}
@@ -146,7 +146,7 @@ class Lockout {
 	 * @return  array
 	 */
 	public function filter_site_admin_option( $pre_option ) {
-		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === VIP_LOCKOUT_STATE ) {
+		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === constant( 'VIP_LOCKOUT_STATE' ) ) {
 			if ( is_automattician() ) {
 				return $pre_option;
 			}
@@ -167,7 +167,7 @@ class Lockout {
 	 * Instead, just block updates to the option if a site is locked.
 	 */
 	public function filter_prevent_site_admin_option_updates( $value, $old_value ) {
-		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === VIP_LOCKOUT_STATE ) {
+		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === constant( 'VIP_LOCKOUT_STATE' ) ) {
 			return $old_value;
 		}
 

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -34,14 +34,14 @@ class Private_Sites {
 
 	public static function is_jetpack_private() {
 		// If constant is defined and is set to `false`, bypass any other logic; site has opted out
-		$is_opted_out = defined( 'VIP_JETPACK_IS_PRIVATE' ) && false === VIP_JETPACK_IS_PRIVATE;
+		$is_opted_out = defined( 'VIP_JETPACK_IS_PRIVATE' ) && false === constant( 'VIP_JETPACK_IS_PRIVATE' );
 		if ( $is_opted_out ) {
 			return false;
 		}
 
-		$by_constant        = defined( 'VIP_JETPACK_IS_PRIVATE' ) && true === VIP_JETPACK_IS_PRIVATE;
-		$by_basic_auth      = defined( 'WPCOM_VIP_BASIC_AUTH' ) && true === WPCOM_VIP_BASIC_AUTH;
-		$by_ip_restrictions = defined( 'WPCOM_VIP_IP_ALLOW_LIST' ) && true === WPCOM_VIP_IP_ALLOW_LIST;
+		$by_constant        = defined( 'VIP_JETPACK_IS_PRIVATE' ) && true === constant( 'VIP_JETPACK_IS_PRIVATE' );
+		$by_basic_auth      = defined( 'WPCOM_VIP_BASIC_AUTH' ) && true === constant( 'WPCOM_VIP_BASIC_AUTH' );
+		$by_ip_restrictions = defined( 'WPCOM_VIP_IP_ALLOW_LIST' ) && true === constant( 'WPCOM_VIP_IP_ALLOW_LIST' );
 
 		// For now, this is only enabled on sites that have defined the constant
 		return $by_constant || $by_basic_auth || $by_ip_restrictions;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,6 +25,7 @@ function _manually_load_plugin() {
 
 	require_once __DIR__ . '/../async-publish-actions.php';
 	require_once __DIR__ . '/../performance.php';
+
 	require_once __DIR__ . '/../security.php';
 
 	require_once __DIR__ . '/../schema.php';
@@ -113,6 +114,7 @@ switch ( getenv( 'WPVIP_PARSELY_INTEGRATION_TEST_MODE' ) ) {
 		break;
 }
 
+require_once __DIR__ . '/mock-constants.php';
 require_once __DIR__ . '/mock-header.php';
 
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/mock-constants.php
+++ b/tests/mock-constants.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Automattic\Test {
+	use InvalidArgumentException;
+
+	abstract class Constant_Mocker {
+		private static $constants = [];
+
+		public static function clear(): void {
+			self::$constants = [];
+		}
+
+		public static function define( string $constant, $value ): void {
+			if ( isset( self::$constants[ $constant ] ) ) {
+				throw new InvalidArgumentException( sprintf( 'Constant "%s" is already defined', $constant ) );
+			}
+
+			self::$constants[ $constant ] = $value;
+		}
+
+		public static function defined( string $constant ): bool {
+			return isset( self::$constants[ $constant ] );
+		}
+
+		public static function constant( string $constant ) {
+			if ( ! isset( self::$constants[ $constant ] ) ) {
+				throw new InvalidArgumentException( sprintf( 'Constant "%s" is not defined', $constant ) );
+			}
+
+			return self::$constants[ $constant ];
+		}
+	}
+}
+
+namespace Automattic\VIP\Security {
+	use Automattic\Test\Constant_Mocker;
+
+	function defined( $constant ) {
+		return Constant_Mocker::defined( $constant );
+	}
+
+	function constant( $constant ) {
+		return Constant_Mocker::constant( $constant );
+	}
+}

--- a/tests/security/test-class-private-sites.php
+++ b/tests/security/test-class-private-sites.php
@@ -2,75 +2,61 @@
 
 namespace Automattic\VIP\Security;
 
+use Automattic\Test\Constant_Mocker;
 use WP_UnitTestCase;
 
 class Private_Sites_Test extends WP_UnitTestCase {
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test__is_jetpack_private_regular_site() {
-		define( 'WPCOM_VIP_BASIC_AUTH', false );
-		define( 'WPCOM_VIP_IP_ALLOW_LIST', false );
+	public function setUp(): void {
+		parent::setUp();
+		Constant_Mocker::clear();
+	}
 
-		$is_jp_private = \Automattic\VIP\Security\Private_Sites::is_jetpack_private();
+	public function test__is_jetpack_private_regular_site() {
+		Constant_Mocker::define( 'WPCOM_VIP_BASIC_AUTH', false );
+		Constant_Mocker::define( 'WPCOM_VIP_IP_ALLOW_LIST', false );
+
+		$is_jp_private = Private_Sites::is_jetpack_private();
 
 		$this->assertFalse( $is_jp_private );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__is_jetpack_private_when_constant_set_false() {
-		define( 'VIP_JETPACK_IS_PRIVATE', false );
+		Constant_Mocker::define( 'VIP_JETPACK_IS_PRIVATE', false );
 
 		// But also set other constants that would otherwise set it to private
-		define( 'WPCOM_VIP_BASIC_AUTH', true );
+		Constant_Mocker::define( 'WPCOM_VIP_BASIC_AUTH', true );
 
-		$is_jp_private = \Automattic\VIP\Security\Private_Sites::is_jetpack_private();
+		$is_jp_private = Private_Sites::is_jetpack_private();
 
 		$this->assertFalse( $is_jp_private );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__is_jetpack_private_when_constant_set_true() {
-		define( 'VIP_JETPACK_IS_PRIVATE', true );
+		Constant_Mocker::define( 'VIP_JETPACK_IS_PRIVATE', true );
 
 		// But also set other constants that would otherwise not set it to private
-		define( 'WPCOM_VIP_BASIC_AUTH', false );
-		define( 'WPCOM_VIP_IP_ALLOW_LIST', false );
+		Constant_Mocker::define( 'WPCOM_VIP_BASIC_AUTH', false );
+		Constant_Mocker::define( 'WPCOM_VIP_IP_ALLOW_LIST', false );
 
-		$is_jp_private = \Automattic\VIP\Security\Private_Sites::is_jetpack_private();
+		$is_jp_private = Private_Sites::is_jetpack_private();
 
 		$this->assertTrue( $is_jp_private );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__is_jetpack_private_with_ip_restrictions() {
-		define( 'WPCOM_VIP_BASIC_AUTH', false );
-		define( 'WPCOM_VIP_IP_ALLOW_LIST', true );
+		Constant_Mocker::define( 'WPCOM_VIP_BASIC_AUTH', false );
+		Constant_Mocker::define( 'WPCOM_VIP_IP_ALLOW_LIST', true );
 
-		$is_jp_private = \Automattic\VIP\Security\Private_Sites::is_jetpack_private();
+		$is_jp_private = Private_Sites::is_jetpack_private();
 
 		$this->assertTrue( $is_jp_private );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__is_jetpack_private_with_http_basic_auth() {
-		define( 'WPCOM_VIP_BASIC_AUTH', true );
-		define( 'WPCOM_VIP_IP_ALLOW_LIST', false );
+		Constant_Mocker::define( 'WPCOM_VIP_BASIC_AUTH', true );
+		Constant_Mocker::define( 'WPCOM_VIP_IP_ALLOW_LIST', false );
 
-		$is_jp_private = \Automattic\VIP\Security\Private_Sites::is_jetpack_private();
+		$is_jp_private = Private_Sites::is_jetpack_private();
 
 		$this->assertTrue( $is_jp_private );
 	}
@@ -83,7 +69,7 @@ class Private_Sites_Test extends WP_UnitTestCase {
 			'something-else',
 		);
 
-		$private = \Automattic\VIP\Security\Private_Sites::instance();
+		$private = Private_Sites::instance();
 
 		$filtered = $private->filter_jetpack_active_modules( $modules );
 
@@ -98,7 +84,7 @@ class Private_Sites_Test extends WP_UnitTestCase {
 			'something-else'        => true,
 		);
 
-		$private = \Automattic\VIP\Security\Private_Sites::instance();
+		$private = Private_Sites::instance();
 
 		$filtered = $private->filter_jetpack_get_available_modules( $modules );
 
@@ -110,14 +96,8 @@ class Private_Sites_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $filtered );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__filter_blog_public_option_for_sync() {
-		define( 'VIP_JETPACK_IS_TRUE', true );
-
-		$private = \Automattic\VIP\Security\Private_Sites::instance();
+		$private = Private_Sites::instance();
 
 		$input = array( 'blog_public', 'foo', '1' );
 
@@ -126,14 +106,8 @@ class Private_Sites_Test extends WP_UnitTestCase {
 		$this->assertEquals( '-1', $filtered[2] );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__filter_blog_public_option_for_sync_other_option() {
-		define( 'VIP_JETPACK_IS_TRUE', true );
-
-		$private = \Automattic\VIP\Security\Private_Sites::instance();
+		$private = Private_Sites::instance();
 
 		$input = array( 'foo', 'bar', '1' );
 
@@ -144,9 +118,7 @@ class Private_Sites_Test extends WP_UnitTestCase {
 	}
 
 	public function test__filter_blog_public_option_for_full_sync() {
-		define( 'VIP_JETPACK_IS_TRUE', true );
-
-		$private = \Automattic\VIP\Security\Private_Sites::instance();
+		$private = Private_Sites::instance();
 
 		$input = array(
 			'blog_public' => 1,

--- a/tests/security/test-lockout.php
+++ b/tests/security/test-lockout.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\VIP\Security;
 
+use Automattic\Test\Constant_Mocker;
 use WP_UnitTestCase;
 
 require_once __DIR__ . '/../../security/class-lockout.php';
@@ -10,10 +11,6 @@ require_once __DIR__ . '/../../vip-support/class-vip-support-role.php';
 
 // phpcs:disable WordPress.DB.DirectDatabaseQuery
 
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
 class Lockout_Test extends WP_UnitTestCase {
 
 	/**
@@ -25,6 +22,8 @@ class Lockout_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->lockout = new Lockout();
+
+		Constant_Mocker::clear();
 	}
 
 	/**
@@ -38,7 +37,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__user_seen_notice__warning() {
-		define( 'VIP_LOCKOUT_STATE', 'warning' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'warning' );
 
 		$user = $this->factory->user->create_and_get();
 
@@ -47,7 +46,7 @@ class Lockout_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			get_user_meta( $user->ID, Lockout::USER_SEEN_WARNING_KEY, true ),
-			VIP_LOCKOUT_STATE
+			Constant_Mocker::constant( 'VIP_LOCKOUT_STATE' )
 		);
 		$this->assertNotEmpty(
 			get_user_meta( $user->ID, Lockout::USER_SEEN_WARNING_TIME_KEY, true )
@@ -55,7 +54,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__user_seen_notice__locked() {
-		define( 'VIP_LOCKOUT_STATE', 'locked' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
 
 		$user = $this->factory->user->create_and_get();
 
@@ -64,7 +63,7 @@ class Lockout_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			get_user_meta( $user->ID, Lockout::USER_SEEN_WARNING_KEY, true ),
-			VIP_LOCKOUT_STATE
+			Constant_Mocker::constant( 'VIP_LOCKOUT_STATE' )
 		);
 		$this->assertNotEmpty(
 			get_user_meta( $user->ID, Lockout::USER_SEEN_WARNING_TIME_KEY, true )
@@ -72,7 +71,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__user_seen_notice__already_seen() {
-		define( 'VIP_LOCKOUT_STATE', 'locked' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
 
 		$user = $this->factory->user->create_and_get();
 
@@ -94,7 +93,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__filter_user_has_cap__locked() {
-		define( 'VIP_LOCKOUT_STATE', 'locked' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
 
 		$user = $this->factory->user->create_and_get( [
 			'role' => 'editor',
@@ -109,7 +108,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__filter_user_has_cap__warning() {
-		define( 'VIP_LOCKOUT_STATE', 'warning' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'warning' );
 
 		$user = $this->factory->user->create_and_get( [
 			'role' => 'editor',
@@ -135,7 +134,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__filter_user_has_cap__locked_vip_support() {
-		define( 'VIP_LOCKOUT_STATE', 'locked' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
 
 		$user_id = \Automattic\VIP\Support_User\User::add( [
 			'user_email' => 'user@automattic.com',
@@ -153,7 +152,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__filter_site_admin_option__locked() {
-		define( 'VIP_LOCKOUT_STATE', 'locked' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
 
 		$pre_option = [ 'test1', 'test2' ];
 
@@ -163,7 +162,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__filter_site_admin_option__warning() {
-		define( 'VIP_LOCKOUT_STATE', 'warning' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'warning' );
 
 		$pre_option = [ 'test1', 'test2' ];
 
@@ -186,8 +185,8 @@ class Lockout_Test extends WP_UnitTestCase {
 		$user = $this->factory->user->create_and_get();
 		grant_super_admin( $user->ID );
 
-		define( 'VIP_LOCKOUT_STATE', 'locked' );
-		define( 'VIP_LOCKOUT_MESSAGE', 'Oh no!' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
+		Constant_Mocker::define( 'VIP_LOCKOUT_MESSAGE', 'Oh no!' );
 
 		// Recreate Lockout to re-init filters
 		$this->lockout = new Lockout();


### PR DESCRIPTION
This PR refactors tests for Private Sites and Lockouts and Warnings by mocking all calls to `defined()` and `constant()`; this allows us to run all those tests in a single process.

For this to work, I had to patch `security/class-private-sites.php` and `security/class-lockout.php` to use `constant()` instead of accessing constants directly.

Mocking relies upon the [name resolution rules](http://php.net/manual/en/language.namespaces.rules.php) of PHP namespaces. However, because the PHP compiler tries to optimize away all calls to `defined()`, it is crucial that the mock is loaded before the tested class.

Timings (PS + Lockout)
* Before: 23.92 seconds + 31.89 seconds
* After: 2.68 seconds + 3.53 seconds
