### PR TITLE
Search: Cache index_exists requests

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -733,6 +733,7 @@ class Search {
 			'delete_index',
 			'refresh_indices',
 			'put_mapping',
+			'bulk_index',
 		];
 		if ( ! in_array( $type, $index_actions, true ) ) {
 			return $request;

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -740,10 +740,7 @@ class Search {
 		}
 
 		$option_name = $this->get_index_exists_option_name( $query['url'] );
-		$option      = get_option( $option_name );
-		if ( false !== $option ) {
-			delete_option( $option_name );
-		}
+		delete_option( $option_name );
 
 		return $request;
 	}


### PR DESCRIPTION
## Description
We should start caching index_exists requests since we use it as a check in many places (e.g. get_current_field_count).

## Changelog Description
### Plugin Updated: Enterprise Search

Cache index_exists requests into an option.
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Check out PR
2) Shell in
3) Do an index_exists request:
```
$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
$indexable->index_exists();
```
4) Check it exists in the option: `wp option get es_index_exists_vip-200508-post-1` (you may need to change it accordingly to your index name since the format is `es_index_exists_<index-name>`
5) Delete the index: `wp vip-search delete-index`
6) Check the option does not exist `wp option get es_index_exists_vip-200508-post-1`