### PR TITLE
Run VIP Cache Manager tests in a single process

### DIFF
--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -2,10 +2,6 @@
 
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
 class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 	use ExpectPHPException;
 


### PR DESCRIPTION
This PR removes the `@runTestsInSeparateProcesses` declaration from `VIP_Go_Cache_Manager_Test`, as the tests seem safe to run in the same process.

Timings:
* before: 25.2 seconds
* after: 3.88 seconds
