### PR TITLE
Refactor Environment tests

### DIFF
--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\VIP;
 
+use Automattic\Test\Constant_Mocker;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
@@ -9,17 +10,15 @@ require_once __DIR__ . '/../../../lib/environment/class-environment.php';
 
 // phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
 
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
 class Environment_Test extends TestCase {
 	use ExpectPHPException;
 
 	private $error_reporting;
 
 	protected function setUp(): void {
+		parent::setUp();
 		$this->error_reporting = error_reporting();
+		Constant_Mocker::clear();
 	}
 
 	protected function tearDown(): void {
@@ -28,11 +27,11 @@ class Environment_Test extends TestCase {
 	}
 
 	public function get_var_standard_env() {
-		define( 'VIP_ENV_VAR_MY_VAR', 'VIP_ENV_VAR_MY_VAR' );
+		Constant_Mocker::define( 'VIP_ENV_VAR_MY_VAR', 'VIP_ENV_VAR_MY_VAR' );
 	}
 
 	public function get_var_legacy_env() {
-		define( 'MY_VAR', 'MY_VAR' );
+		Constant_Mocker::define( 'MY_VAR', 'MY_VAR' );
 	}
 
 	// tests the use-case where $key parameter is not found

--- a/tests/lib/helpers/test-environment.php
+++ b/tests/lib/helpers/test-environment.php
@@ -4,24 +4,24 @@ namespace Automattic\VIP\Helpers;
 
 require_once __DIR__ . '/../../../lib/helpers/environment.php';
 
+use Automattic\Test\Constant_Mocker;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
-// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
-
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
 class Environment_Test extends TestCase {
 	use ExpectPHPException;
 
+	public function setUp(): void {
+		parent::setUp();
+		Constant_Mocker::clear();
+	}
+
 	public function get_var_standard_env() {
-		define( 'VIP_ENV_VAR_MY_VAR', 'FOO' );
+		Constant_Mocker::define( 'VIP_ENV_VAR_MY_VAR', 'FOO' );
 	}
 
 	public function get_var_legacy_env() {
-		define( 'MY_VAR', 'FOO' );
+		Constant_Mocker::define( 'MY_VAR', 'FOO' );
 	}
 
 	// tests the use-case where $key parameter is not found
@@ -34,8 +34,6 @@ class Environment_Test extends TestCase {
 
 	/**
 	 * tests the use-case where $key parameter does not have the prefix
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	public function test_get_var_legacy_key() {
 		$this->get_var_legacy_env();
@@ -45,8 +43,6 @@ class Environment_Test extends TestCase {
 
 	/**
 	 * tests the use-case where $key parameter is lower case
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	public function test_get_var_lower_key() {
 		$this->get_var_standard_env();
@@ -56,8 +52,6 @@ class Environment_Test extends TestCase {
 
 	/**
 	 * tests the use-case where $key parameter is ''
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	public function test_get_var_empty_key() {
 		$this->expectNotice();
@@ -67,10 +61,6 @@ class Environment_Test extends TestCase {
 		$this->assertEquals( 'BAR', $val );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test_get_var() {
 		$this->get_var_standard_env();
 		$val = vip_get_env_var( 'MY_VAR', 'BAR' );

--- a/tests/mock-constants.php
+++ b/tests/mock-constants.php
@@ -55,3 +55,15 @@ namespace Automattic\VIP\Utils {
 		return Constant_Mocker::constant( $constant );
 	}
 }
+
+namespace Automattic\VIP {
+	use Automattic\Test\Constant_Mocker;
+
+	function defined( $constant ) {
+		return Constant_Mocker::defined( $constant );
+	}
+
+	function constant( $constant ) {
+		return Constant_Mocker::constant( $constant );
+	}
+}


### PR DESCRIPTION
Refactor Environment tests to allow them to run in a single process.

Timings (tests/lib/environment/test-class-environment.php + tests/lib/helpers/test-environment.php):
* before: 51.87 seconds + 17.36 seconds
* after: 2.97 seconds + 2.8 seconds
