### PR TITLE
Refactor Vary Cache tests

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -4,8 +4,6 @@ namespace Automattic\VIP\Cache;
 
 use WP_Error;
 
-// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-
 class Vary_Cache {
 	const COOKIE_NOCACHE = 'vip-go-cb';
 	const COOKIE_SEGMENT = 'vip-go-seg';
@@ -334,8 +332,8 @@ class Vary_Cache {
 	 */
 	public static function enable_encryption() {
 		// Validate that we have the secret values.
-		if ( ( ! defined( 'VIP_GO_AUTH_COOKIE_KEY' ) || ! defined( 'VIP_GO_AUTH_COOKIE_IV' ) ||
-			empty( constant( 'VIP_GO_AUTH_COOKIE_KEY' ) ) || empty( constant( 'VIP_GO_AUTH_COOKIE_IV' ) ) ) ) {
+		if ( ! defined( 'VIP_GO_AUTH_COOKIE_KEY' ) || ! defined( 'VIP_GO_AUTH_COOKIE_IV' ) ||
+			empty( constant( 'VIP_GO_AUTH_COOKIE_KEY' ) ) || empty( constant( 'VIP_GO_AUTH_COOKIE_IV' ) ) ) {
 			trigger_error( 'Vary_Cache: Cannot enable encryption because the required constants (VIP_GO_AUTH_COOKIE_KEY and VIP_GO_AUTH_COOKIE_IV) are not defined correctly. Please contact VIP Support for assistance.', E_USER_ERROR );
 		}
 
@@ -433,7 +431,7 @@ class Vary_Cache {
 			}
 
 			// Remove the site prefix at the beginning
-			$prefix = VIP_GO_APP_ID . '.';
+			$prefix = constant( 'VIP_GO_APP_ID' ) . '.';
 			if ( 0 === strpos( $auth_cookie, $prefix ) ) {
 				$value = substr( $auth_cookie, strlen( $prefix ) );
 			}
@@ -600,7 +598,7 @@ class Vary_Cache {
 				header( 'Vary: X-VIP-Go-Segmentation', false );
 			}
 
-			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
+			if ( defined( 'WP_DEBUG' ) && true === constant( 'WP_DEBUG' ) ) {
 				header( 'X-VIP-Go-Segmentation-Debug: ' . self::stringify_groups() );
 			}
 		}
@@ -646,9 +644,6 @@ class Vary_Cache {
 
 		return true;
 	}
-
-
-
 }
 
 Vary_Cache::load();

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\VIP\Cache;
 
+use Automattic\Test\Constant_Mocker;
 use WP_UnitTestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
@@ -25,6 +26,7 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 		header_remove();
 
 		Vary_Cache::load();
+		Constant_Mocker::clear();
 	}
 
 	public function tearDown(): void {
@@ -395,32 +397,23 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 		$this->assertNull( $actual_result );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__enable_encryption_invalid_empty_constants() {
 		$this->markTestSkipped( 'Skip for now until PHPUnit is updated in Travis' );
 		$this->expectError();
 
-		define( 'VIP_GO_AUTH_COOKIE_KEY', '' );
-		define( 'VIP_GO_AUTH_COOKIE_IV', '' );
+		Constant_Mocker::define( 'VIP_GO_AUTH_COOKIE_KEY', '' );
+		Constant_Mocker::define( 'VIP_GO_AUTH_COOKIE_IV', '' );
 
 		$actual_result = Vary_Cache::enable_encryption();
 		$this->assertNull( $actual_result );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__enable_encryption_true_valid() {
-		define( 'VIP_GO_AUTH_COOKIE_KEY', 'abc' );
-		define( 'VIP_GO_AUTH_COOKIE_IV', '123' );
+		Constant_Mocker::define( 'VIP_GO_AUTH_COOKIE_KEY', 'abc' );
+		Constant_Mocker::define( 'VIP_GO_AUTH_COOKIE_IV', '123' );
 
 		$actual_result = Vary_Cache::enable_encryption();
 		$this->assertNull( $actual_result );
-
 	}
 
 	public function get_test_data__validate_cookie_value_invalid() {
@@ -489,13 +482,9 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 		self::assertContains( 'Vary: yay', $headers, true );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test__send_vary_headers__sent_for_group_with_encryption() {
-		define( 'VIP_GO_AUTH_COOKIE_KEY', 'abc' );
-		define( 'VIP_GO_AUTH_COOKIE_IV', '123' );
+		Constant_Mocker::define( 'VIP_GO_AUTH_COOKIE_KEY', 'abc' );
+		Constant_Mocker::define( 'VIP_GO_AUTH_COOKIE_IV', '123' );
 		Vary_Cache::register_group( 'dev-group' );
 		Vary_Cache::enable_encryption();
 
@@ -697,17 +686,15 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 
 	/**
 	 * @dataProvider get_test_data__parse_group_cookies
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	public function test__parse_group_cookie_valid( $secrets, $initial_cookie, $headers, $expected_result ) {
 		$_SERVER                       = array_merge( $_SERVER, $headers );
 		$_COOKIE                       = $initial_cookie;
 		$get_parse_group_cookie_method = self::get_vary_cache_method( 'parse_group_cookie' );
 		if ( ! empty( $secrets ) ) {
-			define( 'VIP_GO_AUTH_COOKIE_KEY', $secrets['key'] );
-			define( 'VIP_GO_AUTH_COOKIE_IV', $secrets['iv'] );
-			define( 'VIP_GO_APP_ID', $secrets['siteid'] );
+			Constant_Mocker::define( 'VIP_GO_AUTH_COOKIE_KEY', $secrets['key'] );
+			Constant_Mocker::define( 'VIP_GO_AUTH_COOKIE_IV', $secrets['iv'] );
+			Constant_Mocker::define( 'VIP_GO_APP_ID', $secrets['siteid'] );
 			Vary_Cache::enable_encryption();
 		}
 		$get_parse_group_cookie_method->invokeArgs( null, [] );

--- a/tests/mock-constants.php
+++ b/tests/mock-constants.php
@@ -79,3 +79,15 @@ namespace Automattic\VIP\Files\Acl {
 		return Constant_Mocker::constant( $constant );
 	}
 }
+
+namespace Automattic\VIP\Cache {
+	use Automattic\Test\Constant_Mocker;
+
+	function defined( $constant ) {
+		return Constant_Mocker::defined( $constant );
+	}
+
+	function constant( $constant ) {
+		return Constant_Mocker::constant( $constant );
+	}
+}


### PR DESCRIPTION
Refactor Vary Cache tests to allow them to run in a single process.

Timings:
* before: 27.38 seconds
* after: 2.61 seconds
