### PR TITLE
Fix incompatibilities with PHP 8.1

### DIFF
--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -25,8 +25,8 @@ const COOKIE_TTL = 2 * HOUR_IN_SECONDS;
 add_action( 'muplugins_loaded', __NAMESPACE__ . '\init_debug_mode' );
 
 function init_debug_mode() {
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$enable = filter_var( $_GET['a8c-debug'] ?? '', FILTER_SANITIZE_STRING );
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$enable = $_GET['a8c-debug'] ?? '';
 	if ( in_array( $enable, [ 'true', 'false' ], true ) ) {
 		set_debug_mode( 'true' === $enable );
 	}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1532,7 +1532,7 @@ class Search {
 
 		// Assume all host names are in the format es-ha-$dc.vipv2.net
 		$matches = array();
-		if ( preg_match( '/^es-ha[-.](.*)\.vipv2\.net$/', $host, $matches ) ) {
+		if ( preg_match( '/^es-ha[-.](.*)\.vipv2\.net$/', (string) $host, $matches ) ) {
 			$key_parts[] = $matches[1]; // DC of ES node
 			$key_parts[] = 'ha' . $port . '_vipgo'; // HA endpoint e.g. ha9235_vipgo
 		} else {
@@ -1881,8 +1881,11 @@ class Search {
 		return $dc;
 	}
 
+	/**
+	 * @return string|null
+	 */
 	public function get_origin_dc_from_es_endpoint( $url ) {
-		$dc = null;
+		$dc = '';
 
 		if ( ! $url ) {
 			return null;

--- a/vip-helpers/class-user-cleanup.php
+++ b/vip-helpers/class-user-cleanup.php
@@ -10,10 +10,14 @@ if ( defined( 'VIP_SKIP_USER_CLEANUP' ) && true === VIP_SKIP_USER_CLEANUP ) {
 }
 
 class User_Cleanup {
+	/**
+	 * @param string|null|false $emails_string
+	 * @return array
+	 */
 	public static function parse_emails_string( $emails_string ) {
 		$emails = [];
 
-		$emails_string = trim( $emails_string );
+		$emails_string = trim( (string) $emails_string );
 
 		if ( false !== strpos( $emails_string, ',' ) ) {
 			$emails_raw = explode( ',', $emails_string );

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -347,19 +347,19 @@ function widont( $str = '' ) {
 // Leave these wrapped in function_exists() b/c they are so generically named
 if ( ! function_exists( 'wp_startswith' ) ) :
 	function wp_startswith( $haystack, $needle ) {
-		return 0 === strpos( $haystack, $needle );
+		return 0 === strpos( (string) $haystack, (string) $needle );
 	}
 endif;
 
 if ( ! function_exists( 'wp_endswith' ) ) :
 	function wp_endswith( $haystack, $needle ) {
-		return substr( $haystack, -strlen( $needle ) ) === $needle;
+		return substr( (string) $haystack, -strlen( (string) $needle ) ) === $needle;
 	}
 endif;
 
 if ( ! function_exists( 'wp_in' ) ) :
 	function wp_in( $needle, $haystack ) {
-		return false !== strpos( $haystack, $needle );
+		return false !== strpos( (string) $haystack, (string) $needle );
 	}
 endif;
 


### PR DESCRIPTION
## Description

This PR fixes incompatibilities with PHP 8.1 described in #2667.

## Changelog Description

### Plugin Updated: VIP Init

Fix incompatibilities with PHP 8.1

### Plugin Updated: VIP Search

Fix incompatibilities with PHP 8.1

### Plugin Updated: VIP Helpers

Fix incompatibilities with PHP 8.1

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass; PHP 8.1 will still fail.
