### PR TITLE
Updating Parsely 3.0 to 3.0.0-RC2

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -125,3 +125,4 @@ yarn.lock
 /wp-parsely-*/CODE_OF_CONDUCT.md
 /wp-parsely-*/init.py
 /wp-parsely-*/tests
+/wp-parsely-*/phpunit-integration.xml.dist

--- a/.deployignore
+++ b/.deployignore
@@ -122,7 +122,6 @@ yarn.lock
 /wp-parsely-*/.prettierrc
 /wp-parsely-*/bin
 /wp-parsely-*/CHANGELOG.md
-/wp-parsely-*/CODE_OF_CONDUCT.md
 /wp-parsely-*/init.py
 /wp-parsely-*/tests
 /wp-parsely-*/phpunit-integration.xml.dist

--- a/wp-parsely-3.0/.github/dependabot.yml
+++ b/wp-parsely-3.0/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/wp-parsely-3.0/.github/workflows/deploy.yml
+++ b/wp-parsely-3.0/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy to WordPress.org
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [released]
 jobs:
   tag:
     name: New tag

--- a/wp-parsely-3.0/.github/workflows/e2e-tests.yml
+++ b/wp-parsely-3.0/.github/workflows/e2e-tests.yml
@@ -1,14 +1,8 @@
 name: End-to-end (e2e) Tests
 
 on:
-  # Run on all pushes and on all pull requests.
-  # Prevent the "push" build from running when there are only irrelevant changes.
-  push:
-    paths-ignore:
-      - '**.md'
+  # Run on all pull requests.
   pull_request:
-  # Allow manually triggering the workflow.
-  workflow_dispatch:
 
 jobs:
   test:
@@ -27,9 +21,6 @@ jobs:
         with:
           node-version: lts/*
           cache: 'npm'
-
-      - name: Update npm to latest
-        run: npm i -g npm
 
       - name: Installing dependencies
         run: npm ci

--- a/wp-parsely-3.0/.github/workflows/node.js.yml
+++ b/wp-parsely-3.0/.github/workflows/node.js.yml
@@ -1,21 +1,15 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# This workflow will do a clean install of node dependencies, build the source code and run tests.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/*.js.yml
-      - '**/*[tj]sx?'
-      - package*.json
   push:
     paths:
       - .github/workflows/*.js.yml
       - '**/*[tj]sx?'
       - package*.json
-  # Allow manually triggering the workflow.
-  workflow_dispatch:
 
 jobs:
   build:
@@ -23,8 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/wp-parsely-3.0/CHANGELOG.md
+++ b/wp-parsely-3.0/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - 2021-11-23
+## [3.0.0] - 2021-11-26
 
 ## Important information about this release
 
@@ -13,17 +13,21 @@ wp-parsely 3.0.0 is a major release of the Parse.ly WordPress plugin. The major 
 
 The biggest breaking change is the new minimum requirements for running the plugin. You now need PHP 7.1 or newer and WordPress 5.0 or newer. If you are running one of those old versions, you shouldn't get the update option on your WordPress admin.
 
-If you are using the plugin without any code-level customizations (for instance, calling the plugin's routines or hooking in the plugin's WordPress hooks), this update should be seamless and everything should keep operating normally. The plugin's way of working is still fundamentally the same. If you are using those customizations, we recommend you going through the detailed changelog to see if they affect you. In most of the cases, only trivial changes will be required to make your code work.
+If you are using the plugin without any code-level customizations (for instance, calling the plugin's functions or methods or hooking in the plugin's WordPress hooks), this update should be seamless and everything should keep operating normally. The plugin's way of working is still fundamentally the same. If you are using those customizations, we recommend you going through the detailed changelog to see if they affect you. In most of the cases, only trivial changes will be required to make your code work.
 
 ### Added
 
-- Namespaces to files. [#430](https://github.com/Parsely/wp-parsely/pull/430) [#475](https://github.com/Parsely/wp-parsely/pull/475) [#477](https://github.com/Parsely/wp-parsely/pull/477) Now all functions and classes are under the `Parsely` namespace. If plugin's function is being called without the namespace, that might need to be updated.
-- Strict typing (`strict_types=1`) to all files in the codebase [#420](https://github.com/Parsely/wp-parsely/pull/420). Passing a value to a function in wp-parsely with an incorrect type will now raise an error. All function return [#429](https://github.com/Parsely/wp-parsely/pull/429) and argument [#455](https://github.com/Parsely/wp-parsely/pull/455) types have been updated.
-- Checkboxes in fields that accept multiple selection on the settings page. [#482](https://github.com/Parsely/wp-parsely/pull/482)
-- Translation support for Yes and No fields in the settings page. [#463](https://github.com/Parsely/wp-parsely/pull/463)
-- `wp_parsely_should_insert_metadata` filter. [#440](https://github.com/Parsely/wp-parsely/pull/440) The filters controls whether the Parse.ly metadata should be inserted in the page's HTML. By default, the meta tags are rendered (the filter returns `true`).
-- `wp_parsely_enable_cfasync_tag` filter. [#473](https://github.com/Parsely/wp-parsely/pull/473). Cloudflare `cfasync` attributes are now not rendered by default, they can be enabled by returning `true` to this filter.
-- WordPress plugin uninstall script. [#444](https://github.com/Parsely/wp-parsely/pull/444) When the plugin is uninstalled, the options will be removed from the database.
+- Namespaces to files. [#430](https://github.com/Parsely/wp-parsely/pull/430) [#475](https://github.com/Parsely/wp-parsely/pull/475) [#477](https://github.com/Parsely/wp-parsely/pull/477)
+  - Now all functions and classes are under the `Parsely` namespace, or a child namespace of that e.g. `Parsely\Parsely` or `Parsely\UI\Recommended_Widget`. If your code is calling a wp-parsely function (directly, or as a hook callback) without the namespace, then you'll need to update that call.
+- Strict typing (`strict_types=1`) to all files in the codebase [#420](https://github.com/Parsely/wp-parsely/pull/420).
+  - Passing a value to a function in wp-parsely with an incorrect type will now raise an error.
+- Type declarations have been added to function returns [#429](https://github.com/Parsely/wp-parsely/pull/429) and arguments [#455](https://github.com/Parsely/wp-parsely/pull/455).
+- `wp_parsely_should_insert_metadata` filter. [#440](https://github.com/Parsely/wp-parsely/pull/440)
+  - The filter controls whether the Parse.ly metadata should be inserted in the page's HTML. By default, the meta tags are rendered (the filter returns `true`).
+- `wp_parsely_enable_cfasync_tag` filter. [#473](https://github.com/Parsely/wp-parsely/pull/473).
+  - The Cloudflare `cfasync` attributes are now not rendered by default, but they can be enabled by returning `true` to this filter.
+- WordPress plugin uninstall script. [#444](https://github.com/Parsely/wp-parsely/pull/444)
+  - When the plugin is uninstalled, the options will be removed from the database. Deactivating the plugin will not cause the options to be deleted.
 - `npm run dev:start` and `npm run dev:stop` commands to run the plugin locally for development purposes. [#493](https://github.com/Parsely/wp-parsely/pull/493)
 - E2E test for recommended widget. [#434](https://github.com/Parsely/wp-parsely/pull/434)
 - JavaScript code-scanning [#453](https://github.com/Parsely/wp-parsely/pull/453)
@@ -32,22 +36,27 @@ If you are using the plugin without any code-level customizations (for instance,
 
 - Minimum PHP and WP versions required to run the plugin are now 7.1 (from 5.6) and 5.0 from (4.0), respectively. [#416](https://github.com/Parsely/wp-parsely/pull/416)
 - The development Node JS version has been bumped from 14 to 16.
-- Renaming functions on `Scripts` class [#481](https://github.com/Parsely/wp-parsely/pull/481):
-  - `register_js` to `register_scripts`.
-  - `load_js_api` to `enqueue_js_api`.
-  - `load_js_tracker` to `enqueue_js_tracker`.
-- _Open on Parse.ly_ links are displayed by default. [#433](https://github.com/Parsely/wp-parsely/pull/433) To disable the feature, the `wp_parsely_enable_row_action_links` filter must return `false`.
-- `Parsely::get_current_url` default value for argument `string $parsely_type` changed from `nonpost` to `non-post`. [#447](https://github.com/Parsely/wp-parsely/pull/447) This change has been done to better align with Parse.ly's backend.
-- Enqueue scripts with theme independent hook. [#458](https://github.com/Parsely/wp-parsely/pull/458) The JS scripts are now enqueued with `wp_enqueue_scripts` instead of `wp_footer`.
-- Renamed `Parsely_Recommended_Widget` class to `Recommended_Widget`.
-- Extracted logic from `class-parsely.php` file:
+- Extract logic from `class-parsely.php` file:
   - Extract admin warning to `Parsely\UI\Admin_Warning`. [#468](https://github.com/Parsely/wp-parsely/pull/468)
   - Extract tracker logic to `Parsely\Scripts` [#478](https://github.com/Parsely/wp-parsely/pull/478)
   - Extract settings page to `Parsely\UI\Settings_Page`. [#467](https://github.com/Parsely/wp-parsely/pull/467)
+- Rename `Parsely_Recommended_Widget` class to `Parsely\UI\Recommended_Widget`.
+- Rename methods in `Parsely\Scripts` class [#481](https://github.com/Parsely/wp-parsely/pull/481):
+  - `register_js()` to `register_scripts()`.
+  - `load_js_api()` to `enqueue_js_api()`.
+  - `load_js_tracker()` to `enqueue_js_tracker()`.
 - Move Parse.ly settings file to `views/parsely-settings.php`. [#459](https://github.com/Parsely/wp-parsely/pull/459)
-- Making class members private [#486](https://github.com/Parsely/wp-parsely/pull/486):
-  - `Facebook_Instant_Articles`: `REGISTRY_IDENTIFIER`, `REGISTRY_DISPLAY_NAME`, `get_embed_code`.
-  - `Recommended_Widget`: `get_api_url`.
+- _Open on Parse.ly_ links are displayed by default. [#433](https://github.com/Parsely/wp-parsely/pull/433)
+  - To disable the feature, the `wp_parsely_enable_row_action_links` filter must return `false`.
+- `Parsely::get_current_url()` default value for argument `string $parsely_type` changed from `nonpost` to `non-post`. [#447](https://github.com/Parsely/wp-parsely/pull/447)
+  - This change has been done to better align with Parse.ly's backend.
+- Enqueue scripts with theme independent hook. [#458](https://github.com/Parsely/wp-parsely/pull/458)
+  - The JavaScript scripts are now enqueued at the `wp_enqueue_scripts` hook instead of `wp_footer`.
+- Replace multi-select fields with checkboxes on the settings page. [#482](https://github.com/Parsely/wp-parsely/pull/482)
+  - Existing selections will be retained.
+- Made class members private [#486](https://github.com/Parsely/wp-parsely/pull/486):
+  - `Parsely\Integrations\Facebook_Instant_Articles`: `REGISTRY_IDENTIFIER`, `REGISTRY_DISPLAY_NAME`, `get_embed_code()`.
+  - `Parsely\UI\Recommended_Widget`: `get_api_url()`.
 - Tests: Specify `coverage: none` where it is not needed. [#419](https://github.com/Parsely/wp-parsely/pull/419)
 - Bump @wordpress/e2e-test-utils from 5.4.3 to 5.4.8. [#492](https://github.com/Parsely/wp-parsely/pull/492)
 - Bump @wordpress/scripts from 18.0.1 to 19.1.0. [#480](https://github.com/Parsely/wp-parsely/pull/480)
@@ -55,24 +64,33 @@ If you are using the plugin without any code-level customizations (for instance,
 
 ### Fixed
 
+- Fix missing translation support for Yes and No labels in the settings page. [#463](https://github.com/Parsely/wp-parsely/pull/463)
 - Avoid making duplicate calls to Parse.ly API on the Recommended Widget's front-end. [#460](https://github.com/Parsely/wp-parsely/pull/460)
 - Fix JS string translation in settings page. [#462](https://github.com/Parsely/wp-parsely/pull/462)
-- Constant return types on `update_metadata_endpoint`. [#446](https://github.com/Parsely/wp-parsely/pull/446) The function used to return different return types, now it always returns `void`.
-- Constant return type on `insert_parsely_page`. [#443](https://github.com/Parsely/wp-parsely/pull/443) The function used to return `string|null|array`, now it returns `void`. 
-- Tests: Stop using deprecated setMethods method. [#427](https://github.com/Parsely/wp-parsely/pull/427)
+- Consistent return types on `update_metadata_endpoint`. [#446](https://github.com/Parsely/wp-parsely/pull/446)
+  - The function used to return different return types, now it always returns `void`.
+- Consistent return type on `insert_parsely_page`. [#443](https://github.com/Parsely/wp-parsely/pull/443)
+  - The function used to return `string|null|array`, now it returns `void`. 
+- Tests: Stop using deprecated `setMethods()` method. [#427](https://github.com/Parsely/wp-parsely/pull/427)
 - e2e tests: fix watch command. [#476](https://github.com/Parsely/wp-parsely/pull/476)
 - Fix non-working README code example. [#439](https://github.com/Parsely/wp-parsely/pull/439)
 
 ### Removed
 
-- Deprecated filter `after_set_parsely_page`. [#436](https://github.com/Parsely/wp-parsely/pull/436) Use `wp_parsely_metadata` instead.
-- Deprecated filter `parsely_filter_insert_javascript`. [#437](https://github.com/Parsely/wp-parsely/pull/437) Use `wp_parsely_load_js_tracker` instead.
-- `post_has_viewable_type` function. [#417](https://github.com/Parsely/wp-parsely/pull/417) Use `is_post_viewable` instead.
+- Previously deprecated filter `after_set_parsely_page`. [#436](https://github.com/Parsely/wp-parsely/pull/436)
+  - Use `wp_parsely_metadata` instead.
+- Previously deprecated filter `parsely_filter_insert_javascript`. [#437](https://github.com/Parsely/wp-parsely/pull/437)
+  - Use `wp_parsely_load_js_tracker` instead.
+- `post_has_viewable_type` function. [#417](https://github.com/Parsely/wp-parsely/pull/417)
+  - Use `is_post_viewable` instead. The `post_has_viewable_type` function was only added to support older versions of WordPress.
 - Custom Parse.ly load text domain. [#457](https://github.com/Parsely/wp-parsely/pull/457)
+  - Since the plugin now supports versions of WordPress that load custom text domains automatically, the plugins doesn't have to explicitly load the text domain itself. 
 - Empty functions for admin settings. [#456](https://github.com/Parsely/wp-parsely/pull/456)
+  - The callbacks were never utilised.
 - Redundant code coverage annotations. [#469](https://github.com/Parsely/wp-parsely/pull/469)
 - Old init Python script. [#441](https://github.com/Parsely/wp-parsely/pull/441)
 - "Add admin warning for minimum requirements in 3.0" notice. [#424](https://github.com/Parsely/wp-parsely/pull/424)
+  - This was only added in the previous version of the plugin.
 - Upgrade README notice. [#470](https://github.com/Parsely/wp-parsely/pull/470)
 
 ## [2.6.1] - 2021-10-15

--- a/wp-parsely-3.0/README.md
+++ b/wp-parsely-3.0/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.0.0
+Stable tag: 3.0.0-beta
 Requires at least: 5.0  
 Tested up to: 5.8  
 Requires PHP: 7.1  

--- a/wp-parsely-3.0/src/UI/class-settings-page.php
+++ b/wp-parsely-3.0/src/UI/class-settings-page.php
@@ -760,9 +760,9 @@ final class Settings_Page {
 
 		foreach ( $select_options as $key => $val ) {
 			$selected = in_array( $val, $options[ $args['option_key'] ], true );
-			echo sprintf( "<p><input type='checkbox' name='%s[]' id='%s' value='%s' ", esc_attr( $name ), esc_attr( $name ), esc_attr( $key ) );
+			echo sprintf( '<p><input type="checkbox" name="%1$s[]" id="%1$s-%2$s" value="%2$s" ', esc_attr( $name ), esc_attr( $key ) );
 			echo checked( true === $selected, true, false );
-			echo sprintf( " /> <label for='%s'>%s</label></p>", esc_attr( $name ), esc_attr( $val ) );
+			echo sprintf( ' /> <label for="%1$s-%2$s">%2$s</label></p>', esc_attr( $name ), esc_attr( $val ) );
 		}
 
 		if ( isset( $args['help_text'] ) ) {

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -788,7 +788,7 @@ class Parsely {
 						$post_author   = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
 						// In case the user has been deleted while plugin was deactivated.
 						if ( ! empty( $post_author ) ) {
-							$coauthors[] = $post_author;
+							$coauthors[] = new WP_User( $post_author );
 						}
 					}
 				} elseif ( ! $coauthors_plus->force_guest_authors ) {
@@ -856,11 +856,12 @@ class Parsely {
 		 *
 		 * @since 1.14.0
 		 *
-		 * @param array   $authors One or more authors as WP_User objects (may also be `false`).
-		 * @param WP_Post $post    Post object.
+		 * @param WP_User[] $authors One or more authors as WP_User objects.
+		 * @param WP_Post   $post    Post object.
 		 */
 		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
 
+		// Getting the author name for each author.
 		$authors = array_map( array( $this, 'get_author_name' ), $authors );
 
 		/**

--- a/wp-parsely-3.0/tests/e2e/README.md
+++ b/wp-parsely-3.0/tests/e2e/README.md
@@ -10,7 +10,7 @@ Once there's a functioning back end, we leverage the `@wordpress/scripts` utilit
 
 The tests use the [Jest framework](https://jestjs.io/) to drive a user flow and assert on expected outcomes. In addition to the [Puppeteer API](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md), there are a number of helpers to accomplish frequently performed tasks in the [`@wordpress/e2e-test-utils` package](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-e2e-test-utils/).
 
-See this post for more infomation: https://make.wordpress.org/core/2019/06/27/introducing-the-wordpress-e2e-tests/
+See this post for more information: https://make.wordpress.org/core/2019/06/27/introducing-the-wordpress-e2e-tests/
 
 ## How to Run
 

--- a/wp-parsely-3.0/tests/e2e/specs/activation-flow.spec.js
+++ b/wp-parsely-3.0/tests/e2e/specs/activation-flow.spec.js
@@ -13,7 +13,6 @@ import {
 import { activatePluginApiKey, deactivatePluginApiKey, waitForWpAdmin } from '../utils';
 
 describe( 'Activation flow', () => {
-	jest.setTimeout( 30000 );
 	it( 'Should progress as intended', async () => {
 		await loginUser();
 		await activatePlugin( 'wp-parsely' );

--- a/wp-parsely-3.0/tests/e2e/specs/plugin-action-link.spec.js
+++ b/wp-parsely-3.0/tests/e2e/specs/plugin-action-link.spec.js
@@ -13,11 +13,10 @@ import {
 import { waitForWpAdmin } from '../utils';
 
 describe( 'Plugin action link', () => {
-	jest.setTimeout( 30000 );
 	it( 'Should link to plugin settings page', async () => {
 		await loginUser();
 		await activatePlugin( 'wp-parsely' );
-		await visitAdminPage( '/plugins.php' );
+		await visitAdminPage( '/plugins.php', '' );
 
 		await waitForWpAdmin();
 

--- a/wp-parsely-3.0/tests/e2e/specs/recommended-widget.spec.js
+++ b/wp-parsely-3.0/tests/e2e/specs/recommended-widget.spec.js
@@ -11,9 +11,7 @@ import {
  * Internal dependencies
  */
 import {
-	activatePluginApiKey,
-	deactivatePluginApiKey,
-	deactivatePluginApiSecret,
+	changeKeysState,
 	waitForWpAdmin,
 } from '../utils';
 
@@ -52,8 +50,6 @@ const checkForNonActiveWidgetText = async () => {
 };
 
 describe( 'Recommended widget', () => {
-	jest.setTimeout( 30000 );
-
 	beforeAll( () => {
 		page.once( 'dialog', async function( dialog ) {
 			await dialog.accept();
@@ -63,8 +59,7 @@ describe( 'Recommended widget', () => {
 	it( 'Widget should be available but inactive without api key and secret', async () => {
 		await loginUser();
 		await activatePlugin( 'wp-parsely' );
-		await deactivatePluginApiKey();
-		await deactivatePluginApiSecret();
+		await changeKeysState( false, false );
 
 		await visitAdminPage( '/widgets.php', '' );
 		await waitForWpAdmin();
@@ -79,8 +74,7 @@ describe( 'Recommended widget', () => {
 	it( 'Widget should be available but inactive without api secret', async () => {
 		await loginUser();
 		await activatePlugin( 'wp-parsely' );
-		await activatePluginApiKey();
-		await deactivatePluginApiSecret();
+		await changeKeysState( true, false );
 
 		await visitAdminPage( '/widgets.php', '' );
 		await waitForWpAdmin();

--- a/wp-parsely-3.0/tests/e2e/utils.js
+++ b/wp-parsely-3.0/tests/e2e/utils.js
@@ -2,8 +2,27 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 
-export const deactivatePluginApiKey = async () => {
+export const changeKeysState = async (activateApiKey, activateApiSecret ) => {
+	await visitAdminPage( '/options-general.php', '?page=parsely' );
+
+	await page.evaluate( () => document.getElementById( 'apikey' ).value = '' );
+	if ( activateApiKey ) {
+		await page.focus( '#apikey' );
+		await page.keyboard.type( 'e2etest.example.com' );
+	}
+
+	await page.evaluate( () => document.getElementById( 'api_secret' ).value = '' );
+	if ( activateApiSecret ) {
+		await page.focus( '#api_secret' );
+		await page.keyboad.type( 'somesecret' );
+	}
+
+	const [ input ] = await page.$x( '//p[contains(@class, \'submit\')]//input' );
+	await input.click();
 	await waitForWpAdmin();
+};
+
+export const deactivatePluginApiKey = async () => {
 	await visitAdminPage( '/options-general.php', '?page=parsely' );
 	await page.evaluate( () => document.getElementById( 'apikey' ).value = '' );
 	const [ input ] = await page.$x( '//p[contains(@class, \'submit\')]//input' );
@@ -11,16 +30,7 @@ export const deactivatePluginApiKey = async () => {
 	await waitForWpAdmin();
 };
 
-export const deactivatePluginApiSecret = async () => {
-	await waitForWpAdmin();
-	await visitAdminPage( '/options-general.php', '?page=parsely' );
-	await page.evaluate( () => document.getElementById( 'api_secret' ).value = '' );
-	await page.keyboard.press( 'Enter' );
-	await waitForWpAdmin();
-};
-
 export const activatePluginApiKey = async () => {
-	await waitForWpAdmin();
 	await visitAdminPage( '/options-general.php', '?page=parsely' );
 	await page.focus( '#apikey' );
 	await page.evaluate( () => document.getElementById( 'apikey' ).value = '' );

--- a/wp-parsely-3.0/wp-parsely.php
+++ b/wp-parsely-3.0/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog.
- * Version:           3.0.0
+ * Version:           3.0.0-beta
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -39,7 +39,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.0.0';
+const PARSELY_VERSION = '3.0.0-beta';
 const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
## Description

This PR pulls the latest version of the 3.0.0 release of the wp-parsely plugin (Release Candidate 2). The following command was run:

```
bin/manage-wp-parsely-subtree.sh 3.0 3.0.0-RC2 
```

## Changelog Description

### Updating Parsely 3.0 to 3.0.0-RC2

Pulling the latest version of wp-parsely.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.