### PR TITLE
 Ensure the file exists before trying to delete it

### DIFF
--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -248,7 +248,7 @@ function generate_personal_data_export_file( $request_id ) {
 	// If a filename meta exists, use it.
 	if ( ! empty( $archive_filename ) ) {
 		$archive_pathname = $exports_dir . $archive_filename;
-	} elseif ( ! empty( $archive_pathname ) ) {
+	} elseif ( ! empty( $archive_pathname ) && is_file( $archive_pathname ) ) {
 		// If a full path meta exists, use it and create the new meta value.
 		$archive_filename = basename( $archive_pathname );
 
@@ -267,7 +267,7 @@ function generate_personal_data_export_file( $request_id ) {
 
 	$archive_url = $exports_url . $archive_filename;
 
-	if ( ! empty( $archive_pathname ) && file_exists( $archive_pathname ) ) {
+	if ( ! empty( $archive_pathname ) && is_file( $archive_pathname ) ) {
 		wp_delete_file( $archive_pathname );
 	}
 


### PR DESCRIPTION
Fixes #2677

## Description
The `generate_personal_data_export_file` function generates an error when it is trying to generate the personal data report when the report has its `_export_file_path` meta set to `/` or any other existing dir path. 

It isn't expected to store a dir path in this meta filed, but it can happen if a filter is used or if the meta value is manually/programmatically updated (it happened to a customer already).

When this happens, the `wp_delete_file` function ([here](https://github.com/Automattic/vip-go-mu-plugins/blob/7624078badd666531b5a3ccc67d7c51ac719e128/001-core/privacy.php#L268)) fails because it is expecting the path of a file to be deleted. This also causes some orphaned files in the `/tmp/` folder, as [the code that is designed to unlink the previously generated JSON and HTML report files](https://github.com/Automattic/vip-go-mu-plugins/blob/7624078badd666531b5a3ccc67d7c51ac719e128/001-core/privacy.php#L319-L322) isn't executed. 

This fix adds an extra check in the conditional (`&& is_file( $archive_pathname )`) that checks if the report already has a `_export_file_path` meta to only use it if it's a path to an existing file. 

It also changes the `file_exists( $archive_pathname )` function that is used just before trying to delete the file to use `is_file( $archive_pathname )` instead, as the `file_exists` function returns true when the provided string is a directory path. Using `is_file` the code will always confirm that the provided string points to a file (and not a directory). 

## Changelog

### Plugin Updated: VIP Go Core Modifications

Ensure the file exists before trying to delete it.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Request a new report from Tools > Export Personal Data
2. Update its `_export_file_path` meta to `/`.
3. Click the `Send export link` link to process and send the export.
4. Check if the export process is finished without any errors.

If it finishes without any errors:
- All the temporary files generated in the `/tmp/` folder would have been removed.
- The exported zip file would have been uploaded to the VIP file system and should be available using the link that has been sent  to the requested email address. 
