### PR TITLE
Adds "VIP_AKISMET_SKIP_LOAD" constant to allow disabling of Akismet

### DIFF
--- a/akismet.php
+++ b/akismet.php
@@ -16,6 +16,11 @@ if ( defined( 'VIP_JETPACK_SKIP_LOAD' ) && true === VIP_JETPACK_SKIP_LOAD ) {
 	return;
 }
 
+// Avoid loading Akismet if VIP_AKISMET_SKIP_LOAD is set to true
+if ( defined( 'VIP_AKISMET_SKIP_LOAD' ) && true === VIP_AKISMET_SKIP_LOAD ) {
+	return;
+}
+
 // Load the core Akismet plugin
 require_once __DIR__ . '/akismet/akismet.php';
 


### PR DESCRIPTION
## Description
Akismet will check for the constant: "VIP_AKISMET_SKIP_LOAD"  when it loads.

If the value is set to `true` the plugin will be disabled.

## Changelog Description

The Akismet plugin, in Must-Use plugins, may now be disabled by adding the "VIP_AKISMET_SKIP_LOAD" constant, and setting the value to "true".

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Add a line with: `define( 'VIP_AKISMET_SKIP_LOAD', true );` to wp-config.php or wp-config-multisite.php 
1. Go to `wp-admin` > `Jetpack`
1. The Akismet Anti-Spam sub-menu should be missing
