### PR TITLE
Increase the logstash limit to 100 in web and 500 in CLI contexts and set 'http_user_agent' based on _SERVER['HTTP_USER_AGENT']

### DIFF
--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -300,8 +300,8 @@ class Logger {
 			'user_id'         => get_current_user_id(),                       // Optional.
 			'extra'           => [],                                          // Optional.
 			'timestamp'       => gmdate( 'Y-m-d H:i:s' ),                     // Required.
-			'index'           => 'log2logstash',                              // Required,
-			'http_user_agent' => self::get_user_agent(),
+			'index'           => 'log2logstash',                              // Required.
+			'http_user_agent' => self::get_user_agent(),                      // Optional.
 		];
 
 		if ( ! isset( $params['file'] ) && ! isset( $params['line'] ) ) {

--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -558,10 +558,10 @@ class Logger {
 	public static function get_user_agent() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			return 'cli';
-		} else {
-			// Match handling in other places
-			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-			return substr( sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' ), 0, 255 );
 		}
+		
+		// Match handling in other places
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		return substr( sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' ), 0, 255 );
 	}
 }

--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -557,9 +557,8 @@ class Logger {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			return 'cli';
 		}
-		
-		// Match handling in other places
+
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-		return substr( sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' ), 0, 255 );
+		return sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' );
 	}
 }

--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -111,6 +111,7 @@ class Logger {
 		'file',
 		'http_host',
 		'http_response_code',
+		'http_user_agent',
 		'index',
 		'line',
 		'message',
@@ -290,20 +291,17 @@ class Logger {
 	protected static function parse_params( array $params ) : array {
 		// Prepare data.
 		$default_params = [
-			'site_id'   => get_current_network_id(),                  // Required.
-			'blog_id'   => get_current_blog_id(),                     // Required.
-			'http_host' => strtolower( $_SERVER['HTTP_HOST'] ?? '' ), // phpcs:ignore -- Optional.
-
-			'severity'  => '',                                        // Optional.
-			'feature'   => '',                                        // Required.
-			'message'   => '',                                        // Required.
-
-			'user_id'   => get_current_user_id(),                     // Optional.
-
-			'extra'     => [],                                        // Optional.
-			'timestamp' => gmdate( 'Y-m-d H:i:s' ),                   // Required.
-			'index'     => 'log2logstash',                            // Required,
-			'user_ua'   => self::get_user_agent(),
+			'site_id'         => get_current_network_id(),                    // Required.
+			'blog_id'         => get_current_blog_id(),                       // Required.
+			'http_host'       => strtolower( $_SERVER['HTTP_HOST'] ?? '' ),   // phpcs:ignore -- Optional.
+			'severity'        => '',                                          // Optional.
+			'feature'         => '',                                          // Required.
+			'message'         => '',                                          // Required.
+			'user_id'         => get_current_user_id(),                       // Optional.
+			'extra'           => [],                                          // Optional.
+			'timestamp'       => gmdate( 'Y-m-d H:i:s' ),                     // Required.
+			'index'           => 'log2logstash',                              // Required,
+			'http_user_agent' => self::get_user_agent(),
 		];
 
 		if ( ! isset( $params['file'] ) && ! isset( $params['line'] ) ) {
@@ -396,7 +394,7 @@ class Logger {
 	 *
 	 * @internal          The following user-specific keys are set for you automatically:
 	 *                    - `user_id` : Optional. Default is current user ID.
-	 *                    - `user_ua` : Optional. Default is current user-agent.
+	 *                    - `http_user_agent` : Optional. Default is current user-agent or "cli"
 	 */
 	public static function log2logstash( array $data ) : void {
 		// Prepare data.

--- a/tests/logstash/test-logger.php
+++ b/tests/logstash/test-logger.php
@@ -54,13 +54,14 @@ class Logger_Test extends WP_UnitTestCase {
 		];
 
 		$expected = array_merge( $data, [
-			'feature'   => 'a8c_vip_test',
-			'site_id'   => 1,
-			'blog_id'   => 1,
-			'http_host' => 'example.org',
-			'user_id'   => 0,
-			'extra'     => '[]',
-			'index'     => 'log2logstash',
+			'feature'         => 'a8c_vip_test',
+			'site_id'         => 1,
+			'blog_id'         => 1,
+			'http_host'       => 'example.org',
+			'http_user_agent' => '',
+			'user_id'         => 0,
+			'extra'           => '[]',
+			'index'           => 'log2logstash',
 		] );
 
 		Logger::log2logstash( $data );

--- a/tests/logstash/test-logger.php
+++ b/tests/logstash/test-logger.php
@@ -69,7 +69,7 @@ class Logger_Test extends WP_UnitTestCase {
 	}
 
 	public function test__log2logstash__too_many_entries() {
-		$entries = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 ];
+		$entries = range( 0, 101 );
 		$data    = [
 			'severity' => 'alert',
 			'feature'  => 'test',
@@ -80,7 +80,7 @@ class Logger_Test extends WP_UnitTestCase {
 
 		Logger::log2logstash( $data );
 
-		$this->assertError( 'Excessive calls to Automattic\VIP\Logstash\Logger::log2logstash(). Maximum is 30 log entries.', E_USER_WARNING );
+		$this->assertError( 'Excessive calls to Automattic\VIP\Logstash\Logger::log2logstash(). Maximum is 100 log entries.', E_USER_WARNING );
 
 		// No new entries added
 		$this->assertEquals( $entries, Testable_Logger::get_entries() );

--- a/tests/logstash/test-logger.php
+++ b/tests/logstash/test-logger.php
@@ -58,7 +58,7 @@ class Logger_Test extends WP_UnitTestCase {
 			'site_id'         => 1,
 			'blog_id'         => 1,
 			'http_host'       => 'example.org',
-			'http_user_agent' => '',
+			'http_user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? '', // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			'user_id'         => 0,
 			'extra'           => '[]',
 			'index'           => 'log2logstash',


### PR DESCRIPTION
## Description

Currently, we have a cut-off of 30 logstash entries per request, as a failsafe. The problem is we call trigger_error when we're over the threshold. This leads to an unhelpful situation where a useful log entry gets replaced by an unuseful generic error not providing any information beyond the fact that it happened.

This PR increases the limit to 100 for web requests and 500 for CLI requests - this may change pending feedback.
When a threshold is crossed only one E_USER_WARNING is triggered.

Additionally, this PR also surfaces user agent for request (if available) 


## Changelog Description

### Library updated: Logger

We've updated the internal logging library to surface the user agent information for custom log entries and to increase the maximum number of logs to be processed during a single request.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
