### PR TITLE
Add caching to the months dropdown filter for posts

### DIFF
--- a/performance/vip-tweaks.php
+++ b/performance/vip-tweaks.php
@@ -3,9 +3,10 @@
 /**
  * This is a list of performance tweaks that will become default for All VIP sites
  */
+add_action( 'after_setup_theme', 'wpcom_vip_enable_performance_tweaks' );
 function wpcom_vip_enable_performance_tweaks() {
 
-	// This disables the adjacent_post links in the header that are almost never beneficial and are very slow to compute.
+	// Disables the adjacent_post links in the header that are almost never beneficial and are very slow to compute.
 	remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );
 
 	if ( function_exists( 'wpcom_vip_enable_old_slug_redirect_caching' ) ) {
@@ -15,8 +16,20 @@ function wpcom_vip_enable_performance_tweaks() {
 	if ( function_exists( 'wpcom_vip_enable_maybe_skip_old_slug_redirect' ) ) {
 		wpcom_vip_enable_maybe_skip_old_slug_redirect();
 	}
+
+	if ( is_admin() ) {
+		// Prevent expensive media library queries, and cache the available months for filtering.
+		add_filter( 'media_library_show_video_playlist', '__return_true' );
+		add_filter( 'media_library_show_audio_playlist', '__return_true' );
+		add_filter( 'media_library_months_with_files', 'wpcom_vip_media_library_months_with_files' );
+
+		// Cache the available months for filtering on posts/CPTs.
+		add_filter( 'pre_months_dropdown_query', 'wpcom_vip_available_post_listing_months', 10, 2 );
+	}
+
+	// Busts the month's filtering caches when needed for both attachments and posts/CPTs.
+	add_action( 'save_post', 'wpcom_vip_maybe_bust_available_months_cache', 10, 2 );
 }
-add_action( 'after_setup_theme', 'wpcom_vip_enable_performance_tweaks' );
 
 /**
  * Use this function to disable the loading of performance tweaks
@@ -25,124 +38,118 @@ function wpcom_vip_disable_performance_tweaks() {
 	remove_action( 'after_setup_theme', 'wpcom_vip_enable_performance_tweaks' );
 }
 
-
-add_action( 'add_attachment', 'wpcom_vip_bust_media_months_cache' );
-function wpcom_vip_bust_media_months_cache( $post_id ) {
-	if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
-		return;
+/**
+ * Caches an expensive query used to generate the available
+ * months/years used in filters in the media library.
+ *
+ * @param object[]|null $months
+ * @return object[]
+ */
+function wpcom_vip_media_library_months_with_files( $months ) {
+	if ( null !== $months ) {
+		// Something is already filtering, abort.
+		return $months;
 	}
 
-	// Grab the transient to see if it needs updating
-	$media_months = get_transient( 'wpcom_media_months_array' );
-
-	// Make sure month and year exists in transient before comparing
-	$cached_latest_year  = ( ! empty( $media_months[0]->year ) ) ? $media_months[0]->year : '';
-	$cached_latest_month = ( ! empty( $media_months[0]->month ) ) ? $media_months[0]->month : '';
-
-	// If the transient exists, and the attachment uploaded doesn't match the first (latest) month or year in the transient, lets clear it.
-	$matches_latest_year  = get_the_time( 'Y', $post_id ) === $cached_latest_year;
-	$matches_latest_month = get_the_time( 'n', $post_id ) === $cached_latest_month;
-	if ( false !== $media_months && ( ! $matches_latest_year || ! $matches_latest_month ) ) {
-		// the new attachment is not in the same month/year as the data in our transient
-		delete_transient( 'wpcom_media_months_array' );
-	}
+	return wpcom_vip_get_available_months_for_filters( 'attachment' );
 }
 
-if ( is_admin() ) {
-	add_filter( 'media_library_show_video_playlist', '__return_true' );
-	add_filter( 'media_library_show_audio_playlist', '__return_true' );
-
-	add_filter( 'media_library_months_with_files', 'wpcom_vip_media_library_months_with_files' );
-	function wpcom_vip_media_library_months_with_files() {
-		global $wpdb;
-
-		$months = get_transient( 'wpcom_media_months_array' );
-
-		if ( false === $months ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			$months = $wpdb->get_results( $wpdb->prepare( "
-				SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
-					FROM $wpdb->posts
-					WHERE post_type = %s
-					ORDER BY post_date DESC
-				", 'attachment' ) );
-			set_transient( 'wpcom_media_months_array', $months );
-		}
-
+/**
+ * Caches an expensive query used to generate the available
+ * months/years used in filters on posts/CPTs admin pages.
+ *
+ * @param object[]|false $months
+ * @param string         $post_type
+ * @return object[]|false
+ */
+function wpcom_vip_available_post_listing_months( $months, $post_type ) {
+	if ( false !== $months ) {
+		// Something is already filtering, abort.
 		return $months;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( isset( $_GET['post_status'] ) ) {
+		// Avoid interferring if user filtered by a particular post status.
+		return false;
+	}
+
+	return wpcom_vip_get_available_months_for_filters( $post_type );
+}
+
+/**
+ * Helper method to bust the "available months" cache when needed.
+ *
+ * Note that we only bust the cache when a new month is added,
+ * For deletions, we just let the 24-hour TTL handle that.
+ *
+ * @param string $post_type
+ * @return object[]
+ */
+function wpcom_vip_maybe_bust_available_months_cache( $post_id ) {
+	$post_type = get_post_type( $post_id );
+	$cache_key = "available_filter_months_$post_type";
+
+	$existing_months = wp_cache_get( $cache_key, 'vip' );
+	if ( ! is_array( $existing_months ) ) {
+		// No cache to bust.
+		return false;
+	}
+
+	$post_year  = get_the_time( 'Y', $post_id );
+	$post_month = get_the_time( 'n', $post_id );
+
+	$found = false;
+	foreach ( $existing_months as $date ) {
+		if ( $post_year === $date->year && $post_month === $date->month ) {
+			$found = true;
+		}
+	}
+
+	if ( ! $found ) {
+		// The month/year doesn't exist yet, so just bust the cache and let it re-generate.
+		wp_cache_delete( $cache_key, 'vip' );
 	}
 }
 
 /**
- * Improves performance of all the post listing pages that display the months dropdown filter.
- * A unique transient is created for each post type.
+ * Query wrapper that caches the results of available months given a particular post type.
+ *
+ * See WP_List_Table::months_dropdown() & wp_enqueue_media() in WP core.
+ *
+ * @param string $post_type
+ * @return object[]
  */
-if ( is_admin() ) {
+function wpcom_vip_get_available_months_for_filters( $post_type ) {
+	global $wpdb;
 
-	add_filter( 'pre_months_dropdown_query', 'wpcom_vip_pre_months_dropdown_query', 10, 2 );
-	function wpcom_vip_pre_months_dropdown_query( $months, $post_type ) {
-		global $wpdb;
-		
-		// Don't set a transient for trashed post.
-		if ( isset( $_GET['post_status'] ) && "trash" === $_GET['post_status'] ) {
-			return __return_null();
-		}
-
-		$months = get_transient( 'wpcom_vip_pre_months_dropdown_query_'.$post_type );
-
-		if ( false === $months ) {
-
-			$extra_checks = "AND post_status != 'auto-draft'";
-			if ( ! isset( $_GET['post_status'] ) || 'trash' !== $_GET['post_status'] ) {
-				$extra_checks .= " AND post_status != 'trash'";
-			} elseif ( isset( $_GET['post_status'] ) ) {
-				$extra_checks = $wpdb->prepare( ' AND post_status = %s', $_GET['post_status'] );
-			}
-
-			$months = $wpdb->get_results(
-				$wpdb->prepare(
-					"
-					SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
-					FROM $wpdb->posts
-					WHERE post_type = %s
-					$extra_checks
-					ORDER BY post_date DESC
-					",
-					$post_type
-				)
-			);
-			set_transient( 'wpcom_vip_pre_months_dropdown_query_'.$post_type, $months );
-		}
+	$cache_key = "available_filter_months_$post_type";
+	$months    = wp_cache_get( $cache_key, 'vip' );
+	if ( is_array( $months ) ) {
+		// Happiest-path, cache exists already :).
 		return $months;
 	}
-}
-/**
- * Bust the months dropdown cache when needed.
- */
-add_action( 'save_post', 'wpcom_vip_bust_post_months_cache', 10, 2 );
-function wpcom_vip_bust_post_months_cache( $post_id, $post ) {
-	if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
-		return;
+
+	$extra_checks = '';
+	if ( 'attachment' !== $post_type ) {
+		$extra_checks = " AND post_status != 'auto-draft' AND post_status != 'trash'";
 	}
 
-	// Reset the transient if we are untrashing a post
-	if( "untrash" === $_GET['action'] ) {
-		delete_transient( 'wpcom_vip_pre_months_dropdown_query_'.$post->post_type );
-		return;
-	}
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$months = $wpdb->get_results(
+		$wpdb->prepare(
+			"
+			SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+			FROM $wpdb->posts
+			WHERE post_type = %s
+			$extra_checks
+			ORDER BY post_date DESC
+			",
+			$post_type
+		)
+	);
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-	// Grab the transient to see if it needs updating
-	$post_months = get_transient( 'wpcom_vip_pre_months_dropdown_query_'.$post->post_type );
-
-	// Make sure month and year exists in transient before comparing
-	$cached_latest_year = ( ! empty( $post_months[0]->year ) ) ? $post_months[0]->year : '';
-	$cached_latest_month = ( ! empty( $post_months[0]->month ) ) ? $post_months[0]->month : '';
-
-	// If the transient exists, and the post doesn't match the first (latest) month or year in the transient, lets clear it.
-	$matches_latest_year = get_the_time( 'Y', $post_id ) === $cached_latest_year;
-	$matches_latest_month = get_the_time( 'n', $post_id ) === $cached_latest_month;
-	if ( false !== $post_months && ( ! $matches_latest_year || ! $matches_latest_month ) ) {
-		// the post is not in the same month/year as the data in our transient
-		delete_transient( 'wpcom_vip_pre_months_dropdown_query_'.$post->post_type );
-	}
+	wp_cache_set( $cache_key, $months, 'vip', DAY_IN_SECONDS );
+	return $months;
 }

--- a/performance/vip-tweaks.php
+++ b/performance/vip-tweaks.php
@@ -5,7 +5,6 @@
  */
 add_action( 'after_setup_theme', 'wpcom_vip_enable_performance_tweaks' );
 function wpcom_vip_enable_performance_tweaks() {
-
 	// Disables the adjacent_post links in the header that are almost never beneficial and are very slow to compute.
 	remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );
 
@@ -18,12 +17,8 @@ function wpcom_vip_enable_performance_tweaks() {
 	}
 
 	if ( is_admin() ) {
-		// Prevent expensive media library queries, and cache the available months for filtering.
-		add_filter( 'media_library_show_video_playlist', '__return_true' );
-		add_filter( 'media_library_show_audio_playlist', '__return_true' );
+		// Cache the available months for filtering on posts/attachments/CPTs.
 		add_filter( 'media_library_months_with_files', 'wpcom_vip_media_library_months_with_files' );
-
-		// Cache the available months for filtering on posts/CPTs.
 		add_filter( 'pre_months_dropdown_query', 'wpcom_vip_available_post_listing_months', 10, 2 );
 	}
 
@@ -146,6 +141,7 @@ function wpcom_vip_maybe_bust_available_months_cache( $post_id ) {
 	foreach ( $existing_months as $date ) {
 		if ( $post_year === $date->year && $post_month === $date->month ) {
 			$found = true;
+			break;
 		}
 	}
 

--- a/performance/vip-tweaks.php
+++ b/performance/vip-tweaks.php
@@ -78,41 +78,6 @@ function wpcom_vip_available_post_listing_months( $months, $post_type ) {
 }
 
 /**
- * Helper method to bust the "available months" cache when needed.
- *
- * Note that we only bust the cache when a new month is added,
- * For deletions, we just let the 24-hour TTL handle that.
- *
- * @param string $post_type
- * @return object[]
- */
-function wpcom_vip_maybe_bust_available_months_cache( $post_id ) {
-	$post_type = get_post_type( $post_id );
-	$cache_key = "available_filter_months_$post_type";
-
-	$existing_months = wp_cache_get( $cache_key, 'vip' );
-	if ( ! is_array( $existing_months ) ) {
-		// No cache to bust.
-		return false;
-	}
-
-	$post_year  = get_the_time( 'Y', $post_id );
-	$post_month = get_the_time( 'n', $post_id );
-
-	$found = false;
-	foreach ( $existing_months as $date ) {
-		if ( $post_year === $date->year && $post_month === $date->month ) {
-			$found = true;
-		}
-	}
-
-	if ( ! $found ) {
-		// The month/year doesn't exist yet, so just bust the cache and let it re-generate.
-		wp_cache_delete( $cache_key, 'vip' );
-	}
-}
-
-/**
  * Query wrapper that caches the results of available months given a particular post type.
  *
  * See WP_List_Table::months_dropdown() & wp_enqueue_media() in WP core.
@@ -152,4 +117,39 @@ function wpcom_vip_get_available_months_for_filters( $post_type ) {
 
 	wp_cache_set( $cache_key, $months, 'vip', DAY_IN_SECONDS );
 	return $months;
+}
+
+/**
+ * Helper method to bust the "available months" cache when needed.
+ *
+ * Note that we only bust the cache when a new month is added,
+ * For deletions, we just let the 24-hour TTL handle that.
+ *
+ * @param string $post_type
+ * @return object[]
+ */
+function wpcom_vip_maybe_bust_available_months_cache( $post_id ) {
+	$post_type = get_post_type( $post_id );
+	$cache_key = "available_filter_months_$post_type";
+
+	$existing_months = wp_cache_get( $cache_key, 'vip' );
+	if ( ! is_array( $existing_months ) ) {
+		// No cache to bust.
+		return false;
+	}
+
+	$post_year  = get_the_time( 'Y', $post_id );
+	$post_month = get_the_time( 'n', $post_id );
+
+	$found = false;
+	foreach ( $existing_months as $date ) {
+		if ( $post_year === $date->year && $post_month === $date->month ) {
+			$found = true;
+		}
+	}
+
+	if ( ! $found ) {
+		// The month/year doesn't exist yet, so just bust the cache and let it re-generate.
+		wp_cache_delete( $cache_key, 'vip' );
+	}
 }

--- a/performance/vip-tweaks.php
+++ b/performance/vip-tweaks.php
@@ -28,7 +28,8 @@ function wpcom_vip_enable_performance_tweaks() {
 	}
 
 	// Busts the month's filtering caches when needed for both attachments and posts/CPTs.
-	add_action( 'save_post', 'wpcom_vip_maybe_bust_available_months_cache', 10, 2 );
+	add_action( 'add_attachment', 'wpcom_vip_maybe_bust_available_months_cache' );
+	add_action( 'save_post', 'wpcom_vip_maybe_bust_available_months_cache' );
 }
 
 /**


### PR DESCRIPTION
## Description
Follow-up to https://github.com/Automattic/vip-go-mu-plugins/pull/1883.

tl;dr, the query to generate the year/month filter dropdown on posts pages can be a bit expensive on large sites and is never cached. There is a new filter in WP core that will allow us to intercept and cache the results: https://core.trac.wordpress.org/ticket/51660

## Changelog Description

### Performance: Cache the year/month dropdown on admin post pages

To prevent an expensive query occurring on every admin posts-edit page load, this caches the available months/years for the dropdown filter.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Go to a listing page e.g.: `/wp-admin/edit.php` or a custom post type listing page (`/wp-admin/edit.php?post_type=myCustomPostType`) or media library (`/wp-admin/upload.php`)
2. When the page is first loaded, the query should take place and the cache is populated.
3. Reload the listing page and note the query does not need to re-occur.
4. Bust the cache by added a post that belongs to a new month/year: `wp post generate --count=1 --post_type=post --post_date=2021-08-25`. Reload and check that the new month/year appears in the dropdown filter.