### PR TITLE
Reduce the maximum amount of jobs to 3 to reduce indexing pressure

### DIFF
--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -191,7 +191,7 @@ class Cron_Test extends WP_UnitTestCase {
 		return [
 			[
 				[ 0, 1, 2, 3, 4, 5 ],
-				5,
+				3,
 			],
 			[
 				[ new \WP_Error( 'not-good' ) ],

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -254,7 +254,7 @@ class Cron_Test extends WP_UnitTestCase {
 				20,
 				[ 'vip_search_queue_processor' => 3 ],
 			],
-			[ // max of 5 takes over
+			[ // max of 3 takes over
 				30,
 				[ 'vip_search_queue_processor' => 3 ],
 			],

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -223,7 +223,7 @@ class Cron_Test extends WP_UnitTestCase {
 		$partially_mocked_cron->method( 'get_processor_job_count' )
 			->willReturnOnConsecutiveCalls( ...$job_counts );
 		$partially_mocked_cron->method( 'get_max_concurrent_processor_job_count' )
-			->willReturn( 5 );
+			->willReturn( 3 );
 
 		$partially_mocked_cron->sweep_jobs();
 	}

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -252,11 +252,11 @@ class Cron_Test extends WP_UnitTestCase {
 			],
 			[
 				20,
-				[ 'vip_search_queue_processor' => 5 ],
+				[ 'vip_search_queue_processor' => 3 ],
 			],
 			[ // max of 5 takes over
 				30,
-				[ 'vip_search_queue_processor' => 5 ],
+				[ 'vip_search_queue_processor' => 3 ],
 			],
 		];
 	}


### PR DESCRIPTION
## Description

Reduce the maximum amount of jobs to 3 to reduce indexing pressure.

Don't log the fact the processor job couldn't be scheduled as it's correct behavior in case the concurrency limit is hit. 


## Changelog Description

### Plugin Updated: Enteprise Search

We've reduced the maximum number of concurrent jobs to prevent indexing operations potentially affecting search performance. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
