### PR TITLE
Action schedule dynamic queue: drop php 7.4 syntax

### DIFF
--- a/cron/action-scheduler-dynamic-queue.php
+++ b/cron/action-scheduler-dynamic-queue.php
@@ -33,7 +33,9 @@ class Action_Scheduler_Dynamic_Queue {
 		add_filter( 'action_scheduler_allow_async_request_runner', '__return_false', 30 );
 
 		// Allow each queue to run for 120 seconds by default.
-		add_filter( 'action_scheduler_queue_runner_time_limit', fn() => 120, 30 );
+		add_filter( 'action_scheduler_queue_runner_time_limit', function() {
+			return 120;
+		}, 30 );
 
 		// Configure concurrency.
 		add_filter( 'a8c_cron_control_concurrent_event_whitelist', [ $this, 'configure_cron_control_concurrency' ] );


### PR DESCRIPTION
Followup fix for https://github.com/Automattic/vip-go-mu-plugins/pull/2441, since svn pre-commit hooks aren't updated yet.

Skipping changelog on this one.