### PR TITLE
Remove ununsed filter / constant to improve user cleanup command

### DIFF
--- a/vip-helpers/class-user-cleanup.php
+++ b/vip-helpers/class-user-cleanup.php
@@ -4,11 +4,6 @@ namespace Automattic\VIP\Helpers;
 
 use WP_Error;
 
-// If the constant is set, don't run the cleanup
-if ( defined( 'VIP_SKIP_USER_CLEANUP' ) && true === VIP_SKIP_USER_CLEANUP ) {
-	add_filter( 'vip_do_user_cleanup', '__return_false' );
-}
-
 class User_Cleanup {
 	/**
 	 * @param string|null|false $emails_string

--- a/wp-cli/class-vip-user-cli-command.php
+++ b/wp-cli/class-vip-user-cli-command.php
@@ -26,13 +26,6 @@ class VIP_User_CLI_Command extends WPCOM_VIP_CLI_Command {
 	 * wp vip user cleanup --emails="user@example.com,another@example.net"
 	 */
 	public function cleanup( $args, $assoc_args ) {
-		// Allow sites (e.g. Automattic internal) to bypass this cleanup if they have manual cleanup routines.
-		$should_do_cleanup = apply_filters( 'vip_do_user_cleanup', true );
-		if ( false === $should_do_cleanup ) {
-			\WP_CLI::success( 'Cleanup has been bypassed by the environment.' );
-			return;
-		}
-
 		$emails_arg = \WP_CLI\Utils\get_flag_value( $assoc_args, 'emails' );
 
 		$emails = User_Cleanup::parse_emails_string( $emails_arg );


### PR DESCRIPTION

## Description

Remove unused filter / constant that allows bypassing user cleanup. Removing this filter would allow us to pass `--skip-plugins` and `--skip-themes` when running this command and fix the many instances when this command fails due to customer code.

"Unused" has been verified by a search of VIP codebases and environment variable names. However, this probably needs more scrutiny.

## Changelog Description

### Remove filter `vip_do_user_cleanup` and related constant `VIP_SKIP_USER_CLEANUP`

Remove filter `vip_do_user_cleanup` and related constant `VIP_SKIP_USER_CLEANUP`. This allows us to skip loading of plugins and themes when removing Automattic users from VIP sites.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

