### PR TITLE
Use a sub-directory for CF7 uploads to avoid CF7 cleanup deleting unrelated files

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -15,7 +15,7 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
  * so let's just tell CF7 to put them in `/tmp/cf7/`.
  */
 if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) ) {
-	define( 'WPCF7_UPLOADS_TMP_DIR', get_temp_dir() . '/cf7/' );
+	define( 'WPCF7_UPLOADS_TMP_DIR', get_temp_dir() . 'cf7/' );
 }
 
 /**

--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -12,10 +12,10 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
  *
  * The plugin attempts to write to a `wp-content` path which will fail.
  * These files are transient and only meant to be included as attachment,
- * so let's just tell CF7 to put them in `/tmp/`.
+ * so let's just tell CF7 to put them in `/tmp/cf7/`.
  */
 if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) ) {
-	define( 'WPCF7_UPLOADS_TMP_DIR', get_temp_dir() );
+	define( 'WPCF7_UPLOADS_TMP_DIR', get_temp_dir() . '/cf7/' );
 }
 
 /**


### PR DESCRIPTION
Fixes #2710 

## Description

This changes our Contact Form 7 workaround to use a subdirectory rather than storing files directly in `/tmp`, which CF7 then tries to clean-up, including any unrelated files.

## Changelog Description
### Compatibility: Contact Form 7
Changed path of `WPCF7_UPLOADS_TMP_DIR` to use a subdirectory of `/tmp`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Install and activate a recent version of Contact Form 7 on a VIP Go site and sandbox it.
2. Check for the presence of `/tmp/cf7`
3. On the sandbox, add some files directly to `/tmp` both as a privileged user and unprivileged user
4. The cleanup is initiated on `template_redirect` so navigate through some pages.
5. Check logs for warnings for failed deletes to files in the `/tmp` dir
6. Check for removed files added as an unprivileged user in `/tmp`.

Note there are some workarounds needed to actually test attachments with CF7 versions 5.0.5 and above - see related issue
