### PR TITLE
Search: Add more information to search_http_error logging

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -12,10 +12,10 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
  *
  * The plugin attempts to write to a `wp-content` path which will fail.
  * These files are transient and only meant to be included as attachment,
- * so let's just tell CF7 to put them in `/tmp/`.
+ * so let's just tell CF7 to put them in `/tmp/cf7/`.
  */
 if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) ) {
-	define( 'WPCF7_UPLOADS_TMP_DIR', get_temp_dir() );
+	define( 'WPCF7_UPLOADS_TMP_DIR', get_temp_dir() . 'cf7/' );
 }
 
 /**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -948,15 +948,8 @@ class Search {
 				$this->maybe_increment_stat( $statsd_prefix . $stat );
 			}
 
-			$this->logger->log(
-				'error',
-				'search_http_error',
-				implode( ';', $error_messages ),
-				[
-					'is_cli'  => $is_cli,
-					'request' => $encoded_request,
-				]
-			);
+			$error_message = implode( ';', $error_messages );
+			$error_type    = 'search_http_error';
 		} else {
 			$response_body_json = wp_remote_retrieve_body( $response );
 			$response_body      = json_decode( $response_body_json, true );
@@ -964,32 +957,30 @@ class Search {
 
 			$this->maybe_increment_stat( $statsd_prefix . '.error' );
 
-			$query_for_logging = $this->sanitize_ep_query_for_logging( $query );
-
 			$error_message = $response_error['reason'] ?? 'Unknown Elasticsearch query error';
-			
-			if ( ! $is_cli ) {
-				global $wp;
-				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-				$url = esc_url_raw( add_query_arg( $wp->query_vars, home_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
-			}
-
-			$this->logger->log(
-				'error',
-				'search_query_error',
-				$error_message,
-				[
-					'error_type' => $response_error['type'] ?? 'Unknown error type',
-					'root_cause' => $response_error['root_cause'] ?? null,
-					'query'      => $query_for_logging,
-					'backtrace'  => wp_debug_backtrace_summary(),   // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
-					'is_cli'     => $is_cli,
-					'request'    => $encoded_request,
-					'response'   => $response_body,
-					'url'        => $url ?? null,
-				]
-			);
+			$error_type    = 'search_query_error';
 		}
+
+		if ( ! $is_cli ) {
+			global $wp;
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			$request_url_for_logging = esc_url_raw( add_query_arg( $wp->query_vars, home_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
+		}
+		$this->logger->log(
+			'error',
+			$error_type,
+			$error_message,
+			[
+				'error_type' => $response_error['type'] ?? 'Unknown error type',
+				'root_cause' => $response_error['root_cause'] ?? null,
+				'query'      => $this->sanitize_ep_query_for_logging( $query ),
+				'backtrace'  => wp_debug_backtrace_summary(),   // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
+				'is_cli'     => $is_cli,
+				'request'    => $encoded_request,
+				'response'   => $response_body ?? null,
+				'url'        => $request_url_for_logging ?? null,
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Since we want to add more information to our `search_http_error` errors, let's just re-factor it into the same logging code piece for `search_query_error`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.