### PR TITLE
Move invariant function calls out of the loop

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -897,6 +897,9 @@ class Search {
 					$warning_messages = array( $warning_messages );
 				}
 
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
+				$backtrace       = wp_debug_backtrace_summary();
+				$sanitized_query = $this->sanitize_ep_query_for_logging( $query );
 				foreach ( $warning_messages as $message ) {
 					trigger_error( esc_html( $message ), \E_USER_WARNING );
 					\Automattic\VIP\Logstash\log2logstash( array(
@@ -904,8 +907,8 @@ class Search {
 						'feature'  => 'search_es_warning',
 						'message'  => $message,
 						'extra'    => [
-							'query'     => $this->sanitize_ep_query_for_logging( $query ),
-							'backtrace' => wp_debug_backtrace_summary(),    // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
+							'query'     => $sanitized_query,
+							'backtrace' => $backtrace,
 						],
 					) );
 				}
@@ -915,9 +918,9 @@ class Search {
 		if ( is_wp_error( $response ) ) {
 			// Return a generic VIP Search WP_Error instead of the one from wp_remote_request
 			return new \WP_Error( 'vip-search-upstream-request-failed', 'There was an error connecting to the upstream search server' );
-		} else {
-			return $response;
 		}
+
+		return $response;
 	}
 
 	public function ep_handle_failed_request( $request, $response, $query, $statsd_prefix, $type ) {
@@ -996,11 +999,9 @@ class Search {
 	 * Given an ElasticPress query object, strip out anything that shouldn't be logged
 	 */
 	public function sanitize_ep_query_for_logging( $query ) {
-		if ( ! isset( $query['args']['headers']['Authorization'] ) ) {
-			return $query;
+		if ( isset( $query['args']['headers']['Authorization'] ) ) {
+			$query['args']['headers']['Authorization'] = '<redacted>';
 		}
-
-		$query['args']['headers']['Authorization'] = '<redacted>';
 
 		return $query;
 	}


### PR DESCRIPTION
## Description

This PR refactors error handling in the `filter__ep_do_intercept_request()` function by moving invariant function calls out of the loop.

## Changelog Description

### Plugin Updated: VIP Search

Refactor error handling by moving expensive function calls out of the loop.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
