### PR TITLE
Search: For index_exists cached option, only cache if response code is valid

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -789,11 +789,13 @@ class Search {
 			'put_mapping',
 			'bulk_index',
 		];
+		$valid_index_exists_response_codes = [ 200, 404 ];
 		if ( 'index_exists' === $type || in_array( $type, $index_exists_invalidation_actions, true ) ) {
 			$index_exists_option_name    = $this->get_index_exists_option_name( $query['url'] );
 			$cached_index_exists_request = get_option( $index_exists_option_name );
 			if ( false !== $cached_index_exists_request ) {
-				if ( 'index_exists' === $type ) {
+				$cached_index_exists_response_code = (int) wp_remote_retrieve_response_code( $cached_index_exists_request );
+				if ( 'index_exists' === $type && in_array( $cached_index_exists_response_code, $valid_index_exists_response_codes, true ) ) {
 					// Return cached index_exists option.
 					return $cached_index_exists_request;
 				} else {
@@ -883,7 +885,6 @@ class Search {
 			return new \WP_Error( 'vip-search-upstream-request-failed', 'There was an error connecting to the upstream search server' );
 		}
 
-		$valid_index_exists_response_codes = [ 200, 404 ];
 		if ( 'index_exists' === $type && in_array( $response_code, $valid_index_exists_response_codes, true ) ) {
 			// Cache index_exists into option since we didn't return a cached value earlier.
 			update_option( $index_exists_option_name, $response );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -883,7 +883,8 @@ class Search {
 			return new \WP_Error( 'vip-search-upstream-request-failed', 'There was an error connecting to the upstream search server' );
 		}
 
-		if ( 'index_exists' === $type ) {
+		$valid_index_exists_response_codes = [ 200, 404 ];
+		if ( 'index_exists' === $type && in_array( $response_code, $valid_index_exists_response_codes, true ) ) {
 			// Cache index_exists into option since we didn't return a cached value earlier.
 			update_option( $index_exists_option_name, $response );
 		}


### PR DESCRIPTION
## Description
Since only need to cache if the response is a 200 or 404. All other ones (i.e. 410) should be ignored and not cached. If a bad response has been stored, invalidate it.

## Changelog Description

### Plugin Updated: Search

Only cache index_exists requests that are valid. Invalidate if response code is not in safelist.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
To test the actual caching of the index_exists option:

1) Make an index_exists request:
```
 $indexable = \ElasticPress\Indexables::factory()->get( 'post' );
$indexable->index_exists();
```
2) Get the option `wp option get es_index_exists_vip-200508-post-1`