### PR TITLE
Search: Alert if we don't have a queue count value cached OR if the queue count isn't decreasing

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1157,15 +1157,21 @@ class Search {
 		$queue_stats = $this->queue->get_queue_stats();
 
 		if ( $queue_stats->average_wait_time > self::STALE_QUEUE_WAIT_LIMIT ) {
-			$message = sprintf(
-				'Average index queue wait time for application %d - %s is currently %d seconds. There are %d items in the queue and the oldest item is %d seconds old',
-				FILES_CLIENT_SITE_ID,
-				home_url(),
-				$queue_stats->average_wait_time,
-				$queue_stats->queue_count,
-				$queue_stats->longest_wait_time
-			);
-			$this->alerts->send_to_chat( self::SEARCH_ALERT_SLACK_CHAT, $message, self::SEARCH_ALERT_LEVEL );
+			$cached_queue_count = wp_cache_get( 'vip_search_queue_count_alert', 'vip' );
+			if ( false === $cached_queue_count || ( $cached_queue_count && $cached_queue_count <= $queue_stats->queue_count ) ) {
+				// Alert if we don't have a queue count value cached OR if the queue count isn't decreasing.
+				$message = sprintf(
+					'Average index queue wait time for application %d - %s is currently %d seconds. There are %d items in the queue and the oldest item is %d seconds old',
+					FILES_CLIENT_SITE_ID,
+					home_url(),
+					$queue_stats->average_wait_time,
+					$queue_stats->queue_count,
+					$queue_stats->longest_wait_time
+				);
+				$this->alerts->send_to_chat( self::SEARCH_ALERT_SLACK_CHAT, $message, self::SEARCH_ALERT_LEVEL );
+
+				wp_cache_set( 'vip_search_queue_count_alert', $queue_stats->queue_count, 'vip', 15 * MINUTE_IN_SECONDS );
+			}
 		}
 	}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1170,7 +1170,7 @@ class Search {
 				);
 				$this->alerts->send_to_chat( self::SEARCH_ALERT_SLACK_CHAT, $message, self::SEARCH_ALERT_LEVEL );
 
-				wp_cache_set( 'vip_search_queue_count_alert', $queue_stats->queue_count, 'vip', 15 * MINUTE_IN_SECONDS );
+				wp_cache_set( 'vip_search_queue_count_alert', $queue_stats->queue_count, 'vip', 45 * MINUTE_IN_SECONDS );
 			}
 		}
 	}


### PR DESCRIPTION
## Description
To reduce the noise, let's add caching for the queue count and alert when the queue count isn't decreasing. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.