### PR TITLE
Do not sync index on fake term updates

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -245,6 +245,10 @@ class Search {
 
 		require_once __DIR__ . '/class-queue.php';
 
+		require_once __DIR__ . '/class-syncmanager-helper.php';
+
+		SyncManager_Helper::instance();
+
 		$this->queue = new Queue();
 		$this->queue->init();
 

--- a/search/includes/classes/class-syncmanager-helper.php
+++ b/search/includes/classes/class-syncmanager-helper.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+use WP_Term;
+
+final class SyncManager_Helper {
+	private static $instance = null;
+
+	/** @var WP_Term[] */
+	private $terms = [];
+
+	public static function instance(): self {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	private function __construct() {
+		$this->init();
+	}
+
+	public function init(): void {
+		$this->terms = [];
+
+		/*
+		 * Hook sequence:
+		 * - wp_update_term_parent
+		 * - edit_terms <====== we hook into this one to get the term before it gets updated
+		 * - wp_update_term_data
+		 * - (database update happens here)
+		 * - edited_terms
+		 * - edit_term_taxonomy
+		 * - (term-taxonomy relationship update happens here)
+		 * - edited_term_taxonomy
+		 * - edit_term
+		 * - edit_{$taxonomy}
+		 * - term_id_filter
+		 * - (term cache gets cleaned here, get_term() will return the updated value)
+		 * - edited_term 
+		 * -    <====== we use this action to get the fully updated term (priority=0)
+		 * -    <====== EP uses this hook with priority=10 to sync the term (priority=10)
+		 * - edited_{$taxonomy}
+		 * - saved_term <====== we use this action to clean up after edit_terms
+		 * - saved_{$taxonomy}
+		 */
+
+		add_action( 'edit_terms', [ $this, 'edit_terms' ], 10, 2 );
+		add_action( 'edited_term', [ $this, 'edited_term' ], 0, 3 );
+		add_action( 'saved_term', [ $this, 'saved_term' ] );
+
+		add_filter( 'ep_skip_action_edited_term', [ $this, 'ep_skip_action_edited_term' ], 10, 4 );
+	}
+
+	public function cleanup(): void {
+		$this->terms = [];
+
+		remove_action( 'edit_terms', [ $this, 'edit_terms' ], 10 );
+		remove_action( 'edited_term', [ $this, 'edited_term' ], 0 );
+		remove_action( 'saved_term', [ $this, 'saved_term' ] );
+
+		remove_filter( 'ep_skip_action_edited_term', [ $this, 'ep_skip_action_edited_term' ], 10 );
+	}
+
+	/**
+	 * Fires immediately before the given terms are edited.
+	 *
+	 * @param int $term_id      Term ID.
+	 * @param string $taxonomy  Taxonomy slug.
+	 * @return void
+	 */
+	public function edit_terms( $term_id, $taxonomy ): void {
+		$term = get_term( $term_id, $taxonomy );
+		$key  = "{$term_id}:{$taxonomy}";
+
+		if ( $term instanceof WP_Term ) {
+			$this->terms[ $key ] = $term;
+		}
+	}
+
+	/**
+	 * Fires after a term has been updated, and the term cache has been cleaned.
+	 *
+	 * @param int $term_id      Term ID.
+	 * @param int $tt_id        Term taxonomy ID.
+	 * @param string $taxonomy  Taxonomy slug.
+	 * @return void
+	 */
+	public function edited_term( $term_id, $tt_id, $taxonomy ): void {
+		$key = "{$term_id}:{$taxonomy}";
+		if ( isset( $this->terms[ $key ] ) ) {
+			$new = get_term( $term_id, $taxonomy );
+			if ( $new instanceof WP_Term ) {
+				$old = $this->terms[ $key ];
+				foreach ( [ 'name', 'slug', 'parent', 'term_taxonomy_id' ] as $field ) {
+					if ( $old->$field !== $new->$field ) {
+						unset( $this->terms[ $key ] );
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Fires after a term has been saved, and the term cache has been cleared.
+	 *
+	 * @return void
+	 */
+	public function saved_term(): void {
+		$this->terms = [];
+	}
+
+	/**
+	 * @param mixed $skip       Whether to skip the update
+	 * @param int $term_id      Term ID.
+	 * @param int $tt_id        Term taxonomy ID.
+	 * @param string $taxonomy  Taxonomy slug.
+	 * @return bool
+	 */
+	public function ep_skip_action_edited_term( $skip, $term_id, $tt_id, $taxonomy ) {
+		$key = "{$term_id}:{$taxonomy}";
+		if ( isset( $this->terms[ $key ] ) ) {
+			$skip = true;
+		}
+
+		return $skip;
+	}
+}

--- a/search/includes/classes/class-syncmanager-helper.php
+++ b/search/includes/classes/class-syncmanager-helper.php
@@ -41,7 +41,7 @@ final class SyncManager_Helper {
 		 * - (term cache gets cleaned here, get_term() will return the updated value)
 		 * - edited_term 
 		 * -    <====== we use this action to get the fully updated term (priority=0)
-		 * -    <====== EP uses this hook with priority=10 to sync the term (priority=10)
+		 * -    <====== EP uses this hook to sync the term index (priority=10)
 		 * - edited_{$taxonomy}
 		 * - saved_term <====== we use this action to clean up after edit_terms
 		 * - saved_{$taxonomy}

--- a/tests/search/includes/classes/test-syncmanager-helper.php
+++ b/tests/search/includes/classes/test-syncmanager-helper.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+use WP_UnitTest_Factory;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/../../../../search/includes/classes/class-syncmanager-helper.php';
+
+class Test_SyncManager_Helper extends WP_UnitTestCase {
+	/** @var int */
+	private static $tag_id;
+
+	/** @var bool|null */
+	private $outcome;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		$tag_id = $factory->tag->create( [
+			'name' => 'Test Tag',
+		] );
+
+		self::assertIsInt( $tag_id );
+		self::$tag_id = $tag_id;
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Make sure nobody disturbs us
+		remove_all_actions( 'edited_term' );
+		remove_all_filters( 'ep_skip_action_edited_term' );
+
+		$this->outcome = null;
+		add_action( 'edited_term', [ $this, 'edited_term' ], 10, 3 );
+
+		// Reinitialize, as WPTL cleans up all hooks after the test
+		SyncManager_Helper::instance()->init();
+	}
+
+	public function edited_term( int $term_id, int $tt_id, string $taxonomy ): void {
+		$this->outcome = apply_filters( 'ep_skip_action_edited_term', false, $term_id, $tt_id, $taxonomy );
+	}
+
+	public function test_real_update(): void {
+		$data = wp_update_term( self::$tag_id, 'post_tag', [ 'slug' => 'the-tag' ] );
+
+		self::assertIsArray( $data );
+		self::assertFalse( $this->outcome );
+	}
+
+	public function test_fake_update(): void {
+		$data = wp_update_term( self::$tag_id, 'post_tag' );
+
+		self::assertIsArray( $data );
+		self::assertTrue( $this->outcome );
+	}
+}


### PR DESCRIPTION
## Description

Implementation of @rinatkhaziev's Automattic/ElasticPress#132 for mu-plugins

## Changelog Description

### Plugin Updated: VIP Search

Do not synchronize index on term updates that update nothing (e.g., when a user clicks Save without modifying anything).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass — I have added unit tests for this feature.
