### PR TITLE
Search: remove autohealing alert

### DIFF
--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -121,16 +121,6 @@ class HealthJob {
 		if ( is_wp_error( $results ) && 'content_validation_already_ongoing' !== $results->get_error_code() ) {
 			$message = sprintf( 'Cron validate-contents error for site %d (%s): %s', FILES_CLIENT_SITE_ID, home_url(), $results->get_error_message() );
 			wpcom_vip_irc( '#vip-go-es-alerts', $message, 2 );
-		} elseif ( ! empty( $results ) ) {
-			$self_healed_post_count = count( $results );
-			$total_post_count       = $this->count_indexable_posts();
-
-			$alert_threshold = $total_post_count * self::AUTOHEALED_ALERT_THRESHOLD;
-
-			if ( $self_healed_post_count > $alert_threshold ) {
-				$message = sprintf( 'Cron validate-contents for site %d (%s): Autohealing executed for %d records.', FILES_CLIENT_SITE_ID, home_url(), count( $results ) );
-				wpcom_vip_irc( '#vip-go-es-alerts', $message, 2 );
-			}
 		}
 
 	}


### PR DESCRIPTION
## Description
The autohealing alert is not necessary — I think we only need to alert if an error occurred. Otherwise, it's safe to assume that it went fine and dandy.