### PR TITLE
Search: rework the queue command, remove the stress-queue subcommand and introduce purge subcommand

### DIFF
--- a/search/includes/classes/commands/class-queuecommand.php
+++ b/search/includes/classes/commands/class-queuecommand.php
@@ -5,6 +5,8 @@ namespace Automattic\VIP\Search\Commands;
 use \WP_CLI;
 use \WP_CLI\Utils;
 
+use \Automattic\VIP\Search\Queue\Schema;
+
 require_once __DIR__ . '/../class-health.php';
 
 /**
@@ -44,8 +46,14 @@ class QueueCommand extends \WPCOM_VIP_CLI_Command {
 
 		$search = \Automattic\VIP\Search\Search::instance();
 		$queue  = $search->queue;
-
+		$schema = new Schema();
 		$result = $queue->empty_queue();
-		WP_CLI::success( sprintf( 'Total items removed from queue: %d', is_int( $result ) ? $result : 'error' ) );
+
+		// int means the query is successful and indicates the number of rows affected
+		if ( is_int( $result ) ) {
+			WP_CLI::success( sprintf( 'Total items removed from queue: %d', $result ) );
+		} else {
+			WP_CLI::error( 'Purge has failed, please inspect the ' . $schema->get_table_name() . ' table manually.' );
+		}
 	}
 }

--- a/search/includes/classes/commands/class-queuecommand.php
+++ b/search/includes/classes/commands/class-queuecommand.php
@@ -15,15 +15,6 @@ require_once __DIR__ . '/../class-health.php';
  * @package Automattic\VIP\Search
  */
 class QueueCommand extends \WPCOM_VIP_CLI_Command {
-	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
-	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
-
-	public function __construct() {
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-		parent::__construct();
-	}
-
 	/**
 	 * Purge the queue
 	 *


### PR DESCRIPTION
## Description

Remove `stress-test`. It was a subcommand from the early days of the product, we don't really need it anymore, because we have plenty of real-world usage.

Introduce `purge` subcommand to be able to quickly remove all items from queue.

## Changelog Description

### Plugin Updated: Enterprise Search

We've introduced `wp vip-search queue purge` command that would clear everything from async index queue.

Examle usage: 

> wp vip-search queue purge

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Run `wp vip-search queue purge`, verify it asks for confirmation
1. Run `wp vip-search queue purge --skip-confirm`, verify it doesn't ask for confirmation
1. Verify the queue is actually empty 


