### PR TITLE
Search: Add response code and message if available

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -963,12 +963,18 @@ class Search {
 		} else {
 			$response_body_json = wp_remote_retrieve_body( $response );
 			$response_body      = json_decode( $response_body_json, true );
-			$response_error     = $response_body['error'] ?? [];
+			if ( isset( $response_body['error']['reason'] ) ) {
+				$error_message = $response_body['error']['reason'];
+			} else {
+				$response_code    = wp_remote_retrieve_response_code( $response );
+				$response_message = wp_remote_retrieve_response_message( $response );
+				$error_message    = $response_code && ! empty( $response_message ) ? 
+				(string) $response_code . ' ' . $response_message : 'Unknown Elasticsearch query error';
+			}
 
 			$this->maybe_increment_stat( $statsd_prefix . '.error' );
 
-			$error_message = $response_error['reason'] ?? 'Unknown Elasticsearch query error';
-			$error_type    = 'search_query_error';
+			$error_type = 'search_query_error';
 		}
 
 		if ( ! $is_cli ) {

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2227,7 +2227,8 @@ class Search_Test extends WP_UnitTestCase {
 		$stats_prefix    = 'foo';
 		$mocked_response = [
 			'response' => [
-				'code' => 400,
+				'code'    => 400,
+				'message' => 'Bad Request',
 			],
 		];
 
@@ -2680,9 +2681,13 @@ class Search_Test extends WP_UnitTestCase {
 			],
 			[
 				[
-					'body' => '{ "error": {} }',
+					'body'     => '{ "error": {} }',
+					'response' => [
+						'code'    => 401,
+						'message' => 'Unauthorized',
+					],
 				],
-				'Unknown Elasticsearch query error',
+				'401 Unauthorized',
 			],
 			[
 				[


### PR DESCRIPTION
## Description
If the response code and message are available, we should return those instead of the generic default error message for better details.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Make a bad request
2) Expect to see the response code and message returned in the logging 