### PR TITLE
Fix tests for WP trunk

### DIFF
--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -19,6 +19,8 @@ class Versioning_Test extends WP_UnitTestCase {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
+		remove_all_actions( 'init' );
+
 		if ( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) {
 			define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
 				'https://es-endpoint1',


### PR DESCRIPTION
Tests for WP trunk [fail](https://app.circleci.com/pipelines/github/Automattic/vip-go-mu-plugins/9248/workflows/fbf2e035-0f44-4be1-8eee-7b693fc44074/jobs/88669) because of the modifications to how the blocks are registered (arre yaar, I wish there was a way to tell WP not to load all that block stuff if I don't need it).

Here I am trying to fix that.
