### PR TITLE
Search: Basic request cache invalidation via last_changed approach

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -841,7 +841,7 @@ class Search {
 
 		// Cache handling
 		$is_cacheable            = $this->is_url_query_cacheable( $query['url'], $args );
-		$cache_key               = 'es_query_cache:' . md5( $query['url'] . wp_json_encode( $args ) );
+		$cache_key               = 'es_query_cache:' . md5( $query['url'] . wp_json_encode( $args ) ) . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
 		$staleness_threshold_sec = apply_filters( 'vip_search_stale_request_threshold', 45, $args );
 		/**
 		 * Serve cached response right away, if available and not stale and the query is cacheable

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -841,7 +841,7 @@ class Search {
 
 		// Cache handling
 		$is_cacheable            = $this->is_url_query_cacheable( $query['url'], $args );
-		$cache_key               = 'es_query_cache:' . md5( $query['url'] . wp_json_encode( $args ) ) . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
+		$cache_key               = 'es_query_cache:' . md5( $query['url'] . wp_json_encode( $args ) ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
 		$staleness_threshold_sec = apply_filters( 'vip_search_stale_request_threshold', 45, $args );
 		/**
 		 * Serve cached response right away, if available and not stale and the query is cacheable

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -840,9 +840,9 @@ class Search {
 		$statsd_prefix          = $this->get_statsd_prefix( $query['url'], $statsd_mode );
 
 		// Cache handling
-		$is_cacheable            = $this->is_url_query_cacheable( $query['url'], $args );
-		$cache_key               = 'es_query_cache:' . md5( $query['url'] . wp_json_encode( $args ) ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
-		$staleness_threshold_sec = apply_filters( 'vip_search_stale_request_threshold', 45, $args );
+		$is_cacheable = $this->is_url_query_cacheable( $query['url'], $args );
+		$cache_key    = 'es_query_cache:' . md5( $query['url'] . wp_json_encode( $args ) ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
+
 		/**
 		 * Serve cached response right away, if available and not stale and the query is cacheable
 		 */
@@ -850,10 +850,8 @@ class Search {
 
 		// Disabled for testing
 		// TODO: switch to Feature gradual rollout
-		if ( ! ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === VIP_GO_APP_ENVIRONMENT ) &&
-			isset( $cached_response['response'] ) && 
-			microtime( true ) - $cached_response['timestamp'] <= $staleness_threshold_sec ) {
-			return $cached_response['response'];
+		if ( ! ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === VIP_GO_APP_ENVIRONMENT ) && $cached_response ) {
+			return $cached_response;
 		}
 
 		$start_time = microtime( true );
@@ -961,12 +959,8 @@ class Search {
 		}
 
 		if ( $is_cacheable ) {
-			$entry = [
-				'timestamp' => $end_time,
-				'response'  => $response,
-			];
 			// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
-			wp_cache_set( $cache_key, $entry, self::SEARCH_CACHE_GROUP, 5 * MINUTE_IN_SECONDS );
+			wp_cache_set( $cache_key, $response, self::SEARCH_CACHE_GROUP, 5 * MINUTE_IN_SECONDS );
 		}
 
 		return $response;

--- a/search/includes/classes/class-syncmanager-helper.php
+++ b/search/includes/classes/class-syncmanager-helper.php
@@ -52,6 +52,9 @@ final class SyncManager_Helper {
 		add_action( 'saved_term', [ $this, 'saved_term' ] );
 
 		add_filter( 'ep_skip_action_edited_term', [ $this, 'ep_skip_action_edited_term' ], 10, 4 );
+
+		// Invalidate the request cache on these hooks
+		add_action( 'save_post', [ $this, 'bump_last_changed' ] );
 	}
 
 	public function cleanup(): void {
@@ -62,6 +65,15 @@ final class SyncManager_Helper {
 		remove_action( 'saved_term', [ $this, 'saved_term' ] );
 
 		remove_filter( 'ep_skip_action_edited_term', [ $this, 'ep_skip_action_edited_term' ], 10 );
+	}
+
+	/**
+	 * Bump last updated what we can use to invalidate any cached requests
+	 *
+	 * @return void
+	 */
+	public function bump_last_changed() {
+		wp_cache_set( 'last_changed', microtime(), Search::SEARCH_CACHE_GROUP );
 	}
 
 	/**

--- a/search/includes/classes/class-syncmanager-helper.php
+++ b/search/includes/classes/class-syncmanager-helper.php
@@ -102,7 +102,7 @@ final class SyncManager_Helper {
 	 *
 	 * @return bool 
 	 */
-	public function bump_last_changed() {
+	private function bump_last_changed() {
 		return wp_cache_set( 'last_changed', microtime(), Search::SEARCH_CACHE_GROUP );
 	}
 

--- a/search/includes/classes/class-syncmanager-helper.php
+++ b/search/includes/classes/class-syncmanager-helper.php
@@ -56,7 +56,7 @@ final class SyncManager_Helper {
 		// Invalidate the request cache on these hooks
 
 		add_action( 'ep_after_bulk_index', [ $this, 'ep_after_bulk_index' ], 10, 3 );
-		add_action( 'ep_after_index', [ $this, 'ep_after_index' ] );
+		add_action( 'ep_after_index', [ $this, 'ep_after_index' ], 10, 2 );
 	}
 
 	public function cleanup(): void {


### PR DESCRIPTION
## Description

This adds basic invalidation via adding `last_changed` as a suffix for the cache key.

## Changelog Description

### Plugin Updated: Enterprise Search

We have implemented cache invalidation after index and bulk index to make sure that any cached requests will not use stale data.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Hit a search `?s=test`
3. Open Debug Bar or Query Monitor and verify there's a remote request to ES
4. Hit the search again
5. Verify there's no request
6. Perform an action that results in an indexing (e.g. save a post)
7. Hit the search again and verify the request is made again.

