### PR TITLE
Add "cron control next, v2" submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "search/debug-bar-elasticpress"]
 	path = search/debug-bar-elasticpress
 	url = https://github.com/10up/debug-bar-elasticpress.git
+[submodule "cron-control-next-v2"]
+	path = cron-control-next-v2
+	url = https://github.com/Automattic/Cron-Control.git

--- a/001-cron.php
+++ b/001-cron.php
@@ -157,10 +157,14 @@ if ( ! wpcom_vip_use_core_cron() ) {
 	add_action( 'a8c_cron_control_freeing_event_locks_after_uncaught_error', 'wpcom_vip_log_cron_control_event_object' );
 	add_action( 'a8c_cron_control_uncacheable_cron_option', 'wpcom_vip_log_cron_control_uncacheable_cron_option', 10, 3 );
 
-	$cron_control_next_version = __DIR__ . '/cron-control-next/cron-control.php';
+	$cron_control_next_version    = __DIR__ . '/cron-control-next/cron-control.php';
+	$cron_control_next_version_v2 = __DIR__ . '/cron-control-next-v2/cron-control.php';
 
-	if ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION' ) && true === VIP_CRON_CONTROL_USE_NEXT_VERSION && file_exists( $cron_control_next_version ) ) {
+	if ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION_V2' ) && true === VIP_CRON_CONTROL_USE_NEXT_VERSION_V2 && file_exists( $cron_control_next_version_v2 ) ) {
 		// Use latest version for testing
+		require_once $cron_control_next_version_v2;
+	} elseif ( defined( 'VIP_CRON_CONTROL_USE_NEXT_VERSION' ) && true === VIP_CRON_CONTROL_USE_NEXT_VERSION && file_exists( $cron_control_next_version ) ) {
+		// Keep using the prev iteration of "cron control next"
 		require_once $cron_control_next_version;
 	} else {
 		// Use regular version


### PR DESCRIPTION
## Description

Add new submodule pointing towards https://github.com/Automattic/Cron-Control/pull/231 to allow for a a slow rollout / incremental testing. Nothing is currently using the new constant, so this PR wont' have any effect on its own.

Initial plan was to replace the existing `VIP_CRON_CONTROL_USE_NEXT_VERSION` instance, but there are a handful of production sites using it still - and would prefer to not push out to productions right away.

Once we are done w/ the rollout, all additional instances will be removed and just `cron-control` will remain w/ the updated version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Add `define( 'VIP_CRON_CONTROL_USE_NEXT_VERSION_V2', true );` to vip-config.php
2. Check that new version of cron control is loaded.

Note: the linting test aren't meant to pass for things in this plugin.
