### PR TITLE
Exclude cron-control-next-v2 from linting

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,6 +15,7 @@
 	<exclude-pattern>/advanced-post-cache/*</exclude-pattern>
 	<exclude-pattern>/cron-control/*</exclude-pattern>
 	<exclude-pattern>/cron-control-next/*</exclude-pattern>
+	<exclude-pattern>/cron-control-next-v2/*</exclude-pattern>
 	<exclude-pattern>/debug-bar-cron/*</exclude-pattern>
 	<exclude-pattern>/http-concat/*</exclude-pattern>
 	<exclude-pattern>/jetpack/*</exclude-pattern>


### PR DESCRIPTION
Exclude `cron-control-next-v2` from PHPCS checks.
