### PR TITLE
Support Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,10 @@
         "johnpbloch/wordpress-core": "5.8.2",
         "wp-phpunit/wp-phpunit": "5.8.2",
         "wp-cli/wp-cli": "2.5.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for Composer 2.2.

Composer 2.2 introduces [more secure plugin execution](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution) and this PR adds support for it.

The idea was taken from Parsely/wp-parsely#559 :-) 