### PR TITLE
Fix flaky test

### DIFF
--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -283,14 +283,15 @@ class Queue_Test extends WP_UnitTestCase {
 			$expected_job_ids[] = $this->queue->queue_object( $object['id'], $object['type'] );
 		}
 
-		$expected_scheduled_time = gmdate( 'Y-m-d H:i:s' );
-
-		$jobs = $this->queue->checkout_jobs( 10 );
+		$expected_scheduled_time_low  = gmdate( 'Y-m-d H:i:s' );
+		$jobs                         = $this->queue->checkout_jobs( 10 );
+		$expected_scheduled_time_high = gmdate( 'Y-m-d H:i:s' );
 
 		// Should have the right status and scheduled_time set
 		foreach ( $jobs as $job ) {
-			$this->assertEquals( 'scheduled', $job->status, "Job $job->job_id was expected to have status 'scheduled'" );
-			$this->assertEquals( $expected_scheduled_time, $job->scheduled_time, "Job $job->job_id has the wrong scheduled_time" );
+			self::assertEquals( 'scheduled', $job->status, "Job $job->job_id was expected to have status 'scheduled'" );
+			self::assertGreaterThanOrEqual( $expected_scheduled_time_low, $job->scheduled_time, "Job {$job->job_id} has the wrong scheduled_time" );
+			self::assertLessThanOrEqual( $expected_scheduled_time_high, $job->scheduled_time, "Job {$job->job_id} has the wrong scheduled_time" );
 		}
 
 		$object_ids = wp_list_pluck( $jobs, 'object_id' );


### PR DESCRIPTION
Ref: https://app.circleci.com/pipelines/github/Automattic/vip-go-mu-plugins/9317/workflows/0fb186e8-f2c8-496f-9e21-4f3b2cb19fd4/jobs/89967

> 1) Automattic\VIP\Search\Queue_Test::test_checkout_jobs
> Job 3 has the wrong scheduled_time
> Failed asserting that two strings are equal.
> --- Expected
> +++ Actual
> @@ @@
> -'2021-12-24 02:59:01'
> +'2021-12-24 02:59:02'

This happens when the `$expected_scheduled_time` value is captured on the last microseconds of the current second; `checkout_jobs()` happens then the next second and the test fails. This PR tries to fix it.
