### PR TITLE
Remove/travis mentiones from ci

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -28,7 +28,6 @@ set +e
 # Remove VCS and CI config
 find ${DEPLOY_BUILD_DIR} -name ".svn" -exec rm -rfv {} \; 2> /dev/null
 find ${DEPLOY_BUILD_DIR} -name ".git*" -not -name ".github" -exec rm -rfv {} \; 2> /dev/null
-find ${DEPLOY_BUILD_DIR} -name ".travis.yml" -exec rm -rfv {} \; 2> /dev/null
 
 # Remove everything unnecessary to running this (tests, deploy scripts, etc)
 rm -v ${DEPLOY_BUILD_DIR}/README.md
@@ -41,7 +40,6 @@ mv -v ${DEPLOY_BUILD_DIR}/ci/templates/composer.json ${DEPLOY_BUILD_DIR}/compose
 # @FIXME: We will need to replace this ci dir with one which can run tests on the public repo
 # BUT this public ci dir cannot include our insecure key (and does not need to)
 rm -rfv ${DEPLOY_BUILD_DIR}/ci/
-rm -v ${DEPLOY_BUILD_DIR}/.travis.yml
 
 # We've finished with commands which may fail, so return to exiting the script
 # if any command exits with a non-zero


### PR DESCRIPTION

## Description

We dropped travis some time ago, but left the mention to the travis.yml in one of the CI scripts. This removes the mention


## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
