### PR TITLE
Fix X-Forwarded-For in VIP_Request_Block

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -23,20 +23,23 @@ class VIP_Request_Block {
 	 * 🛑 ALWAYS: use `whois {IP}` to look up the IP before making the changes.
 	 *
 	 * @param string $value target IP address to be blocked.
+	 * @return bool|void
 	 */
 	public static function ip( string $value ) {
 		// Don't try to block if the passed value is not a valid IP.
 		if ( ! filter_var( $value, FILTER_VALIDATE_IP ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'VIP Request Block: The value passed is not a correct IP address: ' . $value );
-			return;
+			if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'VIP Request Block: The value passed is not a correct IP address: ' . $value );
+			}
+
+			return false;
 		}
 
 		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.
 		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 		if ( isset( $_SERVER['HTTP_TRUE_CLIENT_IP'] ) && $value === $_SERVER['HTTP_TRUE_CLIENT_IP'] ) {
-			self::block_and_log( $value, 'true-client-ip' );
-			return;
+			return self::block_and_log( $value, 'true-client-ip' );
 		}
 
 		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
@@ -44,22 +47,26 @@ class VIP_Request_Block {
 			// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$ips = array_map( 'trim', explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
 			if ( in_array( $value, $ips, true ) ) {
-				self::block_and_log( $value, 'x-forwarded-for' );
+				return self::block_and_log( $value, 'x-forwarded-for' );
 			}
 		}
+
+		return false;
 	}
 
 	/**
 	 * Block by exact match of the user agent header
 	 *
 	 * @param string $user_agent target user agent to be blocked.
-	 * @return void
+	 * @return void|bool
 	 */
 	public static function ua( string $user_agent ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
 		if ( $user_agent === $_SERVER['HTTP_USER_AGENT'] ) {
-			self::block_and_log( $user_agent, 'user-agent' );
+			return self::block_and_log( $user_agent, 'user-agent' );
 		}
+
+		return false;
 	}
 
 	/**
@@ -67,7 +74,7 @@ class VIP_Request_Block {
 	 *
 	 * @param string $header HTTP header.
 	 * @param string $value header value.
-	 * @return void
+	 * @return void|bool
 	 */
 	public static function header( string $header, string $value ) {
 		// Normalize the header to what PHP exposes in $_SERVER:
@@ -76,8 +83,10 @@ class VIP_Request_Block {
 		$key = sprintf( 'HTTP_%s', str_ireplace( 'HTTP_', '', $key ) );
 
 		if ( isset( $_SERVER[ $key ] ) && $value === $_SERVER[ $key ] ) {
-			self::block_and_log( $value, $header );
+			return self::block_and_log( $value, $header );
 		}
+
+		return false;
 	}
 
 	/**
@@ -85,16 +94,20 @@ class VIP_Request_Block {
 	 *
 	 * @param string $value value of the header for a block.
 	 * @param string $criteria header field used for a block.
-	 * @return void
+	 * @return true|void
 	 */
 	public static function block_and_log( string $value, string $criteria ) {
-		http_response_code( 403 );
-		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
-		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+		if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
+			http_response_code( 403 );
+			header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
+			header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 
-		fastcgi_finish_request();
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
-		exit;
+			fastcgi_finish_request();
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
+			exit;
+		}
+
+		return true;
 	}
 }

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -35,15 +35,16 @@ class VIP_Request_Block {
 		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.
 		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 		if ( isset( $_SERVER['HTTP_TRUE_CLIENT_IP'] ) && $value === $_SERVER['HTTP_TRUE_CLIENT_IP'] ) {
-			return self::block_and_log( $value, 'true-client-ip' );
+			self::block_and_log( $value, 'true-client-ip' );
+			return;
 		}
 
 		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 		if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 			// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$position = stripos( $_SERVER['HTTP_X_FORWARDED_FOR'], $value );
-			if ( false !== $position ) {
-				return self::block_and_log( $value, 'x-forwarded-for' );
+			$ips = array_map( 'trim', explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+			if ( in_array( $value, $ips, true ) ) {
+				self::block_and_log( $value, 'x-forwarded-for' );
 			}
 		}
 	}

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -4,6 +4,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 require_once __DIR__ . '/../../lib/class-vip-request-block.php';
 
+// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+
 class VIP_Request_Block_Test extends WP_UnitTestCase {
 	use ExpectPHPException;
 
@@ -13,49 +15,38 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 	 */
 
 	public function test__no_error_raised_when_ip_is_not_present() {
-		$this->expectNotToPerformAssertions();
-
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
-		$_SERVER['HTTP_TRUE_CLIENT_IP'] = '4.4.4.4';
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+		$_SERVER['HTTP_TRUE_CLIENT_IP']  = '4.4.4.4';
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 8.8.8.8';
-		VIP_Request_Block::ip( '2.2.2.2' );
-		// Expecting that no exception has been raised up to this point
+
+		$actual = VIP_Request_Block::ip( '2.2.2.2' );
+		self::assertFalse( $actual );
 	}
 
 	public function test__invalid_ip_should_not_raise_error() {
-		$this->expectNotToPerformAssertions();
-
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 8.8.8.8';
-		VIP_Request_Block::ip( '1' );
-		// Expecting that no exception has been raised up to this point
+		
+		$actual = VIP_Request_Block::ip( '1' );
+		self::assertFalse( $actual );
 	}
 
 	public function test__error_raised_when_true_client_ip() {
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 		$_SERVER['HTTP_TRUE_CLIENT_IP'] = '4.4.4.4';
-		// We're detecting that the block is successful by expecting
-		// "Cannot modify header information" headers already sent by warning
-		$this->expectWarning();
-		VIP_Request_Block::ip( '4.4.4.4' );
+
+		$actual = VIP_Request_Block::ip( '4.4.4.4' );
+		self::assertTrue( $actual );
 	}
 
 	public function test__error_raised_first_ip_forwarded() {
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 8.8.8.8';
-		// We're detecting that the block is successful by expecting
-		// "Cannot modify header information" headers already sent by warning
-		$this->expectWarning();
-		VIP_Request_Block::ip( '1.1.1.1' );
+
+		$actual = VIP_Request_Block::ip( '1.1.1.1' );
+		self::assertTrue( $actual );
 	}
 
 	public function test__error_raised_second_ip_forwarded() {
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 8.8.8.8';
-		// We're detecting that the block is successful by expecting
-		// "Cannot modify header information" headers already sent by warning
-		$this->expectWarning();
-		VIP_Request_Block::ip( '8.8.8.8' );
+
+		$actual = VIP_Request_Block::ip( '8.8.8.8' );
+		self::assertTrue( $actual );
 	}
 }

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -24,7 +24,7 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 
 	public function test__invalid_ip_should_not_raise_error() {
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 8.8.8.8';
-		
+
 		$actual = VIP_Request_Block::ip( '1' );
 		self::assertFalse( $actual );
 	}
@@ -48,5 +48,12 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 
 		$actual = VIP_Request_Block::ip( '8.8.8.8' );
 		self::assertTrue( $actual );
+	}
+
+	public function test_partial_match_xff(): void {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '11.1.1.11, 8.8.8.8';
+
+		$actual = VIP_Request_Block::ip( '1.1.1.1' );
+		self::assertFalse( $actual );
 	}
 }


### PR DESCRIPTION
## Description

The original implementation of `VIP_Request_Block::ip()` incorrectly handles the `X-Forwarded-For` header, which sometimes leads to up to 2,625 additional IPs being blocked. This PR attempts to fix this issue.

For example, `VIP_Request_Block::ip( '1.1.1.1' )` could result in `11.1.1.1`, `21.1.1.1`,…, `251.1.1.199` being blocked.

As a side effect, this PR makes the `VIP_Request_Block` class more testable.

## Changelog Description

### Plugin Updated: VIP Request Block

The plugin now correctly handles partial IP matches in the X-Forwarded-For header.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

I have added a test for my bug fix. The CI should pass.
