### PR TITLE
Better check for if current query is cacheable

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -980,7 +980,7 @@ class Search {
 			return $is_cacheable;
 		}
 
-		$is_cacheable = (bool) preg_match( '#(/_(search|mget|doc))', $url );
+		$is_cacheable = (bool) preg_match( '#(/_(search|mget|doc))#', $url );
 
 
 		/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -980,7 +980,7 @@ class Search {
 			return $is_cacheable;
 		}
 
-		$is_cacheable = (bool) preg_match( '#(/_(search|mget|doc))#', $url );
+		$is_cacheable = (bool) preg_match( '#/_(search|mget|doc)#', $url );
 
 
 		/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -980,12 +980,8 @@ class Search {
 			return $is_cacheable;
 		}
 
-		foreach ( [ '_search', '_mget', '_doc' ] as $needle ) {
-			if ( wp_in( $needle, $url ) ) {
-				$is_cacheable = true;
-				break;
-			}
-		}
+		$is_cacheable = (bool) preg_match( '#(/_(search|mget|doc))', $url );
+
 
 		/**
 		 * Filter if request is cacheable

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -196,7 +196,7 @@ class Search_Test extends WP_UnitTestCase {
 					'url' => 'https://foo.com/index/type/_anything',
 				),
 				// The expected result
-				2,
+				false,
 			),
 		);
 	}

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -142,6 +142,78 @@ class Search_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function vip_search_is_url_query_cacheable_data() {
+		return array(
+			// Regular search
+			array(
+				// The $query object
+				array(
+					'url' => 'https://foo.com/index/_search',
+				),
+				// The expected result
+				true,
+			),
+			// Regular search
+			array(
+				// The $query object
+				array(
+					'url' => 'https://foo.com/index/_mget',
+				),
+				// The expected result
+				true,
+			),
+			// Regular search
+			array(
+				// The $query object
+				array(
+					'url' => 'https://foo.com/index/type/_doc/_mget',
+				),
+				// The expected result
+				true,
+			),
+			// Bulk index
+			array(
+				// The $query object
+				array(
+					'url' => 'https://foo.com/index/_bulk',
+				),
+				// The expected result
+				false,
+			),
+			// Url containing _bulk
+			array(
+				// The $query object
+				array(
+					'url' => 'https://foo.com/index/_bulk/bar?_mget',
+				),
+				// The expected result
+				false,
+			),
+			// Random other url
+			array(
+				// The $query object
+				array(
+					'url' => 'https://foo.com/index/type/_anything',
+				),
+				// The expected result
+				2,
+			),
+		);
+	}
+
+	/**
+	 * Test that we correctly calculate the HTTP request timeout value for ES requests
+	 *
+	 * @dataProvider vip_search_is_url_query_cacheable_data()
+	 */
+	public function test__is_url_query_cacheable( $query, $expected_is_cacheable ) {
+		$es = new \Automattic\VIP\Search\Search();
+
+		$is_cacheable = $es->is_url_query_cacheable( $query, array() );
+
+		$this->assertEquals( $expected_is_cacheable, $is_cacheable );
+	}
+
 	/**
 	 * Test `ep_index_name` filter with versioning
 	 *
@@ -1071,30 +1143,6 @@ class Search_Test extends WP_UnitTestCase {
 		$enabled = apply_filters( 'ep_allow_post_content_filtered_index', true );
 
 		$this->assertFalse( $enabled );
-	}
-
-	/**
-	 * Ensure we only cache specific endpoints.
-	 */
-	public function test__is_url_query_cacheable() {
-		$es = new \Automattic\VIP\Search\Search();
-		$es->init();
-
-		$urls = [
-			'http://vip-search:9200/vip-200508-post-1/_search',
-			'http://vip-search:9200/_mget?fields=blog_id,post_id,author_id',
-			'http://vip-search:9200/vip-200508-post-1/_doc/48',
-		];
-		$args = [];
-
-		foreach ( $urls as $url ) {
-			$cacheable = $es->is_url_query_cacheable( $url, $args );
-			$this->assertTrue( $cacheable );
-		}
-
-		$_GET['vip-debug'] = true;
-		$cacheable         = $es->is_url_query_cacheable( $url[0], $args );
-		$this->assertFalse( $cacheable );
 	}
 
 	/*

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -153,7 +153,7 @@ class Search_Test extends WP_UnitTestCase {
 				// The expected result
 				true,
 			),
-			// Regular search
+			// Regular multiget
 			array(
 				// The $query object
 				array(
@@ -162,7 +162,7 @@ class Search_Test extends WP_UnitTestCase {
 				// The expected result
 				true,
 			),
-			// Regular search
+			// Regular entity multiget
 			array(
 				// The $query object
 				array(

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -209,7 +209,7 @@ class Search_Test extends WP_UnitTestCase {
 	public function test__is_url_query_cacheable( $query, $expected_is_cacheable ) {
 		$es = new \Automattic\VIP\Search\Search();
 
-		$is_cacheable = $es->is_url_query_cacheable( $query, array() );
+		$is_cacheable = $es->is_url_query_cacheable( $query['url'], array() );
 
 		$this->assertEquals( $expected_is_cacheable, $is_cacheable );
 	}


### PR DESCRIPTION
## Description

Instead of a `foreach` check using Jetpack's helper function  `wp_in` this check can be simplified by using a regex.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
