### PR TITLE
Search: Remove redundant alerting from heal_index_settings 

### DIFF
--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -87,8 +87,6 @@ class SettingsHealthJob {
 		}
 
 		$this->process_indexables_settings_health_results( $unhealthy_indexables );
-
-		$this->heal_index_settings( $unhealthy_indexables );
 	}
 
 	public function process_indexables_settings_health_results( $results ) {
@@ -128,14 +126,11 @@ class SettingsHealthJob {
 				$this->send_alert( '#vip-go-es-alerts', $message, 2, "{$indexable_slug}" );
 			}
 		}
+
+		$this->heal_index_settings( $results );
 	}
 
 	public function heal_index_settings( $unhealthy_indexables ) {
-		// If the whole thing failed, return
-		if ( is_wp_error( $unhealthy_indexables ) ) {
-			return;
-		}
-
 		foreach ( $unhealthy_indexables as $indexable_slug => $versions ) {
 			if ( is_wp_error( $versions ) ) {
 				continue;

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -131,22 +131,13 @@ class SettingsHealthJob {
 	}
 
 	public function heal_index_settings( $unhealthy_indexables ) {
-		// If the whole thing failed, error
+		// If the whole thing failed, return
 		if ( is_wp_error( $unhealthy_indexables ) ) {
-			$message = sprintf( 'Error while attempting to heal index settings for %s: %s', home_url(), $unhealthy_indexables->get_error_message() );
-
-			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
-
 			return;
 		}
 
 		foreach ( $unhealthy_indexables as $indexable_slug => $versions ) {
-			// If there's an error, alert
 			if ( is_wp_error( $versions ) ) {
-				$message = sprintf( 'Error while attempting to heal index settings for indexable %s on %s: %s', $indexable_slug, home_url(), $versions->get_error_message() );
-
-				$this->send_alert( '#vip-go-es-alerts', $message, 2 );
-
 				continue;
 			}
 
@@ -181,19 +172,7 @@ class SettingsHealthJob {
 					$message = sprintf( 'Failed to heal index settings for indexable %s and index version %d on %s: %s', $indexable_slug, $result['index_version'], home_url(), $result['result']->get_error_message() );
 
 					$this->send_alert( '#vip-go-es-alerts', $message, 2 );
-
-					continue;
 				}
-
-				$message = sprintf(
-					'Index settings updated for %s: (indexable: %s, index_version: %d, index_name: %s)',
-					home_url(),
-					$indexable_slug,
-					$result['index_version'] ?? '<missing index version>',
-					$result['index_name'] ?? '<missing name>'
-				);
-
-				$this->send_alert( '#vip-go-es-alerts', $message, 2, "{$indexable_slug}" );
 			}
 		}
 	}

--- a/tests/search/includes/classes/test-class-settingshealthjob.php
+++ b/tests/search/includes/classes/test-class-settingshealthjob.php
@@ -14,7 +14,7 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 		\Automattic\VIP\Search\Search::instance()->init();
 	}
 
-	public function test__heal_index_settings__reports_error() {
+	public function test__process_indexables_settings_health_results__reports_error() {
 		$error = new \WP_Error( 'foo', 'Bar' );
 
 		$stub = $this->getMockBuilder( \Automattic\VIP\Search\SettingsHealthJob::class )
@@ -25,10 +25,10 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 		$stub->expects( $this->once() )
 			->method( 'send_alert' );
 
-		$stub->heal_index_settings( $error );
+		$stub->process_indexables_settings_health_results( $error );
 	}
 
-	public function test__heal_index_settings__reports_error_per_indexable() {
+	public function test__process_indexables_settings_health_results__reports_error_per_indexable() {
 		$error                = new \WP_Error( 'foo', 'Bar' );
 		$unhealthy_indexables = [
 			'post' => $error,
@@ -43,7 +43,7 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 		$stub->expects( $this->exactly( count( $unhealthy_indexables ) ) )
 			->method( 'send_alert' );
 
-		$stub->heal_index_settings( $unhealthy_indexables );
+		$stub->process_indexables_settings_health_results( $unhealthy_indexables );
 	}
 
 	public function test__heal_index_settings__reports_error_per_failed_indexable_retrieval() {
@@ -116,9 +116,6 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 
 		$stub->indexables = $indexables_mock;
 		$stub->health     = $health_mock;
-
-		$stub->expects( $this->exactly( $indexable_versions_with_non_empty_diff ) )
-			->method( 'send_alert' );
 
 		$health_mock->expects( $this->exactly( $indexable_versions_with_non_empty_diff ) )
 			->method( 'heal_index_settings_for_indexable' );


### PR DESCRIPTION
## Description

1) There is redundant alerting in `heal_index_settings()`. The same alerting logic lives in `process_indexables_settings_health_results()`, albeit with different wording:
- https://github.com/Automattic/vip-go-mu-plugins/blob/21052843b3b037453f2e5bf14dbb74d000e125e2/search/includes/classes/class-settingshealthjob.php#L96-L102
- https://github.com/Automattic/vip-go-mu-plugins/blob/21052843b3b037453f2e5bf14dbb74d000e125e2/search/includes/classes/class-settingshealthjob.php#L106-L111
2) I don't think it's necessary to alert when index settings are updated, just when there is failure of some sort, so let's remove that.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.