### PR TITLE
Search: Do not do any offloading if we are skipping term actions

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -260,7 +260,7 @@ class Queue {
 	}
 
 	public function setup_hooks() {
-		add_action( 'edited_terms', [ $this, 'offload_term_indexing_to_queue' ], 0, 2 );
+		add_action( 'saved_term', [ $this, 'offload_term_indexing_to_queue' ], 0, 3 );
 		add_action( 'pre_delete_term', [ $this, 'offload_indexing_to_queue' ] );
 
 		// For handling indexing failures
@@ -885,11 +885,15 @@ class Queue {
 	/**
 	 * Offload term indexing to the queue
 	 */
-	public function offload_term_indexing_to_queue( $term_id, $taxonomy ) {
+	public function offload_term_indexing_to_queue( $term_id, $tt_id, $taxonomy ) {
 		$term = \get_term( $term_id, $taxonomy );
 
 		if ( is_wp_error( $term ) || ! is_object( $term ) ) {
 			return;
+		}
+
+		if ( true === apply_filters( 'ep_skip_action_edited_term', false, $term_id, $tt_id, $taxonomy ) ) {
+			return; // Do not offload if we are skipping actions on the edited term.
 		}
 
 		// If the number of affected posts is low enough, process them now rather than send them to cron

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -260,7 +260,8 @@ class Queue {
 	}
 
 	public function setup_hooks() {
-		add_action( 'saved_term', [ $this, 'offload_term_indexing_to_queue' ], 0, 3 );
+		add_action( 'saved_term', [ $this, 'offload_term_indexing_to_queue' ], 0, 3 ); // saved_term fires after SyncManager_Helper actions
+
 		add_action( 'pre_delete_term', [ $this, 'offload_indexing_to_queue' ] );
 
 		// For handling indexing failures
@@ -893,7 +894,7 @@ class Queue {
 		}
 
 		if ( true === apply_filters( 'ep_skip_action_edited_term', false, $term_id, $tt_id, $taxonomy ) ) {
-			return; // Do not offload if we are skipping actions on the edited term.
+			return; // Do not offload if SyncManager_Helper is skipping actions on immaterial term changes
 		}
 
 		// If the number of affected posts is low enough, process them now rather than send them to cron


### PR DESCRIPTION
## Description
#2722 introduced the prevention of performing any actions on immaterial term updates. However, it was pointed out by @rinatkhaziev that we are still offloading ALL term updates:
https://github.com/Automattic/vip-go-mu-plugins/blob/41c4b4ac10c08dbfd0a9d5ad3faaa64ea1614ba3/search/includes/classes/class-queue.php#L263

This PR uses the value of the filter `ep_skip_action_edited_term` derived from `SyncManager_Helper ` to check before we perform any logic towards offloading the term update. It also adjusts the hook to use a later one to ensure we have the filtered value. 

## Changelog Description

### Plugin Updated: Enterprise Search

Skip offloading immaterial term updates to queue.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create a category called "Fruits"
2) Go to the edit page for "Fruits"
3) Make no changes and ensure that it does not get offloaded
4) Go back to the edit page for "Fruits" and change it to "Fruit"
5) Check that it still gets offloaded