### PR TITLE
Search Dev Tools: prevent potential fatals on requests that resulted in a WP_Error (timeouts/connectivity issues)

### DIFF
--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -74,10 +74,19 @@ function rest_callback( \WP_REST_Request $request ) {
 		[
 			'body'   => $request['query'],
 			'method' => 'POST',
-		]
+		],
+		[],
+		'query'
 	);
 
-	$result['body'] = sanitize_query_response( json_decode( $result['body'] ) );
+	if ( ! is_wp_error( $result ) ) {
+		$result = sanitize_query_response( json_decode( $result['body'] ) );
+	} else {
+		$result = [
+			'body' => $result->get_error_messages(),
+		];
+	}
+
 	return rest_ensure_response( [ 'result' => $result ] );
 }
 


### PR DESCRIPTION
## Description

There's a potential fatal in the rest endpoint for Search dev tools when a request times out due to the fact that WP_Error was treated as an array. This PR addresses that by explicitly checking for `is_wp_error` and handling appropriately.

## Changelog Description

### Plugin Updated: Enterprise Search Dev Tools

Enterprise Search Dev Tools now correctly handle requests that have timed out

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Apply the PR
2. Load a search page and pop the dev tools open
3. in Search::filter_Do_intercept_request break an URL in any way (e.g. domain)
4. try to run a query from Search Dev Tools
5. Now you should see the correct message in the response section instead of a 500.
