### PR TITLE
E2E: Undo 'colors' fix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,9 +41,7 @@ jobs:
         working-directory: vip-go-mu-plugins
 
       - name: Install VIP CLI
-        run: |
-          npm install --prefix=$HOME/.local -g @automattic/vip
-          cd $HOME/.local/lib/node_modules/@automattic/vip && npm i colors@1.4.1 --force
+        run: npm install --prefix=$HOME/.local -g @automattic/vip
 
       - name: Determine WP version
         id: wpver


### PR DESCRIPTION
This PR undoes the fix to the `vip` package for the broken version of `colors` introduced in #2788 

It must not be merged until `vip` gets rid of the `colors` package.

OK to merge, we released `@automattic/vip` 2.7.1 yesterday.
