### PR TITLE
E2E: Roll back to colors@1.4.0 instead of 1.4.1

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install VIP CLI
         run: |
           npm install --prefix=$HOME/.local -g @automattic/vip
-          cd $HOME/.local/lib/node_modules/@automattic/vip && npm i colors@1.4.1 --force
+          cd $HOME/.local/lib/node_modules/@automattic/vip && npm i colors@1.4.0 --force
 
       - name: Determine WP version
         id: wpver


### PR DESCRIPTION
colors@1.4.1 still has the bad code; it does not show up because the dependencies are probably using `colors/safe`; still, we need to fix this.

Ref: #2788 
