### PR TITLE
Search: in build_new_job(), pass in string slug instead

### DIFF
--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -275,7 +275,6 @@ class SettingsHealthJob {
 			[
 				'return'     => 'all',
 				'exit_error' => false,
-				'launch'     => false,
 			],
 		);
 

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -251,23 +251,23 @@ class SettingsHealthJob {
 			
 			return;
 		} elseif ( ! wp_next_scheduled( self::CRON_EVENT_BUILD_NAME, [ $indexable ] ) ) {
-			wp_schedule_single_event( time() + 30, self::CRON_EVENT_BUILD_NAME, [ $indexable ] );
+			wp_schedule_single_event( time() + 30, self::CRON_EVENT_BUILD_NAME, [ $indexable->slug ] );
 		}
 	}
 
 	/**
 	 * Build new index and hot-swap it afterwards as part of auto healing to ensure shard requirements are met.
 	 *
-	 * @param object $indexable The Indexable we want to rebuild.
+	 * @param string $indexable_slug The slug of the Indexable we want to rebuild.
 	 */
-	public function build_new_index( $indexable ) {
+	public function build_new_index( $indexable_slug ) {
 		update_option( self::BUILD_LOCK_NAME, time() ); // Set lock for starting rebuild.
 
 		// Do the indexing.
 		$assoc_args = [
 			'using-versions' => true,
 			'skip-confirm'   => true,
-			'indexables'     => $indexable->slug,
+			'indexables'     => $indexable_slug,
 		];
 		$cmd        = 'vip-search index ' . WP_CLI\Utils\assoc_args_to_str( $assoc_args );
 		$result     = WP_CLI::runcommand(
@@ -281,10 +281,10 @@ class SettingsHealthJob {
 
 		if ( '' !== $result->stderr ) {
 			// Surface any error messages that occurred into an alert.
-			$message = sprintf( 'An error occurred during build of new %s index on %s for shard requirements: %s', $indexable->slug, home_url(), $result->stderr );
+			$message = sprintf( 'An error occurred during build of new %s index on %s for shard requirements: %s', $indexable_slug, home_url(), $result->stderr );
 		} else {
 			// TODO: Remove this alert eventually.
-			$message = sprintf( 'Successfully built new %s index for shard requirements on %s!', $indexable->slug, home_url() );
+			$message = sprintf( 'Successfully built new %s index for shard requirements on %s!', $indexable_slug, home_url() );
 		}
 		$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -275,6 +275,7 @@ class SettingsHealthJob {
 			[
 				'return'     => 'all',
 				'exit_error' => false,
+				'launch'     => false,
 			],
 		);
 

--- a/tests/search/includes/classes/test-class-settingshealthjob.php
+++ b/tests/search/includes/classes/test-class-settingshealthjob.php
@@ -152,7 +152,7 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 
 		$stub->maybe_schedule_build_new_index( $indexable );
 
-		$event = \wp_next_scheduled( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_BUILD_NAME, [ $indexable ] );
+		$event = \wp_next_scheduled( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_BUILD_NAME, [ $indexable->slug ] );
 		$this->assertIsInt( $event );
 	}
 
@@ -171,7 +171,7 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 
 		$stub->maybe_schedule_build_new_index( $indexable );
 
-		$event = \wp_next_scheduled( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_BUILD_NAME, [ $indexable ] );
+		$event = \wp_next_scheduled( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_BUILD_NAME, [ $indexable->slug ] );
 		$this->assertFalse( $event );
 	}
 
@@ -190,14 +190,14 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 
 		$stub->maybe_schedule_build_new_index( $indexable );
 
-		$event = \wp_next_scheduled( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_BUILD_NAME, [ $indexable ] );
+		$event = \wp_next_scheduled( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_BUILD_NAME, [ $indexable->slug ] );
 		$this->assertFalse( $event );
 
 		delete_option( \Automattic\VIP\Search\SettingsHealthJob::BUILD_LOCK_NAME );
 
 		$stub->maybe_schedule_build_new_index( $indexable );
 
-		$event = \wp_next_scheduled( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_BUILD_NAME, [ $indexable ] );
+		$event = \wp_next_scheduled( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_BUILD_NAME, [ $indexable->slug ] );
 		$this->assertIsInt( $event );
 	}
 }


### PR DESCRIPTION
## Description

In `build_new_job()`, pass in the slug rather than the entire object since we don't need it and I want to prevent any potential bugs that occur during serialization/deserialization.