### PR TITLE
CANTINA-848: ignore 404 errors in update_attachment_meta()

### DIFF
--- a/files/class-meta-updater.php
+++ b/files/class-meta-updater.php
@@ -175,7 +175,7 @@ class Meta_Updater {
 
 		$filesize = $this->get_filesize_from_file( $attachment_id );
 
-		if ( 0 >= $filesize ) {
+		if ( $filesize < 0 ) {
 			return [ 'fail-get-filesize', 'failed to get filesize' ];
 		}
 
@@ -203,10 +203,16 @@ class Meta_Updater {
 		if ( is_wp_error( $response ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error( sprintf( '%s: failed to HEAD attachment %s because %s', __METHOD__, esc_html( $attachment_url ), esc_html( $response->get_error_message() ) ), E_USER_WARNING );
+			return -1;
+		}
+
+		$status = wp_remote_retrieve_response_code( $response );
+		if ( 404 === $status ) {
 			return 0;
 		}
 
-		return (int) wp_remote_retrieve_header( $response, 'Content-Length' );
+		$length = wp_remote_retrieve_header( $response, 'Content-Length' );
+		return is_numeric( $length ) ? (int) $length : -1;
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR mainly adds logging for `get_filesize_from_file()` and some logic to ignore 404 errors for metadata updates.

## Changelog Description

### Plugin Updated: Automattic File Hosting Service

Ignore 404 errors on metadata updates.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

N/A
