### PR TITLE
Search: Fix inaccuracy in validate-counts command

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -139,6 +139,13 @@ class Health {
 	public function get_index_entity_count_from_elastic_search( array $query_args, \ElasticPress\Indexable $indexable ) {
 		// Get total count in ES index
 		try {
+			$protected_content         = \ElasticPress\Features::factory()->get_registered_feature( 'protected_content' );
+			$protected_content_enabled = $protected_content ? $protected_content->is_active() : false;
+			// Include password-protected posts in health count query if protected_content feature is used.
+			if ( $protected_content_enabled ) {
+				add_filter( 'ep_exclude_password_protected_from_search', '__return_false' );
+			}
+
 			$query          = self::query_objects( $query_args, $indexable->slug );
 			$formatted_args = $indexable->format_args( $query->query_vars, $query );
 


### PR DESCRIPTION
## Description
When `protected_content` feature is enabled and passworded posts exist, the `validate-post-counts`  and `validate-counts` will return inaccurate results due to not querying for posts that have a password. 

## Changelog Description

### Plugin Updated: Enterprise Search

Fix validate-counts and validate-post-counts command to work with passworded posts

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Enable protected_content: `wp vip-search activate-feature protected_content`
2) Reindex: `wp vip-search index --setup`
3) Create a post with a password to it
4) Run `wp vip-search health validate-posts-count` and ensure that there is no difference between DB and ES values