### PR TITLE
Search: Disable search weighting engine by default

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -616,6 +616,9 @@ class Search {
 		add_filter( 'ep_post_tax_excluded_wp_query_root_check', [ $this, 'exclude_es_query_reserved_names' ] );
 
 		add_filter( 'ep_sync_indexable_kill', [ $this, 'do_not_sync_if_no_index' ], PHP_INT_MAX, 2 );
+
+		// Disable search weighting engine for a simplified ES search query
+		add_filter( 'ep_disable_search_weighting', '__return_true' );
 	}
 
 	protected function load_commands() {


### PR DESCRIPTION
## Description

#2799 needs to be merged in before this PR.

This PR disables the EP search weighting engine to improve the default search query.

**Marked as BLOCKED for the time being until PRs have been opened for the appropriate customers who are utilizing the search weighting engine.** 

## Changelog Description

### Plugin Updated: Enterprise Search

Disable search weighting engine by default

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Search for "test" and notice the below query via Search Dev Tools:

```
{
  "from": 0,
  "size": 10,
  "sort": [
    {
      "_score": {
        "order": "desc"
      }
    }
  ],
  "query": {
    "function_score": {
      "query": {
        "bool": {
          "should": [
            {
              "bool": {
                "must": [
                  {
                    "bool": {
                      "must": [
                        {
                          "multi_match": {
                            "query": "test",
                            "type": "phrase",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.post_tag.name^1",
                              "terms.category.name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "boost": 3,
                            "operator": "AND"
                          }
                        },
                        {
                          "multi_match": {
                            "query": "test",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.post_tag.name^1",
                              "terms.category.name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "type": "phrase",
                            "slop": 5
                          }
                        }
                      ]
                    }
                  }
                ],
                "filter": [
                  {
                    "match": {
                      "post_type.raw": "post"
                    }
                  }
                ]
              }
            },
            {
              "bool": {
                "must": [
                  {
                    "bool": {
                      "must": [
                        {
                          "multi_match": {
                            "query": "test",
                            "type": "phrase",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "boost": 3,
                            "operator": "AND"
                          }
                        },
                        {
                          "multi_match": {
                            "query": "test",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "type": "phrase",
                            "slop": 5
                          }
                        }
                      ]
                    }
                  }
                ],
                "filter": [
                  {
                    "match": {
                      "post_type.raw": "page"
                    }
                  }
                ]
              }
            }
          ]
        }
      },
      "functions": [
        {
          "gauss": {
            "post_date_gmt": {
              "scale": "360d",
              "decay": 0.9,
              "offset": "0d"
            }
          }
        },
        {
          "weight": 0.001
        }
      ],
      "score_mode": "multiply",
      "boost_mode": "multiply"
    }
  },
  "post_filter": {
    "bool": {
      "must": [
        {
          "terms": {
            "post_type.raw": [
              "post",
              "page"
            ]
          }
        },
        {
          "terms": {
            "post_status": [
              "publish"
            ]
          }
        }
      ],
      "must_not": [
        {
          "exists": {
            "field": "post_password"
          }
        }
      ]
    }
  },
  "track_total_hits": true,
  "timeout": "2s"
}
```
2) Apply patch
3) Search for "test" again and notice the simplified query via Search Dev Tools:

```
{
  "from": 0,
  "size": 10,
  "sort": [
    {
      "_score": {
        "order": "desc"
      }
    }
  ],
  "query": {
    "function_score": {
      "query": {
        "bool": {
          "must": [
            {
              "multi_match": {
                "query": "test",
                "type": "phrase",
                "fields": [
                  "post_title",
                  "post_excerpt",
                  "post_content"
                ],
                "boost": 3,
                "operator": "AND"
              }
            },
            {
              "multi_match": {
                "query": "test",
                "fields": [
                  "post_title",
                  "post_excerpt",
                  "post_content"
                ],
                "type": "phrase",
                "slop": 5
              }
            }
          ]
        }
      },
      "functions": [
        {
          "gauss": {
            "post_date_gmt": {
              "scale": "360d",
              "decay": 0.9,
              "offset": "0d"
            }
          }
        },
        {
          "weight": 0.001
        }
      ],
      "score_mode": "multiply",
      "boost_mode": "multiply"
    }
  },
  "post_filter": {
    "bool": {
      "must": [
        {
          "terms": {
            "post_type.raw": [
              "post",
              "page"
            ]
          }
        },
        {
          "terms": {
            "post_status": [
              "publish"
            ]
          }
        }
      ],
      "must_not": [
        {
          "exists": {
            "field": "post_password"
          }
        }
      ]
    }
  },
  "track_total_hits": true,
  "timeout": "2s"
}
```