### PR TITLE
Search: Only check index settings for active version

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -940,7 +940,7 @@ class Health {
 		$unhealthy = array();
 
 		foreach ( $indexables as $indexable ) {
-			$diff = $this->get_index_versions_settings_diff_for_indexable( $indexable );
+			$diff = $this->get_active_index_settings_diff_for_indexable( $indexable );
 
 			if ( is_wp_error( $diff ) ) {
 				$unhealthy[ $indexable->slug ] = $diff;
@@ -958,20 +958,16 @@ class Health {
 		return $unhealthy;
 	}
 
-	public function get_index_versions_settings_diff_for_indexable( \ElasticPress\Indexable $indexable ) {
-		$versions = $this->search->versioning->get_versions( $indexable );
+	public function get_active_index_settings_diff_for_indexable( \ElasticPress\Indexable $indexable ) {
+		$version = $this->search->versioning->get_active_version_number( $indexable );
 
-		$diff = array();
+		$version_result = $this->get_index_settings_diff_for_indexable( $indexable, array(
+			'index_version' => $version,
+		) );
 
-		foreach ( $versions as $version ) {
-			$version_result = $this->get_index_settings_diff_for_indexable( $indexable, array(
-				'index_version' => $version['number'],
-			) );
+		$diff = [];
 
-			if ( empty( $version_result ) ) {
-				continue;
-			}
-
+		if ( ! empty( $version_result ) ) {
 			$diff[] = $version_result;
 		}
 


### PR DESCRIPTION
## Description
It is not necessary to check the index settings for inconsistencies on an inactive version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Add some "bad" settings to current index "1", e.g.
```
$bad_settings = [ 'index.number_of_replicas' => 8, 'index.max_result_window' => 50 ];
$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
$indexable-> update_index_settings( $bad_settings );
```
2) Create a new post index version "2" `wp vip-search index-versions add post`
3) Swap to the new index "2" `wp vip-search index-versions activate post next`
4) Ensure that the old index "1" isn't returned from `get_index_settings_health_for_all_indexables()`