### PR TITLE
Make Context available for non-MU sites

### DIFF
--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -8,21 +8,16 @@
 
 $mu_plugins_base = dirname( __DIR__ );
 
-// Load custom error logging functions, if available
-if ( file_exists( $mu_plugins_base . '/lib/wpcom-error-handler/wpcom-error-handler.php' ) ) {
-	require_once $mu_plugins_base . '/lib/wpcom-error-handler/wpcom-error-handler.php';
-}
+$files = [
+	'/lib/wpcom-error-handler/wpcom-error-handler.php',
+	'/lib/class-vip-request-block.php',
+	'/lib/environment/class-environment.php',
+	'/lib/helpers/environment.php',
+	'/lib/utils/class-context.php',
+];
 
-// Load VIP_Request_Block utility class, if available
-if ( file_exists( $mu_plugins_base . '/lib/class-vip-request-block.php' ) ) {
-	require_once $mu_plugins_base . '/lib/class-vip-request-block.php';
-}
-
-// Load Environment utility class and its helpers, if available
-if ( file_exists( $mu_plugins_base . '/lib/environment/class-environment.php' ) ) {
-	require_once $mu_plugins_base . '/lib/environment/class-environment.php';
-}
-
-if ( file_exists( $mu_plugins_base . '/lib/helpers/environment.php' ) ) {
-	require_once $mu_plugins_base . '/lib/helpers/environment.php';
+foreach ( $files as $file ) {
+	if ( file_exists( $mu_plugins_base . $file ) ) {
+		require_once $mu_plugins_base . $file;
+	}
 }

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -9,6 +9,8 @@
  * Remember vip-init.php? This is like that, but better!
  */
 
+use Automattic\VIP\Utils\Context;
+
 /**
  * By virtue of the filename, this file is included first of
  * all the files in the VIP Go MU plugins directory. All
@@ -41,13 +43,17 @@ if ( ! defined( 'WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE' ) ) {
 	define( 'WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE', false );
 }
 
+if ( ! class_exists( Context::class ) ) {
+	require_once __DIR__ . '/lib/utils/class-context.php';
+}
+
 // Sites can be blocked for various reasons - usually maintenance, so exit
 // early if the constant has been set (defined by VIP Go in config/wp-config.php)
 if ( WPCOM_VIP_SITE_MAINTENANCE_MODE ) {
 	$allow_front_end = WPCOM_VIP_SITE_ADMIN_ONLY_MAINTENANCE && ! REST_REQUEST && ! WP_ADMIN;
 
 	// WP CLI is allowed, but disable cron
-	if ( ( defined( 'WP_CLI' ) && WP_CLI ) || $allow_front_end ) {
+	if ( Context::is_wp_cli() || $allow_front_end ) {
 		add_filter( 'pre_option_a8c_cron_control_disable_run', function() {
 			return 1;
 		}, 9999 );
@@ -192,7 +198,7 @@ if ( true === defined( 'WPCOM_VIP_CLEAN_TERM_CACHE' ) && true === constant( 'WPC
 }
 
 // Load WP_CLI helpers
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
+if ( Context::is_wp_cli() ) {
 	require_once __DIR__ . '/vip-helpers/vip-wp-cli.php';
 	require_once __DIR__ . '/vip-helpers/class-vip-backup-user-role-cli.php';
 }


### PR DESCRIPTION
## Description

#2758 had to be reverted because of a sudden spike in errors; supposedly, that was because of the asynchronous nature of deployments: if the "main" code gets updated before `requires.php` does, this will cause fatal errors.

We now want to try another approach: first, deploy the code that makes the Context class globally available. After that, try to deploy the rest of the original PR.

## Changelog Description

### Plugin Updated: VIP Init

`Context` class is now available in a single-site mode.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Unfortunately, tests do not catch the bugs here :-(
