### PR TITLE
Search: Increase timeout for _open actions

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1110,7 +1110,7 @@ class Search {
 		}
 
 		// Bulk index request so increase timeout
-		if ( wp_endswith( $query_path, '_bulk' ) ) {
+		if ( wp_endswith( $query_path, '_bulk' ) || wp_endswith( $query_path, '_open' ) ) {
 			$timeout = 5;
 
 			if ( $is_cli && $is_post_request ) {


### PR DESCRIPTION
## Description
The `_open` action needs a longer timeout or else the request will fail due to the short timeout, which causes `open_index` to fail: https://github.com/Automattic/ElasticPress/blob/139dc6ce4d9aa82724bf8828cf1c3624ac3462dc/includes/classes/Elasticsearch.php#L905.

## Changelog Description

### Plugin Updated: Enterprise Search

Increase timeout for _open actions

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Call `open_index()` and see it fail
2) Apply PR
3) Call `open_index()` again and see it successfully return a 200