### PR TITLE
Fixing Parse.ly 3.0 release

### DIFF
--- a/wp-parsely-3.0/src/Integrations/class-amp.php
+++ b/wp-parsely-3.0/src/Integrations/class-amp.php
@@ -76,10 +76,14 @@ class Amp implements Integration {
 	 *
 	 * @since 2.6.0
 	 *
-	 * @param array $analytics The analytics registry.
+	 * @param array|null $analytics The analytics registry.
 	 * @return array The analytics registry.
 	 */
-	public function register_parsely_for_amp_analytics( array $analytics ): array {
+	public function register_parsely_for_amp_analytics( ?array $analytics ): array {
+		if ( $analytics === null ) {
+			$analytics = array();
+		}
+
 		$options = get_option( Parsely::OPTIONS_KEY );
 
 		if ( empty( $options['apikey'] ) ) {
@@ -104,10 +108,14 @@ class Amp implements Integration {
 	 *
 	 * @since 2.6.0
 	 *
-	 * @param array $analytics The analytics registry.
+	 * @param array|null $analytics The analytics registry.
 	 * @return array The analytics registry.
 	 */
-	public function register_parsely_for_amp_native_analytics( array $analytics ): array {
+	public function register_parsely_for_amp_native_analytics( ?array $analytics ): array {
+		if ( $analytics === null ) {
+			$analytics = array();
+		}
+
 		$options = get_option( Parsely::OPTIONS_KEY );
 
 		if ( ! empty( $options['disable_amp'] ) && true === $options['disable_amp'] ) {

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -186,15 +186,7 @@ class Parsely {
 
 		// Assign default values for LD+JSON
 		// TODO: Mapping of an install's post types to Parse.ly post types (namely page/post).
-		if ( is_int( $post ) ) {
-			$parsed_post = WP_Post::get_instance( $post );
-			if ( $parsed_post === false ) {
-				return;
-			}
-			$parsely_page = $this->construct_parsely_metadata( $parsely_options, $parsed_post );
-		} else {
-			$parsely_page = $this->construct_parsely_metadata( $parsely_options, $post );
-		}
+		$parsely_page = $this->construct_parsely_metadata( $parsely_options, get_post( $post ) );
 
 		// Something went wrong - abort.
 		if ( empty( $parsely_page ) || ! isset( $parsely_page['headline'] ) ) {

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -730,7 +730,7 @@ class Parsely {
 				$term_name = $this->get_bottom_level_term( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
 			}
 
-			if ( $term_name !== false ) {
+			if ( is_string( $term_name ) ) {
 				$category = $term_name;
 			}
 		}

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -774,7 +774,7 @@ class Parsely {
 	 * @return string|false Name of the custom taxonomy.
 	 */
 	private function get_bottom_level_term( int $post_id, string $taxonomy_name ) {
-		$terms    = get_the_terms( $post_id, $taxonomy_name );
+		$terms = get_the_terms( $post_id, $taxonomy_name );
 
 		if ( ! is_array( $terms ) ) {
 			return false;

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -733,7 +733,7 @@ class Parsely {
 				$term_name = $this->get_bottom_level_term( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
 			}
 
-			if ( '' === $term_name ) {
+			if ( is_string( $term_name ) && 0 < strlen( $term_name ) ) {
 				$category = $term_name;
 			}
 		}

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -254,7 +254,13 @@ class Parsely {
 		$this->insert_page_header_metadata();
 
 		global $post;
-		return $this->construct_parsely_metadata( $this->get_options(), $post );
+
+		$parsed_post = get_post( $post );
+		if ( ! $parsed_post instanceof WP_Post ) {
+			return array();
+		}
+
+		return $this->construct_parsely_metadata( $this->get_options(), $parsed_post );
 	}
 
 	/**

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -733,7 +733,7 @@ class Parsely {
 				$term_name = $this->get_bottom_level_term( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
 			}
 
-			if ( is_string( $term_name ) ) {
+			if ( '' === $term_name ) {
 				$category = $term_name;
 			}
 		}
@@ -774,13 +774,13 @@ class Parsely {
 	 *
 	 * @param int    $post_id The post id you're interested in.
 	 * @param string $taxonomy_name The name of the taxonomy.
-	 * @return string|false Name of the custom taxonomy.
+	 * @return string Name of the custom taxonomy.
 	 */
-	private function get_bottom_level_term( int $post_id, string $taxonomy_name ) {
+	private function get_bottom_level_term( int $post_id, string $taxonomy_name ): string {
 		$terms = get_the_terms( $post_id, $taxonomy_name );
 
 		if ( ! is_array( $terms ) ) {
-			return false;
+			return '';
 		}
 
 		$term_ids = wp_list_pluck( $terms, 'term_id' );

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -184,9 +184,14 @@ class Parsely {
 			return;
 		}
 
+		$parsed_post = get_post( $post );
+		if ( ! $parsed_post instanceof WP_Post ) {
+			return;
+		}
+
 		// Assign default values for LD+JSON
 		// TODO: Mapping of an install's post types to Parse.ly post types (namely page/post).
-		$parsely_page = $this->construct_parsely_metadata( $parsely_options, get_post( $post ) );
+		$parsely_page = $this->construct_parsely_metadata( $parsely_options, $parsed_post );
 
 		// Something went wrong - abort.
 		if ( empty( $parsely_page ) || ! isset( $parsely_page['headline'] ) ) {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -15,8 +15,8 @@ namespace Automattic\VIP\WP_Parsely_Integration;
 
 // The default version is the first entry in the SUPPORTED_VERSIONS list.
 const SUPPORTED_VERSIONS = [
-	'2.6',
 	'3.0',
+	'2.6',
 ];
 
 /**


### PR DESCRIPTION
## Description

Fixing some errors we saw on Parse.ly 3.0 due to type errors. This PR makes some additional checks on parameters to ensure types are always consistent.

This PR changes files on the wp-parsely source code. We will back port them to the main plugin.

## Changelog Description

### Fixing Parse.ly 3.0 release

Fixes potential issues on wp-parsely 3.0.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Activate Parse.ly on your site and check it renders correctly.
