### PR TITLE
Fix empty name on Parse.ly 3.0

### DIFF
--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -795,8 +795,13 @@ class Parsely {
 		foreach ( $terms_not_parents as $index => $value ) {
 			$terms_not_parents_cleaned[] = $value;
 		}
-		// if you assign multiple child terms in a custom taxonomy, will only return the first.
-		return $terms_not_parents_cleaned[0]->name;
+
+		if ( ! empty( $terms_not_parents_cleaned ) ) {
+			// if you assign multiple child terms in a custom taxonomy, will only return the first.
+			return $terms_not_parents_cleaned[0]->name ?? '';
+		}
+
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fixes an issue when the `name` property of a term would not be defined on some circumstances.

## Changelog Description

### Fix empty name on Parse.ly 3.0

Fix an issue when getting the terms.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.