### PR TITLE
Fix wp-parsely Type Errors for the 3.0 tree

### DIFF
--- a/wp-parsely-3.0/src/Integrations/class-amp.php
+++ b/wp-parsely-3.0/src/Integrations/class-amp.php
@@ -76,10 +76,14 @@ class Amp implements Integration {
 	 *
 	 * @since 2.6.0
 	 *
-	 * @param array $analytics The analytics registry.
+	 * @param array|null $analytics The analytics registry.
 	 * @return array The analytics registry.
 	 */
-	public function register_parsely_for_amp_analytics( array $analytics ): array {
+	public function register_parsely_for_amp_analytics( ?array $analytics ): array {
+		if ( $analytics === null ) {
+			$analytics = array();
+		}
+
 		$options = get_option( Parsely::OPTIONS_KEY );
 
 		if ( empty( $options['apikey'] ) ) {
@@ -104,10 +108,14 @@ class Amp implements Integration {
 	 *
 	 * @since 2.6.0
 	 *
-	 * @param array $analytics The analytics registry.
+	 * @param array|null $analytics The analytics registry.
 	 * @return array The analytics registry.
 	 */
-	public function register_parsely_for_amp_native_analytics( array $analytics ): array {
+	public function register_parsely_for_amp_native_analytics( ?array $analytics ): array {
+		if ( $analytics === null ) {
+			$analytics = array();
+		}
+
 		$options = get_option( Parsely::OPTIONS_KEY );
 
 		if ( ! empty( $options['disable_amp'] ) && true === $options['disable_amp'] ) {

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -961,7 +961,7 @@ class Parsely {
 	 * @return string
 	 */
 	public function get_clean_parsely_page_value( ?string $val ): string {
-		if ( $val === null) {
+		if ( $val === null ) {
 			return '';
 		}
 

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -495,7 +495,11 @@ class Parsely {
 		 * @param WP_Post $post            Post object.
 		 * @param array   $parsely_options The Parsely options.
 		 */
-		return apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
+		$filtered = apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
+		if ( is_array( $filtered ) ) {
+			return $filtered;
+		}
+		return array();
 	}
 
 	/**
@@ -953,10 +957,14 @@ class Parsely {
 	 *
 	 * @since 2.6.0
 	 *
-	 * @param string $val The content you'd like sanitized.
+	 * @param string|null $val The content you'd like sanitized.
 	 * @return string
 	 */
-	public function get_clean_parsely_page_value( string $val ): string {
+	public function get_clean_parsely_page_value( ?string $val ): string {
+		if ( $val === null) {
+			return '';
+		}
+
 		$val = str_replace( "\n", '', $val );
 		$val = str_replace( "\r", '', $val );
 		$val = wp_strip_all_tags( $val );

--- a/wp-parsely-3.0/src/class-parsely.php
+++ b/wp-parsely-3.0/src/class-parsely.php
@@ -799,8 +799,13 @@ class Parsely {
 		foreach ( $terms_not_parents as $index => $value ) {
 			$terms_not_parents_cleaned[] = $value;
 		}
-		// if you assign multiple child terms in a custom taxonomy, will only return the first.
-		return $terms_not_parents_cleaned[0]->name;
+
+		if ( ! empty( $terms_not_parents_cleaned ) ) {
+			// if you assign multiple child terms in a custom taxonomy, will only return the first.
+			return $terms_not_parents_cleaned[0]->name ?? '';
+		}
+
+		return '';
 	}
 
 	/**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -15,8 +15,8 @@ namespace Automattic\VIP\WP_Parsely_Integration;
 
 // The default version is the first entry in the SUPPORTED_VERSIONS list.
 const SUPPORTED_VERSIONS = [
-	'2.6',
 	'3.0',
+	'2.6',
 ];
 
 /**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -15,8 +15,8 @@ namespace Automattic\VIP\WP_Parsely_Integration;
 
 // The default version is the first entry in the SUPPORTED_VERSIONS list.
 const SUPPORTED_VERSIONS = [
-	'3.0',
 	'2.6',
+	'3.0',
 ];
 
 /**


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

Fixing some errors we saw on Parse.ly 3.0 due to type errors. This PR makes some additional checks on parameters to ensure types are always consistent.

This PR changes files on the wp-parsely source code. We will back port them to the main plugin.

This pulls in previous fixes in #2823 & #2824 (which got reverted in #2826 & #2825, respectively) & also adds  a couple of additional fixes to guard against type errors.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->

Fix type errors on Parse.ly 3.0
Fix two issues when getting metadata in certain circumstances.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

### Confirm the taxonomy metadata issue

* Run the main branch.
* Add the following to an mu-plugin:

```

add_filter( 'get_term', function ( $term, $taxonomy ) {
        if ( 'category' === $taxonomy && 'uncategorized' === $term->slug ) {
                $term->name = null;
        }
        return $term;
}, 10, 2 );
```

* Browse to `/category/uncategorized/`
* Confirm fatal error

### Confirm the taxonomy metadata fix

* Switch to this branch (leaving the `get_term` filter in place)
* Browse to `/category/uncategorized/` while logged out of the site.
* Confirm no fatal error is shown

### Confirm the non-array metadata issue

* Run the main branch
* Add the following to an mu-plugin: `add_filter( 'wp_parsely_metadata', '__return_false' );`
* Browse to any front end post or page while logged out of the site.
* Confirm fatal error

### Confirm the non-array metadata fix

* Switch to this branch (leaving the `wp_parsely_metadata` filter in place)
* Browse to any front end post or page while logged out of the site.
* Confirm no fatal error is shown & metadata are correctly not present in the page source
