### PR TITLE
Setting Parse.ly 3.0 as the default version

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -15,8 +15,8 @@ namespace Automattic\VIP\WP_Parsely_Integration;
 
 // The default version is the first entry in the SUPPORTED_VERSIONS list.
 const SUPPORTED_VERSIONS = [
-	'2.6',
 	'3.0',
+	'2.6',
 ];
 
 /**


### PR DESCRIPTION
## Description

This PR changes the default wp-parsely version that gets loaded on sites that have the managed support of the plugin enabled. 

We are changing from version 2.6 to 3.0, which contains breaking changes.

## Changelog Description

### wp-parsely default version to 3.0

Changed the default version of wp-parsely from 2.6 to 3.0.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Make sure wp-parsely is enabled.
3. Check that the version loaded is 3.0.