### PR TITLE
Load cron control for archived/spam/deactivated subsites

### DIFF
--- a/001-cron.php
+++ b/001-cron.php
@@ -4,7 +4,7 @@ Plugin Name: Cron Control
 Plugin URI:
 Description: Execute WordPress cron events in parallel, using a custom post type for event storage.
 Author: Erick Hitter, Automattic
-Version: 2.0
+Version: 3.1
 Text Domain: automattic-cron-control
 */
 
@@ -13,27 +13,13 @@ if ( file_exists( __DIR__ . '/cron/cron.php' ) ) {
 }
 
 /**
- * Determine if Cron Control is called for
+ * Determine if we should load cron control, which disables core WP cron running by default.
  *
- * Inactive multisite subsites and local environments are generally unavailable
- *
- * @return bool
+ * @return bool True if we should not load cron control.
  */
 function wpcom_vip_use_core_cron() {
 	// Do not load outside of VIP environments, unless explicitly requested
 	if ( false === WPCOM_IS_VIP_ENV && ( ! defined( 'WPCOM_VIP_LOAD_CRON_CONTROL_LOCALLY' ) || ! WPCOM_VIP_LOAD_CRON_CONTROL_LOCALLY ) ) {
-		return true;
-	}
-
-	// Bail early for anything else that isn't a multisite subsite
-	if ( ! is_multisite() || is_main_site() ) {
-		return false;
-	}
-
-	$details = get_blog_details( get_current_blog_id(), false );
-
-	// get_blog_details() uses numeric strings for backcompat
-	if ( in_array( '1', array( $details->archived, $details->spam, $details->deleted ), true ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
## Description

After https://github.com/Automattic/vip-go-mu-plugins/pull/2839, we can allow cron control to still be active for archived/spam subsites. Helps keep things consistent across the platform.

Also increments the plugin version.

## Changelog Description
n/a, will add a note with the other cron control changelog post.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.
