### PR TITLE
Bump the metadata for QM

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -5,12 +5,12 @@
  * @package   query-monitor
  * @link      https://github.com/johnbillion/query-monitor
  * @author    John Blackbourn <john@johnblackbourn.com>
- * @copyright 2009-2021 John Blackbourn
+ * @copyright 2009-2022 John Blackbourn
  * @license   GPL v2 or later
  *
  * Plugin Name:  Query Monitor
  * Description:  The Developer Tools Panel for WordPress.
- * Version:      3.7.1
+ * Version:      3.8.2
  * Plugin URI:   https://querymonitor.com/
  * Author:       John Blackbourn
  * Author URI:   https://querymonitor.com/


### PR DESCRIPTION
This just bumps some metadata that was missed in #2805. Prevents confusion when looking at the version number in the file.

## Changelog Description

### Plugin Updated: Query Monitor

* Fix plugin metadata
