### PR TITLE
JP Connection Pilot: Ensure "last_heartbeat" is an array

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -64,7 +64,7 @@ class Connection_Pilot {
 		}
 
 		// Making sure each time CP is called it reads the correct heartbeat
-		self::$instance->last_heartbeat = get_option( self::HEARTBEAT_OPTION_NAME );
+		self::$instance->last_heartbeat = get_option( self::HEARTBEAT_OPTION_NAME, [] );
 
 		return self::$instance;
 	}
@@ -208,7 +208,7 @@ class Connection_Pilot {
 	 * @return void
 	 */
 	private function update_backoff_factor(): void {
-		$backoff_factor = (int) $this->last_heartbeat['backoff_factor'];
+		$backoff_factor = isset( $this->last_heartbeat['backoff_factor'] ) ? (int) $this->last_heartbeat['backoff_factor'] : 0;
 
 		if ( $backoff_factor >= self::MAX_BACKOFF_FACTOR ) {
 			return;


### PR DESCRIPTION
## Description

Fixes this fatal:

> PHP message: PHP Fatal error: Caught Error: Trying to access array offset on value of type bool in /wp-content/mu-plugins/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php:211 

Occurs under a quite rare circumstance, but tis possible so patching it up.

## Changelog Description

n/a, can skip.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Run `do_action( 'wpcom_vip_run_jetpack_connection_pilot' );`
