### PR TITLE
Bump down the default content validation batch size to 300

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -9,7 +9,7 @@ use \WP_User_Query as WP_User_Query;
 use \WP_Error as WP_Error;
 
 class Health {
-	const CONTENT_VALIDATION_BATCH_SIZE        = 500;
+	const CONTENT_VALIDATION_BATCH_SIZE        = 300;
 	const CONTENT_VALIDATION_MAX_DIFF_SIZE     = 1000;
 	const CONTENT_VALIDATION_LOCK_NAME         = 'vip_search_content_validation_lock';
 	const CONTENT_VALIDATION_LOCK_TIMEOUT      = 900; // 15 min


### PR DESCRIPTION
## Description

Decreasing the batch size to 300 to slow down the jobs. 

## Changelog Description

### Plugin Updated: Enterprise Search

We've reduced the batch size for content validation checks from 500 to 300.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test


