### PR TITLE
Remove AMP fix

### DIFF
--- a/performance/plugins.php
+++ b/performance/plugins.php
@@ -3,9 +3,3 @@
 // Plugin-specific tweaks go in here
 
 namespace Automattic\VIP\Performance;
-
-// AMP: disable reverse attachment lookups since they usually don't work (querystrings) and are slow
-// This is fixed in AMP > v0.4
-add_action( 'amp_extract_image_dimensions_callbacks_registered', function() {
-	remove_filter( 'amp_extract_image_dimensions', array( 'AMP_Image_Dimension_Extractor', 'extract_from_attachment_metadata' ) );
-} );


### PR DESCRIPTION
## Description
AMP is currently at 2.2.0 right now, I think it's time to remove the fix intended for versions < 0.4.

## Changelog Description

### Plugin Updated: VIP Performance

Removed AMP fix for issue affecting AMP plugins < 0.4


## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.
