### PR TITLE
Add annotations for Renovate to GitHub workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,13 +61,13 @@ jobs:
             e2e-test-site.vipdev.lndo.site:80
 
       - name: Check out repository code
-        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
         with:
           submodules: true
           path: vip-go-mu-plugins
 
       - name: Setup Node
-        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # renovate: tag=v2.5.1
         with:
           node-version: 'lts/*'
           cache: npm
@@ -106,7 +106,7 @@ jobs:
         working-directory: vip-go-mu-plugins
 
       - name: Archive test results
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # renovate: tag=v2.3.1
         if: failure()
         with:
           name: test-results

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,18 +28,18 @@ jobs:
           - "1"
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
         with:
           submodules: recursive
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@da0e8547371daac1784abb79f9bb2af76dcdfaf0 # renovate: tag=2.16.0
         with:
           coverage: none
           php-version: ${{ matrix.php }}
 
       - name: Install PHP Dependencies
-        uses: ramsey/composer-install@2.1.0
+        uses: ramsey/composer-install@f680dac46551dffb2234a240d65ae806c2999dd6 # renovate: tag=2.1.0
 
       - name: Run tests
         run: ./bin/test.sh --wp nightly --php ${{ matrix.php }} --multisite ${{ matrix.multisite }} --phpunit 9 --order-by=random

--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -40,18 +40,18 @@ jobs:
             mode: "filter_and_option_enabled"
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
         with:
           submodules: recursive
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@da0e8547371daac1784abb79f9bb2af76dcdfaf0 # renovate: tag=2.16.0
         with:
           coverage: none
           php-version: ${{ matrix.php }}
 
       - name: Install PHP Dependencies
-        uses: ramsey/composer-install@2.1.0
+        uses: ramsey/composer-install@f680dac46551dffb2234a240d65ae806c2999dd6 # renovate: tag=2.1.0
 
       - name: Run tests
         run: |

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -15,12 +15,12 @@ jobs:
       id: ${{ steps.id-generator.outputs.id }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@14dc64f30986eaa2ad2dddcec073f5aab18e5a24 # v1
+        uses: step-security/harden-runner@14dc64f30986eaa2ad2dddcec073f5aab18e5a24 # renovate: tag=v1.3.0
         with:
           egress-policy: audit
 
       - name: Check out source code
-        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
 
       - name: Retrieve tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -44,7 +44,7 @@ jobs:
         run: git push --tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: softprops/action-gh-release@6232f0b438cb856c39d14f8743e3a7c99fc879af # v0.1.14
+      - uses: softprops/action-gh-release@6232f0b438cb856c39d14f8743e3a7c99fc879af # renovate: tag=v0.1.14
         with:
           generate_release_notes: true
           tag_name: ${{ steps.id-generator.outputs.id }}
@@ -54,15 +54,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@14dc64f30986eaa2ad2dddcec073f5aab18e5a24 # v1
+        uses: step-security/harden-runner@14dc64f30986eaa2ad2dddcec073f5aab18e5a24 # renovate: tag=v1.3.0
         with:
           egress-policy: audit
 
       - name: Check out source code
-        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
 
       - name: Set up Node.js environment
-        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2.5.1
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # renovate: tag=v2.5.1
         with:
           node-version: 14
           cache: npm


### PR DESCRIPTION
Without these annotations, Renovate just picks the latest commit and creates a PR to update the action with the commit hash.

With these annotations, Renovate will follow the tags and will not offer potentially unstable commits to the main branch.

Reference: https://docs.renovatebot.com/modules/manager/github-actions/#additional-information
