### PR TITLE
Allow for using VIP Filesystem Wrapper before plugins_loaded fires

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -112,6 +112,12 @@ class API_Client {
 		$file_size = filesize( $local_path );
 		$file_name = basename( $local_path );
 
+		/**
+		 * `wp_check_filetype()` indirectly calls `wp_get_current_user()`, which is loaded from `pluggable.php`
+		 * `pluggable.php` is loaded after all plugins. Therefore, if a plugin creates a file under `wp-content/uploads`
+		 * before `pluggable.php` is loaded, we should not call `wp_check_filetype()` because it will generate
+		 * a fatal error.
+		 */
 		if ( function_exists( 'wp_get_current_user' ) ) {
 			$file_info = wp_check_filetype( $file_name );
 			$file_mime = $file_info['type'] ?? '';

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -111,8 +111,13 @@ class API_Client {
 
 		$file_size = filesize( $local_path );
 		$file_name = basename( $local_path );
-		$file_info = wp_check_filetype( $file_name );
-		$file_mime = $file_info['type'] ?? '';
+
+		if ( function_exists( 'wp_get_current_user' ) ) {
+			$file_info = wp_check_filetype( $file_name );
+			$file_mime = $file_info['type'] ?? '';
+		} else {
+			$file_mime = '';
+		}
 
 		$request_timeout = $this->calculate_upload_timeout( $file_size );
 


### PR DESCRIPTION
## Description

If a third-party plugin tries to create a file in `wp-content` before `plugins_loaded` fires (hello mailpoet), this results in a fatal error, because of the use of `wp_check_filetype()` function, which (indirectly) relies upon `wp_get_current_user()`, which is loaded from `pluggable.php`.

This PR adds a check whether `wp_get_current_user()` is available before calling `wp_check_filetype()`.

## Changelog Description

### Plugin Updated: VIP Filesystem

Do not generate a fatal error if a file upload happens before `plugins_loaded` action fires.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
