### PR TITLE
Search: Re-factor build_new_index() to not use WP_CLI::runcommand()

### DIFF
--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -239,8 +239,7 @@ class SettingsHealthJob {
 		}
 
 		// Do not schedule new index build if index version limit is reached (2 versions per Indexable).
-		$search           = \Automattic\VIP\Search\Search::instance();
-		$current_versions = $search->versioning->get_versions( $indexable );
+		$current_versions = $this->search->versioning->get_versions( $indexable );
 		if ( count( $current_versions ) > 1 ) {
 			$message = sprintf(
 				'Cannot automatically build new %s index on %s to meet shard requirements. Please ensure there is less than 2 index versions.',
@@ -250,7 +249,7 @@ class SettingsHealthJob {
 			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 			
 			return;
-		} elseif ( ! wp_next_scheduled( self::CRON_EVENT_BUILD_NAME, [ $indexable ] ) ) {
+		} elseif ( ! wp_next_scheduled( self::CRON_EVENT_BUILD_NAME, [ $indexable->slug ] ) ) {
 			wp_schedule_single_event( time() + 30, self::CRON_EVENT_BUILD_NAME, [ $indexable->slug ] );
 		}
 	}
@@ -263,27 +262,69 @@ class SettingsHealthJob {
 	public function build_new_index( $indexable_slug ) {
 		update_option( self::BUILD_LOCK_NAME, time() ); // Set lock for starting rebuild.
 
-		// Do the indexing.
-		$assoc_args = [
-			'using-versions' => true,
-			'skip-confirm'   => true,
-			'indexables'     => $indexable_slug,
-		];
-		$cmd        = 'vip-search index ' . WP_CLI\Utils\assoc_args_to_str( $assoc_args );
-		$result     = WP_CLI::runcommand(
-			$cmd,
-			[
-				'return'     => 'all',
-				'exit_error' => false,
-			],
-		);
+		$indexable = $this->indexables->get( $slug );
+		if ( ! $indexable ) {
+			$indexable = new WP_Error( 'indexable-not-found', sprintf( 'Indexable %s not found - is the feature active?', $slug ) );
+		}
+		if ( is_wp_error( $indexable ) ) {
+			$message = sprintf( 'An error occurred during build of new %s index on %s for shard requirements: %s', $indexable_slug, home_url(), $indexable->get_error_message() );
+			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 
-		if ( '' !== $result->stderr ) {
-			// Surface any error messages that occurred into an alert.
-			$message = sprintf( 'An error occurred during build of new %s index on %s for shard requirements: %s', $indexable_slug, home_url(), $result->stderr );
+			return;
+		}
+		$new_version = $this->search->versioning->add_version( $indexable );
+		if ( is_wp_error( $new_version ) ) {
+			$message = sprintf( 'An error occurred during build of new %s index on %s for shard requirements: %s', $indexable_slug, home_url(), $new_version->get_error_message() );
+			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
+
+			return;
+		}
+
+		$new_version = $this->search->versioning->set_current_version_number( $indexable, 'next' );
+		if ( is_wp_error( $new_version ) ) {
+			$message = sprintf( 'An error occurred during build of new %s index on %s for shard requirements: %s', $indexable_slug, home_url(), $new_version->get_error_message() );
+			$this->send_alert( '#vip-go-es-alerts', $message, 2 );
+
+			return;
+		}
+
+		// Delete CLI option for tracking command successfully finished
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			delete_site_option( 'ep_last_cli_index' );
 		} else {
-			// TODO: Remove this alert eventually.
-			$message = sprintf( 'Successfully built new %s index for shard requirements on %s!', $indexable_slug, home_url() );
+			delete_option( 'ep_last_cli_index' );
+		}
+
+		// Do the indexing.
+		$cmd        = new \ElasticPress\Command();
+		$args       = [];
+		$assoc_args = [
+			'yes'        => true,
+			'indexables' => $indexable_slug,
+		];
+		$cmd->index( $args, $assoc_args );
+
+		$option = defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? get_site_option( 'ep_last_cli_index' ) : get_option( 'ep_last_cli_index' );
+		if ( $option ) {
+			$activate_version = $this->search->versioning->activate_version( $indexable, 'next' );
+			if ( is_wp_error( $activate_version ) ) {
+				$message = sprintf( 'An error occurred during activation of new %s index on %s for shard requirements: %s', $indexable_slug, home_url(), $activate_version->get_error_message() );
+				$this->send_alert( '#vip-go-es-alerts', $message, 2 );
+	
+				return;
+			}
+			
+			$delete_version = $this->search->versioning->delete_version( $indexable, 'previous' );
+			if ( is_wp_error( $versioning ) ) {
+				$message = sprintf( 'An error occurred during deletion of old %s index on %s for shard requirements: %s', $indexable_slug, home_url(), $delete_version->get_error_message() );
+				$this->send_alert( '#vip-go-es-alerts', $message, 2 );
+	
+				return;
+			}
+
+			$message = sprintf( 'Successfully built new %s index for shard requirements on %s.', $indexable_slug, home_url() );
+		} else {
+			$message = sprintf( 'Build failure of new %s index on %s for shard requirements!', $indexable_slug, home_url() );
 		}
 		$this->send_alert( '#vip-go-es-alerts', $message, 2 );
 

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -260,7 +260,7 @@ class SettingsHealthJob {
 	 * @param string $indexable_slug The slug of the Indexable we want to rebuild.
 	 */
 	public function build_new_index( $indexable_slug ) {
-		update_option( self::BUILD_LOCK_NAME, time() ); // Set lock for starting rebuild.
+		update_option( self::BUILD_LOCK_NAME, time(), false ); // Set lock for starting rebuild.
 
 		$indexable = $this->indexables->get( $slug );
 		if ( ! $indexable ) {

--- a/tests/search/includes/classes/test-class-settingshealthjob.php
+++ b/tests/search/includes/classes/test-class-settingshealthjob.php
@@ -147,6 +147,8 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 			->setMethods( [ 'wp_schedule_single_event', 'send_alert' ] )
 			->getMock();
 
+		$stub->search = self::$search;
+
 		$stub->expects( $this->never() )
 			->method( 'send_alert' );
 
@@ -166,6 +168,8 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 			->setMethods( [ 'wp_schedule_single_event', 'send_alert' ] )
 			->getMock();
 
+		$stub->search = self::$search;
+
 		$stub->expects( $this->once() )
 			->method( 'send_alert' );
 
@@ -184,6 +188,8 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->setMethods( [ 'send_alert' ] )
 			->getMock();
+
+		$stub->search = self::$search;
 
 		$stub->expects( $this->never() )
 			->method( 'send_alert' );


### PR DESCRIPTION
## Description
Due to limitations with PHP-fpm requiring `WP_CLI::runcommand()` to set the 'launch' flag to `false`, I've decided to go about another way since it wouldn't capture any STDERR. This is continuation of the work from #2776.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
To test with the post Indexable:
1) `$es = new \Automattic\VIP\Search\Search();`
2) `$es->init();`
3) `$hj = new \Automattic\VIP\Search\SettingsHealthJob( $es );`
4) `$hj->build_new_index( 'post' );`