### PR TITLE
Search: Disable CLI activating unsupported features and throw warning when search is deactivated

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -423,4 +423,26 @@ class CoreCommand extends \ElasticPress\Command {
 		}
 		return false;
 	}
+
+	/**
+	 * Dectivate a feature.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <feature-slug>
+	 * : The feature slug
+	 *
+	 * @subcommand deactivate-feature
+	 * 
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function deactivate_feature( $args, $assoc_args ) {
+		if ( 'search' === $args[0] ) {
+			WP_CLI::confirm( "Are you sure you want to deactivate $args[0]? This will break all search-related functionality!" );
+		}
+
+		array_unshift( $args, 'elasticpress', 'deactivate-feature' );
+		WP_CLI::run_command( $args, $assoc_args );
+	}
 }

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -387,4 +387,40 @@ class CoreCommand extends \ElasticPress\Command {
 
 		WP_CLI::line( wp_json_encode( $indexes ) );
 	}
+
+	/**
+	 * Activate a feature. If a re-indexing is required, you will need to do it manually.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <feature-slug>
+	 * : The feature slug
+	 *
+	 * @subcommand activate-feature
+	 * 
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function activate_feature( $args, $assoc_args ) {
+		if ( $this->is_unsupported_feature( $args[0] ) ) {
+			WP_CLI::error( "The feature {$args[0]} is not currently supported." );
+		}
+
+		array_unshift( $args, 'elasticpress', 'activate-feature' );
+		WP_CLI::run_command( $args, $assoc_args );
+	}
+
+	/**
+	 * Check if feature is unsupported.
+	 * 
+	 * @param string $feature EP feature
+	 * @return bool Whether feature is unsupported or not.
+	 */
+	private function is_unsupported_feature( $feature ) {
+		$unsupported_features = [ 'autosuggest', 'documents' ];
+		if ( in_array( $feature, $unsupported_features, true ) ) {
+			return true;
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
## Description
This PR does two things:
A) Disallows the CLI activation of unsupported features
B) Throws warning when the search feature is to be deactivated

## Changelog Description

### Plugin Updated: Enterprise Search

CLI: Disable activating unsupported features and throw warning when search is deactivated
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Scenario A)
1) Attempt to activate unsupported feature: `wp vip-search activate-feature autosuggest`
2) Receive warning that it is not a supported feature

Scenario B):
1) Attempt to deactivate search feature: `wp vip-search deacivate-feature search`
2) Expect confirmation prompt before proceeding