### PR TITLE
Search: Add wrapper function to get related posts

### DIFF
--- a/search/includes/functions/utils.php
+++ b/search/includes/functions/utils.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Wrapper for getting related posts. The feature Related_posts must be active.
+ * 
+ * @param $post_id Post ID
+ * @param $return Posts per page to return.
+ * 
+ * @return array|bool
+ */
+function vip_es_get_related_posts( $post_id, $return ) {
+	return ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id, $return );
+}

--- a/search/includes/functions/utils.php
+++ b/search/includes/functions/utils.php
@@ -4,10 +4,10 @@
  * Wrapper for getting related posts. The feature Related_posts must be active.
  * 
  * @param $post_id Post ID
- * @param $return Posts per page to return.
+ * @param $return Posts per page to return. Defaults to 5.
  * 
  * @return array|bool
  */
-function vip_es_get_related_posts( $post_id, $return ) {
+function vip_es_get_related_posts( $post_id, $return = 5 ) {
 	return ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id, $return );
 }

--- a/search/search.php
+++ b/search/search.php
@@ -18,6 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+require_once __DIR__ . '/includes/functions/utils.php';
 require_once __DIR__ . '/includes/classes/class-search.php';
 
 if ( \Automattic\VIP\Search\Search::are_es_constants_defined() ) {


### PR DESCRIPTION
## Description
Let's add a wrapper `vip_es_get_related_posts()` for getting related posts when the related_posts feature is active.

TODO: Update documentation after this is deployed

## Changelog Description

### Plugin Updated: Enterprise Search

Add wrapper `vip_es_get_related_posts()` for getting related posts when the related_posts feature is active.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Ensure `related_posts` feature is active: `wp vip-search activate-feature related_posts`
2) Call `vip_es_get_related_posts()` with a post_id: `vip_es_get_related_posts( 22 );`
3) Expect an array of posts returned