### PR TITLE
fix `wp vip files update-filesizes` to include pre-VIP uploaded PDF attachments

### DIFF
--- a/files/class-meta-updater.php
+++ b/files/class-meta-updater.php
@@ -109,7 +109,7 @@ class Meta_Updater {
 		$filtered = [];
 		foreach ( $attachments as $attachment_id ) {
 			$meta = wp_get_attachment_metadata( $attachment_id );
-			if ( ( is_array( $meta ) && ! isset( $meta['filesize'] ) ) || '' === $meta ) {
+			if ( ( is_array( $meta ) && ! isset( $meta['filesize'] ) ) || empty( $meta ) ) {
 				$filtered[] = $attachment_id;
 			}
 		}


### PR DESCRIPTION
## Description

For the `wp vip files update-filesizes` cmd, there are situations where an upload that doesn't have `wp_get_attachment_metadata()['filesize']` might get incorrectly skipped.

Ex: PDFs uploaded outside of VIP (without our `filter_wp_generate_attachment_metadata` filter adding file size), may have a `false` return from `wp_get_attachment_metadata()`. Without considering that `false` return in our check for attachment meta, the filesize meta backfill will be skipped, despite needing it.

I imagine this applies to other filetypes besides pdf, but pdf would be the big one.

## Changelog Description

fix `wp vip files update-filesizes` to include PDF attachments that don't already have a post attachment metadata

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. on the main/master branch, comment out or remove this VIP filter that adds filesize on new uploads https://github.com/Automattic/vip-go-mu-plugins/blob/30acf90f5a2cda3466f11fdcdc36b6b8482eb5c4/files/class-vip-filesystem.php#L101
2. Upload a PDF to wp-admin, note the ID
3. notice via `wp shell` that `wp_generate_attachment_metadata(<ID>)` is false (how PDF attachment meta uploads look outside of VIP with the `filter_wp_generate_attachment_metadata` filter removed)
4. still on the main/master branch, run `wp vip files update-filesizes`, notice the output says "found 0 attachments without a filesize", despite the previously uploaded pdf clearly not having the filesize attachment meta or any attachment meta values for that matter
5. checkout this pr
6. run `wp vip files update-filesizes` again, notice how the missing value was detected ("found 1 attachments without a filesize") and repaired
7. check `wp shell` & `wp_generate_attachment_metadata(<ID>)` again, notice the filesize is now present