### PR TITLE
Remove the unused private method count_indexable_posts()

### DIFF
--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -125,24 +125,6 @@ class HealthJob {
 
 	}
 
-	private function count_indexable_posts() {
-		$post_indexable = $this->indexables->get( 'post' );
-
-		$post_types    = $post_indexable->get_indexable_post_types();
-		$post_statuses = $post_indexable->get_indexable_post_status();
-
-
-		$sum = 0;
-		foreach ( $post_types as $post_type ) {
-			$counts = wp_count_posts( $post_type );
-			foreach ( $post_statuses as $status ) {
-				$count = $counts->$status ?? 0;
-				$sum  += $count;
-			}
-		}
-		return $sum;
-	}
-
 	/**
 	 * Is health check job enabled
 	 *


### PR DESCRIPTION
`HealthJob::count_indexable_posts()` is a private method and is no longer referenced from the code. It's time to remove it :-) 

The last reference was removed in f7910629262b1b1dd816124c6b39c65c7c4bf432.