### PR TITLE
Search: Make log message more filterable for successful deletes

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -902,19 +902,16 @@ class Versioning {
 			} else {
 				$this->update_versions( $indexable, $versions );
 
-				$message = sprintf(
-					"Application %d - %s updated index versions for '%s' indexable",
-					FILES_CLIENT_SITE_ID,
-					home_url(),
-					$indexable->slug
-				);
-
 				\Automattic\VIP\Logstash\log2logstash(
 					array(
 						'severity' => 'info',
 						'feature'  => 'search_versioning',
-						'message'  => $message,
-						'extra'    => $versions,
+						'message'  => 'Recreated index versions for persistence',
+						'extra'    => [
+							'homeurl'   => home_url(),
+							'versions'  => $versions,
+							'indexable' => $indexable->slug,
+						],
 					)
 				);
 			}

--- a/search/includes/classes/class-versioningcleanupjob.php
+++ b/search/includes/classes/class-versioningcleanupjob.php
@@ -132,18 +132,16 @@ class VersioningCleanupJob {
 			);
 			\Automattic\VIP\Utils\Alerts::chat( self::SEARCH_ALERT_SLACK_CHAT, $message );
 		} else {
-			$message = sprintf(
-				"Application %d - %s Successfully deleted inactive index version %s for '%s' indexable",
-				FILES_CLIENT_SITE_ID,
-				home_url(),
-				$version,
-				$indexable->slug
-			);
 			\Automattic\VIP\Logstash\log2logstash(
 				array(
 					'severity' => 'info',
 					'feature'  => 'search_versioning',
-					'message'  => $message,
+					'message'  => 'Successfully deleted inactive index version',
+					'extra'    => [
+						'homeurl'         => home_url(),
+						'version_deleted' => $version,
+						'indexable'       => $indexable->slug,
+					],
 				)
 			);
 		}


### PR DESCRIPTION
## Description
It's hard to filter through the Kibana logs for `search_versioning` since the messages can differ.