### PR TITLE
Roll out index re-building for non-production sites at 25%

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -17,7 +17,9 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = [];
+	public static $feature_percentages = [
+		'es-delete-index' => 0.25,
+	];
 
 	/**
 	 * Holds feature slug and then, key of ids with bool value to enable E.g.

--- a/search/includes/classes/class-versioningcleanupjob.php
+++ b/search/includes/classes/class-versioningcleanupjob.php
@@ -119,6 +119,11 @@ class VersioningCleanupJob {
 			return;
 		}
 
+		$feature_enabled = \Automattic\VIP\Feature::is_enabled_by_percentage( 'es-delete-index' );
+		if ( ! $feature_enabled ) {
+			return;
+		}
+
 		$delete_version = $this->versioning->delete_version( $indexable, $version );
 
 		if ( is_wp_error( $delete_version ) ) {


### PR DESCRIPTION
## Description
This should go out alongside #2886 to ensure that the new criteria for re-building indexes isn't triggered all at once.