### PR TITLE
Jetpack: Return on no object for $jetpack_search in debug bar

### DIFF
--- a/jetpack-10.6/3rd-party/debug-bar/class-jetpack-search-debug-bar.php
+++ b/jetpack-10.6/3rd-party/debug-bar/class-jetpack-search-debug-bar.php
@@ -98,6 +98,11 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 			Jetpack_Search\Instant_Search::instance() :
 			Jetpack_Search\Classic_Search::instance()
 		);
+		
+		if ( ! $jetpack_search ) {
+			return;
+		}
+
 		$last_query_info = $jetpack_search->get_last_query_info();
 
 		// If not empty, let's reshuffle the order of some things.


### PR DESCRIPTION
## Description
To prevent the below fatal from occurring:

```
PHP Fatal error:  Uncaught Error: Call to a member function get_last_query_info() on null
```