### PR TITLE
Search: Ensure option in cache is deleted after we invalidate it

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -822,6 +822,11 @@ class Search {
 				} else {
 					// Invalidate index_exists caching on certain actions.
 					delete_option( $index_exists_option_name );
+
+					// Ensure the cache for the option was actually deleted.
+					if ( false !== wp_cache_get( $index_exists_option_name, 'options' ) ) {
+						wp_cache_delete( $index_exists_option_name, 'options' );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description
We're seeing that sometimes when we delete an option, the option still remains floating in the cache. This adds a check to ensure that the option cache actually gets deleted after we delete the option.