### PR TITLE
Use add_option over update_option for better concurrency handling

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -940,7 +940,7 @@ class Search {
 
 		if ( 'index_exists' === $type && in_array( $response_code, $valid_index_exists_response_codes, true ) ) {
 			// Cache index_exists into option since we didn't return a cached value earlier.
-			update_option( $index_exists_option_name, $response );
+			add_option( $index_exists_option_name, $response );
 		}
 
 		if ( $is_cacheable ) {


### PR DESCRIPTION
## Description
Part of the issue described in #2909, we were finding that the option was stored in the `options` group rather than `alloptions`. Let's use `add_option()` instead since it checks if the `$autoload` parameter is set before deciding which option group it's set at: https://github.com/WordPress/WordPress/blob/a4026420cc1845aec29661239e625c5d3cfee452/wp-includes/option.php#L645-L651

Compared to `update_option()` where it only checks the current state of alloptions: https://github.com/WordPress/WordPress/blob/a4026420cc1845aec29661239e625c5d3cfee452/wp-includes/option.php#L508-L514