### PR TITLE
Search: Add backfilling EP option wrapper

### DIFF
--- a/search/includes/functions/utils.php
+++ b/search/includes/functions/utils.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\VIP\Utils\Alerts;
+
 /**
  * Wrapper for getting related posts. The feature Related_posts must be active.
  * 
@@ -10,4 +12,44 @@
  */
 function vip_es_get_related_posts( $post_id, $return = 5 ) {
 	return ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id, $return );
+}
+
+/**
+ * Wrapper for backfilling an EP option if it doesn't exist on a per-site basis, but exists on a network one.
+ * 
+ * @param $value array|bool Pass in per-site option value.
+ * @param $option string Pass in per-site option.
+ * 
+ * @return $value array|bool Option value to return.
+ */
+function vip_maybe_backfill_ep_option( $value, $option ) {
+	if ( empty( $value ) ) {
+		$site_option_value = get_site_option( $option );
+		if ( ! empty( $site_option ) ) {
+			$option_added = add_option( $option, $site_option_value );
+
+			$blog_id  = get_current_blog_id();
+			$home_url = home_url();
+			if ( $option_added ) {
+				\Automattic\VIP\Logstash\log2logstash(
+					array(
+						'severity' => 'info',
+						'feature'  => 'search_ep_option',
+						'message'  => "Successfully added {$option} option to subsite.",
+						'extra'    => [
+							'homeurl' => $home_url,
+							'blog_id' => $blog_id,
+							'option'  => wp_json_encode( $site_option ),
+						],
+					)
+				);
+			} else {
+				Alerts::chat( '#vip-go-es-alerts', "Unsuccessfully added option {$option} to subsite {$blog_id}: {$home_url}" );
+			}
+
+			return $site_option_value;
+		}
+	}
+
+	return $value;
 }


### PR DESCRIPTION
## Description
This is for https://github.com/Automattic/ElasticPress/pull/149, but certain EP options are on a network level and we want to start towards transitioning them to a site one. This is so individual subsites can have more granular control on a per-site basis, rather than assuming network level.

## Changelog Description

### Plugin Updated: Enterprise Search

Added vip_maybe_backfill_ep_option() to utils

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create any a network option that doesn't exist on a site basis: `update_site_option( 'ep_test_option', [ 1, 2, 3 ] );`
2) Call helper function `vip_maybe_backfill_ep_option( false, 'ep_test_option' );
3) Check if option was created on a site level `get_option( 'ep_test_option' );`