### PR TITLE
Don't typecast $user object for wp_login callback

### DIFF
--- a/vip-support/class-vip-support-user.php
+++ b/vip-support/class-vip-support-user.php
@@ -614,7 +614,13 @@ class User {
 	 *
 	 * @return void
 	 */
-	public function action_wp_login( $_user_login, WP_User $user ) {
+	public function action_wp_login( $_user_login, $user ) {
+		if ( ! ( $user instanceof WP_User ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- gettype() is safe
+			_doing_it_wrong( __METHOD__, sprintf( '$user must be an instance of WP_User, %s given', gettype( $user ) ), '' );
+			return;
+		}
+
 		if ( ! is_multisite() ) {
 			return;
 		}


### PR DESCRIPTION
Moving Automattic/vip-support#62 into mu-plugins repo.