### PR TITLE
Search: Remove the JP Search toggling page

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1460,18 +1460,6 @@ class Search {
 	}
 
 	/**
-	 * Remove the marketing admin page for Jetpack Search if VIP Search is enabled
-	 */
-	public function remove_jetpack_menu_search(): void {
-		if ( class_exists( 'Jetpack_Search_Dashboard_Page' ) ) {
-			remove_submenu_page(
-				'jetpack',
-				'jetpack-search',
-			);
-		}
-	}
-
-	/**
 	 * Remove the search widget from Jetpack widget include list
 	 */
 	public function filter__jetpack_widgets_to_include( $widgets ) {

--- a/search/search.php
+++ b/search/search.php
@@ -31,7 +31,6 @@ if ( \Automattic\VIP\Search\Search::are_es_constants_defined() ) {
 		add_filter( 'jetpack_active_modules', array( $search_plugin, 'filter__jetpack_active_modules' ), PHP_INT_MAX );
 		add_filter( 'jetpack_widgets_to_include', array( $search_plugin, 'filter__jetpack_widgets_to_include' ), PHP_INT_MAX );
 		add_filter( 'jetpack_search_should_handle_query', '__return_false', PHP_INT_MAX );
-		add_action( 'admin_menu', array( $search_plugin, 'remove_jetpack_menu_search' ), PHP_INT_MAX );
 	}
 
 	do_action( 'vip_search_loaded' );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -700,3 +700,17 @@ function add_jetpack_menu_placeholder(): void {
 }
 
 add_action( 'admin_menu', 'add_jetpack_menu_placeholder', 999 );
+
+/**
+ * Remove the page that allows you to toggle Search and Instant Search on and off. 
+ * Use code or CLI instead to toggle Search module and open a ZD ticket for enabling Instant Search.
+ * 
+ * @return void
+ */
+function vip_remove_jetpack_search_menu_page() {
+	remove_submenu_page( 
+		'jetpack',
+		'jetpack-search'
+	);
+}
+add_action( 'admin_menu', 'vip_remove_jetpack_search_menu_page', PHP_INT_MAX ); 


### PR DESCRIPTION
## Description
The current recommended process for activating the search module is via code or CLI: https://docs.wpvip.com/technical-references/elasticsearch/integrating-jetpack-search/#how-to-activate-the-search-module

For activating Instant Search, that requires opening a ZD ticket. This PR disables the page that allows activating Instant Search.

Also, the `Jetpack_Search_Dashboard_Page` class doesn't seem to exist any longer.

## Changelog Description

### Plugin Updated: Jetpack

Removed page to toggle Search and Instant Search. To toggle search on and off, use code and for Instant Search, please open a ZD ticket with us.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Sandbox
2) Apply PR 
3) Go to Jetpack menu and see no "Search" anymore.
