### PR TITLE
Add .dockerignore for k8s build

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,4 +1,10 @@
+# While we are in the transition period we have both .deployignore and .dockerignore files
+# In the future we should remove .deployignore once we stop syncing code to SVN
+#
+# .deployignore is currently being used by our sync scripts to SVN while
+# .dockerignore is used by k8s build process when creating images from git repository
 .deployignore
+.dockerignore
 
 .ackrc
 .babelrc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.deployignore


### PR DESCRIPTION
## Description
When we are building docker image from the code we need dockerignore file in place. We used to use `.deployignore` to limit files that are synced to SVN, and then build from that down the line.

As we are getting rid of the sync step, switching to dockerignore makes sense.
 

## Steps to Test

Not really applicable here. Just checking the output when deploying the code.
