### PR TITLE
setting orderby to none for db counts

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -101,6 +101,9 @@ class Health {
 		}
 
 		try {
+			// to avoid an expensive orderby query on large datasets, we can set the orderby to none here.
+			$query_args['orderby'] = 'none';
+			
 			// Get total count in DB
 			$db_result = $indexable->query_db( $query_args );
 

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -103,6 +103,8 @@ class Health {
 		try {
 			// to avoid an expensive orderby query on large datasets, we can set the orderby to none here.
 			$query_args['orderby'] = 'none';
+			// Disable advanced pagination so it doesn't override the orderby set
+			$query_args['ep_indexing_advanced_pagination'] = false;
 			
 			// Get total count in DB
 			$db_result = $indexable->query_db( $query_args );


### PR DESCRIPTION
## Description
When doing a DB count, having an `orderby` in the query clause can be quite expensive for large datasets, so setting its value to `none` could provide some speed benefits.

## Changelog Description

### Plugin Updated: Enterprise Search

Avoid excessive resource usage by setting `orderby` to `none` for the `health validate-counts` command.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. apply the patch
2. measure time it take to run before and after the patch against

```
wp vip-search health validate-counts
```
