### PR TITLE
Search: Escape WP_Error namespace and use $indexable_slug not $slug

### DIFF
--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -261,9 +261,9 @@ class SettingsHealthJob {
 	public function build_new_index( $indexable_slug ) {
 		update_option( self::BUILD_LOCK_NAME, time(), false ); // Set lock for starting rebuild.
 
-		$indexable = $this->indexables->get( $slug );
+		$indexable = $this->indexables->get( $indexable_slug );
 		if ( ! $indexable ) {
-			$indexable = new WP_Error( 'indexable-not-found', sprintf( 'Indexable %s not found - is the feature active?', $slug ) );
+			$indexable = new \WP_Error( 'indexable-not-found', sprintf( 'Indexable %s not found - is the feature active?', $slug ) );
 		}
 		if ( is_wp_error( $indexable ) ) {
 			$message = sprintf( 'An error occurred during build of new %s index on %s for shard requirements: %s', $indexable_slug, home_url(), $indexable->get_error_message() );


### PR DESCRIPTION
## Description
Bugfix for the auto-rebuilding of indexes - in https://github.com/Automattic/vip-go-mu-plugins/pull/2795/files forgot to include changing `$slug` to `$indexable_slug` 

Tihs also escapes WP_Error

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
```
$es = new \Automattic\VIP\Search\Search();
$es->init();
$hj = new \Automattic\VIP\Search\SettingsHealthJob( $es );
$hj->build_new_index( 'post' )
```