### PR TITLE
Set retry window to 10 and threshold for failing at 5 for Search requests

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -879,7 +879,7 @@ class Search {
 		 * Any timeouts happening in non-search/non-query context shouldn't count towards the request disabling threshold.
 		 */
 		if ( 'query' === $type ) {
-			$response = vip_safe_wp_remote_request( $query['url'], false, 3, $timeout, 20, $args );
+			$response = vip_safe_wp_remote_request( $query['url'], false, 5, $timeout, 10, $args );
 		} else {
 			$args['timeout'] = $timeout;
 			$response        = wp_remote_request( $query['url'], $args );


### PR DESCRIPTION
## Description

We previously had it set that after 3 failed requests any subsequent requests would be blocked. This is not great because with a higher rate of requests we essentially block requests even though the blip could be momentary. This PR reduces the retry window to 10s (minimum allowed value) and cautiously sets the threshold to 5. It can probably be bumped up, but I'd like to err on the side of caution.

## Changelog Description

### Plugin Updated: Enterprise Search

We have tweaked thresholds that control early server request termination in case of repeated request errors.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

