### PR TITLE
adds .secrets/.svn to ignored files

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -35,6 +35,7 @@
 .phpcs.xml.dist
 .scrutinizer.yml
 .travis.yml
+.secrets/.svn
 .wordpress-org/
 composer.json
 composer.lock


### PR DESCRIPTION

## Description
Adds `.secrets/.svn` to ignored files. This is useful during k8s build when we combine mu-plugins with `.secrets` folder hosted in `.svn`
