### PR TITLE
JP /bin/ Scripts: Fix adding and updating subtree properly

### DIFF
--- a/bin/add-jetpack-subtree.sh
+++ b/bin/add-jetpack-subtree.sh
@@ -21,4 +21,4 @@ fi
 
 echo "Creating new jetpack subtree $tree_dir using jetpack tag $jetpack_tag"
 
-git subtree add --squash -P $tree_dir https://github.com/Automattic/jetpack-production $jetpack_tag -m "Add jetpack $tree_version subtree with tag $jetpack_tag"
+git subtree add -P $tree_dir --squash https://github.com/Automattic/jetpack-production $jetpack_tag -m "Add jetpack $tree_version subtree with tag $jetpack_tag"

--- a/bin/update-jetpack-subtree.sh
+++ b/bin/update-jetpack-subtree.sh
@@ -19,4 +19,4 @@ fi
 
 echo "Updating jetpack subtree $tree_dir to the jetpack tag $jetpack_tag"
 
-git subtree pull --squash -P $tree_dir https://github.com/Automattic/jetpack-production $jetpack_tag -m "Update jetpack $tree_version subtree to tag $jetpack_tag"
+git subtree pull -P $tree_dir --squash https://github.com/Automattic/jetpack-production $jetpack_tag -m "Update jetpack $tree_version subtree to tag $jetpack_tag"


### PR DESCRIPTION
## Description
Currently, the subtree isn't added properly resulting in the below error when you attempt to update it:

```
─$ ./bin/update-jetpack-subtree.sh 10.7 10.7-beta2
Updating jetpack subtree jetpack-10.7 to the jetpack tag 10.7-beta2
From https://github.com/Automattic/jetpack-production
 * tag                   10.7-beta2 -> FETCH_HEAD
Can't squash-merge: 'jetpack-10.7' was never added.
```

This PR fixes that.
