### PR TITLE
Ignore Parse.ly WINDOWS file on deploys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -123,6 +123,7 @@ yarn.lock
 /wp-parsely-*/.prettierrc
 /wp-parsely-*/bin
 /wp-parsely-*/CHANGELOG.md
+/wp-parsely-*/WINDOWS.md
 /wp-parsely-*/init.py
 /wp-parsely-*/tests
 /wp-parsely-*/phpunit-integration.xml.dist


### PR DESCRIPTION
## Description

Adding the WINDOWS file to deploy ignore so it doesn't get included.