### PR TITLE
Search: Fix updated variable in case it was affecting the cron job

### DIFF
--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -364,7 +364,7 @@ class SettingsHealthJob {
 			}
 			
 			$delete_version = $this->search->versioning->delete_version( $indexable, 'previous' );
-			if ( is_wp_error( $versioning ) ) {
+			if ( is_wp_error( $delete_version ) ) {
 				$message = sprintf(
 					'Application %s: An error occurred during deletion of old %s index on %s for shard requirements: %s',
 					FILES_CLIENT_SITE_ID,


### PR DESCRIPTION
## Description
Updated variable to `$delete_version` but it still checks if `$versioning` is a WP_Error. This could potentially cause the cron job to silently fail if there is a notice being thrown.