### PR TITLE
Detect if new Parse.ly versions are manually loaded

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -51,7 +51,7 @@ function maybe_load_plugin() {
 	}
 
 	// Bail if the plugin has already initialized elsewhere
-	if ( class_exists( 'Parsely' ) ) {
+	if ( class_exists( 'Parsely' ) || class_exists( 'Parsely\Parsely' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description

After the release of wp-parsely 3.0, the main class got namespaced, so its name changed from `Parsely` to `Parsely\Parsely`. This PR updates the wrapper code that loads the plugin to catch that change. If some rare circumstances were met, this could lead to a fatal error.

## Changelog Description

### Updated wp-parsely wrapper

We upgraded the wp-parsely wrapper to detect if new versions of Parse.ly are manually loaded.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Upload wp-parsely >= 3.0 manually to your client plugins repo and load it using `wpcom_vip_load_plugin`. 
3. Make this filter return true: `add_filter( 'wpvip_parsely_load_mu', '__return_true' );`
4. Without the PR, you should get a fatal. Otherwise, it should load the version defined manually.