### PR TITLE
Search: Add temporary command clean-ep-feature-settings before we backfill ep_feature_settings

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -465,4 +465,25 @@ class CoreCommand extends \ElasticPress\Command {
 			WP_CLI::line( sprintf( 'Last indexed object ID: %d', $last_id ) );
 		}
 	}
+
+	/**
+	 * Clean the ep_feature_settings individual blog option if it exists for sites with EP_IS_NETWORK.
+	 * 
+	 * @subcommand clean-ep-feature-settings
+	 * 
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function clean_ep_feature_settings( $args, $assoc_args ) {
+		if ( is_multisite() && defined( 'EP_IS_NETWORK' ) && true === constant( 'EP_IS_NETWORK' ) ) {
+			$delete_option = delete_option( 'ep_feature_settings' );
+			if ( $delete_option ) {
+				WP_CLI::success( 'Deleted ep_feature_settings blog option!' );
+			} else {
+				WP_CLI::error( 'Failed to delete ep_feature_settings_blog_option!' );
+			}
+		} else {
+			WP_CLI::error( 'Not a multisite or EP_IS_NETWORK is not enabled!' );
+		}
+	}
 }


### PR DESCRIPTION
## Description
Just in-case we have rogue ep_feature_settings option on multisites with the `EP_IS_NETWORK` constant is defined, let's add a command to delete it.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) `wp option update ep_feature_settings test`
2) `wp vip-search clean-ep-feature-settings`