### PR TITLE
Rollback default JP version

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -25,7 +25,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.8', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.4' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.7' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.6' );
 	}
 }
 


### PR DESCRIPTION
Ran into some issues during 10.7 deploy, rolling back to 10.6 for now (no db upgrades, so is safe to go back).