### PR TITLE
Remove string speficiying the platform as it's now redundant

### DIFF
--- a/vip-dashboard/vip-dashboard.php
+++ b/vip-dashboard/vip-dashboard.php
@@ -171,9 +171,6 @@ function vip_contact_form_handler() {
 	$content .= "\nSite URLs: " . site_url() . ' | ' . admin_url();
 	$content .= "\nTheme: " . get_option( 'stylesheet' ) . ' | ' . $theme->get( 'Name' );
 
-	// added for VIPv2.
-	$content .= "\nPlatform: VIP Go";
-
 	// send date and time.
 	// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- ISO 8601 date includes the TZ info
 	$content .= sprintf( "\n\nSent from %s on %s", home_url(), date( 'c', time() ) );


### PR DESCRIPTION
## Description

Removing the platform description from the text included with support tickets opened from the VIP screen in WP Admin.

## Changelog Description

### VIP WP Admin screen updated

Removed unnecessary content from the body of support tickets.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
