### PR TITLE
Search: Index re-building - log instead of alert on successful build and roll out to 25% of non-production

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -17,7 +17,9 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = [];
+	public static $feature_percentages = [
+		'rebuild-index' => 0.25,
+	];
 
 	/**
 	 * Holds feature slug and then, key of ids with bool value to enable E.g.
@@ -26,12 +28,7 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_ids = [
-		'rebuild-index' => [
-			4785 => true,
-			4927 => true,
-		],
-	];
+	public static $feature_ids = [];
 
 	public static function is_enabled( $feature ) {
 		return static::is_enabled_by_percentage( $feature );

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -196,7 +196,8 @@ class SettingsHealthJob {
 				}
 				// Check if index needs to be re-built in the background.
 				if ( true === array_key_exists( 'index.number_of_shards', $result['diff'] ) ) {
-					if ( \Automattic\VIP\Feature::is_enabled_by_ids( 'rebuild-index' ) ) {
+					// Rollout for 25% of non-production environments.
+					if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT && \Automattic\VIP\Feature::is_enabled_by_percentage( 'rebuild-index' ) ) {
 						$this->maybe_process_build( $indexable );
 					}
 				}

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -463,11 +463,16 @@ class SettingsHealthJob {
 			return;
 		}
 
-		$message = sprintf(
-			'Application %s: Successfully built new %s index for shard requirements on %s.',
-			FILES_CLIENT_SITE_ID,
-			$indexable->slug,
-			home_url()
+		\Automattic\VIP\Logstash\log2logstash(
+			array(
+				'severity' => 'info',
+				'feature'  => 'search_versioning',
+				'message'  => 'Built new index to meet shard requirements',
+				'extra'    => [
+					'homeurl'   => home_url(),
+					'indexable' => $indexable->slug,
+				],
+			)
 		);
 
 		// Clean up


### PR DESCRIPTION
## Description
Continuing work from #2954, this PR:
- logs instead of alerts on successful index re-building
- rolls out the change to 25% of non-production environments