### PR TITLE
Remove unnecessary SDS logging

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -218,15 +218,6 @@ class Site_Details_Index {
 
 			vip_safe_wp_remote_request( $url, false, 3, 5, 10, $args );
 		}
-
-		\Automattic\VIP\Logstash\log2logstash(
-			array(
-				'severity' => 'info',
-				'feature'  => self::LOG_FEATURE_NAME,
-				'message'  => 'Site details update',
-				'extra'    => $site_details,
-			)
-		);
 	}
 
 	/**

--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -90,11 +90,6 @@ class Sync {
 
 		if ( $value_from_option !== $expected ) {
 			$this->sync_jetpack_privacy_settings( $expected, $value_from_option );
-		} else {
-			$this->log( 'info', 'Privacy Settings were determined to be consistent', array(
-				'expected'    => $expected,
-				'from_option' => $value_from_option,
-			) );
 		}
 	}
 


### PR DESCRIPTION
## Description

These two logging lines happen on every SDS sync, so is a bit noisy and feels unnecessary (since they happen every time during the "ideal" path). Currently floods the batch logs quite a bit.

## Changelog Description
n/a

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
 n/a
