### PR TITLE
Jetpack: Make 10.7 default version

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -25,7 +25,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.8', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.4' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.6' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.7' );
 	}
 }
 


### PR DESCRIPTION
## Description
This PR makes Jetpack 10.7 the default version. Previously rolled back in #2962.

## Changelog Description

### Plugin Updated: Jetpack 10.7

Jetpack 10.7 is the new default version. 

