### PR TITLE
SDI: Index wporg plugin slugs

### DIFF
--- a/tests/config/test-site-details-index.php
+++ b/tests/config/test-site-details-index.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Tests SDI data syncing.
+ *
+ * @phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
+ * @phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
+ */
 
 namespace Automattic\VIP\Config;
 
@@ -11,170 +17,99 @@ require_once __DIR__ . '/../../config/class-site-details-index.php';
  * @preserveGlobalState disabled
  */
 class Site_Details_Index_Test extends WP_UnitTestCase {
-	public function test__cron_event_should_not_be_hooked_if_no_init() {
+	public function test__data_filter_should_not_be_hooked_if_no_init() {
 		$sdi = new Site_Details_Index();
 
 		$this->assertFalse( has_filter( 'vip_site_details_index_data', [ $sdi, 'set_env_and_core' ] ) );
 	}
 
-	public function test__cron_event_should_be_hooked_if_init() {
-		// Getting the instance should call init which should add set_env_and_core to the hook
+	public function test__data_filter_should_be_hooked_if_init() {
+		// Getting the instance should call init which should add set_env_and_core to the hook.
 		$sdi = Site_Details_Index::instance();
-		
+
 		$this->assertTrue( is_integer( has_filter( 'vip_site_details_index_data', [ $sdi, 'set_env_and_core' ] ) ) );
 	}
 
-	public function test__set_env_and_core() {
+	public function test__vip_site_details_index_data_filter() {
 		global $wp_version;
 
-		$plugins = array(
-			'hello.php' => array(
-				'Name'    => 'Hello Tests',
-				'Version' => '4.5',
-			),
-			'world.php' => array(
-				'Name'    => 'Testing World',
-				'Version' => '8.6',
-			),
-		);
+		$test_plugins = [
+			'hello.php' => [ 'Name' => 'Hello Tests', 'Version' => '4.5', 'UpdateURI' => '' ],
+			'world.php' => [ 'Name' => 'Testing World', 'Version' => '8.6', 'UpdateURI' => '' ],
+			'woocommerce/woocommerce.php' => [ 'Name' => 'WooCommerce', 'Version' => '1.2.3', 'UpdateURI' => '' ],
+		];
 
-		// Set the cache for plugins and the option for enabling a plugin	
-		wp_cache_set( 'plugins', array( '' => $plugins ), 'plugins' );
-		update_option( 'active_plugins', array( 'world.php' ) );
-
-		$site_details = Site_Details_Index::instance( 100 )->set_env_and_core( array() );
-
-		$this->assertTrue( array_key_exists( 'timestamp', $site_details ), 'timestamp should exist' );
-		$this->assertTrue( is_integer( $site_details['timestamp'] ), 'timestamp should be int' );
-		$this->assertEquals( 100, $site_details['timestamp'], 'timestamp should be 100 since it was mocked to be 100' );
-
-		$this->assertTrue( array_key_exists( 'client_site_id', $site_details ), 'client_site_id should exist' );
-		$this->assertTrue( is_integer( $site_details['client_site_id'] ), 'client_site_id should be int' );
-		$this->assertEquals( 123, $site_details['client_site_id'], 'client_site_id should be 123' );
-
-		$this->assertTrue( array_key_exists( 'environment_name', $site_details ), 'environment_name should exist' );
-		$this->assertTrue( is_string( $site_details['environment_name'] ), 'environment_name should be string' );
-		$this->assertEquals( '', $site_details['environment_name'], 'environment_name should be blank since it\'s not current set' ); // Not set in test environment currently
-
-		$this->assertTrue( array_key_exists( 'plugins', $site_details ), 'plugins should exist' );
-		$this->assertTrue( is_array( $site_details['plugins'] ), 'plugins should be array' );
-		$this->assertEquals(
-			array(
-				array(
-					'path'         => 'hello.php',
-					'name'         => 'Hello Tests',
-					'version'      => '4.5',
-					'active'       => false,
-					'activated_by' => null,
-				),
-				array(
-					'path'         => 'world.php',
-					'name'         => 'Testing World',
-					'version'      => '8.6',
-					'active'       => true,
-					'activated_by' => 'option',
-				),
-			),
-			$site_details['plugins'] 
-		);
-
-		$this->assertTrue( array_key_exists( 'core', $site_details ), 'core should exist' );
-		$this->assertTrue( is_array( $site_details['core'] ), 'core should be array' );
-
-		$this->assertTrue( array_key_exists( 'wp_version', $site_details['core'] ), 'wp_version should exist in core' );
-		$this->assertTrue( is_string( $site_details['core']['wp_version'] ), 'wp_version should be string' );
-		$this->assertEquals( $wp_version, $site_details['core']['wp_version'], 'wp_version should be equal to global wp_version' );
-
-		$this->assertTrue( array_key_exists( 'blog_id', $site_details['core'] ), 'blog_id should exist in core' );
-		$this->assertTrue( is_integer( $site_details['core']['blog_id'] ), 'blog_id should be int' );
-		$this->assertEquals( get_current_blog_id(), $site_details['core']['blog_id'], 'blog_id should be equal to get_current_blog_id()' );
-
-		$this->assertTrue( array_key_exists( 'site_url', $site_details['core'] ), 'site_url should exist in core' );
-		$this->assertTrue( is_string( $site_details['core']['site_url'] ), 'site_url should be string' );
-		$this->assertEquals( get_site_url(), $site_details['core']['site_url'], 'site_url should be equal to get_site_url()' );
-
-		$this->assertTrue( array_key_exists( 'is_multisite', $site_details['core'] ), 'is_multisite should exist in core' );
-		$this->assertTrue( is_bool( $site_details['core']['is_multisite'] ), 'is_multisite should be bool' );
-		$this->assertEquals( is_multisite(), $site_details['core']['is_multisite'], 'is_multisite should be equal to is_multisite()' );
-	}
-
-	public function test__vip_site_details_index_data() {
-		global $wp_version;
-
-		$plugins = array(
-			'hello.php' => array(
-				'Name'    => 'Hello Tests',
-				'Version' => '4.5',
-			),
-			'world.php' => array(
-				'Name'    => 'Testing World',
-				'Version' => '8.6',
-			),
-		);
-
-		// Set the cache for plugins and the option for enabling a plugin	
-		wp_cache_set( 'plugins', array( '' => $plugins ), 'plugins' );
+		// Mock the list of plugins, which are active, and which have available updates from WPorg.
+		wp_cache_set( 'plugins', array( '' => $test_plugins ), 'plugins' );
 		update_option( 'active_plugins', array( 'hello.php' ) );
+		add_filter( 'pre_site_transient_update_plugins', [ $this, 'mock_update_plugins_transient' ], 999 );
 
 		Site_Details_Index::instance( 100 );
 
 		$site_details = apply_filters( 'vip_site_details_index_data', array() );
 
-		$this->assertTrue( array_key_exists( 'timestamp', $site_details ), 'timestamp should exist' );
-		$this->assertTrue( is_integer( $site_details['timestamp'] ), 'timestamp should be int' );
-		$this->assertEquals( 100, $site_details['timestamp'], 'timestamp should be 100 since it was mocked to be 100' );
-
-		$this->assertTrue( array_key_exists( 'client_site_id', $site_details ), 'client_site_id should exist' );
-		$this->assertTrue( is_integer( $site_details['client_site_id'] ), 'client_site_id should be int' );
-		$this->assertEquals( 123, $site_details['client_site_id'], 'client_site_id should be 123' );
-
-		$this->assertTrue( array_key_exists( 'environment_name', $site_details ), 'environment_name should exist' );
-		$this->assertTrue( is_string( $site_details['environment_name'] ), 'environment_name should be string' );
-		$this->assertEquals( '', $site_details['environment_name'], 'environment_name should be blank since it\'s not current set' ); // Not set in test environment currently
-
-		$this->assertTrue( array_key_exists( 'plugins', $site_details ), 'plugins should exist' );
-		$this->assertTrue( is_array( $site_details['plugins'] ), 'plugins should be array' );
+		$this->assertSame( 100, $site_details['timestamp'], 'timestamp should be 100 since it was mocked to be 100' );
+		$this->assertSame( 123, $site_details['client_site_id'], 'client_site_id should be 123' );
+		$this->assertSame( '', $site_details['environment_name'], 'environment_name should be blank since it\'s not currently set' ); // Not set in test environment currently
+		$this->assertSame( $wp_version, $site_details['core']['wp_version'], 'wp_version should be equal to global wp_version' );
+		$this->assertSame( get_current_blog_id(), $site_details['core']['blog_id'], 'blog_id should be equal to get_current_blog_id()' );
+		$this->assertSame( get_site_url(), $site_details['core']['site_url'], 'site_url should be equal to get_site_url()' );
+		$this->assertSame( get_home_url(), $site_details['core']['home_url'], 'home_url should be equal to get_home_url()' );
+		$this->assertSame( is_multisite(), $site_details['core']['is_multisite'], 'is_multisite should be equal to is_multisite()' );
 		$this->assertEquals(
-			array(
-				array(
+			[
+				[
 					'path'         => 'hello.php',
 					'name'         => 'Hello Tests',
+					'wporg_slug'   => 'hello-wporg-slug',
 					'version'      => '4.5',
 					'active'       => true,
 					'activated_by' => 'option',
-				),
-				array(
+				],
+				[
 					'path'         => 'world.php',
 					'name'         => 'Testing World',
+					'wporg_slug'   => null, // wasn't present in the update_plugins transient
 					'version'      => '8.6',
 					'active'       => false,
 					'activated_by' => null,
-				),
-			),
-			$site_details['plugins'] 
+				],
+				[
+					'path'         => 'woocommerce/woocommerce.php',
+					'name'         => 'WooCommerce',
+					'wporg_slug'   => 'woocommerce',
+					'version'      => '1.2.3',
+					'active'       => false,
+					'activated_by' => null,
+				],
+			],
+			$site_details['plugins']
 		);
 
-		$this->assertTrue( array_key_exists( 'core', $site_details ), 'core should exist' );
-		$this->assertTrue( is_array( $site_details['core'] ), 'core should be array' );
-
-		$this->assertTrue( array_key_exists( 'wp_version', $site_details['core'] ), 'wp_version should exist in core' );
-		$this->assertTrue( is_string( $site_details['core']['wp_version'] ), 'wp_version should be string' );
-		$this->assertEquals( $wp_version, $site_details['core']['wp_version'], 'wp_version should be equal to global wp_version' );
-
-		$this->assertTrue( array_key_exists( 'blog_id', $site_details['core'] ), 'blog_id should exist in core' );
-		$this->assertTrue( is_integer( $site_details['core']['blog_id'] ), 'blog_id should be int' );
-		$this->assertEquals( get_current_blog_id(), $site_details['core']['blog_id'], 'blog_id should be equal to get_current_blog_id()' );
-
-		$this->assertTrue( array_key_exists( 'site_url', $site_details['core'] ), 'site_url should exist in core' );
-		$this->assertTrue( is_string( $site_details['core']['site_url'] ), 'site_url should be string' );
-		$this->assertEquals( get_site_url(), $site_details['core']['site_url'], 'site_url should be equal to get_site_url()' );
-
-		$this->assertTrue( array_key_exists( 'is_multisite', $site_details['core'] ), 'is_multisite should exist in core' );
-		$this->assertTrue( is_bool( $site_details['core']['is_multisite'] ), 'is_multisite should be bool' );
-		$this->assertEquals( is_multisite(), $site_details['core']['is_multisite'], 'is_multisite should be equal to is_multisite()' );
+		remove_filter( 'pre_site_transient_update_plugins', [ $this, 'mock_update_plugins_transient' ], 999 );
 	}
 
-	public function test__get_default_current_timestamp() {
+	public function mock_update_plugins_transient() {
+		$updates_available = [
+			'hello.php' => (object) [ 'slug' => 'hello-wporg-slug' ],
+		];
+
+		$no_updates = [
+			'woocommerce/woocommerce.php' => (object) [ 'slug' => 'woocommerce' ],
+		];
+
+		// Helps prevent the wp_update_plugins() call from needing to do an actual remote lookup.
+		$checked_plugins = [ 'hello.php' => '4.5', 'world.php' => '8.6', 'woocommerce' => '1.2.3' ];
+
+		return (object) [
+			'last_checked' => time(),
+			'response'     => $updates_available,
+			'no_update'    => $no_updates,
+			'checked'      => $checked_plugins,
+		];
+	}
+
+	public function test__get_current_timestamp() {
 		$timestamp = Site_Details_Index::instance()->get_current_timestamp();
 
 		$this->assertEquals( gmdate( 'd-m-Y', $timestamp / 1000 ), gmdate( 'd-m-Y', round( microtime( true ) ) ) );


### PR DESCRIPTION
## Description

This PR adds the WordPress.org plugin slug to the plugin data for the Sites Details Index.

The process for finding the proper `slug` of a WordPress.org plugin is pretty complicated, as you can't guarantee that the folder/file path is an accurate representation. The only way to know for sure is to use the same process that WP core uses when checking for plugin updates. So that's what we are doing here.

### Unit Testing Changes

Cleaned up the unit test a bit as well, removing a bit of duplicate logic. Testing the output of the `vip_site_details_index_data` filter is sufficient, don't really need to do the exact same checks for one of the functions that are hooked onto the filter. And then rather than testing if the key exists, is of the right type, and has the right value - can just use `assertSame()` which has type safety and will of course throw an error if the index doesn't exist in the array.

For the new logic being tested, I'm mocking the `update_plugins` site transient to both prevent external calls & ensure we are testing all possible scenarios.

## Changelog Description

### Site Details Index: Index the plugin slug for WordPress.org plugins.

Indexes the proper `slug` for WordPress.org-listed plugins.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Is a pretty complicated setup for a full end to end test for this, but the unit tests here are pretty comprehensive for the feature being added.
