### PR TITLE
Auto publish changelog on merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,7 @@ jobs:
                 --wp-endpoint=https://public-api.wordpress.com/wp/v2/sites/wpvipchangelog.wordpress.com/posts \
                 --wp-tag-ids=1784989 \
                 --wp-channel-ids=267076 \
+                --wp-status=publish \
                 --debug
 
   search-dev-tools:


### PR DESCRIPTION
## Description
This is a suggestion PR. Now when we have release channels on [changelog page](https://wpvipchangelog.wordpress.com/). I think we can start to auto-publish staging changelog entries. 

That way the entry is pushed before the release is actually deployed to staging but not much longer in advance and it removes some of our manual work while giving our customers more transparency.

