### PR TITLE
Search: Remove app_id in logging for deleting stale inactive indexes 

### DIFF
--- a/search/includes/classes/class-versioningcleanupjob.php
+++ b/search/includes/classes/class-versioningcleanupjob.php
@@ -135,7 +135,6 @@ class VersioningCleanupJob {
 						'homeurl'         => home_url(),
 						'version_deleted' => $version,
 						'indexable'       => $indexable->slug,
-						'app_id'          => FILES_CLIENT_SITE_ID,
 					],
 				)
 			);


### PR DESCRIPTION
## Description
No need to have the app_id, since it's already in the namespace.