### PR TITLE
Add support for WP 6.0's attachment filesize changes

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -175,7 +175,7 @@ class A8C_Files {
 		if ( defined( 'VIP_JETPACK_SKIP_LOAD' ) && true === VIP_JETPACK_SKIP_LOAD ) {
 			return false;
 		}
-		
+
 		if ( defined( 'WPCOM_VIP_USE_JETPACK_PHOTON' ) && true === WPCOM_VIP_USE_JETPACK_PHOTON ) {
 			return true;
 		}

--- a/files/class-image-sizes.php
+++ b/files/class-image-sizes.php
@@ -16,7 +16,7 @@ class ImageSizes {
 
 	/** @var Image Image to be resized. */
 	public $image;
-	
+
 	/** @var int Attachment ID. */
 	public $attachment_id;
 

--- a/files/class-image.php
+++ b/files/class-image.php
@@ -32,6 +32,9 @@ class Image {
 	/** @var bool $is_resized Whether the attachment has been resized yet, or not. */
 	private $is_resized = false;
 
+	/** @var int $filesize Image original filesize */
+	private $filesize;
+
 	/**
 	 * Constructs the image object.
 	 *
@@ -50,6 +53,7 @@ class Image {
 		$this->width           = $data['width'];
 		$this->height          = $data['height'];
 		$this->mime_type       = $mime_type;
+		$this->filesize        = isset( $data['filesize'] ) ? $data['filesize'] : 0;
 	}
 
 	/**
@@ -82,7 +86,7 @@ class Image {
 	 *
 	 * @param array $size_data Array of width, height, and crop properties of a size.
 	 *
-	 * @return array|\WP_Error An array containing file, width, height, and mime-type keys and it's values. WP_Error on failure.
+	 * @return array|\WP_Error An array containing file, width, height, filesize, and mime-type keys and it's values. WP_Error on failure.
 	 */
 	public function get_size( $size_data ) {
 
@@ -97,6 +101,7 @@ class Image {
 			'width'     => $this->get_width(),
 			'height'    => $this->get_height(),
 			'mime-type' => $this->get_mime_type(),
+			'filesize'  => $this->get_filesize(),
 		];
 	}
 
@@ -155,6 +160,18 @@ class Image {
 	 */
 	public function get_mime_type() {
 		return $this->mime_type;
+	}
+
+	/**
+	 * Returns the images filesize.
+	 *
+	 * Since we don't actually create new files for different attachment sizes,
+	 * the filesize on each entry in the attachment sizes array will just be that of the original.
+	 *
+	 * @return int
+	 */
+	public function get_filesize() {
+		return (int) $this->filesize;
 	}
 
 	/**

--- a/files/class-image.php
+++ b/files/class-image.php
@@ -163,7 +163,7 @@ class Image {
 	}
 
 	/**
-	 * Returns the images filesize.
+	 * Returns the images filesize (in bytes).
 	 *
 	 * Since we don't actually create new files for different attachment sizes,
 	 * the filesize on each entry in the attachment sizes array will just be that of the original.

--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -330,7 +330,10 @@ class VIP_Filesystem {
 	}
 
 	/**
-	 * Filters the generated attachment metadata
+	 * Filters the generated attachment metadata and adds "filesize".
+	 *
+	 * WP 6.0+ will be handling this automatically.
+	 * @see https://core.trac.wordpress.org/ticket/49412
 	 *
 	 * @return array
 	 */

--- a/tests/files/test-image-sizes.php
+++ b/tests/files/test-image-sizes.php
@@ -23,6 +23,13 @@ class A8C_Files_ImageSizes_Test extends WP_UnitTestCase {
 	public $test_image = VIP_GO_MUPLUGINS_TESTS__DIR__ . '/fixtures/image.jpg'; //@todo: consider using `DIR_TESTDATA . '/images/canola.jpg';`
 
 	/**
+	 * The test image's filesize in bytes.
+	 *
+	 * @var int
+	 */
+	public $test_image_filesize = 6941712;
+
+	/**
 	 * The test PDF file.
 	 *
 	 * @var string
@@ -221,6 +228,7 @@ class A8C_Files_ImageSizes_Test extends WP_UnitTestCase {
 			'width'     => intval( $data['width'] ),
 			'height'    => intval( $data['height'] ),
 			'mime-type' => 'image/jpeg',
+			'filesize'  => $this->test_image_filesize,
 		];
 		$this->assertEquals( $expected_resize, $generate_sizes->invokeArgs( $image_sizes, [ $data ] ) );
 	}
@@ -239,36 +247,42 @@ class A8C_Files_ImageSizes_Test extends WP_UnitTestCase {
 						'width'     => 150,
 						'height'    => 150,
 						'mime-type' => 'image/jpeg',
+						'filesize'  => $this->test_image_filesize,
 					],
 					'medium'       => [
 						'file'      => 'image.jpg?resize=300,169',
 						'width'     => 300,
 						'height'    => 169,
 						'mime-type' => 'image/jpeg',
+						'filesize'  => $this->test_image_filesize,
 					],
 					'medium_large' => [
 						'file'      => 'image.jpg?resize=768,432',
 						'width'     => 768,
 						'height'    => 432,
 						'mime-type' => 'image/jpeg',
+						'filesize'  => $this->test_image_filesize,
 					],
 					'large'        => [
 						'file'      => 'image.jpg?resize=1024,576',
 						'width'     => 1024,
 						'height'    => 576,
 						'mime-type' => 'image/jpeg',
+						'filesize'  => $this->test_image_filesize,
 					],
 					'1536x1536'    => [
 						'file'      => 'image.jpg?resize=1536,865',
 						'width'     => 1536,
 						'height'    => 865,
 						'mime-type' => 'image/jpeg',
+						'filesize'  => $this->test_image_filesize,
 					],
 					'2048x2048'    => [
 						'file'      => 'image.jpg?resize=2048,1153',
 						'width'     => 2048,
 						'height'    => 1153,
 						'mime-type' => 'image/jpeg',
+						'filesize'  => $this->test_image_filesize,
 					],
 				],
 			],
@@ -479,17 +493,15 @@ class A8C_Files_ImageSizes_Test extends WP_UnitTestCase {
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $this->test_image ) );
 
 		$postmeta = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
-
 		$this->assertEmpty( $postmeta['sizes'], 'Intermediate image sizes has been physically created.' );
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
-
 		$this->assertNotEmpty( $metadata['sizes'], 'Virtual copies were not created.' );
 	}
 
 	/**
 	 * Integration test of the virtual creation of intermediate sizes for non-image files.
-	 * No physical copies are being created.
+	 * No physical or virtual copies should be created.
 	 *
 	 * @group srcset-pdf
 	 */
@@ -502,14 +514,13 @@ class A8C_Files_ImageSizes_Test extends WP_UnitTestCase {
 		);
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $this->test_pdf ) );
 
-		$postmeta = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
+		$postmeta          = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
+		$postmeta['sizes'] = $postmeta['sizes'] ?? [];
+		$this->assertEmpty( $postmeta['sizes'], 'Intermediate image sizes has been physically created.' );
 
-		$this->assertEmpty( $postmeta, 'Intermediate image sizes has been physically created.' );
-
-		$metadata = wp_get_attachment_metadata( $attachment_id );
-
-		$this->assertEmpty( $metadata, 'Virtual copies were created.' );
-
+		$metadata          = wp_get_attachment_metadata( $attachment_id );
+		$metadata['sizes'] = $metadata['sizes'] ?? [];
+		$this->assertEmpty( $metadata['sizes'], 'Virtual copies were created.' );
 	}
 
 	/**

--- a/tests/files/test-image.php
+++ b/tests/files/test-image.php
@@ -17,6 +17,13 @@ class A8C_Files_Image_Test extends WP_UnitTestCase {
 	public $test_image = VIP_GO_MUPLUGINS_TESTS__DIR__ . '/fixtures/image.jpg'; //@todo: consider using `DIR_TESTDATA . '/images/canola.jpg';`
 
 	/**
+	 * The test image's filesize in bytes.
+	 *
+	 * @var int
+	 */
+	public $test_image_filesize = 6941712;
+
+	/**
 	 * Set the test to the original initial state of the VIP Go.
 	 *
 	 * 1. A8C files being in place, no srcset.
@@ -50,7 +57,7 @@ class A8C_Files_Image_Test extends WP_UnitTestCase {
 
 	/**
 	 * Helper function for accessing protected method.
-	 * 
+	 *
 	 * Renamed from `getMethod` to `get_method` for consistency with `get_property` (see below)
 	 *
 	 * @param string $name Name of the method.
@@ -66,7 +73,7 @@ class A8C_Files_Image_Test extends WP_UnitTestCase {
 
 	/**
 	 * Helper function for accessing protected property.
-	 * 
+	 *
 	 * Renamed from `getProperty` `to `get_property` to avoid conflicts with PHPUnit Polyfill's `getProperty()` method
 	 * which is used by `assertAttributeXXX` assertions.
 	 *
@@ -102,7 +109,14 @@ class A8C_Files_Image_Test extends WP_UnitTestCase {
 		$this->assertEquals( $postmeta['width'], $image->get_width(), 'Wrong image width.' );
 		$this->assertEquals( $postmeta['height'], $image->get_height(), 'Wrong image height.' );
 		$this->assertEquals( 'image/jpeg', $image->get_mime_type(), 'Wrong image mime type.' );
+		$this->assertEquals( $postmeta['filesize'], $image->get_filesize(), 'Wrong image filesize.' );
 		$this->assertFalse( $image->is_resized(), 'Non-resized image is marked as resized.' );
+
+		// If no filesize is passed in, it defaults to 0.
+		$postmeta = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
+		unset( $postmeta['filesize'] );
+		$image = new Automattic\VIP\Files\Image( $postmeta, $attachment_post_data['post_mime_type'] );
+		$this->assertSame( 0, $image->get_filesize(), 'Filesize did not default to 0' );
 	}
 
 	/**
@@ -172,7 +186,7 @@ class A8C_Files_Image_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Unit test covering the object initialisation.
+	 * Test the resize method.
 	 *
 	 * @covers Automattic\VIP\Files\Image::resize
 	 * @dataProvider get_data_for_generate_sizes
@@ -223,6 +237,7 @@ class A8C_Files_Image_Test extends WP_UnitTestCase {
 			'width'     => $expected_resize['width'],
 			'height'    => $expected_resize['height'],
 			'mime-type' => 'image/jpeg',
+			'filesize'  => $this->test_image_filesize,
 		];
 		$this->assertEquals( $expected_size_array, $new_size_array, 'The size array does not match the expected one.' );
 	}


### PR DESCRIPTION
## Description

Fix the currently broken nightly tests :), and adds support for how WP 6.0 will be handling this feature.

With https://core.trac.wordpress.org/ticket/49412 landing in core (WP 6.0), the attachment `filesize` will be saved in attachment postmeta. We happen to [already do this](https://github.com/Automattic/vip-go-mu-plugins/blob/30acf90f5a2cda3466f11fdcdc36b6b8482eb5c4/files/class-vip-filesystem.php#L337-L348), and notably our filter will essentially just early return once core starts adding the meta beforehand. So the switchover on that side of things will be pretty smooth.

Core also stores the `filesize` for each additional attachment/thumbnail sizes though, which we do not currently do. This PR adds in early support for that because once core has this, it becomes an expectation that it exists. Note though that because we don't truly create addition files/thumbnails, there isn't an actual different filesize to be listed. So I opted for just storing the original file's filesize in the place. The other option would be listing `0` which is core's new default for when it can't retrieve a filesize, but I'm leaning towards showing the original filesize being a bit better.

Example:

```
wp> wp_get_attachment_metadata(7);

=> array(6) {
  ["width"]=> int(1353)
  ["height"]=> int(1235)
  ["file"]=> string(24) "2022/03/example.png"
  ["filesize"]=> int(2015937)
  ["sizes"]=>
  array(4) {
    ["medium"]=>
    array(5) {
      ["file"]=> string(24) "example-300x274.png"
      ["width"]=> int(300)
      ["height"]=> int(274)
      ["mime-type"]=> string(9) "image/png"
      ["filesize"]=> int(2015937)
    }
    ["large"]=>
    array(5) {
      ["file"]=> string(25) "example-1024x935.png"
      ["width"]=> int(1024)
      ["height"]=> int(935)
      ["mime-type"]=> string(9) "image/png"
      ["filesize"]=> int(2015937)
    }
    [...]
  }
}
``` 

### Deploy Notes

Let me deploy this please, as I'd like to give it some more testing on live VIP envs while just in staging stacks - both pre-6.0 and nightly builds.

## Changelog Description

### Attachment metadata: Store the filesize within each "additional size" attachment entry.

Stores the attachment's `filesize` within each "virtual sizes" in the attachment metadata. Keeps us in line with how WP core will be handling this same behavior in WP 6.0+: https://core.trac.wordpress.org/ticket/49412

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

- Upload an image.
- Run `wp_get_attachment_metadata( $attachment_id );`

Note that the behavior is different on local dev-envs vs live VIP envs. Live VIP envs should now always have the `filesize` data in the meta and within each additional size. Locally, you'll see this take place only on WP 6.0+ b/c our related code doesn't run when the VIP filesystem isn't initiated.
