### PR TITLE
Remove exception for site 1284

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -543,9 +543,6 @@ class Search {
 		// Disable query fuzziness by default
 		add_filter( 'ep_fuzziness_arg', '__return_zero', 0 );
 
-		// Replace base 'should' with 'must' in Elasticsearch query if formatted args structure matches what's expected
-		add_filter( 'ep_formatted_args', array( $this, 'filter__ep_formatted_args' ), 0, 2 );
-
 		// Disable indexing of filtered content by default, as it's not searched by default
 		add_filter( 'ep_allow_post_content_filtered_index', '__return_false' );
 
@@ -1199,22 +1196,6 @@ class Search {
 			return true;
 		}
 
-		// Bypass a bug in EP Facets that causes aggregations to be run on the main query
-		// This is intended to be a temporary workaround until a better fix is made
-		$bypassed_on_main_query_site_ids = [
-			1284,
-			1286,
-		];
-
-		if ( defined( 'VIP_GO_APP_ID' ) ) {
-			if ( in_array( VIP_GO_APP_ID, $bypassed_on_main_query_site_ids, true ) ) {
-				// Prevent integration on non-search main queries (Facets can wrongly enable itself here)
-				if ( $query && $query->is_main_query() && ! $query->is_search() ) {
-					return true;
-				}
-			}
-		}
-
 		$integration_enabled = self::is_query_integration_enabled();
 
 		// The filter is checking if we should _skip_ query integration...so if it's _not_ enabled
@@ -1712,34 +1693,6 @@ class Search {
 
 		// returns prefix only e.g. 'com.wordpress.elasticsearch.bur.9235_vipgo.search'
 		return implode( '.', $key_parts );
-	}
-
-	/**
-	 * Filter for formatted_args in queries
-	 */
-	public function filter__ep_formatted_args( $formatted_args, $args ) {
-		// Check for expected structure, ie: this filters first
-		if ( ! isset( $formatted_args['query']['bool']['should'][0]['multi_match'] ) ) {
-			return $formatted_args;
-		}
-
-		if ( defined( 'VIP_GO_APP_ID' ) ) {
-			$allow_exact_search_site_ids = array(
-				1284,
-			);
-
-			// Only allow exact search for whitelisted site ids
-			if ( ! in_array( VIP_GO_APP_ID, $allow_exact_search_site_ids, true ) ) {
-				return $formatted_args;
-			}
-		}
-
-		// Replace base 'should' with 'must' and then remove the 'should' from formatted args
-		$formatted_args['query']['bool']['must']                               = $formatted_args['query']['bool']['should'];
-		$formatted_args['query']['bool']['must'][0]['multi_match']['operator'] = 'AND';
-		unset( $formatted_args['query']['bool']['should'] );
-
-		return $formatted_args;
 	}
 
 	public function truncate_search_string_length( &$query ) {

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -1084,35 +1084,6 @@ class Search_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test formatted args structure checks
-	 */
-	public function test__vip_search_filter__ep_formatted_args() {
-		$this->init_es();
-
-		$this->assertEquals( array( 'wrong' ), $this->search_instance->filter__ep_formatted_args( array( 'wrong' ), '' ), 'didn\'t just return formatted args when the structure of formatted args didn\'t match what was expected' );
-
-		$formatted_args = array(
-			'query' => array(
-				'bool' => array(
-					'should' => array(
-						array(
-							'multi_match' => array(
-								'operator' => 'Random string',
-							),
-						),
-						'Random string',
-					),
-				),
-			),
-		);
-
-		$result = $this->search_instance->filter__ep_formatted_args( $formatted_args, '' );
-
-		$this->assertTrue( array_key_exists( 'must', $result['query']['bool'] ), 'didn\'t replace should with must' );
-		$this->assertEquals( $result['query']['bool']['must'][0]['multi_match']['operator'], 'AND', 'didn\'t set the remainder of the query correctly' );
-	}
-
-	/**
 	 * Ensure we disable indexing of filtered content by default
 	 */
 	public function test__vip_search_filter__ep_allow_post_content_filtered_index() {
@@ -3110,7 +3081,7 @@ class Search_Test extends WP_UnitTestCase {
 
 	/**
 	 * Helper function to set required constant, initialize the search instance, and do required action for setting up EP indexables.
-	 * 
+	 *
 	 * @return void
 	 */
 	private function init_es() {


### PR DESCRIPTION
## Description
From the initial days of Enterprise Search we had some per-site implementations in mu-plugins.

The specific site owner has moved those to their client code making it possible for us to remove from mu-plugins repo.

## Changelog Description

### Plugin Updated: Enterprise Search

We have removed deprecated exceptions per site as those were no longer used by anybody.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Search still generates valid queries.
