### PR TITLE
Search: Fix invalid value of "orderby" for Users query

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -101,11 +101,13 @@ class Health {
 		}
 
 		try {
-			// to avoid an expensive orderby query on large datasets, we can set the orderby to none here.
-			$query_args['orderby'] = 'none';
-			// Disable advanced pagination so it doesn't override the orderby set
-			$query_args['ep_indexing_advanced_pagination'] = false;
-			
+			if ( isset( $indexable->slug ) && 'user' !== $indexable->slug ) {
+				// to avoid an expensive orderby query on large datasets, we can set the orderby to none here.
+				$query_args['orderby'] = 'none';
+				// Disable advanced pagination so it doesn't override the orderby set
+				$query_args['ep_indexing_advanced_pagination'] = false;
+			}
+
 			// Get total count in DB
 			$db_result = $indexable->query_db( $query_args );
 
@@ -831,7 +833,7 @@ class Health {
 
 	/**
 	 * Get the last post ID from the database.
-	 * 
+	 *
 	 * @return int $last_db_id The last post ID from the database.
 	 */
 	public static function get_last_db_post_id() {
@@ -845,7 +847,7 @@ class Health {
 
 	/**
 	 * Get the last post ID from Elasticsearch.
-	 * 
+	 *
 	 * @return int $last_es_id The last post ID from ES.
 	 */
 	public static function get_last_es_post_id() {
@@ -869,14 +871,14 @@ class Health {
 
 	/**
 	 * Get the latter post ID between the database and Elasticsearch.
-	 * 
+	 *
 	 * @return int $last The latter post ID.
 	 */
 	public static function get_last_post_id() {
 		$last_db_id = self::get_last_db_post_id();
 		$last_es_id = self::get_last_es_post_id();
 		$last       = max( $last_db_id, $last_es_id );
-		
+
 		return $last;
 	}
 


### PR DESCRIPTION
## Description
Introduced in #2921. For the Users Indexable, `query_db()` uses a direct query, rather than a `WP_User_Query` which forces the value of `orderby` to be `none` in the query (rather than removing it from the SQL statement): https://github.com/Automattic/ElasticPress/blob/cfa08368e168f47ed537c833c288d17b069be889/includes/classes/Indexable/User/User.php#L701.

E.g.
```
SELECT SQL_CALC_FOUND_ROWS ID FROM wp_users ORDER BY none asc LIMIT 0, 350
```

Since the other indexables (Post, Comment, Term) use their respective WP_*_Query for `query_db()`, where `orderby` of `none` is a valid value, we should skip setting it for Users indexable.


## Changelog Description


### Plugin Updated: Enterprise Search
Fix bug where `wp vip-search health validate-counts` was not showing accurate count of users in DB.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Activate users feature: `wp vip-search activate-feature users`
2) Index it: `wp vip-search index`
3) Do `wp vip-search health validate-counts` and see the incorrect results returned:

```
Validating user count

❌  inconsistencies found when counting entity: user, type: N/A, index_version: 1 - (DB: 0, ES: 10, Diff: 10)
```
4) Apply PR
5) Do step 3 again
