### PR TITLE
Admin_Notice: Add Constant_Condition class

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/conditions/class-expression-condition.php';
 require_once __DIR__ . '/conditions/class-date-condition.php';
 require_once __DIR__ . '/conditions/class-capability-condition.php';
 require_once __DIR__ . '/conditions/class-wp-version-condition.php';
+require_once __DIR__ . '/conditions/class-constant-condition.php';
 
 $admin_notice_controller = new Admin_Notice_Controller();
 

--- a/admin-notice/conditions/class-constant-condition.php
+++ b/admin-notice/conditions/class-constant-condition.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Automattic\VIP\Admin_Notice;
+
+class Constant_Condition implements Condition {
+
+	private $constant;
+	private $value;
+
+	public function __construct( string $constant, $value ) {
+		$this->constant = $constant;
+		$this->value    = $value;
+	}
+
+	public function evaluate() {
+		return defined( $this->constant ) && constant( $this->constant ) === $this->value;
+	}
+}

--- a/tests/admin-notice/conditions/test-class-constant-condition.php
+++ b/tests/admin-notice/conditions/test-class-constant-condition.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Automattic\VIP\Admin_Notice;
+
+require_once __DIR__ . '/../../../admin-notice/conditions/interface-condition.php';
+require_once __DIR__ . '/../../../admin-notice/conditions/class-constant-condition.php';
+
+class Constant_Condition_Test extends \PHPUnit\Framework\TestCase {
+
+	public function evaluate_data() {
+		return [
+			[ $this->build_condition( 'TEST_CONSTANT', true ), true ],
+			[ $this->build_condition( 'FOO', 'bar' ), true ],
+			[ $this->build_condition( 'TESTING', 123, false ), false ],
+		];
+	}
+
+	/**
+	 * @dataProvider evaluate_data
+	 */
+	public function test__evaluate( $condition, $expected_result ) {
+		$this->assertEquals( $expected_result, $condition->evaluate() );
+	}
+
+	private function build_condition( string $constant, $value, $defined = true ) {
+		if ( $defined ) {
+			define( $constant, $value );
+		}
+
+		return new Constant_Condition(
+			$constant,
+			$value
+		);
+	}
+}


### PR DESCRIPTION
## Description
Adds a condition to Admin Notice to check if a constant is defined and equates to a certain value

## Changelog Description

### Plugin Updated: Admin Notice

Adds a constant condition to Admin Notice plugin 

## Checklist

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR
2. Add admin notice in admin-notice/admin-notice.php
```
$admin_notice_controller->add(
	new Admin_Notice(
		'Test',
		[
			new Constant_Condition( 'FOO', true ),
		]
) );
```
3. Add conditions
4. Set constant to true `define( 'FOO', true );`
5. See the notice is shown if all conditions are true, otherwise it won't show.
