### PR TITLE
Admin_Notice: Remove notice for 5.9

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -26,20 +26,3 @@ add_action(
 		do_action( 'vip_admin_notice_init', $admin_notice_controller );
 	}
 );
-
-add_action(
-	'vip_admin_notice_init',
-	function( $admin_notice_controller ) {
-		$admin_notice_controller->add(
-			new Admin_Notice(
-				'WordPress 5.9 is targeted for release on January 25, 2022. The latest Release Candidate (RC) is available now. Open a ticket to upgrade a non-prod environment to the latest version for testing.',
-				[
-					new Date_Condition( '2022-01-01', '2022-02-01' ),
-					new WP_Version_Condition( '5.8', '5.9' ),
-					new Capability_Condition( 'administrator' ),
-				],
-				'wp-5.9'
-			)
-		);
-	}
-);


### PR DESCRIPTION
## Description
Let's remove the admin notice for WP 5.9, it's no longer relevant.