### PR TITLE
wp-admin: add notice for Jetpack Search migrations

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -26,3 +26,21 @@ add_action(
 		do_action( 'vip_admin_notice_init', $admin_notice_controller );
 	}
 );
+
+add_action(
+	'vip_admin_notice_init',
+	function( $admin_notice_controller ) {
+		$admin_notice_controller->add(
+			new Admin_Notice(
+				'Jetpack Search custom indexes are targeted for end-of-life on May 4, 2022. <a href="https://lobby.vip.wordpress.com/2022/02/02/enterprise-search-as-default-elasticsearch-solution/" target="_blank" title="Enterprise Search as default Elasticsearch solution">Please use Enterprise Search or Jetpack Instant Search instead.</a>',
+				[
+					new Date_Condition( '2022-01-01', '2022-05-04' ),
+					new Expression_Condition( defined( 'JETPACK_SEARCH_VIP_INDEX' ) && JETPACK_SEARCH_VIP_INDEX ),
+					new Capability_Condition( 'administrator' ),
+				],
+				'search-migrations',
+				'error'
+			)
+		);
+	}
+);

--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -30,9 +30,10 @@ add_action(
 add_action(
 	'vip_admin_notice_init',
 	function( $admin_notice_controller ) {
+		$message = 'Howdy! <br> We have detected the JETPACK_SEARCH_VIP_INDEX constant is still defined on this application. As a friendly reminder, <a href="https://lobby.vip.wordpress.com/2022/02/02/enterprise-search-as-default-elasticsearch-solution/" target="_blank" title="Enterprise Search as default Elasticsearch solution">Jetpack Search custom indexes will no longer be supported on VIP as of May 4, 2022</a>. Please use <a href="https://docs.wpvip.com/how-tos/vip-search/enable/#jetpack-migration-support-path" target="_blank" title="Jetpack migration support path">Enterprise Search</a> or Jetpack Instant Search instead.';
 		$admin_notice_controller->add(
 			new Admin_Notice(
-				'Jetpack Search custom indexes will no longer be supported on VIP as of May 4, 2022. <a href="https://lobby.vip.wordpress.com/2022/02/02/enterprise-search-as-default-elasticsearch-solution/" target="_blank" title="Enterprise Search as default Elasticsearch solution">Please use Enterprise Search or Jetpack Instant Search instead.</a>',
+				$message,
 				[
 					new Date_Condition( '2022-01-01', '2022-05-04' ),
 					new Expression_Condition( defined( 'JETPACK_SEARCH_VIP_INDEX' ) && JETPACK_SEARCH_VIP_INDEX ),

--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -32,7 +32,7 @@ add_action(
 	function( $admin_notice_controller ) {
 		$admin_notice_controller->add(
 			new Admin_Notice(
-				'Jetpack Search custom indexes are targeted for end-of-life on May 4, 2022. <a href="https://lobby.vip.wordpress.com/2022/02/02/enterprise-search-as-default-elasticsearch-solution/" target="_blank" title="Enterprise Search as default Elasticsearch solution">Please use Enterprise Search or Jetpack Instant Search instead.</a>',
+				'Jetpack Search custom indexes will no longer be supported on VIP as of May 4, 2022. <a href="https://lobby.vip.wordpress.com/2022/02/02/enterprise-search-as-default-elasticsearch-solution/" target="_blank" title="Enterprise Search as default Elasticsearch solution">Please use Enterprise Search or Jetpack Instant Search instead.</a>',
 				[
 					new Date_Condition( '2022-01-01', '2022-05-04' ),
 					new Expression_Condition( defined( 'JETPACK_SEARCH_VIP_INDEX' ) && JETPACK_SEARCH_VIP_INDEX ),

--- a/admin-notice/class-admin-notice.php
+++ b/admin-notice/class-admin-notice.php
@@ -42,7 +42,16 @@ class Admin_Notice {
 		}
 
 		printf( '<div %s="%s" class="%s">', esc_html( self::DISMISS_DATA_ATTRIBUTE ), esc_attr( $this->dismiss_identifier ), esc_attr( $notice_class ) );
-		printf( '<p>%s</p>', esc_html( $this->message ) );
+		printf( '<p>%s</p>', wp_kses(
+			$this->message,
+			[
+				'a' => [
+					'href'   => [],
+					'title'  => [],
+					'target' => [],
+				],
+			]
+		) );
 		printf( '</div>' );
 	}
 


### PR DESCRIPTION
## Description
This PR does two things:
- Allows the anchor tag to be used in Admin_Notice
- For sites that still have the `JETPACK_SEARCH_VIP_INDEX` constant defined, adds a notice regarding the EOL.

## Changelog Description

### Plugin Updated: Jetpack Search

Add wp-admin notice to notify user of upcoming end-of-life for Jetpack Search custom indexes

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Check out PR
2) Add `define( 'JETPACK_SEARCH_VIP_INDEX', true );` in vip-config
3) Go to wp-admin and expect to see notice panel
