### PR TITLE
wp-admin: Do not display Search Migrations admin notice for extensions

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -30,6 +30,10 @@ add_action(
 add_action(
 	'vip_admin_notice_init',
 	function( $admin_notice_controller ) {
+		if ( defined( 'SEARCH_MIGRATIONS_EXTENDED_IDS' ) && in_array( FILES_CLIENT_SITE_ID, SEARCH_MIGRATIONS_EXTENDED_IDS, true ) ) {
+			return;
+		}
+
 		$message = 'Howdy! <br> We have detected the JETPACK_SEARCH_VIP_INDEX constant is still defined on this application. As a friendly reminder, <a href="https://lobby.vip.wordpress.com/2022/02/02/enterprise-search-as-default-elasticsearch-solution/" target="_blank" title="Enterprise Search as default Elasticsearch solution">Jetpack Search custom indexes will no longer be supported on VIP as of May 4, 2022</a>. Please use <a href="https://docs.wpvip.com/how-tos/vip-search/enable/#jetpack-migration-support-path" target="_blank" title="Jetpack migration support path">Enterprise Search</a> or Jetpack Instant Search instead.';
 		$admin_notice_controller->add(
 			new Admin_Notice(

--- a/admin-notice/class-admin-notice.php
+++ b/admin-notice/class-admin-notice.php
@@ -50,6 +50,7 @@ class Admin_Notice {
 					'title'  => [],
 					'target' => [],
 				],
+				'br',
 			]
 		) );
 		printf( '</div>' );


### PR DESCRIPTION
## Description
Exclude certain IDs from displaying the message in #3010.