### PR TITLE
Use getallheaders() if available instead of _SERVER superglobal when setting extra headers for Search requests

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -871,19 +871,21 @@ class Search {
 
 		// These are the headers we should pass to better identify the request.
 		$rq_headers = [
-			'HTTP_X_FORWARDED_FOR',
-			'HTTP_TRUE_CLIENT_IP',
-			'HTTP_X_REQUEST_ID',
-			'HTTP_USER_AGENT',
+			'X-Forwarded-For',
+			'True-Client-IP',
+			'X-Request-Id',
+			'User-Agent',
 		];
 
+		$allheaders = function_exists( 'getallheaders' ) ? getallheaders() : [];
+
 		foreach ( $rq_headers as $rq_header ) {
-			if ( ! isset( $_SERVER[ $rq_header ] ) ) {
+			if ( ! isset( $allheaders[ $rq_header ] ) ) {
 				continue;
 			}
 
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$args['headers'][ $rq_header ] = $_SERVER[ $rq_header ];
+			$args['headers'][ $rq_header ] = $allheaders[ $rq_header ];
 		}
 
 		$statsd_mode            = $this->get_statsd_request_mode_for_request( $query['url'], $args );


### PR DESCRIPTION
## Description

#2913 tried to add a few extra headers, unfortunately, there's a bug that prevented the correct headers from being passed. Instead of the proper notation a PHP _SERVER variant was being passed. E.g. `HTTP_USER_AGENT` instead of `User-Agent`. 

This PR addresses that by using `getallheaders()` if available (in web context)

## Changelog Description

### Plugin Updated: Enterprise Search

We've fixed a bug that resulted in not passing extra headers from the Enterprise Search client. 


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Apply the PR
2. Set an XDebug breakpoint around `class-search.php:888`
3. Open a browser tab with XDebug on and hit any search page.
4. Verify that `User-Agent` is present in `$args['headers']`
