### PR TITLE
Parse.ly version manager downloads from WordPress.org

### DIFF
--- a/bin/manage-wp-parsely-subtree.sh
+++ b/bin/manage-wp-parsely-subtree.sh
@@ -8,9 +8,9 @@ if [ $# -lt 2 ]; then
   echo "Example: manage-wp-parsely-subtree.sh 2.4 2.4.1"
   echo
   echo "If subtree already exists:"
-  echo "  This command will update the wp-parsely-2.4 subtree to the tag 2.4.1"
+  echo "  This command will update the wp-parsely-2.4 folder to the tag 2.4.1"
   echo "If the subtree does not already exist:"
-  echo "  This command will create a new subtree wp-parsely-2.4 using the tag 2.4.1"
+  echo "  This command will create a new folder wp-parsely-2.4 using the tag 2.4.1"
   exit 1
 fi
 
@@ -19,12 +19,14 @@ parsely_tag=$2
 
 tree_dir="wp-parsely-${tree_version}"
 if [ -e "$tree_dir" ]; then
-  echo "Updating existing wp-parsely subtree $tree_dir to the tag $parsely_tag"
+  echo "Updating existing wp-parsely folder $tree_dir to the tag $parsely_tag"
 
   rm -rf $tree_dir
 fi
 
-echo "Creating new wp-parsely subtree $tree_dir using tag: $parsely_tag"
+echo "Creating new wp-parsely folder $tree_dir using tag: $parsely_tag"
 
 wget "https://downloads.wordpress.org/plugin/wp-parsely.$parsely_tag.zip"
-unzip "wp-parsely-$parsely_tag.zip" -d $tree_dir
+unzip "wp-parsely.$parsely_tag.zip"
+mv wp-parsely $tree_dir
+rm "wp-parsely.$parsely_tag.zip"

--- a/bin/manage-wp-parsely-subtree.sh
+++ b/bin/manage-wp-parsely-subtree.sh
@@ -19,7 +19,7 @@ parsely_tag=$2
 
 tree_dir="wp-parsely-${tree_version}"
 if [ -e "$tree_dir" ]; then
-  echo "Updating existing wp-parsely folder $tree_dir to the tag $parsely_tag"
+  echo "Removing existing wp-parsely folder $tree_dir with tag $parsely_tag"
 
   rm -rf $tree_dir
 fi

--- a/bin/manage-wp-parsely-subtree.sh
+++ b/bin/manage-wp-parsely-subtree.sh
@@ -21,10 +21,10 @@ tree_dir="wp-parsely-${tree_version}"
 if [ -e "$tree_dir" ]; then
   echo "Updating existing wp-parsely subtree $tree_dir to the tag $parsely_tag"
 
-  git subtree pull --squash -P $tree_dir https://github.com/Parsely/wp-parsely $parsely_tag -m "Update wp-parsely $tree_version subtree to tag $parsely_tag"
-  exit
+  rm -rf $tree_dir
 fi
 
 echo "Creating new wp-parsely subtree $tree_dir using tag: $parsely_tag"
 
-git subtree add --squash -P $tree_dir https://github.com/Parsely/wp-parsely $parsely_tag -m "Add wp-parsely $tree_version subtree with tag $parsely_tag"
+wget "https://downloads.wordpress.org/plugin/wp-parsely.$parsely_tag.zip"
+unzip "wp-parsely-$parsely_tag.zip" -d $tree_dir


### PR DESCRIPTION
## Description

We were previously adding the wp-parsely versions by directly adding a Git subtree from the wp-parsely repository. The issue is that a lot of development-related files got included in the mu-plugins releases, which had many unintended consequences.

We are now shifting this and adding the wp-parsely package from its production version, i.e., we're downloading it from the WordPress.org plugin repository.

PRs with slimmer versions of Parse.ly will follow.

## Changelog Description

### Parse.ly version manager downloads from WordPress.org

We upgraded the way the Parse.ly plugin gets downloaded into mu-plugins.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Run `bin/manage-wp-parsely-subtree.sh 3.1 3.1.3` and check that a slimmer version of Parse.ly is downloaded, but this version keeps working.
