### PR TITLE
Setting Parse.ly 3.2 as the default version

### DIFF
--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -29,6 +29,7 @@ jobs:
         parsely:
           - "2.6"
           - "3.1"
+          - "3.2"
         mode:
           - "filter_enabled"
           - "option_enabled"
@@ -36,7 +37,7 @@ jobs:
           - php: "7.4"
             wp: "latest"
             multisite: "0"
-            parsely: "3.1"
+            parsely: "3.2"
             mode: "filter_and_option_enabled"
     steps:
       - name: Check out source code

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -15,8 +15,8 @@ namespace Automattic\VIP\WP_Parsely_Integration;
 
 // The default version is the first entry in the SUPPORTED_VERSIONS list.
 const SUPPORTED_VERSIONS = [
-	'3.1',
 	'3.2',
+	'3.1',
 	'2.6',
 ];
 


### PR DESCRIPTION
## Description

This PR changes the default wp-parsely version that gets loaded on sites that have the managed support of the plugin enabled. 

We are changing from version 3.1 to 3.2, which does not contain breaking changes.

## Changelog Description

### wp-parsely default version to 3.2

Changed the default version of wp-parsely from 3.1 to 3.2.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Make sure wp-parsely is enabled.
3. Check that the version loaded is 3.2.