### PR TITLE
Updating Parse.ly 3.2 branch to 3.2.1

### DIFF
--- a/wp-parsely-3.2/README.md
+++ b/wp-parsely-3.2/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.2.0  
+Stable tag: 3.2.1  
 Requires at least: 5.0  
 Tested up to: 5.9.2  
 Requires PHP: 7.1  

--- a/wp-parsely-3.2/src/RemoteAPI/class-cached-proxy.php
+++ b/wp-parsely-3.2/src/RemoteAPI/class-cached-proxy.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 
 namespace Parsely\RemoteAPI;
 
-use WP_Error;
-
 /**
  * Caching Decorator for the remote /related endpoint.
  */

--- a/wp-parsely-3.2/src/RemoteAPI/class-wordpress-cache.php
+++ b/wp-parsely-3.2/src/RemoteAPI/class-wordpress-cache.php
@@ -10,27 +10,10 @@ declare(strict_types=1);
 
 namespace Parsely\RemoteAPI;
 
-use WP_Object_Cache;
-
 /**
  * Remote API Adapter for the WordPress Object Cache.
  */
 class WordPress_Cache implements Cache {
-	/**
-	 * The WordPress Object Cache.
-	 *
-	 * @var WP_Object_Cache
-	 */
-	private $cache;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param WP_Object_Cache $cache A class that's compatible with the Cache Interface.
-	 */
-	public function __construct( WP_Object_Cache $cache ) {
-		$this->cache = $cache;
-	}
 
 	/**
 	 * Retrieves the cache contents from the cache by key and group.
@@ -46,7 +29,7 @@ class WordPress_Cache implements Cache {
 	 * @return mixed|false The cache contents on success, false on failure to retrieve contents.
 	 */
 	public function get( $key, string $group = '', bool $force = false, bool $found = null ) {
-		return $this->cache->get( $key, $group, $force, $found );
+		return wp_cache_get( $key, $group, $force, $found );
 	}
 
 	/**
@@ -62,7 +45,8 @@ class WordPress_Cache implements Cache {
 	 *                           Default 0 (no expiration).
 	 * @return bool True on success, false on failure.
 	 */
-	public function set( $key, $data, string $group = '', int $expire = 0 ): bool {
-		return $this->cache->set( $key, $data, $group, $expire );
+	public function set( $key, $data, string $group = '', $expire = 0 ): bool {
+		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+		return wp_cache_set( $key, $data, $group, $expire );
 	}
 }

--- a/wp-parsely-3.2/wp-parsely.php
+++ b/wp-parsely-3.2/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.2.0
+ * Version:           3.2.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -48,7 +48,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.2.0';
+const PARSELY_VERSION = '3.2.1';
 const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';
@@ -141,7 +141,7 @@ function parsely_rest_api_init(): void {
 	$rest->run();
 
 	$proxy        = new Related_Proxy( $GLOBALS['parsely'] );
-	$cached_proxy = new Cached_Proxy( $proxy, new WordPress_Cache( $GLOBALS['wp_object_cache'] ) );
+	$cached_proxy = new Cached_Proxy( $proxy, new WordPress_Cache() );
 	$endpoint     = new Related_API_Proxy( $GLOBALS['parsely'], $cached_proxy );
 	$endpoint->run();
 }


### PR DESCRIPTION
## Description

This PR pulls in the latest minor release of the Parse.ly plugin.

## Changelog Description

### Plugin Updated: Parse.ly 3.2.1

We upgraded wp-parsely from 3.2.0 to 3.2.1

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Sandbox a test VIP Go site to test against (e.g. https://blog.parse.ly)
1. Confirm current status (what plugin version is loading, are meta data printed, is tracking script loaded, etc.)
1. Confirm current status (what plugin version is loading, are meta data printed, is tracking script loaded, etc.)
    * You should see version `3.2.0` at this point and meta data and tracking script should be loaded as before
1. Copy modified files from this branch to the appropriate location on the sandbox (e.g. the `wp-content/mu-plugins/wp-parsely-3.2` directory)
1. Confirm current status (what plugin version is loading, are meta data printed, is tracking script loaded, etc.)
    * You should see version `3.2.1` at this point and meta data and tracking script should be loaded as before

No new errors or warnings should be apparent.