### PR TITLE
Fix update-jetpack-subtree.sh to just remove and add instead

### DIFF
--- a/bin/update-jetpack-subtree.sh
+++ b/bin/update-jetpack-subtree.sh
@@ -19,4 +19,6 @@ fi
 
 echo "Updating jetpack subtree $tree_dir to the jetpack tag $jetpack_tag"
 
-git subtree pull -P $tree_dir --squash https://github.com/Automattic/jetpack-production $jetpack_tag -m "Update jetpack $tree_version subtree to tag $jetpack_tag"
+git rm -r $tree_dir
+git commit -m "Removing $tree_dir for subtree replacement to $jetpack_tag"
+git subtree add -P $tree_dir --squash https://github.com/Automattic/jetpack-production $jetpack_tag -m "Update jetpack $tree_version subtree to tag $jetpack_tag"


### PR DESCRIPTION
## Description
`git subtree` seems to refuse later squash pulls since it can't find earlier adds, so we get an error when attempting to update the subtree when later commits have been added since: 

```
Can't squash-merge: $tree_version was never added.
```

This just modifies the script to remove it and add it back instead since in 99% of scenarios, we'll have commits since the initial subtree addition.