### PR TITLE
Search: Fixed bug when indexing a multisites with over 100 sites in batch mode, a false error of site not existing is returned.

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -145,7 +145,7 @@ class CoreCommand extends \ElasticPress\Command {
 	 *
 	 * [--blog-ids]
 	 * : Index a list of specific blog ids in your multisite work.
-	 * 
+	 *
 	 * [--version]
 	 * : The index version to index into. Used to build up a new index in parallel with the currently active index version.
 	 *
@@ -218,8 +218,6 @@ class CoreCommand extends \ElasticPress\Command {
 
 			$start = microtime( true );
 
-			$all_sites = get_sites( [ 'fields' => 'ids' ] );
-
 			if ( $batch_mode ) {
 				$blog_ids = $assoc_args['blog-ids'];
 				unset( $assoc_args['blog-ids'] );
@@ -233,13 +231,20 @@ class CoreCommand extends \ElasticPress\Command {
 					$sites = [ $blog_ids ];
 				}
 				foreach ( $sites as $site ) {
+					$valid_sites = get_sites(
+						[
+							'fields'   => 'ids',
+							'site__in' => $sites,
+							'number'   => count( $sites ),
+						]
+					);
 					// Verify it's a valid blog ID before proceeding.
-					if ( ! in_array( (int) $site, $all_sites, true ) ) {
+					if ( ! in_array( (int) $site, $valid_sites, true ) ) {
 						WP_CLI::error( "Blog ID {$site} does not exist!" );
 					}
 				}
 			} else {
-				$sites = $all_sites;
+				$sites = get_sites( [ 'fields' => 'ids' ] );
 			}
 
 			foreach ( $sites as $blog_id ) {
@@ -361,9 +366,9 @@ class CoreCommand extends \ElasticPress\Command {
 
 	/**
 	 * Return all index names as a JSON object.
-	 * 
+	 *
 	 * @subcommand get-indexes
-	 * 
+	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
@@ -397,7 +402,7 @@ class CoreCommand extends \ElasticPress\Command {
 	 * : The feature slug
 	 *
 	 * @subcommand activate-feature
-	 * 
+	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
@@ -412,7 +417,7 @@ class CoreCommand extends \ElasticPress\Command {
 
 	/**
 	 * Check if feature is unsupported.
-	 * 
+	 *
 	 * @param string $feature EP feature
 	 * @return bool Whether feature is unsupported or not.
 	 */
@@ -433,7 +438,7 @@ class CoreCommand extends \ElasticPress\Command {
 	 * : The feature slug
 	 *
 	 * @subcommand deactivate-feature
-	 * 
+	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
@@ -448,9 +453,9 @@ class CoreCommand extends \ElasticPress\Command {
 
 	/**
 	 * Get the last indexed post ID on an incomplete indexing operation.
-	 * 
+	 *
 	 * @subcommand get-last-indexed-post-id
-	 * 
+	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
@@ -458,7 +463,7 @@ class CoreCommand extends \ElasticPress\Command {
 		$search = \Automattic\VIP\Search\Search::instance();
 
 		$last_id = get_option( $search::LAST_INDEXED_POST_ID_OPTION );
-		
+
 		if ( false === $last_id ) {
 			WP_CLI::line( 'No last indexed object ID found!' );
 		} else {
@@ -468,9 +473,9 @@ class CoreCommand extends \ElasticPress\Command {
 
 	/**
 	 * Clean the ep_feature_settings individual blog option if it exists for sites with EP_IS_NETWORK.
-	 * 
+	 *
 	 * @subcommand clean-ep-feature-settings
-	 * 
+	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -230,14 +230,14 @@ class CoreCommand extends \ElasticPress\Command {
 					}
 					$sites = [ $blog_ids ];
 				}
+				$valid_sites = get_sites(
+					[
+						'fields'   => 'ids',
+						'site__in' => $sites,
+						'number'   => count( $sites ),
+					]
+				);
 				foreach ( $sites as $site ) {
-					$valid_sites = get_sites(
-						[
-							'fields'   => 'ids',
-							'site__in' => $sites,
-							'number'   => count( $sites ),
-						]
-					);
 					// Verify it's a valid blog ID before proceeding.
 					if ( ! in_array( (int) $site, $valid_sites, true ) ) {
 						WP_CLI::error( "Blog ID {$site} does not exist!" );


### PR DESCRIPTION
## Description
When attempting to index on multisites where there is over 100 sites and using batch mode, it may return a `Error: Blog ID <id> does not exist!` error because the default `number` parameter of `get_sites()` is `100`. This PR fixes that issue by passing in the `site__in` parameter to it and adjusting the `number` to the number of sites passed into batch mode.

## Changelog Description

### Plugin Updated: Enterprise Search

Fixed bug when indexing a multisites with over 100 sites in batch mode, a false error of site not existing is returned.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create a multisite with over 100 sites
2) Attempt to index it in batch mode by passing in a single site ID into the command option `blog-ids` that wouldn't be returned in the first 100: `wp vip-search index --setup --blog-ids=999`
