### PR TITLE
Add hp=vip to kv for stats pixel

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -129,3 +129,12 @@ function send_pixel( $stats ) {
 		'timeout'  => 1,
 	) );
 }
+
+/**
+ * Add extra hp=vip to allow for better tracking via gl
+ */
+add_filter( 'stats_array', __NAMESPACE__ . '\\add_hp' );
+function add_hp( $kvs ) {
+	$kvs['hp'] = 'vip';
+	return $kvs;
+}


### PR DESCRIPTION
## Description

We need that key-value pair for better tracking of VIP sites via Jetpack pixel.

## Changelog Description

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Apply the PR on a sandbox with active Jetpack connection
1. Open the siite's source
1. Verify that `_stq.push(` now contains `hp:"vip"`
