### PR TITLE
Prevent the introduction of known vulnerabilities into the code

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@v3
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@v1


### PR DESCRIPTION
This PR adds a check to prevent the introduction of known supply chain vulnerabilities into our codebase.

Reference: https://github.blog/2022-04-06-prevent-introduction-known-vulnerabilities-into-your-code/