### PR TITLE
GH-2980: make sure `wpcom_vip_override_role_caps()` persists capabilities

### DIFF
--- a/tests/vip-helpers/test-vip-roles.php
+++ b/tests/vip-helpers/test-vip-roles.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Automattic\VIP\Helpers;
+
+use WP_UnitTestCase;
+
+class Test_VIP_Roles extends WP_UnitTestCase {
+	public function test_override_role_caps(): void {
+		wpcom_vip_duplicate_role( 'contributor', 'writer', 'Writer', [] );
+		wpcom_vip_override_role_caps( 'writer', [ 'read' => false ] );
+		wp_roles()->for_site();
+		
+		$actual   = wpcom_vip_get_role_caps( 'writer' );
+		$expected = [ 'read' => false ];
+
+		self::assertEquals( $expected, $actual );
+	}
+}

--- a/vip-helpers/vip-roles.php
+++ b/vip-helpers/vip-roles.php
@@ -88,6 +88,11 @@ function wpcom_vip_override_role_caps( $role, $caps ) {
 
 	$role_obj->capabilities = (array) $caps;
 
+	$roles = wp_roles();
+
+	$roles->roles[ $role ]['capabilities'] = $caps;
+	update_option( $roles->role_key, $roles->roles );
+
 	_wpcom_vip_maybe_refresh_current_user_caps( $role );
 }
 


### PR DESCRIPTION
## Description

This PR fixes #2980 by adding the code to persist the overridden capabilities to the database.

## Changelog Description

### Plugin Updated: VIP Helpers

Bug fix: `wpcom_vip_override_role_caps()` now persists the capabilities to the database.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass -- I have added a test case for this issue.
