### PR TITLE
Pin digests for GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
 			"matchUpdateTypes": ["minor"],
 			"groupName": "all non-major eslint",
 			"groupSlug": "all-minor-patch-eslint"
+		},
+		{
+			"matchDepTypes": ["action"],
+			"pinDigests": true
 		}
 	],
 	"ignorePaths": [


### PR DESCRIPTION
This PR configures Renovate to pin digests for GitHub Actions and update them as necessary.