### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+updates:
+  - directory: /
+    package-ecosystem: github-actions
+    schedule:
+      interval: daily
+
+  - directory: /
+    package-ecosystem: npm
+    schedule:
+      interval: daily
+    versioning-strategy: increase-if-necessary
+
+  - directory: /search/search-dev-tools/
+    package-ecosystem: npm
+    schedule:
+      interval: daily
+    versioning-strategy: increase-if-necessary
+
+  - directory: /
+    package-ecosystem: composer
+    schedule:
+      interval: daily
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Since we removed Renovate in #3060 (sigh), we need to configure Dependabot because we have lock files in non-standard places.
