### PR TITLE
Search: Add fallback elasticsearch version

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -6,6 +6,7 @@ use \WP_CLI;
 use WP_Post;
 
 class Search {
+	public const DEFAULT_ELASTICSEARCH_VERSION      = '7.5.1';
 	public const QUERY_COUNT_CACHE_KEY              = 'query_count';
 	public const QUERY_RATE_LIMITED_START_CACHE_KEY = 'query_rate_limited_start';
 	public const SEARCH_CACHE_GROUP                 = 'vip_search';
@@ -630,6 +631,9 @@ class Search {
 		add_action( 'ep_cli_post_bulk_index', [ $this, 'update_last_processed_post_id_option' ], 10, 2 );
 		add_action( 'ep_wp_cli_after_index', [ $this, 'delete_last_processed_post_id_option' ] );
 		add_action( 'ep_wp_cli_pre_index', [ $this, 'delete_last_processed_post_id_option' ] );
+
+		// Use default ES version as fallback
+		add_filter( 'ep_elasticsearch_version', [ $this, 'fallback_elasticsearch_version' ], PHP_INT_MAX, 1 );
 	}
 
 	protected function load_commands() {
@@ -2282,5 +2286,20 @@ class Search {
 		if ( false !== get_option( self::LAST_INDEXED_POST_ID_OPTION ) ) {
 			delete_option( self::LAST_INDEXED_POST_ID_OPTION );
 		}
+	}
+
+	/**
+	 * Fallback to a default Elasticsearch version string if none is returned.
+	 *
+	 * @param string|bool $version
+	 *
+	 * @return string $version
+	 */
+	public function fallback_elasticsearch_version( $version ) {
+		if ( ! is_string( $version ) ) {
+			$version = self::DEFAULT_ELASTICSEARCH_VERSION;
+		}
+
+		return $version;
 	}
 }


### PR DESCRIPTION
## Description
There's been an increase in `299 Elasticsearch-7.5.1-3ae9ac9a93c95bd0cdc054951cf95d88e1e18d96 "[types removal] Specifying types in search requests is deprecated."` in the warnings which should not be happening since we're on Elasticsearch 7.5.1. This is because requests are being made to `/<index>/post/_search`, when it should be going to `<index>/_search`. 

This is occurring [when this check returns true](https://github.com/10up/ElasticPress/blob/5a9662f95a38477552a7de0b0d3654eec75d0961/includes/classes/Elasticsearch.php#L257) and since the version can potentially be a `false` value if the server doesn't respond (see [here](https://github.com/10up/ElasticPress/blob/5a9662f95a38477552a7de0b0d3654eec75d0961/includes/classes/Elasticsearch.php#L1328) and [here](https://github.com/10up/ElasticPress/blob/5a9662f95a38477552a7de0b0d3654eec75d0961/includes/classes/Elasticsearch.php#L1304)), we should fallback to the current version of 7.5.1 if the value isn't a string.

## Changelog Description

### Plugin Updated: Enterprise Search

Add fallback to default Elasticsearch version to prevent deprecated types being requested.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Add a filter that runs at priority of 10 to return false:
```
add_filter( 'ep_elasticsearch_version', 'test_ep_elasticsearch_version', 10, 1 );

function test_ep_elasticsearch_version( $version ) {
	return false;
}
```
2. Temporarily change value of `DEFAULT_ELASTICSEARCH_VERSION` to whatever you want as a test
3. Shell in:
```
$ wp shell
wp> \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();
```
Expect to see value from step 2 returned.