### PR TITLE
Search: Extend Elasticsearch info cache expiration

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -634,6 +634,8 @@ class Search {
 
 		// Use default ES version as fallback
 		add_filter( 'ep_elasticsearch_version', [ $this, 'fallback_elasticsearch_version' ], PHP_INT_MAX, 1 );
+
+		add_filter( 'ep_es_info_cache_expiration', [ $this, 'filter__es_info_cache_expiration' ], PHP_INT_MAX, 1 );
 	}
 
 	protected function load_commands() {
@@ -2291,9 +2293,8 @@ class Search {
 	/**
 	 * Fallback to a default Elasticsearch version string if none is returned.
 	 *
-	 * @param string|bool $version
-	 *
-	 * @return string $version
+	 * @param string|bool $version Elasticsearch version
+	 * @return string $version New Elasticsearch version
 	 */
 	public function fallback_elasticsearch_version( $version ) {
 		if ( ! is_string( $version ) ) {
@@ -2301,5 +2302,15 @@ class Search {
 		}
 
 		return $version;
+	}
+
+	/**
+	 * Extend default elasticsearch info cache expiration from 5 minutes.
+	 *
+	 * @param int $time Cache time in seconds
+	 * @return int $time New cache time in seconds
+	 */
+	public function filter__es_info_cache_expiration( $time ) {
+		return wp_rand( 24 * HOUR_IN_SECONDS, 36 * HOUR_IN_SECONDS );
 	}
 }


### PR DESCRIPTION
## Description
Default cache time is at 5 minutes which is too low, since this info almost never typically changes (unless an ES upgrade occurs). It's safe to leave it cached for a much longer period of time to avoid doing repeated requests for the information in `get_elasticsearch_info()` after expiration:

https://github.com/Automattic/ElasticPress/blob/be49944aab4723bd699173b356f21dbd916939cd/includes/classes/Elasticsearch.php#L1379-L1385

## Changelog Description

### Plugin Updated: Enterprise Search

Increase cache expiration in get_elasticsearch_info().

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Shell in and populate the cache:
```
\ElasticPress\Elasticsearch::factory()->get_elasticsearch_info();
```
2) Check that the transient hasn't expired after 5 minutes: `get_site_transient( 'ep_es_info' );`