### PR TITLE
Search: Throw error when delete-index command is attempted to be used

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -334,18 +334,15 @@ class CoreCommand extends \ElasticPress\Command {
 	}
 
 	/**
-	 * Delete the index for each indexable. !!Warning!! This removes your elasticsearch index(s)
-	 * for the entire site.
+	 * Throw error when delete-index command is attempted to be used.
 	 *
-	 * @synopsis [--index-name] [--network-wide] [--skip-confirm]
 	 * @subcommand delete-index
 	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function delete_index( $args, $assoc_args ) {
-		self::confirm_destructive_operation( $assoc_args );
-		parent::delete_index( $args, $assoc_args );
+		WP_CLI::error( 'Please use index versioning to manage your indices: https://docs.wpvip.com/how-tos/vip-search/version-with-enterprise-search/' );
 	}
 
 	/**


### PR DESCRIPTION
## Description
We should disallow the command `wp vip-search delete-index` since it doesn't take into account the index versioning nor does it block deleting an active version.

## Changelog Description

### Plugin Updated: Enterprise Search

Disable delete-index command and recommend to use index versioning instead.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Attempt to run command `wp vip-search delete-index` and expect error
