### PR TITLE
Enable JP staging mode during data syncs

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -228,11 +228,6 @@ if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && ! defined( 'WP_ENVIRONMENT_TYPE' ) )
 	}
 
 	define( 'WP_ENVIRONMENT_TYPE', $environment_type );
-
-	// VIP sites should not be set as staging in Jetpack
-	// since it breaks SSO and prevents data from being passed to
-	// WordPress.com
-	add_filter( 'jetpack_is_staging_site', '__return_false' );
 }
 
 // Load config related helpers


### PR DESCRIPTION
## Description

Enable Jetpack staging mode on non-production environments while maintenance mode is active (targeting data syncs).

The goal being to prevent child sites from taking over the parent site's connection during a data sync (before we've had the chance to remove the synced-over parent data and restore the child site's connection info).

Also brought all the functionality together in `jetpack.php` since it was a bit spread out, and only runs if we are planning to load the JP plugins.

The other consideration is to maybe make it so maintenance mode also gives a 503 even to JP requests for child sites during MM, here: https://github.com/Automattic/vip-go-mu-plugins/blob/master/000-vip-init.php#L61-L63. But in theory, enabling `jetpack_is_staging_site` should be sufficient for preventing the IDC issues. Nothing this just in case it turns out to not be. 

## Changelog Description

### Plugin Updated: VIP Jetpack Customizations

Enable Jetpack staging mode on non-production environments while maintenance mode is active (targeting data syncs).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Not very straightforward to test.
