### PR TITLE
Enterprise Search Shows Number of Indexed documents in version list

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -46,8 +46,9 @@ class Health {
 	public $search;
 
 	public function __construct( \Automattic\VIP\Search\Search $search ) {
-		$this->search     = $search;
-		$this->indexables = \ElasticPress\Indexables::factory();
+		$this->search        = $search;
+		$this->indexables    = \ElasticPress\Indexables::factory();
+		$this->elasticsearch = \ElasticPress\Elasticsearch::factory();
 	}
 
 	/**
@@ -1069,5 +1070,38 @@ class Health {
 			'index_version' => $index_version,
 			'result'        => $result,
 		);
+	}
+	/**
+	 * Fetches the count of entities in ES indexable
+	 *
+	 * @since   1.0.0
+	 * @access  public
+	 * @param mixed $indexable Instance of an ElasticPress Indexable Object to search on
+	 * @param array $options options:
+	 *     index_version: if provided that version will be use instead of default
+	 * @return int
+	 */
+	public function index_count( \ElasticPress\Indexable $indexable, array $options = array() ) {
+		if ( isset( $options['index_version'] ) ) {
+			$this->search->versioning->set_current_version_number( $indexable, $options['index_version'] );
+		}
+		$index = $indexable->get_index_name();
+
+		$response      = $this->elasticsearch->remote_request( $index . '/_count' );
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		$result = 0;
+		if ( 200 == $response_code ) {
+			$response_body_json = wp_remote_retrieve_body( $response );
+			$response_body      = json_decode( $response_body_json, true );
+
+			$result = $response_body['count'] ?? 0;
+		}
+
+		if ( isset( $options['index_version'] ) ) {
+			$this->search->versioning->reset_current_version_number( $indexable );
+		}
+
+		return $result;
 	}
 }

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -181,6 +181,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 		$type = $args[0];
 
 		$search = \Automattic\VIP\Search\Search::instance();
+		$health = new \Automattic\VIP\Search\Health( $search );
 
 		$indexable = \ElasticPress\Indexables::factory()->get( $type );
 
@@ -220,11 +221,15 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 		} else {
 			$versions = $search->versioning->get_versions( $indexable );
 
+			foreach ( $versions as &$version ) {
+				$version['document_count'] = $health->index_count( $indexable, [ 'index_version' => $version['number'] ] );
+			}
+
 			if ( is_wp_error( $versions ) ) {
 				return WP_CLI::error( $versions->get_error_message() );
 			}
 
-			\WP_CLI\Utils\format_items( $assoc_args['format'] ?? 'table', $versions, array( 'number', 'active', 'created_time', 'activated_time' ) );
+			\WP_CLI\Utils\format_items( $assoc_args['format'] ?? 'table', $versions, array( 'number', 'active', 'created_time', 'activated_time', 'document_count' ) );
 		}
 	}
 

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -203,21 +203,23 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 
 				$site_versions = $search->versioning->get_versions( $indexable );
 
-				restore_current_blog();
-
 				if ( is_wp_error( $site_versions ) ) {
+					restore_current_blog();
 					return WP_CLI::error( $site_versions->get_error_message() );
 				}
 
 				foreach ( $site_versions as &$version ) {
-					$version['blog_id'] = $site['blog_id'];
-					$version['url']     = $site['domain'] . $site['path'];
+					$version['blog_id']        = $site['blog_id'];
+					$version['url']            = $site['domain'] . $site['path'];
+					$version['document_count'] = $health->index_count( $indexable, [ 'index_version' => $version['number'] ] );
 				}
+
+				restore_current_blog();
 
 				$versions = array_merge( $versions, $site_versions );
 			}
 
-			\WP_CLI\Utils\format_items( $assoc_args['format'] ?? 'table', $versions, array( 'blog_id', 'url', 'number', 'active', 'created_time', 'activated_time' ) );
+			\WP_CLI\Utils\format_items( $assoc_args['format'] ?? 'table', $versions, array( 'blog_id', 'url', 'number', 'active', 'created_time', 'activated_time', 'document_count' ) );
 		} else {
 			$versions = $search->versioning->get_versions( $indexable );
 


### PR DESCRIPTION

## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

## Changelog Description

### Plugin Updated: Enterprise Search

`wp vip-search index-versions list post` now shows the number of documents in each index version. This makes it easier to see if it is safe to switch to a new version.

```
$ wp vip-search index-versions list post
+--------+--------+--------------+----------------+----------------+
| number | active | created_time | activated_time | document_count |
+--------+--------+--------------+----------------+----------------+
| 1      | 1      |              |                | 2              |
| 2      |        | 1650979622   |                | 0              |
+--------+--------+--------------+----------------+----------------+
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Check out the PR
2) Run `wp vip-search index-versions list post` 
3) Add a post/user
4) Change should be propagated.

