### PR TITLE
GH-3092: PHP 8 compat: offset must be contained in haystack for strpos()

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -311,12 +311,16 @@ class VIP_Filesystem {
 	 */
 	private function clean_file_path( $file_path ) {
 		$upload_path = wp_get_upload_dir();
+		$basedir     = $upload_path['basedir'];
+		$basedir_len = strlen( $basedir );
 
-		// Find 2nd occurrence of `basedir`
-		$pos = strpos( $file_path, $upload_path['basedir'], strlen( $upload_path['basedir'] ) );
-		if ( false !== $pos ) {
-			// +1 to account far trailing slash
-			$file_path = substr( $file_path, strlen( $upload_path['basedir'] ) + 1 );
+		// Find 2nd occurrence of `basedir`; `$file_path` should be at least twice as long as `basedir`
+		if ( strlen( $file_path ) >= 2 * $basedir_len ) {
+			$pos = strpos( $file_path, $basedir, $basedir_len );
+			if ( false !== $pos ) {
+				// +1 to account far trailing slash
+				$file_path = substr( $file_path, $basedir_len + 1 );
+			}
 		}
 
 		// Strip any query params that snuck through


### PR DESCRIPTION
## Description

This PR fixes a bug described in #3092: it adds a check to make sure that the `$offset` parameter to `strpos()` is contained in the `$haystack` parameter to avoid fatal errors in PHP 8.

Fixes: #3092

## Changelog Description

### Plugin Updated: VIP Filesystem

Fix compatibility issues with PHP 8.x.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
