### PR TITLE
GH-1850: Replace create_function() with a closure

### DIFF
--- a/debug-bar-cron/debug-bar-cron.php
+++ b/debug-bar-cron/debug-bar-cron.php
@@ -35,7 +35,9 @@ if ( ! function_exists( 'debug_bar_cron_has_parent_plugin' ) ) {
 		$file = plugin_basename( __FILE__ );
 
 		if ( is_admin() && ( ! class_exists( 'Debug_Bar' ) && current_user_can( 'activate_plugins' ) ) && is_plugin_active( $file ) ) {
-			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Cron</strong> Plugin. %sVisit your plugins page to install & activate.\', \'debug-bar-cron\' ), \'<a href="\' . esc_url( admin_url( \'plugin-install.php?tab=search&s=debug+bar\' ) ) . \'">\' ), \'</a></p></div>\';' ) );
+			add_action( 'admin_notices', function () {
+				echo '<div class="error"><p>', sprintf( __( 'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Cron</strong> Plugin. %sVisit your plugins page to install & activate.', 'debug-bar-cron' ), '<a href="' . esc_url( admin_url( 'plugin-install.php?tab=search&s=debug+bar' ) ) . '">' ), '</a></p></div>';
+			} );
 
 			deactivate_plugins( $file, false, is_network_admin() );
 


### PR DESCRIPTION
## Description

Fixes: #1850 

This PR applies PHP 8.0 compatibility fixes to the `debug-bar-cron` plugin. 

## Changelog Description

### Plugin Updated: Debug Bar Cron

Ensure compatibility with PHP 8.0

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
