### PR TITLE
Use PHP 8.0 for linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@ workflows:
   version: 2
   main:
     jobs:
+      - php-lint
       - php74-core-tests
       - php74-core-multisite-tests
-      - php74-lint
       - php74-build-singlesite
       - php74-build-singlesite-58
       - php74-build-singlesite-57
@@ -130,7 +130,7 @@ jobs:
       - image: ghcr.io/automattic/vip-container-images/wp-core-test-runner
       - image: *db_image
 
-  php74-lint:
+  php-lint:
     <<: *lint_job
     docker:
       - image: cimg/php:8.0-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
   php74-lint:
     <<: *lint_job
     docker:
-      - image: cimg/php:7.4-node
+      - image: cimg/php:8.0-node
 
   php74-build-multisite:
     <<: *php_job

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -766,13 +766,11 @@ function vip_get_random_posts( $number = 1, $post_type = 'post', $return_ids = f
 		return $post_ids;
 	}
 
-	$random_posts = get_posts( array(
+	return get_posts( array(
 		'post__in'    => $post_ids,
-		'numberposts' => count( $post_ids ),
+		'numberposts' => count( $post_ids ), // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_numberposts
 		'post_type'   => $post_type,
 	) );
-
-	return $random_posts;
 }
 
 /**


### PR DESCRIPTION
Replace `cimg/php:7.4-node` with `cimg/php:8.0-node` for linting jobs so that we can catch syntax errors specific to PHP 8 (phpcs does not check syntax).