### PR TITLE
Jetpack: Default version to 10.9

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 10.8
+ * Version: 10.9
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -25,7 +25,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.8', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.4' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.8' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.9' );
 	}
 }
 


### PR DESCRIPTION
## Description
The default Jetpack version will now be 10.8

## Changelog Description

### Plugin Updated: Jetpack

We upgraded the default Jetpack version to Jetpack 10.9.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. Go to wp-admin > Jetpack
3. Verify default Jetpack version is 10.9