### PR TITLE
Search: Fix double UI bug appearing for single sites

### DIFF
--- a/search/includes/classes/class-dashboard.php
+++ b/search/includes/classes/class-dashboard.php
@@ -4,8 +4,10 @@ namespace Automattic\VIP\Search;
 
 class Dashboard {
 	public function __construct() {
-		// Ensure Search menu is available on a per-site basis, whether EP_IS_NETWORK is defined or not. 
-		add_action( 'admin_menu', '\ElasticPress\Dashboard\action_admin_menu' );
+		// Ensure Search menu should be available on a per-site basis when EP_IS_NETWORK is defined.
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			add_action( 'admin_menu', '\ElasticPress\Dashboard\action_admin_menu' );
+		}
 
 		add_action( 'admin_menu', array( __CLASS__, 'admin_menu' ) );
 		add_action( 'network_admin_menu', array( __CLASS__, 'network_admin_menu' ) );


### PR DESCRIPTION
## Description
In single sites, it's been reported that there's a double UI admin menu showing — so we should only append the UI if `EP_IS_NETWORK` is defined (else it will already be appended resulting in a double UI)

## Changelog Description

### Plugin Updated: Enterprise Search

Fix bug on single sites where a double UI admin menu was showing twice.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create single site
2) Go to wp-admin
3) See double menu
4) Apply PR
5) See menu singular now