### PR TITLE
Check if Jetpack is loaded before trying to fetch the details

### DIFF
--- a/rest-api/vip-endpoints.php
+++ b/rest-api/vip-endpoints.php
@@ -39,6 +39,8 @@ class WPCOM_VIP_REST_API_Endpoints {
 
 	/**
 	 * Register API routes
+	 *
+	 * Please check the logs for usage/consult the wider team before considering the removal of these endpoints.
 	 */
 	public function rest_api_init() {
 		register_rest_route( $this->namespace, '/sites/', array(
@@ -248,13 +250,18 @@ class WPCOM_VIP_REST_API_Endpoints {
 	 * @return array
 	 */
 	protected function get_jetpack_details_for_site(): array {
-		$connection = new Automattic\Jetpack\Connection\Manager();
-		$data       = [
-			'site_id'       => get_current_blog_id(),
-			'cache_site_id' => Jetpack::get_option( 'id' ),
-			'home_url'      => home_url(),
-			'is_active'     => $connection->is_active(),
+		$data = [
+			'site_id'  => get_current_blog_id(),
+			'home_url' => home_url(),
 		];
+
+		if ( class_exists( 'Jetpack' ) ) {
+			$connection = new Automattic\Jetpack\Connection\Manager();
+			$data       = array_merge( $data, [
+				'cache_site_id' => Jetpack::get_option( 'id' ),
+				'is_active'     => $connection->is_active(),
+			] );
+		}
 
 		return $data;
 	}


### PR DESCRIPTION
## Description

Previously: #3115 led to #3119.

We deemed the endpoint `/vip/v1/jetpack` cruft but in reality, it was used in a limited but very important case. The original PR came up because of an edge-case where disabled Jetpack would lead to endpoint fatals.

This PR addresses that by checking whether Jetpack class exists before trying to fetch the blog id and connection status.

## Changelog Description

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Check out PR, switch permissions_callback to `__return_true`, hit the endpoint with Jetpack on and off, and verify that it doesn't fatal anymore. 
