### PR TITLE
Skip "noindex" and "nofollow" if needed

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -246,6 +246,14 @@ add_filter( 'wp_headers', function( $headers ) {
 	$headers['X-Powered-By'] = 'WordPress VIP <https://wpvip.com>';
 	$headers['Host-Header']  = 'a9130478a60e5f9135f765b23f26593b'; // md5 -s wpvip
 
+	// By default, the 'vip_index_noprod_domains' filter returns an empty array (to prevent indexing any non-production sites).
+	$index_noprod_domains = apply_filters( 'vip_index_noprod_domains', '__return_empty_array' );
+
+	// Skip "noindex" and "nofollow" the site if the filter 'vip_index_noprod_domains' returns true or contains the current domain.
+	if ( true === $index_noprod_domains || in_array( $_SERVER['SERVER_NAME'], $index_noprod_domains, true ) ) {
+		return $headers;
+	}
+
 	// Non-production applications and go-vip.(co|net) domains should not be indexed.
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- should be safe, because we are only looking for a substring and don't use the variable for anything else
 	if ( 'production' !== VIP_GO_ENV || false !== strpos( $_SERVER['HTTP_HOST'] ?? '', '.go-vip.' ) ) {

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -247,7 +247,7 @@ add_filter( 'wp_headers', function( $headers ) {
 	$headers['Host-Header']  = 'a9130478a60e5f9135f765b23f26593b'; // md5 -s wpvip
 
 	// By default, the 'vip_index_noprod_domains' filter returns an empty array (to prevent indexing any non-production sites).
-	$index_noprod_domains = apply_filters( 'vip_index_noprod_domains', '__return_empty_array' );
+	$index_noprod_domains = apply_filters( 'vip_index_noprod_domains', [] );
 
 	// Skip "noindex" and "nofollow" the site if the filter 'vip_index_noprod_domains' returns true or contains the current domain.
 	if ( true === $index_noprod_domains || in_array( $_SERVER['SERVER_NAME'], $index_noprod_domains, true ) ) {

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -250,7 +250,7 @@ add_filter( 'wp_headers', function( $headers ) {
 	$index_noprod_domains = apply_filters( 'vip_index_noprod_domains', [] );
 
 	// Skip "noindex" and "nofollow" the site if the filter 'vip_index_noprod_domains' returns true or contains the current domain.
-	if ( true === $index_noprod_domains || in_array( $_SERVER['SERVER_NAME'], $index_noprod_domains, true ) ) {
+	if ( true === $index_noprod_domains || ( is_array( $index_noprod_domains ) && in_array( $_SERVER['SERVER_NAME'], $index_noprod_domains, true ) ) ) {
 		return $headers;
 	}
 


### PR DESCRIPTION
## Description

By default, all non-production sites aren't indexed but there's a chance that people want to make these sites indexable WEBCCG-182]. For this reason, I'm suggesting adding a new filter (`vip_index_noprod_domains`) to let any dev specify if their non-production sites should be indexed or to provide a list of domains of non-production sites that should be indexed. 

For example, this could be used to force the indexation of all or some non-production sites:

```
// Index all non-production sites.
add_filter( 'vip_index_noprod_domains', '__return_true' );

// Index a wanted non-product sites (specifying their domain).
add_filter( 'vip_index_noprod_domains', 'index_my_custom_domains' );

function index_my_custom_domains( $domains ) {
	$domains_to_index = array(
		'example-domain-1.dev',
		'example-domain-2.dev'
	);
	return $domains_to_index;
}
```


## Changelog Description (not sure if needed for this)

### Plugin Updated: VIP Mu-plugin (000-vip-init.php)

We've added the `vip_index_noprod_domains` to let anyone specify if their non-production sites should be indexed or to provide a list of domains of non-production sites that should be indexed (by default all non-production environments aren't indexed).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [X] I've created a changelog description that aligns with the provided examples.
- [ ] This change has relevant documentation additions / updates (if applicable).


## Steps to Test

1. Create a sandbox of a site and open it in any browser
2. Check the response headers of a page and confirm that by default the `X-Robots-Tag` header is set to `noindex, nofollow`
3. Edit the theme's functions.php (for example) and add the following code:
```
// Index all non-production sites.
add_filter( 'vip_index_noprod_domains', '__return_true' );
```
4. Reload the page and confirm that the `X-Robots-Tag` header isn't set.
5. Remove the previous code and reload the page to confirm that the `X-Robots-Tag` header is set again.
6. Edit the functions.php file again and add the following code (replacing {DOMAIN} with the sandbox domain.
```
// Index a wanted non-product sites (specifying their domain).
add_filter( 'vip_index_noprod_domains', 'index_my_custom_domains' );

function index_my_custom_domains( $domains ) {
	$domains_to_index = array(
		'{DOMAIN}'
	);
	return $domains_to_index;
}
```
7. Reload the page and confirm that the `X-Robots-Tag` header isn't set.
8. Remove the previous code and reload the page to confirm that the `X-Robots-Tag` header is set again.