### PR TITLE
Updating Parse.ly 3.3 branch to 3.3.2

### DIFF
--- a/wp-parsely-3.3/README.md
+++ b/wp-parsely-3.3/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.3.1  
+Stable tag: 3.3.2  
 Requires at least: 5.0  
 Tested up to: 5.9.3  
 Requires PHP: 7.1  

--- a/wp-parsely-3.3/src/UI/class-metadata-renderer.php
+++ b/wp-parsely-3.3/src/UI/class-metadata-renderer.php
@@ -104,7 +104,7 @@ final class Metadata_Renderer {
 
 		// Assign default values for LD+JSON
 		// TODO: Mapping of an install's post types to Parse.ly post types (namely page/post).
-		$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $post );
+		$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $parsed_post );
 
 		// Something went wrong - abort.
 		if ( 0 === count( $metadata ) || ! isset( $metadata['headline'] ) ) {

--- a/wp-parsely-3.3/wp-parsely.php
+++ b/wp-parsely-3.3/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.3.1
+ * Version:           3.3.2
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -49,7 +49,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.3.1';
+const PARSELY_VERSION = '3.3.2';
 const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
## Description

This PR pulls in the latest minor release of the Parse.ly plugin.

## Changelog Description

### Plugin Updated: Parse.ly 3.3.2

We upgraded wp-parsely from 3.3.1 to 3.3.2

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Sandbox a test VIP Go site to test against (e.g. https://blog.parse.ly)
1. Confirm current status (what plugin version is loading, are meta data printed, is tracking script loaded, etc.)
1. Confirm current status (what plugin version is loading, are meta data printed, is tracking script loaded, etc.)
    * You should see version `3.3.1` at this point and meta data and tracking script should be loaded as before
1. Copy modified files from this branch to the appropriate location on the sandbox (e.g. the `wp-content/mu-plugins/wp-parsely-3.3` directory)
1. Confirm current status (what plugin version is loading, are meta data printed, is tracking script loaded, etc.)
    * You should see version `3.3.2` at this point and meta data and tracking script should be loaded as before

No new errors or warnings should be apparent.