### PR TITLE
Jetpack 10.9 Hotfix: Fix namespacing issue in Publicize

### DIFF
--- a/jetpack-10.9/jetpack_vendor/automattic/jetpack-publicize/src/class-publicize.php
+++ b/jetpack-10.9/jetpack_vendor/automattic/jetpack-publicize/src/class-publicize.php
@@ -91,7 +91,7 @@ class Publicize extends Publicize_Base {
 	 * Show a warning when Publicize does not have a connection.
 	 */
 	public function admin_page_warning() {
-		$jetpack   = Jetpack::init();
+		$jetpack   = \Jetpack::init();
 		$blog_name = get_bloginfo( 'blogname' );
 		if ( empty( $blog_name ) ) {
 			$blog_name = home_url( '/' );
@@ -309,7 +309,7 @@ class Publicize extends Publicize_Base {
 						break;
 					case 'empty_state':
 						/* translators: %s is the URL of the Jetpack admin page */
-						$error = sprintf( __( 'No user information was included in your request. Please make sure that your user account has connected to Jetpack. Connect your user account by going to the <a href="%s">Jetpack page</a> within wp-admin.', 'jetpack-publicize-pkg' ), Jetpack::admin_url() );
+						$error = sprintf( __( 'No user information was included in your request. Please make sure that your user account has connected to Jetpack. Connect your user account by going to the <a href="%s">Jetpack page</a> within wp-admin.', 'jetpack-publicize-pkg' ), \Jetpack::admin_url() );
 						break;
 					default:
 						$error = __( 'Something which should never happen, happened. Sorry about that. If you try again, maybe it will work.', 'jetpack-publicize-pkg' );


### PR DESCRIPTION
## Description
Mirrors https://github.com/Automattic/jetpack-production/commit/a4552152c8ae189fc30b9dc0a476230f4c9ad391.

Fixes fatal at `http://wp-admin/options-general.php?page=sharing`:

```
 Fatal error: Uncaught Error: Class 'Automattic\Jetpack\Publicize\Jetpack' not found
in /var/www/wp-content/mu-plugins/jetpack-10.9/jetpack_vendor/automattic/jetpack-publicize/src/class-publicize.php on line 94

Call stack:

Automattic\J\P\Publicize::admin_page_warning()
wp-includes/class-wp-hook.php:307
WP_Hook::apply_filters()
wp-includes/class-wp-hook.php:331
WP_Hook::do_action()
wp-includes/plugin.php:474
do_action()
wp-content/mu-plugins/jetpack-10.9/modules/sharedaddy/sharing.php:242
Sharing_Admin::management_page()
wp-content/mu-plugins/jetpack-10.9/_inc/lib/admin-pages/class.jetpack-admin-page.php:403
Jetpack_Admin_Page::wrap_ui()
wp-content/mu-plugins/jetpack-10.9/modules/sharedaddy/sharing.php:205
Sharing_Admin::wrapper_admin_page()
wp-includes/class-wp-hook.php:307
WP_Hook::apply_filters()
wp-includes/class-wp-hook.php:331
WP_Hook::do_action()
wp-includes/plugin.php:474
do_action()
wp-admin/admin.php:259
require_once()
wp-admin/options-general.php:10
```

## Changelog Description

### Plugin Updated: Jetpack 10.9

Fixes namespacing issue in Publicize.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Go to /wp-admin/options-general.php?page=sharing
2) See fatal
3) Apply PR
4) See no moar fatal
