### PR TITLE
Add additional data to MemcachePool errors.

### DIFF
--- a/lib/wpcom-error-handler/wpcom-error-handler.php
+++ b/lib/wpcom-error-handler/wpcom-error-handler.php
@@ -110,7 +110,8 @@ function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file,
 		( '/var/www/wp-content/object-cache-stable.php' === $file || '/var/www/wp-content/object-cache-next.php' === $file )
 	) {
 		$type = E_WARNING;
-		foreach ( debug_backtrace() as $trace => $value ) { // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue, WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		foreach ( debug_backtrace() as $value ) {
 			if ( 'wpcom_error_handler' === $value['function'] && str_starts_with( $value['args'][1], 'MemcachePool::' ) ) {
 				$message .= sprintf(
 					' (Key: %s, Group: %s, Data Size: %s)',


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

While we have a maximum size of (compressed) data per individual cache key, right now we have no way of determining what keys might be causing these issues at the application layer.

Currently, we will see PHP notices such as this:

> `Notice: MemcachePool::set(): Server example.local. (tcp 12345, udp 0) failed with: SERVER_ERROR object too large for cache (3)`

I'm hoping we can use our custom error handler to extract additional information from the backtrace and add it to the message. I'm also moving this to `E_WARNING` because, in my opinion, this is more in line with the severity of an error like this. Having objects uncached can cause site stability issues.

The new messages would look more like this:

> `Warning: MemcachePool::set(): Server example.local. (tcp 12345, udp 0) failed with: SERVER_ERROR object too large for cache (3) (Key: test123, Group: default, Data Size: 19999999)`

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Library Updated: wpcom-error-handler

Added more descriptive messages for MemcachePool errors.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

I've been testing this in a sandbox using this snippet in a client-mu-plugin:

```php
if ( isset( $_GET['mc-test'] ) && 'thisisabadidea' === $_GET['mc-test'] ) {
	ini_set('display_errors', 1);
	ini_set('display_startup_errors', 1);
	error_reporting(E_ALL);
	$string = substr(str_shuffle(str_repeat($x='12345', ceil(20000000/strlen($x)) )),1,20000000);
	wp_cache_set( 'test123', $string );
	wp_die( 'Ran a large MC test with a size of ' . number_format( strlen( $string ) ) );
}
```

