### PR TITLE
Add PHP 8 migration notice on non-prods

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -52,3 +52,24 @@ add_action(
 		);
 	}
 );
+
+// PHP 8 migration nudge on non-prods
+add_action(
+	'vip_admin_notice_init',
+	function( $admin_notice_controller ) {
+
+		$message = 'PHP 7.4 will <a href="https://href.li/?https://www.php.net/supported-versions.php" target="_blank"> stop receiving security updates</a> on November 28, 2022. On this date, all sites on WordPress VIP still using PHP 7.4 will be upgraded to PHP 8.0 to minimize the risk from unpatched security vulnerabilities. To learn more, please see the <a href="https://lobby.vip.wordpress.com/2022/05/02/php-8-0-available-on-wordpress-vip/" target="_blank">Lobby announcement</a> and the guide on <a href="https://docs.wpvip.com/how-tos/code-scanning-for-php-upgrade/">how to prepare your application for a PHP version upgrade</a>';
+
+		$admin_notice_controller->add(
+			new Admin_Notice(
+				$message,
+				[
+					new Expression_Condition( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ),
+					new Expression_Condition( version_compare( PHP_VERSION, '8.0', '<' ) ),
+				],
+				'php8-migrations',
+				'info'
+			)
+		);
+	}
+);

--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -57,8 +57,7 @@ add_action(
 add_action(
 	'vip_admin_notice_init',
 	function( $admin_notice_controller ) {
-
-		$message = 'PHP 7.4 will <a href="https://href.li/?https://www.php.net/supported-versions.php" target="_blank"> stop receiving security updates</a> on November 28, 2022. On this date, all sites on WordPress VIP still using PHP 7.4 will be upgraded to PHP 8.0 to minimize the risk from unpatched security vulnerabilities. To learn more, please see the <a href="https://lobby.vip.wordpress.com/2022/05/02/php-8-0-available-on-wordpress-vip/" target="_blank">Lobby announcement</a> and the guide on <a href="https://docs.wpvip.com/how-tos/code-scanning-for-php-upgrade/">how to prepare your application for a PHP version upgrade</a>';
+		$message = 'PHP 7.4 will <a href="https://href.li/?https://www.php.net/supported-versions.php" target="_blank"> stop receiving security updates</a> on November 28, 2022. On this date, all sites on WordPress VIP still using PHP 7.4 will be upgraded to PHP 8.0 to minimize the risk from unpatched security vulnerabilities. To learn more, please see the <a href="https://lobby.vip.wordpress.com/2022/05/02/php-8-0-available-on-wordpress-vip/" target="_blank">Lobby announcement</a> and the guide on <a href="https://docs.wpvip.com/how-tos/code-scanning-for-php-upgrade/">how to prepare your application for a PHP version upgrade</a>.';
 
 		$admin_notice_controller->add(
 			new Admin_Notice(


### PR DESCRIPTION
## Description

Just to give folks an extra nudge it was decided to introduce a new notice that would display on non-prods. 
It's likely we'll have to adjust the slug a few times in case folks would dismiss and forget about it. 

## Changelog Description

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

On dev-env: 
1. Check out the PR
2. Start a VIP local dev env using PHP 7.4
3. Verify the notice is displayed.