### PR TITLE
Add restrictions for wpcomvp user

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -195,6 +195,9 @@ require_once __DIR__ . '/vip-helpers/vip-deprecated.php';
 require_once __DIR__ . '/vip-helpers/vip-syndication-cache.php';
 require_once __DIR__ . '/vip-helpers/vip-migrations.php';
 require_once __DIR__ . '/vip-helpers/class-user-cleanup.php';
+require_once __DIR__ . '/vip-helpers/class-wpcomvip-restrictions.php';
+
+add_action( 'init', [ WPComVIP_Restrictions::class, 'instance' ] );
 
 //enabled on selected sites for now
 if ( true === defined( 'WPCOM_VIP_CLEAN_TERM_CACHE' ) && true === constant( 'WPCOM_VIP_CLEAN_TERM_CACHE' ) ) {

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -10,6 +10,7 @@
  */
 
 use Automattic\VIP\Utils\Context;
+use Automattic\VIP\Utils\WPComVIP_Restrictions;
 
 /**
  * By virtue of the filename, this file is included first of

--- a/tests/vip-helpers/test-wpcomvip-restrictions.php
+++ b/tests/vip-helpers/test-wpcomvip-restrictions.php
@@ -1,0 +1,130 @@
+<?php
+
+// phpcs:disable WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+
+namespace Automattic\VIP\Tests;
+
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_UnitTest_Factory;
+use WP_UnitTestCase;
+
+class Test_WPComVIP_Restrictions extends WP_UnitTestCase {
+	private static $user_id;
+	private static $post_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		$user = get_user_by( 'login', 'wpcomvip' );
+		if ( false === $user ) {
+			self::$user_id = $factory->user->create([
+				'user_login' => 'wpcomvip',
+				'role'       => 'Administrator',
+			]);
+		} else {
+			self::$user_id = $user->ID;
+		}
+
+		self::$post_id = $factory->post->create([
+			'post_title'   => 'Test Post',
+			'post_content' => 'Lorem ipsum sit amet',
+			'post_author'  => 1,
+		]);
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( 1 );
+	}
+
+	public function test_insert_post(): void {
+		$data = [
+			'post_author'  => self::$user_id,
+			'post_title'   => 'Test',
+			'post_content' => 'Test',
+		];
+
+		$post_id = wp_insert_post( $data );
+		self::assertNotInstanceOf( WP_Error::class, $post_id );
+
+		$post = get_post( $post_id );
+		self::assertInstanceOf( WP_Post::class, $post );
+
+		self::assertEquals( 1, $post->post_author );
+	}
+
+	public function test_update_post(): void {
+		$data = [
+			'ID'          => self::$post_id,
+			'post_author' => self::$user_id,
+		];
+
+		$result = wp_update_post( $data );
+		self::assertNotInstanceOf( WP_Error::class, $result );
+
+		$actual = get_post( self::$post_id );
+		self::assertInstanceOf( WP_Post::class, $actual );
+
+		self::assertEquals( 1, $actual->post_author );
+	}
+
+	public function test_insert_attachment(): void {
+		$data = [
+			'post_title'   => 'Test Attachment',
+			'post_content' => 'No strings attached',
+			'post_author'  => 1,
+		];
+
+		$att_id = wp_insert_attachment( $data, false, 0 );
+		self::assertNotInstanceOf( WP_Error::class, $att_id );
+
+		$post = get_post( $att_id );
+		self::assertInstanceOf( WP_Post::class, $post );
+
+		self::assertEquals( 1, $post->post_author );
+	}
+
+	/**
+	 * @dataProvider data_wp_dropdown_users
+	 */
+	public function test_wp_dropdown_users( array $args ): void {
+		$html = wp_dropdown_users( $args + [
+			'show' => 'user_login',
+			'echo' => false,
+		] );
+
+		self::assertStringNotContainsString( 'wpcomvip', $html );
+	}
+
+	public function data_wp_dropdown_users(): iterable {
+		return [
+			[
+				[],
+			],
+			[
+				[ 'exclude' => 1048576 ],
+			],
+			[
+				[ 'exclude' => '1048576' ],
+			],
+			[
+				[ 'exclude' => [ 1048576 ] ],
+			],
+		];
+	}
+
+	public function test_rest_api(): void {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$response = rest_do_request( $request );
+
+		self::assertFalse( $response->is_error() );
+		
+		$data = $response->get_data();
+		self::assertIsArray( $data );
+		self::assertCount( 1, $data );
+		self::assertArrayHasKey( 0, $data );
+		self::assertIsArray( $data[0] );
+		self::assertArrayHasKey( 'id', $data[0] );
+		self::assertEquals( 1, $data[0]['id'] );
+	}
+}

--- a/tests/vip-helpers/test-wpcomvip-restrictions.php
+++ b/tests/vip-helpers/test-wpcomvip-restrictions.php
@@ -127,4 +127,21 @@ class Test_WPComVIP_Restrictions extends WP_UnitTestCase {
 		self::assertArrayHasKey( 'id', $data[0] );
 		self::assertEquals( 1, $data[0]['id'] );
 	}
+
+	public function test_insert_post_wpcomvip(): void {
+		wp_set_current_user( self::$user_id );
+		$data = [
+			'post_author'  => self::$user_id,
+			'post_title'   => 'Test',
+			'post_content' => 'Test',
+		];
+
+		$post_id = wp_insert_post( $data );
+		self::assertNotInstanceOf( WP_Error::class, $post_id );
+
+		$post = get_post( $post_id );
+		self::assertInstanceOf( WP_Post::class, $post );
+
+		self::assertEquals( 0, $post->post_author );
+	}
 }

--- a/tests/vip-helpers/test-wpcomvip-restrictions.php
+++ b/tests/vip-helpers/test-wpcomvip-restrictions.php
@@ -15,6 +15,10 @@ class Test_WPComVIP_Restrictions extends WP_UnitTestCase {
 	private static $post_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		remove_all_filters( 'pre_get_lastpostmodified' );
+		remove_all_filters( 'transition_post_status' );
+		remove_all_filters( 'wpcom_vip_bump_lastpostmodified' );
+
 		$user = get_user_by( 'login', 'wpcomvip' );
 		if ( false === $user ) {
 			self::$user_id = $factory->user->create([

--- a/vip-helpers/class-wpcomvip-restrictions.php
+++ b/vip-helpers/class-wpcomvip-restrictions.php
@@ -25,7 +25,8 @@ class WPComVIP_Restrictions {
 		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
 
 		if ( false !== $wpcomvip && isset( $data['post_author'] ) && $data['post_author'] == $wpcomvip->ID ) {
-			$data['post_author'] = get_current_user_id();
+			$current_user_id     = get_current_user_id();
+			$data['post_author'] = $current_user_id == $wpcomvip->ID ? 0 : $current_user_id;
 		}
 
 		return $data;
@@ -36,14 +37,14 @@ class WPComVIP_Restrictions {
 	
 		if ( false !== $wpcomvip ) {
 			if ( empty( $query_args['exclude'] ) ) {
-                // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 				$query_args['exclude'] = [ $wpcomvip->ID ];
 			} else {
 				$exclude = is_array( $query_args['exclude'] ) ? $query_args['exclude'] : (string) $query_args['exclude'];
 				$list    = wp_parse_id_list( $exclude );
 				$list[]  = $wpcomvip->ID;
 
-                // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 				$query_args['exclude'] = $list;
 			}
 		}

--- a/vip-helpers/class-wpcomvip-restrictions.php
+++ b/vip-helpers/class-wpcomvip-restrictions.php
@@ -36,14 +36,14 @@ class WPComVIP_Restrictions {
 	
 		if ( false !== $wpcomvip ) {
 			if ( empty( $query_args['exclude'] ) ) {
-                // phpcs:disable WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+                // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 				$query_args['exclude'] = [ $wpcomvip->ID ];
 			} else {
 				$exclude = is_array( $query_args['exclude'] ) ? $query_args['exclude'] : (string) $query_args['exclude'];
 				$list    = wp_parse_id_list( $exclude );
 				$list[]  = $wpcomvip->ID;
 
-                // phpcs:disable WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+                // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 				$query_args['exclude'] = $list;
 			}
 		}

--- a/vip-helpers/class-wpcomvip-restrictions.php
+++ b/vip-helpers/class-wpcomvip-restrictions.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Automattic\VIP\Utils;
+
 class WPComVIP_Restrictions {
 	protected static $instance = null;
 

--- a/vip-helpers/class-wpcomvip-restrictions.php
+++ b/vip-helpers/class-wpcomvip-restrictions.php
@@ -1,0 +1,61 @@
+<?php
+
+class WPComVIP_Restrictions {
+	protected static $instance = null;
+
+	public static function instance(): self {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_filter( 'wp_insert_post_data', [ $this, 'restrict_post_author' ], PHP_INT_MAX );
+		add_filter( 'wp_insert_attachment_data', [ $this, 'restrict_post_author' ], PHP_INT_MAX );
+		add_filter( 'wp_dropdown_users_args', [ $this, 'restrict_post_author_dropdown' ], PHP_INT_MAX );
+		add_filter( 'rest_user_query', [ $this, 'restrict_post_author_dropdown' ], PHP_INT_MAX );
+		add_filter( 'coauthors_edit_ignored_authors', [ $this, 'restrict_post_author_dropdown_coauthors' ], PHP_INT_MAX );
+	}
+
+	public function restrict_post_author( array $data ): array {
+		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+
+		if ( false !== $wpcomvip && isset( $data['post_author'] ) && $data['post_author'] == $wpcomvip->ID ) {
+			$data['post_author'] = get_current_user_id();
+		}
+
+		return $data;
+	}
+
+	public function restrict_post_author_dropdown( array $query_args ): array {
+		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+	
+		if ( false !== $wpcomvip ) {
+			if ( empty( $query_args['exclude'] ) ) {
+                // phpcs:disable WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+				$query_args['exclude'] = [ $wpcomvip->ID ];
+			} else {
+				$exclude = is_array( $query_args['exclude'] ) ? $query_args['exclude'] : (string) $query_args['exclude'];
+				$list    = wp_parse_id_list( $exclude );
+				$list[]  = $wpcomvip->ID;
+
+                // phpcs:disable WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+				$query_args['exclude'] = $list;
+			}
+		}
+
+		return $query_args;
+	}
+
+	public function restrict_post_author_dropdown_coauthors( array $ignored_authors ): array {
+		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+	
+		if ( false !== $wpcomvip ) {
+			$ignored_authors[] = $wpcomvip->user_nicename;
+		}
+	
+		return $ignored_authors;
+	}
+}


### PR DESCRIPTION
## Description

This PR adds some restrictions for `wpcomvip` user:
* it does not show up in REST;
* it cannot be attributed any posts/pages/attachments;
* it is excluded from `wp_dropdown_users()`.

## Changelog Description

### Plugin Updated: VIP Helpers

Add restrictions to `wpcomvip` user to improve security.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
