### PR TITLE
Skip remote_request_disabled errors from logs, they're noisy and don't actually tell us there's an issue with backend

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1064,7 +1064,7 @@ class Search {
 			// TODO: Report actual request, once we make sure all its fields are sanitized and publishable
 			$encoded_request = 'Not an error.';
 		}
-		
+
 		if ( is_wp_error( $response ) ) {
 			$error_messages        = $response->get_error_messages();
 			$response_failure_code = $response->get_error_code();

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1053,6 +1053,9 @@ class Search {
 			return;
 		}
 
+		// The error code for  the failed response.
+		$response_failure_code = '';
+
 		$is_cli = defined( 'WP_CLI' ) && WP_CLI;
 
 		if ( is_wp_error( $request ) ) {
@@ -1061,9 +1064,10 @@ class Search {
 			// TODO: Report actual request, once we make sure all its fields are sanitized and publishable
 			$encoded_request = 'Not an error.';
 		}
-
+		
 		if ( is_wp_error( $response ) ) {
-			$error_messages = $response->get_error_messages();
+			$error_messages        = $response->get_error_messages();
+			$response_failure_code = $response->get_error_code();
 
 			foreach ( $error_messages as $error_message ) {
 				$stat = $this->is_curl_timeout( $error_message ) ? '.timeout' : '.error';
@@ -1088,6 +1092,11 @@ class Search {
 			$this->maybe_increment_stat( $statsd_prefix . '.error' );
 
 			$error_type = 'search_query_error';
+		}
+
+		// remote_request_disabled is noisy and doesn't necessarily mean that backend is timing out because the request is never made.
+		if ( 'remote_request_disabled' === $response_failure_code ) {
+			return;
 		}
 
 		if ( ! $is_cli ) {


### PR DESCRIPTION
## Description

The defensive logic in `vip_safe_wp_remote_request` returns a `remote_request_disabled` error with highly varying error message, which makes it difficult to filter for in logs. Moreover, since the request is never made it would not be indicative of the backend health. 

## Changelog Description

### Plugin Updated: Enterprise Search

We've implemented error logging improvements to improve signal-to-noise ratio. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
