### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/test-performance-lastpostmodified.php
+++ b/tests/test-performance-lastpostmodified.php
@@ -30,12 +30,6 @@ class lastpostmodified_Test extends WP_UnitTestCase {
 		$this->assertEquals( 1, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
 	}
 
-	public function test__transition_post_status__save_on_update() {
-		\wp_transition_post_status( 'publish', 'publish', $this->post );
-
-		$this->assertEquals( 1, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
-	}
-
 	public function test__transition_post_status__ignore_non_publish_status() {
 		\wp_transition_post_status( 'draft', 'future', $this->post );
 

--- a/tests/test-performance-lastpostmodified.php
+++ b/tests/test-performance-lastpostmodified.php
@@ -8,11 +8,6 @@ use WP_UnitTestCase;
 class lastpostmodified_Test extends WP_UnitTestCase {
 	protected $post;
 
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
-		Last_Post_Modified::init();
-	}
-
 	public function setUp(): void {
 		/** @var wpdb $wpdb */
 		global $wpdb;

--- a/tests/test-performance-lastpostmodified.php
+++ b/tests/test-performance-lastpostmodified.php
@@ -8,8 +8,18 @@ use WP_UnitTestCase;
 class lastpostmodified_Test extends WP_UnitTestCase {
 	protected $post;
 
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		Last_Post_Modified::init();
+	}
+
 	public function setUp(): void {
+		/** @var wpdb $wpdb */
+		global $wpdb;
 		parent::setUp();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", Last_Post_Modified::OPTION_PREFIX . '%' ) );
 
 		$this->post = $this->factory->post->create_and_get( [ 'post_status' => 'draft' ] );
 	}

--- a/tests/vip-helpers/test-wpcomvip-restrictions.php
+++ b/tests/vip-helpers/test-wpcomvip-restrictions.php
@@ -15,10 +15,6 @@ class Test_WPComVIP_Restrictions extends WP_UnitTestCase {
 	private static $post_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
-		remove_all_filters( 'pre_get_lastpostmodified' );
-		remove_all_filters( 'transition_post_status' );
-		remove_all_filters( 'wpcom_vip_bump_lastpostmodified' );
-
 		$user = get_user_by( 'login', 'wpcomvip' );
 		if ( false === $user ) {
 			self::$user_id = $factory->user->create([


### PR DESCRIPTION
It looks like `lastpostmodified_Test` is sensitive to the order in which our tests run and may fail if other tests update a post and run before it.

This PR tries to fix this behavior.
