### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/test-performance-lastpostmodified.php
+++ b/tests/test-performance-lastpostmodified.php
@@ -20,31 +20,39 @@ class lastpostmodified_Test extends WP_UnitTestCase {
 	}
 
 	public function test__transition_post_status__save_on_publish() {
+		$before = did_action( 'wpcom_vip_bump_lastpostmodified' );
 		\wp_transition_post_status( 'publish', 'publish', $this->post );
+		$after = did_action( 'wpcom_vip_bump_lastpostmodified' );
 
-		$this->assertEquals( 1, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+		$this->assertEquals( 1, $after - $before );
 	}
 
 	public function test__transition_post_status__ignore_non_publish_status() {
+		$before = did_action( 'wpcom_vip_bump_lastpostmodified' );
 		\wp_transition_post_status( 'draft', 'future', $this->post );
+		$after = did_action( 'wpcom_vip_bump_lastpostmodified' );
 
-		$this->assertEquals( 0, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+		$this->assertEquals( 0, $after - $before );
 	}
 
 	public function test__transition_post_status__ignore_non_public_post_type() {
+		$before                = did_action( 'wpcom_vip_bump_lastpostmodified' );
 		$this->post->post_type = 'book';
+		$after                 = did_action( 'wpcom_vip_bump_lastpostmodified' );
 
 		\wp_transition_post_status( 'publish', 'publish', $this->post );
 
-		$this->assertEquals( 0, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+		$this->assertEquals( 0, $after - $before );
 	}
 
 	public function test__transition_post_status__ignore_when_locked() {
+		$before = did_action( 'wpcom_vip_bump_lastpostmodified' );
 		// The first update sets the lock so the action should only fire once when updating twice
 		\wp_transition_post_status( 'publish', 'publish', $this->post );
 		\wp_transition_post_status( 'publish', 'publish', $this->post );
+		$after = did_action( 'wpcom_vip_bump_lastpostmodified' );
 
-		$this->assertEquals( 1, did_action( 'wpcom_vip_bump_lastpostmodified' ) );
+		$this->assertEquals( 1, $after - $before );
 	}
 
 	public function test__bump_lastpostmodified__any() {


### PR DESCRIPTION
Fix tests that are relying upon the order they run in.

If another test edits a post, it is possible that `did_action( 'wpcom_vip_bump_lastpostmodified' )` will be more than the test expects. To counter this, we check the difference between values retrieved before and after the action.
