### PR TITLE
Check if headers has already been sent before sending new ones

### DIFF
--- a/security.php
+++ b/security.php
@@ -165,7 +165,10 @@ function wpcom_vip_login_limit_xmlrpc_error( $error, $user ) {
 add_filter( 'xmlrpc_login_error', 'wpcom_vip_login_limit_xmlrpc_error', 10, 2 );
 
 function wpcom_set_status_header_on_xmlrpc_failed_login_requests( $error ) {
-	header( "X-XMLRPC-Error-Code: {$error->code}" );
+	if ( ! headers_sent() ) {
+		header( "X-XMLRPC-Error-Code: {$error->code}" );
+	}
+
 	return $error;
 }
 add_action( 'xmlrpc_login_error', 'wpcom_set_status_header_on_xmlrpc_failed_login_requests' );

--- a/wpcom-vip-two-factor/is-jetpack-sso.php
+++ b/wpcom-vip-two-factor/is-jetpack-sso.php
@@ -29,8 +29,10 @@ add_action( 'jetpack_sso_handle_login', function( $user, $user_data ) {
 }, 10, 2 );
 
 add_action( 'clear_auth_cookie', function() {
-	setcookie( VIP_IS_JETPACK_SSO_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
-	setcookie( VIP_IS_JETPACK_SSO_2SA_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+	if ( ! headers_sent() ) {
+		setcookie( VIP_IS_JETPACK_SSO_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( VIP_IS_JETPACK_SSO_2SA_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+	}
 } );
 
 function is_jetpack_sso() {


### PR DESCRIPTION
This PR fixes several tests by adding a check whether the headers have already been sent before invoking a function that sends additional headers.

This primarily affects WP Core Tests and the cases when it is impossible to mock `header()` and related functions.

Split from #3059 
