### PR TITLE
Skip problematic plugins on WP installation

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -175,4 +175,6 @@ function vip_jetpack_load() {
 	}
 }
 
-vip_jetpack_load();
+if ( ! defined( 'WP_INSTALLING' ) ) {
+	vip_jetpack_load();
+}

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -111,7 +111,9 @@ function wpcom_vip_qm_require() {
 	// We know we haven't got the QM DB drop-in in place, so don't show the message
 	add_filter( 'qm/show_extended_query_prompt', '__return_false' );
 }
-add_action( 'plugins_loaded', 'wpcom_vip_qm_require', 1 );
+if ( ! defined( 'WP_INSTALLING' ) ) {
+	add_action( 'plugins_loaded', 'wpcom_vip_qm_require', 1 );
+}
 
 /**
  * Hooks the wp action to avoid showing Query Monitor on 404 pages

--- a/two-factor.php
+++ b/two-factor.php
@@ -155,7 +155,10 @@ function wpcom_vip_enforce_two_factor_plugin() {
 	}
 }
 
-add_action( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
+if ( ! defined( 'WP_INSTALLING' ) ) {
+	add_action( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
+}
+
 function wpcom_enable_two_factor_plugin() {
 	$enable_two_factor = apply_filters( 'wpcom_vip_enable_two_factor', true );
 	if ( true !== $enable_two_factor ) {

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -46,7 +46,9 @@ add_filter( 'pre_scan_file', function( $should_skip_file, $file ) {
 	return $should_skip_file;
 }, 10, 2 );
 
-require_once __DIR__ . '/vaultpress/vaultpress.php';
+if ( ! defined( 'WP_INSTALLING' ) ) {
+	require_once __DIR__ . '/vaultpress/vaultpress.php';
+}
 
 add_filter( 'in_admin_header', 'vip_remove_vaultpress_connect_notice' );
 

--- a/vip-support.php
+++ b/vip-support.php
@@ -7,4 +7,6 @@
  * License:      GPLv2 or later
  */
 
-require_once __DIR__ . '/vip-support/vip-support.php';
+if ( ! defined( 'WP_INSTALLING' ) ) {
+	require_once __DIR__ . '/vip-support/vip-support.php';
+}


### PR DESCRIPTION
This PR disables the loading of several problematic plugins when `WP_INSTALLING` is `true`. The affected plugins access the database before WP has a chance to create tables, which leads to unpleasant error messages.

Related: #3059 