### PR TITLE
Update debug-bar to 1.1.3

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -4,7 +4,7 @@ Plugin Name: Debug Bar
 Plugin URI: https://wordpress.org/plugins/debug-bar/
 Description: Adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information.
 Author: wordpressdotorg
-Version: 1.1.2
+Version: 1.1.3
 Author URI: https://wordpress.org/
 Text Domain: debug-bar
 */

--- a/debug-bar/debug-bar.php
+++ b/debug-bar/debug-bar.php
@@ -4,7 +4,7 @@
  Plugin URI: https://wordpress.org/plugins/debug-bar/
  Description: Adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information.
  Author: wordpressdotorg
- Version: 1.1.2
+ Version: 1.1.3
  Author URI: https://wordpress.org/
  Text Domain: debug-bar
  */

--- a/debug-bar/panels/class-debug-bar-wp-query.php
+++ b/debug-bar/panels/class-debug-bar-wp-query.php
@@ -10,7 +10,7 @@ class Debug_Bar_WP_Query extends Debug_Bar_Panel {
 	}
 
 	function render() {
-		global $template, $wp_query;
+		global $template, $wp_query, $wpdb;
 
 		$queried_object = get_queried_object();
 		if ( $queried_object && isset( $queried_object->post_type ) ) {
@@ -87,7 +87,11 @@ class Debug_Bar_WP_Query extends Debug_Bar_Panel {
 
 		if ( ! empty( $wp_query->request ) ) {
 			echo '<h3>', __( 'Query SQL:', 'debug-bar' ), '</h3>';
-			echo '<p>' . esc_html( $wp_query->request ) . '</p>';
+			if ( is_callable( array( $wpdb, 'remove_placeholder_escape' ) ) ) {
+				echo '<p>' . esc_html( $wpdb->remove_placeholder_escape( $wp_query->request ) ) . '</p>';
+			} else {
+				echo '<p>' . esc_html( $wp_query->request ) . '</p>';
+			}
 		}
 
 		if ( ! is_null( $queried_object ) ) {

--- a/debug-bar/readme.txt
+++ b/debug-bar/readme.txt
@@ -1,8 +1,8 @@
 === Debug Bar ===
 Contributors: wordpressdotorg, ryan, westi, koopersmith, duck_, mitchoyoshitaka, dd32, jrf, obenland, nacin, evansolomon, Otto42, aidvu, josephscott
 Tags: debug
-Tested up to: 5.5.3
-Stable tag: 1.1.2
+Tested up to: 6.0
+Stable tag: 1.1.3
 Requires at least: 3.4
 
 Adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information.
@@ -28,6 +28,10 @@ Add a PHP/MySQL console with the [Debug Bar Console plugin](https://wordpress.or
 There are numerous other add-ons available to get more insight into, for instance, the registered Post Types, Shortcodes, WP Cron, Language file loading, Actions and Filters and so on. Just [search the plugin directory for 'Debug Bar'](https://wordpress.org/plugins/search/debug+bar/).
 
 == Upgrade Notice ==
+
+= 1.1.3 =
+- Fix notices in HTTP Requests panel when a request is stopped/doesn't finish.
+- Decode the SQL in the WP_Query panel.
 
 = 1.1.2 =
 Fix error checking in HTTP Requests panel.
@@ -114,6 +118,10 @@ Added deprecated function usage tracking
 Initial Release
 
 == Changelog ==
+
+= 1.1.3 =
+- Fix notices in HTTP Requests panel when a request is stopped/doesn't finish.
+- Decode the SQL in the WP_Query panel.
 
 = 1.1.2 =
 Fix error checking in HTTP Requests panel.


### PR DESCRIPTION
## Description

Update debug-bar to 1.1.3

## Changelog Description

### Plugin Updated: Debug Bar

Updated Debug Bar from 1.1.2 to 1.1.3.

Changelog:
  - Fix notices in HTTP Requests panel when a request is stopped/doesn't finish.
  - Decode the SQL in the WP_Query panel.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
