### PR TITLE
Update WPComVIP_Restrictions

### DIFF
--- a/tests/vip-helpers/test-wpcomvip-restrictions.php
+++ b/tests/vip-helpers/test-wpcomvip-restrictions.php
@@ -85,18 +85,19 @@ class Test_WPComVIP_Restrictions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_wp_dropdown_users
+	 * @dataProvider data_wp_dropdown_users_edit
 	 */
-	public function test_wp_dropdown_users( array $args ): void {
+	public function test_wp_dropdown_users_edit( array $args ): void {
 		$html = wp_dropdown_users( $args + [
 			'show' => 'user_login',
 			'echo' => false,
+			'name' => 'post_author_override',
 		] );
 
 		self::assertStringNotContainsString( 'wpcomvip', $html );
 	}
 
-	public function data_wp_dropdown_users(): iterable {
+	public function data_wp_dropdown_users_edit(): iterable {
 		return [
 			[
 				[],
@@ -111,6 +112,15 @@ class Test_WPComVIP_Restrictions extends WP_UnitTestCase {
 				[ 'exclude' => [ 1048576 ] ],
 			],
 		];
+	}
+
+	public function test_wp_dropdown_users_normal(): void {
+		$html = wp_dropdown_users( [
+			'show' => 'user_login',
+			'echo' => false,
+		] );
+
+		self::assertStringContainsString( 'wpcomvip', $html );
 	}
 
 	public function test_rest_api(): void {

--- a/vip-helpers/class-wpcomvip-restrictions.php
+++ b/vip-helpers/class-wpcomvip-restrictions.php
@@ -16,8 +16,8 @@ class WPComVIP_Restrictions {
 	private function __construct() {
 		add_filter( 'wp_insert_post_data', [ $this, 'restrict_post_author' ], PHP_INT_MAX );
 		add_filter( 'wp_insert_attachment_data', [ $this, 'restrict_post_author' ], PHP_INT_MAX );
-		add_filter( 'wp_dropdown_users_args', [ $this, 'restrict_post_author_dropdown' ], PHP_INT_MAX );
-		add_filter( 'rest_user_query', [ $this, 'restrict_post_author_dropdown' ], PHP_INT_MAX );
+		add_filter( 'wp_dropdown_users_args', [ $this, 'restrict_post_author_dropdown' ], PHP_INT_MAX, 2 );
+		add_filter( 'rest_user_query', [ $this, 'hide_wpcomvip' ], PHP_INT_MAX );
 		add_filter( 'coauthors_edit_ignored_authors', [ $this, 'restrict_post_author_dropdown_coauthors' ], PHP_INT_MAX );
 	}
 
@@ -36,25 +36,35 @@ class WPComVIP_Restrictions {
 		return $data;
 	}
 
-	public function restrict_post_author_dropdown( $query_args ) {
+	public function restrict_post_author_dropdown( $query_args, $parsed_args ) {
+		if ( ! is_array( $query_args ) || ! is_array( $parsed_args ) || ! isset( $parsed_args['name'] ) || 'post_author_override' !== $parsed_args['name'] ) {
+			return $query_args;
+		}
+
+		return $this->exclude_wpcomvip( $query_args );
+	}
+
+	public function hide_wpcomvip( $query_args ) {
 		if ( ! is_array( $query_args ) ) {
 			return $query_args;
 		}
 
+		return $this->exclude_wpcomvip( $query_args );
+	}
+
+	private function exclude_wpcomvip( array $query_args ): array {
 		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
-	
 		if ( false !== $wpcomvip ) {
 			if ( empty( $query_args['exclude'] ) ) {
-				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
-				$query_args['exclude'] = [ $wpcomvip->ID ];
+				$list = [ $wpcomvip->ID ];
 			} else {
 				$exclude = is_array( $query_args['exclude'] ) ? $query_args['exclude'] : (string) $query_args['exclude'];
 				$list    = wp_parse_id_list( $exclude );
 				$list[]  = $wpcomvip->ID;
-
-				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
-				$query_args['exclude'] = $list;
 			}
+
+			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+			$query_args['exclude'] = $list;
 		}
 
 		return $query_args;
@@ -62,11 +72,10 @@ class WPComVIP_Restrictions {
 
 	public function restrict_post_author_dropdown_coauthors( $ignored_authors ) {
 		if ( ! is_array( $ignored_authors ) ) {
-			return $ignored_authors;
+			$ignored_authors = [ $ignored_authors ];
 		}
 
 		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
-	
 		if ( false !== $wpcomvip ) {
 			$ignored_authors[] = $wpcomvip->user_nicename;
 		}


### PR DESCRIPTION
## Description

This PR adds changes to address the feedback on `wpcomvip` user restrictions.

Related: #3168

## Changelog Description

### Plugin Updated: VIP Helpers

  * Hide `wpcomvip` from `wp_dropdown_users()` only in Edit Post/Page screens;
  * Convert the parameter to `coauthors_edit_ignored_authors` filter to array if it is not an array. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
