### PR TITLE
Update actions/dependency-review-action to 1.0.2

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,7 +20,7 @@ jobs:
             github.com:443
 
       - name: Check out the source code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
 
       - name: Review dependencies
-        uses: actions/dependency-review-action@39e692fa323107ef86d8fdac0067ce647f239bd7 # tag=v1
+        uses: actions/dependency-review-action@a9c83d3af6b9031e20feba03b904645bb23d1dab # tag=v1.0.2


### PR DESCRIPTION
Have to do this manually while Renovate is suspended.
