### PR TITLE
Fix regression that was introduced by varying the  by adding unique headers, use body of the query to calculate the hash

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -906,21 +906,13 @@ class Search {
 		if ( $is_cacheable ) {
 			$cache_key = 'es_query_cache:' . md5( $query['url'] . $args['body'] ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
 			/**
-			 * Serve cached response right away, if available and not stale and the query is cacheable
+			 * Serve cached response right away, if available
 			 */
-			$cached_response = $is_cacheable ? wp_cache_get( $cache_key, self::SEARCH_CACHE_GROUP ) : false;
+			$cached_response = wp_cache_get( $cache_key, self::SEARCH_CACHE_GROUP );
 
 			if ( $cached_response ) {
 				return $cached_response;
 			}
-		}
-
-		/**
-		 * Serve cached response right away, if available and not stale and the query is cacheable
-		 */
-		$cached_response = $is_cacheable ? wp_cache_get( $cache_key, self::SEARCH_CACHE_GROUP ) : false;
-		if ( $cached_response ) {
-			return $cached_response;
 		}
 
 		$start_time = microtime( true );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -902,7 +902,9 @@ class Search {
 		$statsd_prefix          = $this->get_statsd_prefix( $query['url'], $statsd_mode );
 
 		// Cache handling
-		$is_cacheable = $this->is_url_query_cacheable( $query['url'], $args );
+		$is_cacheable    = $this->is_url_query_cacheable( $query['url'], $args );
+		$cached_response = false;
+
 		if ( $is_cacheable ) {
 			$cache_key = 'es_query_cache:' . md5( $query['url'] . $args['body'] ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
 			/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -903,7 +903,17 @@ class Search {
 
 		// Cache handling
 		$is_cacheable = $this->is_url_query_cacheable( $query['url'], $args );
-		$cache_key    = 'es_query_cache:' . md5( $query['url'] . $args['body'] ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
+		if ( $is_cacheable ) {
+			$cache_key = 'es_query_cache:' . md5( $query['url'] . $args['body'] ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
+			/**
+			 * Serve cached response right away, if available and not stale and the query is cacheable
+			 */
+			$cached_response = $is_cacheable ? wp_cache_get( $cache_key, self::SEARCH_CACHE_GROUP ) : false;
+
+			if ( $cached_response ) {
+				return $cached_response;
+			}
+		}
 
 		/**
 		 * Serve cached response right away, if available and not stale and the query is cacheable

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1021,7 +1021,7 @@ class Search {
 			return $is_cacheable;
 		}
 
-		$is_cacheable = (bool) preg_match( '#/_(search|mget|doc)#', $url ) && in_array( $args['method'], [ 'DELETE', 'PUT' ], true );
+		$is_cacheable = boolval( preg_match( '#/_(search|mget|doc)#', $url ) ) && ! in_array( $args['method'], [ 'DELETE', 'PUT' ], true );
 
 
 		/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -903,7 +903,7 @@ class Search {
 
 		// Cache handling
 		$is_cacheable = $this->is_url_query_cacheable( $query['url'], $args );
-		$cache_key    = 'es_query_cache:' . md5( $query['url'] . wp_json_encode( $args ) ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
+		$cache_key    = 'es_query_cache:' . md5( $query['url'] . $args['body'] ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
 
 		/**
 		 * Serve cached response right away, if available and not stale and the query is cacheable

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -906,7 +906,9 @@ class Search {
 		$cached_response = false;
 
 		if ( $is_cacheable ) {
-			$cache_key = 'es_query_cache:' . md5( $query['url'] . $args['body'] ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
+			// Some requests may not have body
+			$body      = $args['body'] ?? '';
+			$cache_key = 'es_query_cache:' . md5( $query['url'] . $body ) . ':' . wp_cache_get_last_changed( self::SEARCH_CACHE_GROUP );
 			/**
 			 * Serve cached response right away, if available
 			 */

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1021,7 +1021,7 @@ class Search {
 			return $is_cacheable;
 		}
 
-		$is_cacheable = (bool) preg_match( '#/_(search|mget|doc)#', $url );
+		$is_cacheable = (bool) preg_match( '#/_(search|mget|doc)#', $url ) && in_array( $args['method'], [ 'DELETE', 'PUT' ], true );
 
 
 		/**

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -144,6 +144,9 @@ class Search_Test extends WP_UnitTestCase {
 				array(
 					'url' => 'https://foo.com/index/_search',
 				),
+				[
+					'method' => 'POST',
+				],
 				// The expected result
 				true,
 			),
@@ -153,6 +156,10 @@ class Search_Test extends WP_UnitTestCase {
 				array(
 					'url' => 'https://foo.com/index/_mget',
 				),
+				[
+					'method' => 'POST',
+				],
+
 				// The expected result
 				true,
 			),
@@ -162,8 +169,23 @@ class Search_Test extends WP_UnitTestCase {
 				array(
 					'url' => 'https://foo.com/index/type/_doc/_mget',
 				),
+				[
+					'method' => 'POST',
+				],
 				// The expected result
 				true,
+			),
+			// Regular entity multiget
+			array(
+				// The $query object
+				array(
+					'url' => 'https://foo.com/index/type/_doc/123456',
+				),
+				[
+					'method' => 'DELETE',
+				],
+				// The expected result
+				false,
 			),
 			// Bulk index
 			array(
@@ -171,6 +193,9 @@ class Search_Test extends WP_UnitTestCase {
 				array(
 					'url' => 'https://foo.com/index/_bulk',
 				),
+				[
+					'method' => 'POST',
+				],
 				// The expected result
 				false,
 			),
@@ -180,6 +205,9 @@ class Search_Test extends WP_UnitTestCase {
 				array(
 					'url' => 'https://foo.com/index/_bulk/bar?_mget',
 				),
+				[
+					'method' => 'POST',
+				],
 				// The expected result
 				false,
 			),
@@ -189,6 +217,9 @@ class Search_Test extends WP_UnitTestCase {
 				array(
 					'url' => 'https://foo.com/index/type/_anything',
 				),
+				[
+					'method' => 'GET',
+				],
 				// The expected result
 				false,
 			),
@@ -200,8 +231,8 @@ class Search_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider vip_search_is_url_query_cacheable_data()
 	 */
-	public function test__is_url_query_cacheable( $query, $expected_is_cacheable ) {
-		$is_cacheable = $this->search_instance->is_url_query_cacheable( $query['url'], array() );
+	public function test__is_url_query_cacheable( $query, $args, $expected_is_cacheable ) {
+		$is_cacheable = $this->search_instance->is_url_query_cacheable( $query['url'], $args );
 
 		$this->assertEquals( $expected_is_cacheable, $is_cacheable );
 	}

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -1223,7 +1223,7 @@ class Versioning_Test extends WP_UnitTestCase {
 			}
 
 			// For linting, always have to return something
-			return null;
+			return $request;
 		}, 10, 3 );
 
 		$indexable->delete( 1 );


### PR DESCRIPTION
## Description

In #2913 we added a few headers to be able to identify requests along their lifecycle better, this, however, had an unfortunate side-effect of varying the resulting `$cache_key`.
This PR addresses that by only using the query body to determine the cache key hash.

## Changelog Description

### Plugin Updated: Enterprise Search

Fix a regression that resulted in request cache using unique keys thus not using cached responses.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

On a sandbox: 

1. Checkout the PR
2. Search for something and note the HTTP request made 
3. Refresh the page, verify the request is not made anymore but search results are present