### PR TITLE
GH-3179: more robust notice dismissal

### DIFF
--- a/admin-notice/class-admin-notice-controller.php
+++ b/admin-notice/class-admin-notice-controller.php
@@ -31,7 +31,7 @@ class Admin_Notice_Controller {
 	}
 
 	public function enqueue_scripts() {
-		wp_enqueue_script( 'vip-admin-notice-script', plugins_url( '/js/script.js', __FILE__ ), [], '1.0', true );
+		wp_enqueue_script( 'vip-admin-notice-script', plugins_url( '/js/script.js', __FILE__ ), [ 'common' ], '1.1', true );
 		wp_localize_script( 'vip-admin-notice-script', 'dismissal_data', [
 			'nonce'          => wp_create_nonce( self::DISMISS_NONCE_ACTION ),
 			'data_attribute' => Admin_Notice::DISMISS_DATA_ATTRIBUTE,

--- a/admin-notice/js/script.js
+++ b/admin-notice/js/script.js
@@ -1,14 +1,7 @@
-function tryGetNoticeContainer(currentElement) {
-	if (currentElement === null || currentElement.hasAttribute(dismissal_data.data_attribute)) {
-		return currentElement;
-	}
-	return tryGetNoticeContainer(currentElement.parentElement);
-}
-
 function persistDismissedNotice(containerElement) {
 	const dismissIdentifier = containerElement && containerElement.getAttribute(dismissal_data.data_attribute);
 	if (dismissIdentifier) {
-		var formData = new FormData();
+		const formData = new FormData();
 
 		formData.append('_ajax_nonce', dismissal_data.nonce);
 		formData.append('action', 'dismiss_vip_notice');
@@ -21,19 +14,18 @@ function persistDismissedNotice(containerElement) {
 	}
 }
 
-function onDismissed(event) {
-	const noticeContainer = tryGetNoticeContainer(event && event.target);
-	if (noticeContainer) {
-		persistDismissedNotice(noticeContainer);
+function vipNoticeClickHandler( ev ) {
+	const button = ev.target.closest( '.notice-dismiss' );
+	if ( button ) {
+		const noticeContainer = button.closest( `[data="${dismissal_data.data_attribute}"]` );
+		if (noticeContainer) {
+			persistDismissedNotice(noticeContainer);
+		}
 	}
 }
 
 function registerDismissHooks() {
-	const notices = document.querySelectorAll( '.vip-notice .notice-dismiss' );
-
-	for ( const notice of notices ) {
-		notice.addEventListener( "click", onDismissed );
-	}
+	document.querySelectorAll( '.vip-notice' ).forEach( notice => notice.addEventListener( 'click', vipNoticeClickHandler ) );
 }
 
 window.onload = (function (oldLoad) {


### PR DESCRIPTION
## Description

See: #3179

This PR attempts to fix race conditions happening when `common.js` gets loaded after `admin-notice/js/script.js`

## Changelog Description

### Plugin Updated: Admin Notice

More robust notice dismissal

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

See #3179 
