### PR TITLE
Fix "Undefined index" in `wpcom_vip_lost_password_limit()`

### DIFF
--- a/tests/test-security.php
+++ b/tests/test-security.php
@@ -75,7 +75,7 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 		$errors              = new WP_Error();
 		$errors->add( $original_error_code, $original_error_text );
 
-		do_action( 'lostpassword_post', $errors );
+		do_action( 'lostpassword_post', $errors, false );
 
 		$actual_error_codes = $errors;
 
@@ -103,7 +103,7 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 
 		for ( $i = 0; $i <= $just_under_threshold; $i++ ) {
 
-			do_action( 'lostpassword_post', $errors );
+			do_action( 'lostpassword_post', $errors, false );
 
 			// Make sure we haven't received an error yet
 			$this->assertEquals( $errors->get_error_code(), false );
@@ -111,7 +111,7 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 		}
 
 		// Do the lostpassword_post one more time to reach our threshold.
-		do_action( 'lostpassword_post', $errors );
+		do_action( 'lostpassword_post', $errors, false );
 
 		// Now we should have an error.
 		$this->assertEquals( $errors->get_error_code(), 'lost_password_limit_exceeded' );


### PR DESCRIPTION
## Description

This PR fixes a notice in `wpcom_vip_lost_password_limit()` which breaks WordPress core tests.

The bug happens when a `lostpassword_post` action is fired with an empty `$_POST`. This is fine for WordPress, because `retrieve_password()` may be invoked with a user login; in this case, `$_POST` is not used.

## Changelog Description

### Plugin Updated: VIP Security

Fix an "Undefined index" notice in `wpcom_vip_lost_password_limit()`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
