### PR TITLE
Search: Fix bug where health validate-counts on multisite returns incorrect results

### DIFF
--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -148,6 +148,8 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 					continue;
 				}
 
+				switch_to_blog( $site['blog_id'] );
+
 				if ( ! $indexable->index_exists( $site['blog_id'] ) ) {
 					$blog_id = $site['blog_id'];
 					WP_CLI::line( "Skipping validation of '$indexable_slug' index for site $blog_id as it doesn't exist.\n\n" );
@@ -155,8 +157,6 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 				}
 
 				WP_CLI::line( "\nValidating $indexable_slug count for site " . $site['blog_id'] . ' (' . $site['domain'] . $site['path'] . ')\n' );
-
-				switch_to_blog( $site['blog_id'] );
 
 				$this->validate_indexable_count_for_site( $indexable_slug, $version );
 
@@ -327,9 +327,9 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 * options:
 	 *   - missing
 	 *   - mismatch
-	 * 
+	 *
 	 * ## EXAMPLES
-	 * 
+	 *
 	 *     # Simultaneously check for and fix any index inconsistencies (e.g. missing posts and content mismatches) between DB and ES.
 	 *     $ wp vip-search health validate-contents
 	 *     ...✘
@@ -337,7 +337,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	 *     type,id,issue
 	 *     post,5,missing_from_index
 	 *     post,1,mismatch
-	 * 
+	 *
 	 * @link https://docs.wpvip.com/how-tos/vip-search/check-index-health/
 	 *
 	 * @subcommand validate-contents


### PR DESCRIPTION
## Description
We currently cache if an index exists via an option: https://github.com/Automattic/vip-go-mu-plugins/blob/6292ffbc0a6202c3070dd629bd50ac3babd610ab/search/includes/classes/class-search.php#L999-L1002

In multisite, we should be switching into the subsite context BEFORE checking if the index exists. If not, this will result in the option being stored in site 1, which will also return it after as not existing subsequently after any changes are made when `wp vip-search health validate-counts --network-wide` is run. This is because the invalidation logic below will not fire:
https://github.com/Automattic/vip-go-mu-plugins/blob/6292ffbc0a6202c3070dd629bd50ac3babd610ab/search/includes/classes/class-search.php#L846

## Changelog Description

### Plugin Updated: Enterprise Search
Fix bug where health validate-counts command was not returning correct results when using network-wide flag.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create multisite with main site and a subsite
2) Index only the main site: `wp vip-search index --setup`
3) Run `wp vip-search health validate-counts --network-wide` to store the option incorrectly on the main site
4) Index now the subsite: `wp vip-search index --setup --url=subsite.example.com`
5) Run `wp vip-search health validate-counts --network-wide` again to see the incorrect results being returned for the subsite
6) Validate with `wp vip-search health validate-counts --url=subsite.example.com` that the index does infact, exist
7) Apply the PR
8) Run `wp vip-search health validate-counts --network-wide` and see the expected results
