### PR TITLE
Search: Stagger stale index versioning clean up jobs

### DIFF
--- a/search/includes/classes/class-versioningcleanupjob.php
+++ b/search/includes/classes/class-versioningcleanupjob.php
@@ -35,7 +35,7 @@ class VersioningCleanupJob {
 	public function schedule_job() {
 		if ( ! wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
 			// phpcs:disable WordPress.WP.AlternativeFunctions.rand_mt_rand
-			wp_schedule_event( time() + ( mt_rand( 1, 60 ) * MINUTE_IN_SECONDS ), 'weekly', self::CRON_EVENT_NAME );
+			wp_schedule_event( time() + ( mt_rand( 1, 7 ) * DAY_IN_SECONDS ), 'weekly', self::CRON_EVENT_NAME );
 		}
 	}
 

--- a/search/includes/classes/class-versioningcleanupjob.php
+++ b/search/includes/classes/class-versioningcleanupjob.php
@@ -34,7 +34,8 @@ class VersioningCleanupJob {
 	 */
 	public function schedule_job() {
 		if ( ! wp_next_scheduled( self::CRON_EVENT_NAME ) ) {
-			wp_schedule_event( time(), 'weekly', self::CRON_EVENT_NAME );
+			// phpcs:disable WordPress.WP.AlternativeFunctions.rand_mt_rand
+			wp_schedule_event( time() + ( mt_rand( 1, 60 ) * MINUTE_IN_SECONDS ), 'weekly', self::CRON_EVENT_NAME );
 		}
 	}
 


### PR DESCRIPTION
## Description
Let's stagger the stale index version clean up job from 1 to 60 minutes to ensure they don't all run at the same time for multisites that enable Enterprise Search at the exact same time.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
