### PR TITLE
Enqueue Query Monitor scripts only if enabled

### DIFF
--- a/qm-plugins/qm-object-cache/qm-object-cache.php
+++ b/qm-plugins/qm-object-cache/qm-object-cache.php
@@ -7,12 +7,13 @@
  */
 
 add_action( 'plugins_loaded', function() {
-	add_action( 'wp_enqueue_scripts', 'qm_object_cache_assets' );
-	add_action( 'admin_enqueue_scripts', 'qm_object_cache_assets' );
 	/**
-	 * Register collector, only if Query Monitor is enabled.
+	 * Register collector and css, only if Query Monitor is enabled.
 	 */
 	if ( class_exists( 'QM_Collectors' ) ) {
+		add_action( 'wp_enqueue_scripts', 'qm_object_cache_assets' );
+		add_action( 'admin_enqueue_scripts', 'qm_object_cache_assets' );
+
 		include_once 'class-qm-collector-object-cache.php';
 
 		QM_Collectors::add( new QM_Collector_ObjectCache() );


### PR DESCRIPTION
## Description
Query Monitor Cache plugin scripts 

## Changelog Description

### Plugin Updated: Query Monitor: Object Cache

Enqueue css styles for Object cache plugin for Query Monitor, only if Query Monitor is enabled. This change avoids loading CSS scripts for folks that wouldn't see query monitor anyway (e.g. not logged in user)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
