### PR TITLE
Hotfix: properly disable QM on WP installation

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -53,6 +53,10 @@ function wpcom_vip_qm_enable( $enable ) {
 		define( 'QM_COOKIE', 'query_monitor_' . COOKIEHASH );
 	}
 
+	if ( defined( 'WP_INSTALLING' ) ) {
+		return false;
+	}
+
 	if ( current_user_can( 'view_query_monitor' ) ) {
 		return true;
 	}
@@ -111,9 +115,7 @@ function wpcom_vip_qm_require() {
 	// We know we haven't got the QM DB drop-in in place, so don't show the message
 	add_filter( 'qm/show_extended_query_prompt', '__return_false' );
 }
-if ( ! defined( 'WP_INSTALLING' ) ) {
-	add_action( 'plugins_loaded', 'wpcom_vip_qm_require', 1 );
-}
+add_action( 'plugins_loaded', 'wpcom_vip_qm_require', 1 );
 
 /**
  * Hooks the wp action to avoid showing Query Monitor on 404 pages
@@ -127,7 +129,6 @@ function wpcom_vip_qm_disable_on_404() {
 	}
 }
 add_action( 'wp', 'wpcom_vip_qm_disable_on_404' );
-
 
 // We are putting dispatchers as last so that QM still can catch other operations in shutdown action
 // See https://github.com/johnbillion/query-monitor/pull/549


### PR DESCRIPTION
## Changelog Description

Disable Query Monitor while WP is being installed without breaking things.

### Plugin Updated: Query Monitor

Disable plugin on WordPress installation without causing side effects.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
