### PR TITLE
Show plugin vulnerabilities in wp-admin

### DIFF
--- a/codebase-manager/plugins/plugin.php
+++ b/codebase-manager/plugins/plugin.php
@@ -29,7 +29,7 @@ class Plugin {
 		}
 
 		printf( '<tr class="plugin-update-tr%s">', $this->is_active() ? ' active' : '' );
-		printf( '<td colspan="%s" class="plugin-update colspanchange%s">', esc_attr( $number_of_columns ), $this->has_vulnerabilities() ? ' hide-box-shadow' : '' );
+		printf( '<td colspan="%d" class="plugin-update colspanchange%s">', esc_attr( $number_of_columns ), $this->has_vulnerabilities() ? ' hide-box-shadow' : '' );
 		print( '<div class="update-message notice inline notice-warning notice-alt"><p>' );
 
 		// In the future, could do the fancy iframe that core does here. It also allows 3rd party plugins to hook in with `plugins_api` filter to better expose their changelogs.
@@ -53,7 +53,7 @@ class Plugin {
 		}
 
 		printf( '<tr class="plugin-vuln-tr%s">', $this->is_active() ? ' active' : '' );
-		printf( '<td colspan="%s" class="plugin-vuln colspanchange">', esc_attr( $number_of_columns ) );
+		printf( '<td colspan="%d" class="plugin-vuln colspanchange">', esc_attr( $number_of_columns ) );
 		print( '<div class="vuln-message error inline notice-error notice-alt">' );
 
 		/* translators: 1: The number of vulnerabilities associated with the plugin. */
@@ -70,9 +70,11 @@ class Plugin {
 			// "None" could be confusing, let's convert it to "Low".
 			$severity = 'NONE' === $vuln->severity ? 'Low' : ucwords( strtolower( $vuln->severity ) );
 
-			$severity_info = sprintf( '%s severity', esc_html( $severity ) );
+			/* translators: 1: The vulnerability severity rating, such as "High". */
+			$severity_info = sprintf( __( '%s severity' ), esc_html( $severity ) );
 			if ( null !== $vuln->severityScore ) {
-				$severity_info = sprintf( '%s severity: %s/10', esc_html( $severity ), esc_html( $vuln->severityScore ) );
+				/* translators: 1: The vulnerability severity rating, such as "High". 2: The severity score, 0-10. */
+				$severity_info = sprintf( __( '%1$s severity: %2$s/10' ), esc_html( $severity ), esc_html( $vuln->severityScore ) );
 			}
 
 			$vuln_text = sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $vuln->link ), esc_html( $severity_info ) );


### PR DESCRIPTION
## Description

Followup to https://github.com/Automattic/vip-go-mu-plugins/pull/3078 - alongside update notices now any known vulnerabilities are also shown:

![vulns](https://user-images.githubusercontent.com/8536129/172498709-8408373e-e4e5-424d-a378-d52d77fd7e1b.png)

## Changelog Description


### Plugin Updated: Codebase Manager

Nows shows known plugin vulnerabilities in the plugins list in WP Admin.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Live:
1. Apply the two file changes to a Go sandbox (`297` is a good option).
1. Go to the plugins page and ensure all works correctly.

Dev:
1. Apply the PR.
1. Set up api-gw & ccm locally, and update relevant services api constants.
1. Or ping me :)