### PR TITLE
Wp-admin: Display admin notice for older WP versions

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -65,3 +65,25 @@ add_action(
 		);
 	}
 );
+
+// Old WP version w/o pinned Jetpack version
+add_action(
+	'vip_admin_notice_init',
+	function( $admin_notice_controller ) {
+		global $wp_version;
+		$message = "We've noticed that you are running WordPress {$wp_version}, which is an outdated version. This prevents you from running the latest version of Jetpack, as the current version of Jetpack only supports 5.9 and up. Please upgrade to the most recent WordPress version to use the latest features of Jetpack.";
+
+		$admin_notice_controller->add(
+			new Admin_Notice(
+				$message,
+				[
+					new Capability_Condition( 'administrator' ),
+					new Expression_Condition( version_compare( $wp_version, '5.9', '<' ) ),
+					new Expression_Condition( ! defined( 'VIP_JETPACK_PINNED_VERSION' ) ),
+				],
+				'old-wp-versions',
+				'error'
+			)
+		);
+	}
+);


### PR DESCRIPTION
## Description

With Jetpack 11.0 being the default version on VIP, let's display an admin notice for those who haven't pinned Jetpack and are on older WP Versions to let them know about the minimum constraint:

<img width="1452" alt="Screen Shot 2022-06-10 at 10 38 35 AM" src="https://user-images.githubusercontent.com/16962021/173112176-53aba9d6-e45a-470c-9293-64ba6003a45d.png">


## Changelog Description

### Plugin Updated: Wp-admin

Display Jetpack incompatibility admin notice for unpinned Jetpack sites that are running older WP versions

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Start up a local dev environment in WP 5.8.3
2) Go to wp-admin and see notice
3) Add `define( 'VIP_JETPACK_PINNED_VERSION', 'test');` and see admin notice go away
4) Comment out step 3 and upgrade to latest WP version