### PR TITLE
Bail out if PHP setup fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           tools: phpunit:${{ matrix.config.phpunit }}
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          fail-fast: 'true'
 
       - name: Install PHP Dependencies
         uses: ramsey/composer-install@2.1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           coverage: none
           php-version: "8.0"
+        env:
+          fail-fast: 'true'
 
       - name: Setup Node
         uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # tag=v2.5.1

--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           coverage: none
           php-version: ${{ matrix.config.php }}
+        env:
+          fail-fast: 'true'
 
       - name: Install PHP Dependencies
         uses: ramsey/composer-install@2.1.0

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           node-version: 14
           cache: npm
+          cache-dependency-path: bin
 
       - name: Install dependencies
         working-directory: ./bin


### PR DESCRIPTION
By default, PHP tools that cannot be added or disabled gracefully leave an error message in the logs, and the execution is not interrupted.

This has happened [here](https://github.com/Automattic/vip-go-mu-plugins/runs/6903131869?check_suite_focus=true#step:4:17).

This behavior can be changed with the [`fail-fast` flag](https://github.com/shivammathur/setup-php#flags).

This PR sets this flag.
