### PR TITLE
Download phpunit.phar to avoid GitHub's rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,14 @@ jobs:
         with:
           coverage: none
           php-version: ${{ matrix.config.php }}
-          tools: phpunit:${{ matrix.config.phpunit }}
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           fail-fast: 'true'
+
+      - name: Install PHPUnit
+        run: |
+          wget -q -O /usr/local/bin/phpunit "https://phar.phpunit.de/phpunit-${{ matrix.config.phpunit }}.phar"
+          chmod +x /usr/local/bin/phpunit
 
       - name: Install PHP Dependencies
         uses: ramsey/composer-install@2.1.0


### PR DESCRIPTION
Our CI workflow runs many checks; each of them uses GitHub API to find the latest revision of PHPUnit. Sometimes, GitHub applies rate limiting and our workflows fail.

This PR downloads PHPUnit as a PHAR from the official site instead.