### PR TITLE
Speed up "Lint PHP files" workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0
-        with:
-          submodules: recursive
 
       - name: Set up PHP
         uses: shivammathur/setup-php@2.19.1

--- a/bin/php-lint.sh
+++ b/bin/php-lint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-npx phplint '**/*.php' '!vendor/**' '!node_modules/**' > /dev/null
+npx phplint '**/*.php' '!vendor/**' '!node_modules/**' '!jetpack*/**' '!wp-parsely*/**' > /dev/null


### PR DESCRIPTION
If we recursively check out all submodules, it takes ages for `php-lint` to scan all files.

This PR:
1. Turns off module checkout; as a result, the linter has much fewer files to check (it does not make sense to check 3rd party modules anyway)
2. Turns off linting for Jetpack and Parse.ly

These changes reduce the run time from 06:50 down to 01:15. Not bad.