### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,13 @@ jobs:
           - { wp: latest,  ms: 'no',  jp: 'no',  php: '7.4', phpunit: 7 }
           - { wp: latest,  ms: 'yes', jp: 'no',  php: '7.4', phpunit: 7 }
         # PHP 8.0, JetPack 
-          - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9, coverage: 'yes' }
-          - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9, coverage: 'yes' }
+          - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9 }
+          - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9 }
           - { wp: nightly, ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9 }
           - { wp: nightly, ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9 }
+        # Coverage
+          - { wp: 6.x,     ms: 'no',  jp: 'no',  php: '8.0', phpunit: 9, coverage: 'yes' }
+          - { wp: 6.x,     ms: 'yes', jp: 'no',  php: '8.0', phpunit: 9, coverage: 'yes' }
     services:
       mysql:
         image: mariadb:10.3
@@ -62,7 +65,7 @@ jobs:
         run: |
           if [ "${{ matrix.config.coverage }}" = "yes" ]; then
             echo "::set-output name=coverage::pcov"
-            echo '::set-output name=ini::pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|vaultpress)/~"'
+            echo '::set-output name=ini::pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|vaultpress|query-monitor)/~"'
           else
             echo "::set-output name=coverage::none"
             echo "::set-output name=ini::opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=128M"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           - { wp: nightly, ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9, coverage: 'yes' }
     services:
       mysql:
-        image: mariadb:10.3
+        image: ghcr.io/automattic/vip-container-images/mariadb-lite:10.3
         ports:
           - "3306:3306"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,22 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Decide whether to enable coverage
+        id: coverage
+        run: |
+          if [ "${{ matrix.config.phpunit }}" = "9" ]; then
+            echo "::set-output name=coverage::pcov"
+          else
+            echo "::set-output name=coverage::none"
+          fi
+
       - name: Set up PHP
         uses: shivammathur/setup-php@2.19.1
         with:
-          coverage: none
+          coverage: ${{ steps.coverage.outputs.coverage }}
+          ini-values: pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack|wp-parsely)~"
           php-version: ${{ matrix.config.php }}
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           fail-fast: 'true'
 
       - name: Install PHPUnit
@@ -95,7 +104,19 @@ jobs:
         timeout-minutes: 1
 
       - name: Run tests
-        run: phpunit --order-by=random
+        run: |
+          OPTIONS=
+          if [ "${{ steps.coverage.output.coverage }}" != 'none' ]; then
+            OPTIONS="$OPTIONS --coverage-clover=clover.xml"
+          fi
+          phpunit --order-by=random ${OPTIONS}
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v2
+        with:
+          files: clover.xml
+          flags: unittests
+        if: ${{ steps.coverage.output.coverage != 'none' }}
 
   wp-core:
     name: "Run WP Core Tests (WordPress ${{ matrix.wp }}, multisite: ${{ matrix.multisite }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
           - { wp: latest,  ms: 'no',  jp: 'no',  php: '7.4', phpunit: 7 }
           - { wp: latest,  ms: 'yes', jp: 'no',  php: '7.4', phpunit: 7 }
         # PHP 8.0, JetPack 
-          - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9 }
-          - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9 }
+          - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9, coverage: 'yes' }
+          - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9, coverage: 'yes' }
           - { wp: nightly, ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9 }
           - { wp: nightly, ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9 }
     services:
@@ -60,17 +60,19 @@ jobs:
       - name: Decide whether to enable coverage
         id: coverage
         run: |
-          if [ "${{ matrix.config.phpunit }}" = "9" ]; then
+          if [ "${{ matrix.config.coverage }}" = "yes" ]; then
             echo "::set-output name=coverage::pcov"
+            echo '::set-output name=ini::pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|vaultpress)/~"'
           else
             echo "::set-output name=coverage::none"
+            echo "::set-output name=ini::opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=128M"
           fi
 
       - name: Set up PHP
         uses: shivammathur/setup-php@2.19.1
         with:
           coverage: ${{ steps.coverage.outputs.coverage }}
-          ini-values: pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack|wp-parsely)~"
+          ini-values: ${{ steps.coverage.outputs.ini }}
           php-version: ${{ matrix.config.php }}
         env:
           fail-fast: 'true'
@@ -116,7 +118,7 @@ jobs:
         with:
           files: clover.xml
           flags: unittests
-        if: ${{ steps.coverage.output.coverage != 'none' }}
+        if: ${{ steps.coverage.outputs.coverage != 'none' }}
 
   wp-core:
     name: "Run WP Core Tests (WordPress ${{ matrix.wp }}, multisite: ${{ matrix.multisite }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,8 @@ jobs:
         # PHP 8.0, JetPack 
           - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9 }
           - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9 }
-          - { wp: nightly, ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9 }
-          - { wp: nightly, ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9 }
-        # Coverage
-          - { wp: 6.x,     ms: 'no',  jp: 'no',  php: '8.0', phpunit: 9, coverage: 'yes' }
-          - { wp: 6.x,     ms: 'yes', jp: 'no',  php: '8.0', phpunit: 9, coverage: 'yes' }
+          - { wp: nightly, ms: 'no',  jp: 'yes', php: '8.0', phpunit: 9, coverage: 'yes' }
+          - { wp: nightly, ms: 'yes', jp: 'yes', php: '8.0', phpunit: 9, coverage: 'yes' }
     services:
       mysql:
         image: mariadb:10.3
@@ -65,7 +62,7 @@ jobs:
         run: |
           if [ "${{ matrix.config.coverage }}" = "yes" ]; then
             echo "::set-output name=coverage::pcov"
-            echo '::set-output name=ini::pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|vaultpress|query-monitor)/~"'
+            echo '::set-output name=ini::pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|advanced-post-cache|akismet|cron-control|debug-bar|debug-bar-cron|drop-ins|http-concat|lightweight-term-count-update|query-monitor|(search/(elasticpress|debug-bar-elasticpress|es-wp-query))|shared-plugins|rewrite-rules-inspector|vaultpress|wordpress-importer)/~"'
           else
             echo "::set-output name=coverage::none"
             echo "::set-output name=ini::opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=128M"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,8 @@
 		<exclude>
 			<directory>jetpack*</directory>
 			<directory>wp-parsely*</directory>
+			<directory>akismet</directory>
+			<directory>vaultpress</directory>
 			<directory>tests</directory>
 			<directory>vendor</directory>
 			<directory>node_modules</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,24 @@
 		<exclude>
 			<directory>jetpack*</directory>
 			<directory>wp-parsely*</directory>
+
+			<directory>advanced-post-cache</directory>
 			<directory>akismet</directory>
+			<directory>cron-control</directory>
+			<directory>debug-bar</directory>
+			<directory>debug-bar-cron</directory>
+			<directory>drop-ins</directory>
+			<directory>http-concat</directory>
+			<directory>lightweight-term-count-update</directory>
+			<directory>query-monitor</directory>
+			<directory>search/elasticpress</directory>
+			<directory>search/debug-bar-elasticpress</directory>
+			<directory>search/es-wp-query</directory>
+			<directory>shared-plugins</directory>
+			<directory>rewrite-rules-inspector</directory>
 			<directory>vaultpress</directory>
+			<directory>wordpress-importer</directory>
+
 			<directory>tests</directory>
 			<directory>vendor</directory>
 			<directory>node_modules</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,4 +15,16 @@
 	<extensions>
 		<extension class="SpeedUp_Isolated_WP_Tests"/>
 	</extensions>
+	<coverage>
+		<include>
+			<directory suffix=".php">.</directory>
+		</include>
+		<exclude>
+			<directory>jetpack*</directory>
+			<directory>wp-parsely*</directory>
+			<directory>tests</directory>
+			<directory>vendor</directory>
+			<directory>node_modules</directory>
+		</exclude>
+	</coverage>
 </phpunit>


### PR DESCRIPTION
This PR adds a generation of a code coverage report to some tests. These reports are then uploaded to Codecov (we can explore them there and see how far we are from the ideal coverage). Codecov comments on the PR and says how that PR contributes to the global coverage and whether all changes in the PR are covered with tests.

This will help us identify places we should cover with tests.