### PR TITLE
Update CI not to run on develop and staging branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   push:
-    branches:
-      - "**"
+    branches-ignore:
+      - develop
+      - staging
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,13 +3,10 @@ name: CodeQL Analysis
 on:
   push:
     branches:
-      - master
-    paths:
-      - "search/search-dev-tools/src/**.js"
-      - ".github/workflows/codeql-analysis.yml"
+      - develop
   pull_request:
     branches:
-      - master
+      - develop
     paths:
       - "search/search-dev-tools/src/**.js"
       - ".github/workflows/codeql-analysis.yml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,9 @@ name: Lint files
 
 on:
   push:
-    branches:
-      - "**"
+    branches-ignore:
+      - develop
+      - staging
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -2,8 +2,9 @@ name: CI (Parse.ly)
 
 on:
   push:
-    branches:
-      - "**"
+    branches-ignore:
+      - develop
+      - staging
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Do not run CI on pushed to `develop` and `staging`.

Because we require that the branch is up to date with the target branch, the tests we run in PR are exactly the same, and run against exactly the same codebase, as the ones we run on push to the target branches.

By not running the tests, we save time and do not waste the available workers.

The CI will still run on pushes to `production`, just in case :-)