### PR TITLE
Search: Fix uninitialized variable $indexable_slug in swap_index_versions()

### DIFF
--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -460,7 +460,7 @@ class SettingsHealthJob {
 			$message = sprintf(
 				'Application %s: An error occurred during deletion of old %s index on %s for shard requirements: %s',
 				FILES_CLIENT_SITE_ID,
-				$indexable_slug,
+				$indexable->slug,
 				home_url(),
 				$delete_version->get_error_message()
 			);


### PR DESCRIPTION
## Description
Bugfix: We should be using `$indexable->slug` in `swap_index_versions()` instead of `$indexable_slug` since that doesn't exist.