### PR TITLE
Lockout plugin: Fix capability checks on wp-admin notices

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -45,7 +45,8 @@ class Lockout {
 
 			switch ( constant( 'VIP_LOCKOUT_STATE' ) ) {
 				case 'warning':
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'manage_options' ), constant( 'VIP_LOCKOUT_STATE' ), $user );
+					$has_caps    = isset( $user->allcaps['manage_options'] ) && true === $user->allcaps['manage_options'];
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, constant( 'VIP_LOCKOUT_STATE' ), $user );
 					if ( $show_notice ) {
 						$this->render_warning_notice();
 
@@ -55,7 +56,8 @@ class Lockout {
 					break;
 
 				case 'locked':
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $user->has_cap( 'edit_posts' ), constant( 'VIP_LOCKOUT_STATE' ), $user );
+					$has_caps    = isset( $user->allcaps['edit_posts'] ) && true === $user->allcaps['edit_posts'];
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, constant( 'VIP_LOCKOUT_STATE' ), $user );
 					if ( $show_notice ) {
 						$this->render_locked_notice();
 


### PR DESCRIPTION
## Description

When the lockout plugin is enabled, in certain scenarios the lockout notice does not display because it fails the capabilities check. Since it also removes all the capabilities - that can also be done by other plugins, such as the 2FA plugin - and we're only showing the notice to users with `manage_options` and `edit_posts`, the message is never displayed (unless the user is an Automattician).

By accessing directly the `allcaps` array, we can check the original user's capabilities, and make sure that it had the required capabilities (`manage_options` and `edit_posts`) to display the notices. Using `has_cap` in this scenario can be unreliable as the capabilities might have been filtered somewhere else.

## Changelog Description

### Lockout: Check for user capabilities using `allcaps` instead of `has_cap`.

Changes the logic that decides if lockout notices should be displayed depending on the user capabilities.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Set `VIP_LOCKOUT_STATE` environment variable to `warning` and `VIP_LOCKOUT_MESSAGE` to some string. (or, if using a sandboxed site, you can use the CLI subcommand)
1. Access `wp-admin` and you should the notice on every page. 