### PR TITLE
VIP Go Plugin Compat: Enable support for multi-file uploads on Gravity Forms 2.6.3.4+

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -55,3 +55,19 @@ function vip_go_amp_force_query_var_value( $query_vars ) {
 	return $query_vars;
 }
 add_filter( 'request', 'vip_go_amp_force_query_var_value', 9, 1 );
+
+/**
+ * Enable support for multi-file uploads since VIP disables open_dir()
+ *
+ * @link https://docs.gravityforms.com/gform_cleanup_target_dir/
+ *
+ * @return void
+ */
+function vip_disable_gform_cleanup_target_dir() {
+	if ( class_exists( 'GFForms' ) ) {
+		if ( version_compare( GFForms::$version, '2.6.3.4', '>=' ) ) {
+			add_filter( 'gform_cleanup_target_dir', '__return_false' );
+		}
+	}
+}
+add_action( 'plugins_loaded', 'vip_disable_gform_cleanup_target_dir' );


### PR DESCRIPTION
## Description
Since VIP disables `open_dir()`, the filter `gform_cleanup_target_dir` (as of Gravity Forms 2.6.3.4) can be used to bypass functionality that relies on `open_dir()`, enabling support for multi-file uploads: https://docs.gravityforms.com/gform_cleanup_target_dir/

## Changelog Description

### Plugin Updated: VIP Go Plugin Compat

 Enable support for multi-file uploads on Gravity Forms 2.6.3.4+

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
