### PR TITLE
Update dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5501,9 +5501,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -10423,9 +10423,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@automattic/eslint-plugin-wpvip": "^0.1.0-0",
-        "@playwright/test": "1.23.0",
+        "@playwright/test": "1.23.1",
         "asana-phrase": "0.0.8",
         "eslint": "^8.15.0",
         "eslint-plugin-playwright": "^0.9.0",
@@ -1890,14 +1890,26 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.0.tgz",
-      "integrity": "sha512-RPWI8AHBVBiDyfTuxi1BhOaY3yaVy3S5ZsGKkSGGeWpZtSgN4SerInCYvgh9+EunIAK4RJQo+bzupbAn5pVqHQ==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.1.tgz",
+      "integrity": "sha512-dKplLPSYPZgnsBk1xxOophhpx3ZVg8DveoNJgLPe096lDCfmaIIreLsYF+4hqzy3PG61IP+aEnG5VAOjC3bhbA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.23.0"
+        "playwright-core": "1.23.1"
       },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.1.tgz",
+      "integrity": "sha512-9CXsE0gawph4KXl6oUaa0ehHRySZjHvly4TybcBXDvzK3N3o6L/eZ8Q6iVWUiMn0LLS5bRFxo1qEtOETlYJxjw==",
+      "dev": true,
       "bin": {
         "playwright": "cli.js"
       },
@@ -7828,13 +7840,21 @@
       }
     },
     "@playwright/test": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.0.tgz",
-      "integrity": "sha512-RPWI8AHBVBiDyfTuxi1BhOaY3yaVy3S5ZsGKkSGGeWpZtSgN4SerInCYvgh9+EunIAK4RJQo+bzupbAn5pVqHQ==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.1.tgz",
+      "integrity": "sha512-dKplLPSYPZgnsBk1xxOophhpx3ZVg8DveoNJgLPe096lDCfmaIIreLsYF+4hqzy3PG61IP+aEnG5VAOjC3bhbA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.23.0"
+        "playwright-core": "1.23.1"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "1.23.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.1.tgz",
+          "integrity": "sha512-9CXsE0gawph4KXl6oUaa0ehHRySZjHvly4TybcBXDvzK3N3o6L/eZ8Q6iVWUiMn0LLS5bRFxo1qEtOETlYJxjw==",
+          "dev": true
+        }
       }
     },
     "@types/json-schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "husky": "8.0.1",
         "lint-staged": "^13.0.0",
         "phplint": "2.0.5",
-        "playwright": "1.23.0",
+        "playwright": "1.23.1",
         "prettier": "^2.6.2",
         "typescript": "^4.6.2"
       }
@@ -5464,13 +5464,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.23.0.tgz",
-      "integrity": "sha512-rfZfuLueBPGV3UdEqPQxS8Uw7TgVMATWSPb3O0oV8SZBmVAhOndkOU9MPP8dxJoQI68r94yevuObPr14PhW9Xg==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.23.1.tgz",
+      "integrity": "sha512-+lgiy1JZMNPwpBp5tsUdjTGxuJ+lXZbtSKmMDc0/f1oVsNDXXA+r7zeC9Kzd+4jSHteoJJocargxVx2Mn1o2kw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.23.0"
+        "playwright-core": "1.23.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5483,6 +5483,18 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.0.tgz",
       "integrity": "sha512-Zzhyr5RZGoJ1ek2sgfJCt2076kdOg8hnNwFBqAYeLySiutXyxSQk93vZ5gbnFiWV1sHvueCcwla9n35acUTxtA==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.1.tgz",
+      "integrity": "sha512-9CXsE0gawph4KXl6oUaa0ehHRySZjHvly4TybcBXDvzK3N3o6L/eZ8Q6iVWUiMn0LLS5bRFxo1qEtOETlYJxjw==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -10402,12 +10414,20 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.23.0.tgz",
-      "integrity": "sha512-rfZfuLueBPGV3UdEqPQxS8Uw7TgVMATWSPb3O0oV8SZBmVAhOndkOU9MPP8dxJoQI68r94yevuObPr14PhW9Xg==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.23.1.tgz",
+      "integrity": "sha512-+lgiy1JZMNPwpBp5tsUdjTGxuJ+lXZbtSKmMDc0/f1oVsNDXXA+r7zeC9Kzd+4jSHteoJJocargxVx2Mn1o2kw==",
       "dev": true,
       "requires": {
-        "playwright-core": "1.23.0"
+        "playwright-core": "1.23.1"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "1.23.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.1.tgz",
+          "integrity": "sha512-9CXsE0gawph4KXl6oUaa0ehHRySZjHvly4TybcBXDvzK3N3o6L/eZ8Q6iVWUiMn0LLS5bRFxo1qEtOETlYJxjw==",
+          "dev": true
+        }
       }
     },
     "playwright-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6247,9 +6247,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10967,9 +10967,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Automattic",
   "devDependencies": {
     "@automattic/eslint-plugin-wpvip": "^0.1.0-0",
-    "@playwright/test": "1.23.0",
+    "@playwright/test": "1.23.1",
     "asana-phrase": "0.0.8",
     "eslint": "^8.15.0",
     "eslint-plugin-playwright": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "husky": "8.0.1",
     "lint-staged": "^13.0.0",
     "phplint": "2.0.5",
-    "playwright": "1.23.0",
+    "playwright": "1.23.1",
     "prettier": "^2.6.2",
     "typescript": "^4.6.2"
   }

--- a/search/search-dev-tools/package-lock.json
+++ b/search/search-dev-tools/package-lock.json
@@ -4550,9 +4550,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
-      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.19.0.tgz",
+      "integrity": "sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
@@ -13572,9 +13572,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
-      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.19.0.tgz",
+      "integrity": "sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",


### PR DESCRIPTION
* Bump eslint from 8.15.0 to 8.18.0 (#3323)
* Bump prettier from 2.6.2 to 2.7.1 (#3324)
* Bump typescript from 4.6.4 to 4.7.4 (#3325)
* Bump playwright from 1.23.0 to 1.23.1 (#3326)
* Bump @playwright/test from 1.23.0 to 1.23.1 (#3327)
------
* Bump eslint from 8.15.0 to 8.19.0 (#3331)
* Bump eslint from 8.18.0 to 8.19.0 in /search/search-dev-tools (#3332)