### PR TITLE
Bump setup-wordpress-test-library action to 1.1.4

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -76,7 +76,7 @@ runs:
       uses: ramsey/composer-install@2.1.0
 
     - name: Set up WordPress and WordPress Test Library
-      uses: sjinks/setup-wordpress-test-library@1.1.2
+      uses: sjinks/setup-wordpress-test-library@1.1.4
       with:
         version: ${{ inputs.wordpress }}
 


### PR DESCRIPTION
Dependabot missed this one.

Fixes random ENOENT errors while configuring WordPress Test Library.
