### PR TITLE
Changed the jetpack.php file to make Jetpack 11.1 the default version

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.0
+ * Version: 11.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -27,7 +27,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.9', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.9' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.0' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.1' );
 	}
 }
 


### PR DESCRIPTION
## Description
Makes Jetpack 11.1 the default version on the WP VIP platform.

## Changelog Description
### Plugin Updated: mu-plugins
Jetpack 11.1 is now the default version of Jetpack on the WPVIP platform.
## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Jetpack`
1. Verify 11.1 is the displayed version of Jetpack.
