### PR TITLE
Search: Add filter_ep_enable_do_weighting to reduce ES payload if weighting is not used

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -640,6 +640,8 @@ class Search {
 		add_filter( 'ep_elasticsearch_version', [ $this, 'fallback_elasticsearch_version' ], PHP_INT_MAX, 1 );
 
 		add_filter( 'ep_es_info_cache_expiration', [ $this, 'filter__es_info_cache_expiration' ], PHP_INT_MAX, 1 );
+
+		add_filter( 'ep_enable_do_weighting', [ $this, 'filter_ep_enable_do_weighting' ], PHP_INT_MAX, 4 );
 	}
 
 	protected function load_commands() {
@@ -2329,5 +2331,53 @@ class Search {
 	 */
 	public function filter__es_info_cache_expiration( $time ) {
 		return wp_rand( 24 * HOUR_IN_SECONDS, 36 * HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * A filter that only enables weighting if it is needed. E.g. When weightings are set by UI or filtered.
+	 *
+	 * @param bool  Whether to enable weight config, defaults to true for search requests that are public or REST
+	 * @param array $weight_config Current weight config
+	 * @param array $args WP Query arguments
+	 * @param array $formatted_args Formatted ES arguments
+	 * @return bool $should_do_weighting New value on whether to enable weight config
+	 */
+	public function filter_ep_enable_do_weighting( $should_do_weighting, $weight_config, $args, $formatted_args ) {
+		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( VIP_GO_APP_ENVIRONMENT ) ) {
+			// Rollout to non-prod only for now, otherwise skip if production.
+			return $should_do_weighting;
+		}
+
+		if ( ! empty( $weight_config ) ) {
+			return true;
+		}
+
+		global $wp_filter;
+
+		$ep_filters = [
+			'ep_weighting_configuration_for_search',
+			'ep_query_weighting_fields',
+			'ep_weighting_configuration',
+			'ep_weighting_fields_for_post_type',
+		];
+
+		foreach ( $ep_filters as $ep_filter ) {
+			if ( isset( $wp_filter[ $ep_filter ] ) ) {
+				foreach ( $wp_filter[ $ep_filter ]->callbacks as $callback ) {
+					foreach ( $callback as $el ) {
+						if ( $el['function'] instanceof \Closure ) {
+							return true;
+						} else {
+							$class = get_class( $el['function'][0] );
+							if ( false === strpos( $class, 'ElasticPress\Feature' ) ) {
+								return true;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return false;
 	}
 }

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -3107,6 +3107,39 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function test__filter_ep_enable_do_weighting__default_no_weighting() {
+		$this->search_instance->init();
+
+		$this->assertFalse( apply_filters( 'ep_enable_do_weighting', true, [], [], [] ) );
+	}
+
+	public function test__filter_ep_enable_do_weighting__anonymous_function() {
+		$this->search_instance->init();
+
+		add_filter(
+			'ep_weighting_configuration_for_search',
+			function( $weight_config ) {
+				return $weight_config;
+			}
+		);
+
+		$this->assertTrue( apply_filters( 'ep_enable_do_weighting', true, [], [], [] ) );
+	}
+
+	public function test__filter_ep_enable_do_weighting__class_function() {
+		$this->search_instance->init();
+
+		add_filter( 'ep_weighting_configuration_for_search', [ $this, 'some_function' ] );
+
+		$this->assertTrue( apply_filters( 'ep_enable_do_weighting', true, [], [], [] ) );
+	}
+
+	public function test__filter_ep_enable_do_weighting__weight_config() {
+		$this->search_instance->init();
+
+		$this->assertTrue( apply_filters( 'ep_enable_do_weighting', true, [ 'foo' => 'bar' ], [], [] ) );
+	}
+
 	/**
 	 * Helper function for accessing protected methods.
 	 */


### PR DESCRIPTION
## Description
A default ES search request appears to be under the assumption that weighting is always being used: https://github.com/Automattic/ElasticPress/blob/2302acc659745e767ea0908eeb44a81f9dab755d/includes/classes/Feature/Search/Weighting.php#L644-L647

However, if weighting is not being used, we can reduce the payload by not recursively creating subqueries and thus, decrease the total ES query time. More information on the query at hand described in https://github.com/10up/ElasticPress/pull/2512.

This PR adds the filter `filter_ep_enable_do_weighting`, which checks to see if a weighting configuration has been saved or if any of the below filters are hooked onto outside of ElasticPress:
- ep_weighting_configuration_for_search
- ep_query_weighting_fields
- ep_weighting_configuration
- ep_weighting_fields_for_post_type

## Changelog Description

### Plugin Updated: Enterprise Search

Search: Add filter_ep_enable_do_weighting to reduce ES payload if weighting is not used

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Spin-up a new site and do a front-end search `?s=hello` and see the below ES query being executed:
```
{
  "from": 0,
  "size": 10,
  "sort": [
    {
      "_score": {
        "order": "desc"
      }
    }
  ],
  "query": {
    "function_score": {
      "query": {
        "bool": {
          "should": [
            {
              "bool": {
                "must": [
                  {
                    "bool": {
                      "should": [
                        {
                          "multi_match": {
                            "query": "hello",
                            "type": "phrase",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.post_tag.name^1",
                              "terms.category.name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "boost": 3
                          }
                        },
                        {
                          "multi_match": {
                            "query": "hello",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.post_tag.name^1",
                              "terms.category.name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "type": "phrase",
                            "slop": 5
                          }
                        }
                      ]
                    }
                  }
                ],
                "filter": [
                  {
                    "match": {
                      "post_type.raw": "post"
                    }
                  }
                ]
              }
            },
            {
              "bool": {
                "must": [
                  {
                    "bool": {
                      "should": [
                        {
                          "multi_match": {
                            "query": "hello",
                            "type": "phrase",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "boost": 3
                          }
                        },
                        {
                          "multi_match": {
                            "query": "hello",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "type": "phrase",
                            "slop": 5
                          }
                        }
                      ]
                    }
                  }
                ],
                "filter": [
                  {
                    "match": {
                      "post_type.raw": "page"
                    }
                  }
                ]
              }
            }
          ]
        }
      },
      "functions": [
        {
          "gauss": {
            "post_date_gmt": {
              "scale": "360d",
              "decay": 0.9,
              "offset": "0d"
            }
          }
        },
        {
          "weight": 0.001
        }
      ],
      "score_mode": "multiply",
      "boost_mode": "multiply"
    }
  },
  "post_filter": {
    "bool": {
      "must": [
        {
          "terms": {
            "post_type.raw": [
              "post",
              "page"
            ]
          }
        },
        {
          "terms": {
            "post_status": [
              "publish"
            ]
          }
        }
      ]
    }
  },
  "track_total_hits": true,
  "timeout": "2s"
}
```
2) Apply PR
3) Do step 1 and see reduced payload:
```
{
  "from": 0,
  "size": 10,
  "sort": [
    {
      "_score": {
        "order": "desc"
      }
    }
  ],
  "query": {
    "function_score": {
      "query": {
        "bool": {
          "should": [
            {
              "multi_match": {
                "query": "hello",
                "type": "phrase",
                "fields": [
                  "post_title",
                  "post_excerpt",
                  "post_content"
                ],
                "boost": 3
              }
            },
            {
              "multi_match": {
                "query": "hello",
                "fields": [
                  "post_title",
                  "post_excerpt",
                  "post_content"
                ],
                "type": "phrase",
                "slop": 5
              }
            }
          ]
        }
      },
      "functions": [
        {
          "gauss": {
            "post_date_gmt": {
              "scale": "360d",
              "decay": 0.9,
              "offset": "0d"
            }
          }
        },
        {
          "weight": 0.001
        }
      ],
      "score_mode": "multiply",
      "boost_mode": "multiply"
    }
  },
  "post_filter": {
    "bool": {
      "must": [
        {
          "terms": {
            "post_type.raw": [
              "post",
              "page"
            ]
          }
        },
        {
          "terms": {
            "post_status": [
              "publish"
            ]
          }
        }
      ]
    }
  },
  "track_total_hits": true,
  "timeout": "2s"
}
```
4) Add filter:
```
add_filter(
	'ep_weighting_configuration_for_search',
	function( $weight_config ) {
		return $weight_config;
	}
);
```
5) Repeat step 1 and expect to see the original results