### PR TITLE
CANTINA-895: Bump purge-page-cache-btn to v1.2

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -111,7 +111,7 @@ class WPCOM_VIP_Cache_Manager {
 	 */
 	public function button_enqueue_scripts() {
 		if ( $this->current_user_can_purge_cache() ) {
-			wp_enqueue_script( 'purge-page-cache-btn', plugins_url( '/js/admin-bar.js', __FILE__ ), [], '1.1', true );
+			wp_enqueue_script( 'purge-page-cache-btn', plugins_url( '/js/admin-bar.js', __FILE__ ), [], '1.2', true );
 			wp_localize_script( 'purge-page-cache-btn', 'VIPPagePurge', [
 				'nonce'   => wp_create_nonce( 'purge-page' ),
 				'ajaxurl' => add_query_arg( [ 'action' => 'vip_purge_page_cache' ], admin_url( 'admin-ajax.php' ) ),


### PR DESCRIPTION
## Description
https://github.com/Automattic/vip-go-mu-plugins/pull/3300 introduced a bug where some users are not seeing page cache changes take effect on button click, due to the script still being cached.

## Changelog Description

### Plugin Updated: Cache Manager

Fix issue for page cache purging not working

## Checklist

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

