### PR TITLE
Remove the redundant cache-healthcheck code

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -23,10 +23,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit();
 }
 
-// Important - Cache-healthcheck and App healthcheck
-if ( file_exists( __DIR__ . '/healthcheck/healthcheck.php' ) ) {
-	require_once __DIR__ . '/healthcheck/healthcheck.php';
-}
+// Important - Cache-healthcheck and App-healthcheck
+require_once __DIR__ . '/healthcheck/healthcheck.php';
+
 
 if ( ! defined( 'WPCOM_VIP_SITE_MAINTENANCE_MODE' ) ) {
 	define( 'WPCOM_VIP_SITE_MAINTENANCE_MODE', false );

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -23,21 +23,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit();
 }
 
+// Important - Cache-healthcheck and App healthcheck
 if ( file_exists( __DIR__ . '/healthcheck/healthcheck.php' ) ) {
 	require_once __DIR__ . '/healthcheck/healthcheck.php';
-}
-
-// Execute the healthcheck as quickly as possible
-if ( isset( $_SERVER['REQUEST_URI'] ) && '/cache-healthcheck?' === $_SERVER['REQUEST_URI'] ) {
-	if ( function_exists( 'newrelic_end_transaction' ) ) {
-		// Discard the transaction (the `true` param)
-		// See: https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-end-txn
-		newrelic_end_transaction( true );
-	}
-
-	http_response_code( 200 );
-
-	die( 'ok' );
 }
 
 if ( ! defined( 'WPCOM_VIP_SITE_MAINTENANCE_MODE' ) ) {

--- a/healthcheck/healthcheck.php
+++ b/healthcheck/healthcheck.php
@@ -22,7 +22,7 @@ if ( isset( $_SERVER['REQUEST_URI'] ) && '/cache-healthcheck?' === $_SERVER['REQ
 /**
  * `parse_request` provides a good balance between making sure the codebase is loaded and not running the main query.
  */
-if ( isset( $_SERVER['REQUEST_URI'] ) && '/vip-healthcheck' === $_SERVER['REQUEST_URI'] ) {
+if ( isset( $_SERVER['REQUEST_URI'] ) && '/app-healthcheck' === $_SERVER['REQUEST_URI'] ) {
 	add_action( 'parse_request', function( $wp ) {
 		$hc = new Automattic\VIP\Healthcheck();
 		$hc->check();


### PR DESCRIPTION
## Description

In #3039 we moved the cache-healthcheck code inside the healthcheck/healthcheck.php. This code was meant to avoid potential transient errors during deploys.

## Changelog Description

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out the PR on a sandbox and hit the site's `/cache-healthcheck?`
2. Verify it's displayed properly.