### PR TITLE
CI: Fix tagging release not running

### DIFF
--- a/.github/workflows/changelog-summary.yml
+++ b/.github/workflows/changelog-summary.yml
@@ -1,4 +1,4 @@
-name: Changelog Summmary
+name: Changelog Summary
 
 on:
   push:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,7 +1,10 @@
-name: release-changelog
+name: Tag Release
 
 on:
-  workflow_dispatch
+  push:
+    branches:
+      - production
+      - update/ci
 
 permissions:
   contents: read
@@ -49,34 +52,3 @@ jobs:
         with:
           generate_release_notes: true
           tag_name: ${{ steps.id-generator.outputs.id }}
-
-  release-changelog:
-    name: Publish Changelog
-    runs-on: ubuntu-latest
-    needs: tag-release
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813 # tag=v1.4.3
-        with:
-          egress-policy: audit
-
-      - name: Check out source code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-
-      - name: Set up Node.js environment
-        uses: actions/setup-node@v3.3.0
-        with:
-          node-version: 14
-          cache: npm
-          cache-dependency-path: bin
-
-      - name: Install dependencies
-        working-directory: ./bin
-        run: npm ci
-
-      - name: Promote changelog entries
-        env:
-          CHANGELOG_BEARER_TOKEN: ${{ secrets.CHANGELOG_BEARER_TOKEN }}
-          RELEASE_ID: ${{ needs.tag-release.outputs.id }}
-        working-directory: ./bin
-        run: node ./mark-production-changelog.js


### PR DESCRIPTION
Changes were made in https://github.com/Automattic/vip-go-mu-plugins/pull/3316 towards renaming the workflow, but since it didn't get synced to `production`, the workflow isn't running on `push` to `production` as expected.

Edit: I cherry-picked this change directly onto `staging` branch.