### PR TITLE
Search: Roll out filter_ep_enable_do_weighting to 25% of production

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -17,7 +17,9 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = [];
+	public static $feature_percentages = [
+		'reduce-default-es-payload' => 0.25,
+	];
 
 	/**
 	 * Holds feature slug and then, key of ids with bool value to enable E.g.

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2343,8 +2343,9 @@ class Search {
 	 * @return bool $should_do_weighting New value on whether to enable weight config
 	 */
 	public function filter_ep_enable_do_weighting( $should_do_weighting, $weight_config, $args, $formatted_args ) {
-		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( VIP_GO_APP_ENVIRONMENT ) ) {
-			// Rollout to non-prod only for now, otherwise skip if production.
+		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( VIP_GO_APP_ENVIRONMENT ) &&
+		! \Automattic\VIP\Feature::is_enabled_by_percentage( 'reduce-default-es-payload' ) ) {
+			// Rollout to non-prod and 25% of production
 			return $should_do_weighting;
 		}
 


### PR DESCRIPTION
## Description
This rolls out https://github.com/Automattic/vip-go-mu-plugins/pull/3340 to 25% of production environments.