### PR TITLE
Bugfix: When using constant(), use string input not constant

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2343,7 +2343,7 @@ class Search {
 	 * @return bool $should_do_weighting New value on whether to enable weight config
 	 */
 	public function filter_ep_enable_do_weighting( $should_do_weighting, $weight_config, $args, $formatted_args ) {
-		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( VIP_GO_APP_ENVIRONMENT ) &&
+		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( 'VIP_GO_APP_ENVIRONMENT' ) &&
 		! \Automattic\VIP\Feature::is_enabled_by_percentage( 'reduce-default-es-payload' ) ) {
 			// Rollout to non-prod and 25% of production
 			return $should_do_weighting;


### PR DESCRIPTION
## Description
When using `constant()`, input a string not a constant.

## Changelog Description

### Plugin Updated: Enterprise Search

Fix Fatal error: Uncaught Error: Undefined constant "qa"
in /var/www/wp-content/mu-plugins/search/includes/classes/class-search.php on line 2346