### PR TITLE
Search: Fix is_site_indexable() returning incorrect value for blogs with no index

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -642,6 +642,9 @@ class Search {
 		add_filter( 'ep_es_info_cache_expiration', [ $this, 'filter__es_info_cache_expiration' ], PHP_INT_MAX, 1 );
 
 		add_filter( 'ep_enable_do_weighting', [ $this, 'filter_ep_enable_do_weighting' ], PHP_INT_MAX, 4 );
+
+		// Since we disable UI toggling, blog option should be dependent on index existing (since it defaults to 'yes' if not found)
+		add_filter( 'blog_option_ep_indexable', [ $this, 'filter__blog_option_ep_indexable' ], PHP_INT_MAX, 2 );
 	}
 
 	protected function load_commands() {
@@ -2380,5 +2383,19 @@ class Search {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Since we disable the toggling UI for whether subsites in multisite are indexable, we should filter the
+	 * option based on the index for the subsite ID existing, instead of default value of blog option or what
+	 * is being stored. See \ElasticPress\Utils\is_site_indexable().
+	 *
+	 * @param string $value Whether the ep_indexable option is found for the blog. Defaults to 'yes'.
+	 * @param int $blog_id The blog_id we are checking.
+	 * @return string $value Whether the index exists for the $blog_id.
+	 */
+	public function filter__blog_option_ep_indexable( $value, $blog_id ) {
+		$index_exists = \ElasticPress\Indexables::factory()->get( 'post' )->index_exists( $blog_id );
+		return false === $index_exists ? 'no' : 'yes';
 	}
 }


### PR DESCRIPTION
## Description
`get_blog_option()` in `is_site_indexable()` returns `'yes'` for blogs where the `ep_indexable` option doesn't exist:
https://github.com/Automattic/ElasticPress/blob/817e9c7043aa82976a3d2f58710979ee8d382f18/includes/utils.php#L126

This makes sense if you're able to toggle the option by UI, but we've disabled that in:
https://github.com/Automattic/vip-go-mu-plugins/blob/9cf29b6fd38d2fb2b72613d2042190ede324018d/search/includes/classes/class-search.php

Therefore, we should be filtering the `ep_indexable` option depending on whether the index exists or not. 

## Changelog Description

### Plugin Updated: Enterprise Search

Search: Fix is_site_indexable() returning incorrect value for blogs with no index

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Set up a multisite and create two sites
2) Index subsite 1 but not 2
3) Shell in and do `\ElasticPress\Utils\is_site_indexable( 2 );` and expect `false`
