### PR TITLE
Search: Fix processing in get_index_exists_option_name for index name

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -801,13 +801,12 @@ class Search {
 	}
 
 	/**
-	 * Generate option name for cached index_exists request.
+	 * Generate option name for caching index_exists requests
 	 *
-	 * @return string $option_name Name of generated option.
+	 * @param  string $index_name  Index name
+	 * @return string $option_name Name of generated option
 	 */
-	private function get_index_exists_option_name( $url ) {
-		$parsed_url = wp_parse_url( $url );
-		$index_name = isset( $parsed_url['path'] ) ? trim( $parsed_url['path'], '/' ) : '';
+	private function get_index_exists_option_name( $index_name ) {
 		return "es_index_exists_{$index_name}";
 	}
 
@@ -834,7 +833,8 @@ class Search {
 		];
 		$valid_index_exists_response_codes = [ 200, 404 ];
 		if ( 'index_exists' === $type || in_array( $type, $index_exists_invalidation_actions, true ) ) {
-			$index_exists_option_name    = $this->get_index_exists_option_name( $query['url'] );
+			$index_name                  = $this->get_index_name_for_url( $query['url'] );
+			$index_exists_option_name    = $this->get_index_exists_option_name( $index_name );
 			$cached_index_exists_request = get_option( $index_exists_option_name );
 			if ( false !== $cached_index_exists_request ) {
 				$cached_index_exists_response_code = (int) wp_remote_retrieve_response_code( $cached_index_exists_request );


### PR DESCRIPTION
## Description
Processing is incorrect for grabbing the index name since we aren't taking into account URL paths such as `/vip-200508-post-1/_search`. Let's utilize the existing function `get_index_name_for_url()` instead and pass that into `get_index_exists_option_name()`.

## Changelog Description

### Plugin Updated: Enterprise Search

Fix `get_index_exists_option_name()` to account for all paths from request URLs.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Do a request to `http://vip-search:9200/vip-200508-post-1/_search` and expect `get_index_exists_option_name()` to return `es_index_exists_vip-200508-post-1`.