### PR TITLE
Search: Fix stale index exists option on multisites

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -801,13 +801,12 @@ class Search {
 	}
 
 	/**
-	 * Generate option name for cached index_exists request.
+	 * Generate option name for caching index_exists requests
 	 *
-	 * @return string $option_name Name of generated option.
+	 * @param  string $index_name  Index name
+	 * @return string $option_name Name of generated option
 	 */
-	private function get_index_exists_option_name( $url ) {
-		$parsed_url = wp_parse_url( $url );
-		$index_name = isset( $parsed_url['path'] ) ? trim( $parsed_url['path'], '/' ) : '';
+	private function get_index_exists_option_name( $index_name ) {
 		return "es_index_exists_{$index_name}";
 	}
 
@@ -834,7 +833,8 @@ class Search {
 		];
 		$valid_index_exists_response_codes = [ 200, 404 ];
 		if ( 'index_exists' === $type || in_array( $type, $index_exists_invalidation_actions, true ) ) {
-			$index_exists_option_name    = $this->get_index_exists_option_name( $query['url'] );
+			$index_name                  = $this->get_index_name_for_url( $query['url'] );
+			$index_exists_option_name    = $this->get_index_exists_option_name( $index_name );
 			$cached_index_exists_request = get_option( $index_exists_option_name );
 			if ( false !== $cached_index_exists_request ) {
 				$cached_index_exists_response_code = (int) wp_remote_retrieve_response_code( $cached_index_exists_request );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -833,9 +833,13 @@ class Search {
 		];
 		$valid_index_exists_response_codes = [ 200, 404 ];
 		if ( 'index_exists' === $type || in_array( $type, $index_exists_invalidation_actions, true ) ) {
-			$index_name                  = $this->get_index_name_for_url( $query['url'] );
-			$index_exists_option_name    = $this->get_index_exists_option_name( $index_name );
-			$cached_index_exists_request = get_option( $index_exists_option_name );
+			$index_name               = $this->get_index_name_for_url( $query['url'] );
+			$index_exists_option_name = $this->get_index_exists_option_name( $index_name );
+			if ( is_multisite() ) {
+				$cached_index_exists_request = get_site_option( $index_exists_option_name );
+			} else {
+				$cached_index_exists_request = get_option( $index_exists_option_name );
+			}
 			if ( false !== $cached_index_exists_request ) {
 				$cached_index_exists_response_code = (int) wp_remote_retrieve_response_code( $cached_index_exists_request );
 				if ( 'index_exists' === $type && in_array( $cached_index_exists_response_code, $valid_index_exists_response_codes, true ) ) {
@@ -843,7 +847,11 @@ class Search {
 					return $cached_index_exists_request;
 				} else {
 					// Invalidate index_exists caching on certain actions.
-					delete_option( $index_exists_option_name );
+					if ( is_multisite() ) {
+						delete_site_option( $index_exists_option_name );
+					} else {
+						delete_option( $index_exists_option_name );
+					}
 
 					// Ensure the cache for the option was actually deleted.
 					if ( false !== wp_cache_get( $index_exists_option_name, 'options' ) ) {
@@ -997,7 +1005,11 @@ class Search {
 
 		if ( 'index_exists' === $type && in_array( $response_code, $valid_index_exists_response_codes, true ) ) {
 			// Cache index_exists into option since we didn't return a cached value earlier.
-			add_option( $index_exists_option_name, $response );
+			if ( is_multisite() ) {
+				add_site_option( $index_exists_option_name, $response );
+			} else {
+				add_option( $index_exists_option_name, $response );
+			}
 		}
 
 		if ( $is_cacheable ) {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -833,13 +833,9 @@ class Search {
 		];
 		$valid_index_exists_response_codes = [ 200, 404 ];
 		if ( 'index_exists' === $type || in_array( $type, $index_exists_invalidation_actions, true ) ) {
-			$index_name               = $this->get_index_name_for_url( $query['url'] );
-			$index_exists_option_name = $this->get_index_exists_option_name( $index_name );
-			if ( is_multisite() ) {
-				$cached_index_exists_request = get_site_option( $index_exists_option_name );
-			} else {
-				$cached_index_exists_request = get_option( $index_exists_option_name );
-			}
+			$index_name                  = $this->get_index_name_for_url( $query['url'] );
+			$index_exists_option_name    = $this->get_index_exists_option_name( $index_name );
+			$cached_index_exists_request = get_site_option( $index_exists_option_name );
 			if ( false !== $cached_index_exists_request ) {
 				$cached_index_exists_response_code = (int) wp_remote_retrieve_response_code( $cached_index_exists_request );
 				if ( 'index_exists' === $type && in_array( $cached_index_exists_response_code, $valid_index_exists_response_codes, true ) ) {
@@ -847,11 +843,7 @@ class Search {
 					return $cached_index_exists_request;
 				} else {
 					// Invalidate index_exists caching on certain actions.
-					if ( is_multisite() ) {
-						delete_site_option( $index_exists_option_name );
-					} else {
-						delete_option( $index_exists_option_name );
-					}
+					delete_site_option( $index_exists_option_name );
 
 					// Ensure the cache for the option was actually deleted.
 					if ( false !== wp_cache_get( $index_exists_option_name, 'options' ) ) {
@@ -1005,11 +997,7 @@ class Search {
 
 		if ( 'index_exists' === $type && in_array( $response_code, $valid_index_exists_response_codes, true ) ) {
 			// Cache index_exists into option since we didn't return a cached value earlier.
-			if ( is_multisite() ) {
-				add_site_option( $index_exists_option_name, $response );
-			} else {
-				add_option( $index_exists_option_name, $response );
-			}
+			add_site_option( $index_exists_option_name, $response );
 		}
 
 		if ( $is_cacheable ) {


### PR DESCRIPTION
## Description
Note: https://github.com/Automattic/vip-go-mu-plugins/pull/3375 needs to be merged first since it includes changes from there.

Noticed that the `index_exists` option for subsites that aren't 1 were being cached to subsite 1 if an `index_exists()` request was being made in that blog context.  This is problematic and can lead to stale cached requests in the option because it may be invalidating in the wrong context. This rings true especially if we are running `wp vip-search index --setup --network-wide`, it will invalidate the option in the blog 2 context when indexing for site 2 (where the option doesn't exist, because it actually lives in site 1): https://github.com/Automattic/vip-go-mu-plugins/blob/fdd99cf535e55eeda46d7a11a4cbb1603d8bc666/search/includes/classes/commands/class-corecommand.php#L250-L260
For a multi-site, it would make more sense to cache and check the option directly in a network context since no two index names will be the same.

Another approach would be to always check site 1 for the option, but with https://github.com/Automattic/vip-go-mu-plugins/pull/3374, this approach makes more sense.

## Changelog Description

### Plugin Updated: Enterprise Search

For multisites, change index existence caching option towards same blog context as requested one.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create new multisite where blog 1 has an index
2) Create new subsite (blog 2) but ensure it has no index
3) Shell in blog 1 context and populate the option cache for blog 2:
```
\ElasticPress\Indexables::factory()->get( 'post' )->index_exists( 2 );
```
This will return `false` naturally.
4) Run `wp vip-search index --setup --network-wide`
5) Shell in blog 1 context and repeat step 3. See it return `false` still, even after we've indexed it!
6) Apply PR
7) Repeat step 4
8) Repeat step 5 and expect it to return `true` 
