### PR TITLE
Search: Add slowlog settings to index healthjob settings

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -29,11 +29,21 @@ class Health {
 		'index.number_of_replicas',
 		'index.number_of_shards',
 		'index.routing.allocation.include.dc',
+		'index.search.slowlog.threshold.query.warn',
+		'index.search.slowlog.threshold.query.info',
+		'index.search.slowlog.threshold.fetch.warn',
+		'index.indexing.slowlog.threshold.index.warn',
+		'index.indexing.slowlog.source',
 	);
 	const INDEX_SETTINGS_HEALTH_AUTO_HEAL_KEYS = array(
 		'index.max_result_window',
 		'index.number_of_replicas',
 		'index.routing.allocation.include.dc',
+		'index.search.slowlog.threshold.query.warn',
+		'index.search.slowlog.threshold.query.info',
+		'index.search.slowlog.threshold.fetch.warn',
+		'index.indexing.slowlog.threshold.index.warn',
+		'index.indexing.slowlog.source',
 	);
 
 	const REINDEX_JOB_DEFAULT_PRIORITY = 15;
@@ -1033,6 +1043,11 @@ class Health {
 				if ( ! empty( $recursive_diff ) ) {
 					$diff[ $key ] = $recursive_diff;
 				}
+			} elseif ( ! isset( $actual_settings[ $key ] ) ) {
+				$diff[ $key ] = array(
+					'expected' => $desired_settings[ $key ],
+					'actual'   => 'N/A',
+				);
 			} elseif ( $actual_settings[ $key ] != $desired_settings[ $key ] ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
 				$diff[ $key ] = array(
 					'expected' => $desired_settings[ $key ],


### PR DESCRIPTION
## Description

In #3209, we added the slowlog settings for new indexes. Now in this PR, we want to have the settings health cron job auto-heal the slowlog mapping keys the same way we do for the other ones.

## Changelog Description

### Plugin Updated: Enterprise Search

Add slowlog settings to auto-heal in settings health cron job.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Build an index without the slowlog settings. Can do so by commenting out the below lines
https://github.com/Automattic/vip-go-mu-plugins/blob/24e4a4aa7b43bbb9db5684e8f42859be8c9672e0/search/includes/classes/class-search.php#L1604-L1608
And then running `wp vip-search index --setup`.
2) Comment in back the lines in step 1).
3) Check that the index doesn't have slowlog settings by shelling in:
```
$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
$indexable->get_index_settings();
```
And looking for any mapping with `slowlog` in it. 
4) Once verified:
```
$es = new \Automattic\VIP\Search\Search();
$es->init();
$hj = new \Automattic\VIP\Search\SettingsHealthJob( $es );
$hj->check_settings_health();
```
5) Repeat step 3, but this time verify that it has the below slowlog settings in step 1