### PR TITLE
Automate rebuild of search-dev-tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,15 @@ jobs:
         run: |
           if [ "$(git diff --ignore-space-at-eol search/search-dev-tools/ | wc -l)" -gt "0" ]; then
             echo "::warning::There are changes in the built files."
-            git config user.name "WordPress VIP Bot"
-            git config user.email github-actions@github.com
-            git config push.default "current"
-            git add search/search-dev-tools/
-            git commit -m "Regenerate the bundle"
-            git push
+            if [ "${{ github.event.head_commit.committer.email }}" != "github-actions@github.com" ]; then
+              git config user.name "WordPress VIP Bot"
+              git config user.email github-actions@github.com
+              git config push.default "current"
+              git add search/search-dev-tools/
+              git commit -m "Regenerate the bundle"
+              git push
+            else
+              echo "::error::Aborting to avoid the loop."
+              exit 1
+            fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,16 +96,13 @@ jobs:
   search-dev-tools:
     name: Build Search Dev Tools
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out source code
         uses: actions/checkout@v3.0.2
-
-      - name: Sanity check
-        run: |
-          if grep -q webpack-dev-server search/search-dev-tools/build/bundle.js; then
-            echo "Attempted to commit a development version of search-dev-tools, please rebuild with npm run build"
-            exit 1
-          fi
+        with:
+          token: ${{ secrets.WPCOM_VIP_BOT_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v3.4.1
@@ -121,3 +118,15 @@ jobs:
       - name: Build files
         run: npm run build
         working-directory: search/search-dev-tools
+
+      - name: Check the diff
+        run: |
+          if [ "$(git diff --ignore-space-at-eol search/search-dev-tools/ | wc -l)" -gt "0" ]; then
+            echo "::warning::There are changes in the built files."
+            git config user.name "WordPress VIP Bot"
+            git config user.email github-actions@github.com
+            git config push.default "current"
+            git add search/search-dev-tools/
+            git commit -m "Regenerate the bundle"
+            git push
+          fi


### PR DESCRIPTION
This PR automates the rebuild of search-dev-tools when one of its essential dependencies gets updated. This is especially useful when dealing with Dependabot PRs: you don't need to check out every PR, install dependencies, rebuild the bundle and commit the changes anymore.

**How it works:**
The action checks out the code, installs the dependencies, and runs the build. If the build has succeeded, it runs `git diff` against the `search/search-dev-tools` directory. If there are any changes, it commits and pushes them.

The commit is authored by `"WordPress VIP Bot" <github-actions@github.com>` but we can change that if necessary. However, we use the bot's repo access token so that the commit triggers another round of CI.

**How to test:**

1. Check out this branch.
2. Modify a JS file in `search/search-dev-tools/src` (this should be a change to the code, not formatting).
3. Commit the changes.
4. If everything is fine, you should see a new commit with the rebuilt files soon.

![gha-log](https://user-images.githubusercontent.com/7810770/179440345-925bb50e-8121-4581-839d-7dfde7395f53.png)
