### PR TITLE
Add codecov.yml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  notify:
+    after_n_builds: 2
+    wait_for_ci: true
+  coverage:
+    status:
+      project:
+        default:
+          informational: true


### PR DESCRIPTION
Run codecov in informational mode, without necessarily gating PRs on the coverage information.
