### PR TITLE
Use filter instead of a show_admin_bar call to force Admin Bar in debug mode

### DIFF
--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -116,9 +116,9 @@ function enable_debug_tools() {
 		return $user_caps;
 	}, 10, 3 );
 
-	add_action('init', function () {
+	add_action( 'init', function () {
 		add_filter( 'show_admin_bar', '__return_true', PHP_INT_MAX );
-	}, 9999);
+	}, 9999 );
 
 	add_action( 'wp_footer', __NAMESPACE__ . '\show_debug_flag', 9999 ); // output later in the page
 	add_action( 'login_footer', __NAMESPACE__ . '\show_debug_flag', 9999 ); // output later in the page

--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -116,7 +116,9 @@ function enable_debug_tools() {
 		return $user_caps;
 	}, 10, 3 );
 
-	add_action( 'init', fn() => show_admin_bar( true ), 9999 );
+	add_action('init', function () {
+		add_filter( 'show_admin_bar', '__return_true', PHP_INT_MAX );
+	}, 9999);
 
 	add_action( 'wp_footer', __NAMESPACE__ . '\show_debug_flag', 9999 ); // output later in the page
 	add_action( 'login_footer', __NAMESPACE__ . '\show_debug_flag', 9999 ); // output later in the page


### PR DESCRIPTION
## Description

Some customers disable the admin bar via a filter, and we always want to show the admin bar in debug mode.

This PR takes it a bit further by trying to add a filter at the max priority on a `9999` priority. It may seem extreme, but there's no guarantee that a hook with the same priority would be added later during the execution of the request, but this approach should cover the absolute majority of cases.

## Changelog Description

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Pass `?a8c-debug=true` to a request, not logged in.
2. Verify admin bar shows up as expected.
