### PR TITLE
Fix rate-limiting logic incorrectly increasing the counter even for queries that are not supposed to be offloaded to ES

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2219,7 +2219,7 @@ class Search {
 				self::$query_count_ttl
 			);
 
-			$this->logger->log( 'warning', 'search_query_rate_limiting', $message );
+			$this->logger->log( 'warning', 'search_query_rate_limiting', $message, [ 'count' => self::get_query_count() ] );
 		}
 	}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -318,12 +318,12 @@ class Search {
 
 	public function apply_settings() {
 		/**
-		 * The period with which the Elasticsearch query rate limiting threshold is set.
+		 * The period with which the Elasticsearch query rate-limiting threshold is set.
 		 *
-		 * A set amount of queries are allowed per-period before Elasticsearch query rate limiting occurs.
+		 * A set amount of queries are allowed per-period before Elasticsearch query rate-limiting occurs.
 		 *
 		 * @hook vip_search_ratelimit_period
-		 * @param int $period The period, in seconds, for Elasticsearch query rate limiting checks.
+		 * @param int $period The period, in seconds, for Elasticsearch query rate-limiting checks.
 		 */
 		self::$query_count_ttl = apply_filters( 'vip_search_ratelimit_period', self::DEFAULT_QUERY_COUNT_TTL );
 
@@ -360,7 +360,7 @@ class Search {
 		}
 
 		/**
-		 * The number of queries allowed per period before Elasticsearch rate limiting takes effect.
+		 * The number of queries allowed per period before Elasticsearch rate-limiting takes effect.
 		 *
 		 * Ratelimiting works by sending a percentage of traffic to the database rather than Elasticsearch to keep the cluster stable.
 		 *
@@ -406,12 +406,12 @@ class Search {
 		}
 
 		/**
-		 * The chance of an individual request being sent to the database when Elasticsearch queries are rate limited.
+		 * The chance of an individual request being sent to the database when Elasticsearch queries are rate-limited.
 		 *
 		 * This value is compared >= rand( 1, 10 ) so a setting of 5 would cause roughly half of requests to go to the database. A setting of 3 would yield a 70% chance of going to the database.
 		 *
 		 * @hook vip_search_query_db_fallback_value
-		 * @param int $fallback_value The value compared >= rand( 1, 10 ) to determine if a request will go to the database if Elasticsearch query rate limited.
+		 * @param int $fallback_value The value compared >= rand( 1, 10 ) to determine if a request will go to the database if Elasticsearch query rate-limited.
 		 */
 		self::$query_db_fallback_value = apply_filters( 'vip_search_query_db_fallback_value', self::DEFAULT_QUERY_DB_FALLBACK_VALUE );
 
@@ -522,7 +522,7 @@ class Search {
 		add_filter( 'ep_skip_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5, 2 );
 		add_filter( 'ep_skip_user_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5 );
 
-		// Rate limit query integration
+		// rate-limit query integration
 		add_action( 'ep_remote_request', [ $this, 'increment_rate_limit_counter_after_request' ], 10, 2 );
 		add_filter( 'ep_skip_query_integration', [ $this, 'rate_limit_ep_query_integration' ], PHP_INT_MAX, 2 );
 
@@ -1378,7 +1378,7 @@ class Search {
 		}
 
 		$message = sprintf(
-			'Application %d - %s has had its Elasticsearch queries rate limited for %d seconds. Half of traffic is diverted to the database when queries are rate limited.',
+			'Application %d - %s has had its Elasticsearch queries rate-limited for %d seconds. Half of traffic is diverted to the database when queries are rate-limited.',
 			FILES_CLIENT_SITE_ID,
 			home_url(),
 			$query_limiting_time
@@ -2213,7 +2213,7 @@ class Search {
 	public function maybe_log_query_ratelimiting_start() {
 		if ( false === wp_cache_get( self::QUERY_RATE_LIMITED_START_CACHE_KEY, self::SEARCH_CACHE_GROUP ) ) {
 			$message = sprintf(
-				'Application %d - %s has triggered Elasticsearch query rate limiting, which will last up to %d seconds. Subsequent or repeat occurrences are possible. Half of traffic is diverted to the database when queries are rate limited.',
+				'Application %d - %s has triggered Elasticsearch query rate-limiting, which will last up to %d seconds. Subsequent or repeat occurrences are possible. Half of traffic is diverted to the database when queries are rate-limited.',
 				FILES_CLIENT_SITE_ID,
 				\home_url(),
 				self::$query_count_ttl

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -523,7 +523,7 @@ class Search {
 		add_filter( 'ep_skip_user_query_integration', array( __CLASS__, 'ep_skip_query_integration' ), 5 );
 
 		// Rate-limit query integration
-		add_filter( 'ep_skip_query_integration', [ $this, 'rate_limit_ep_query_integration' ], PHP_INT_MAX, 2 );
+		add_filter( 'ep_skip_query_integration', [ $this, 'rate_limit_ep_query_integration' ], PHP_INT_MAX );
 
 		// Disable certain EP Features
 		add_filter( 'ep_feature_active', array( $this, 'filter__ep_feature_active' ), PHP_INT_MAX, 3 );
@@ -1267,11 +1267,9 @@ class Search {
 	 * defined percentage of the queries to the database and the rest through Elasticsearch.
 	 *
 	 * @param $skip current ep_skip_query_integration value
-	 * @param array $query formatted ElasticPress Query object
-	 *
 	 * @return bool new value of ep_skip_query_integration
 	 */
-	public function rate_limit_ep_query_integration( $skip, $query ) {
+	public function rate_limit_ep_query_integration( $skip ) {
 		// Honor previous filters that skip query integration
 		if ( $skip ) {
 			return true;

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -1279,9 +1279,11 @@ class Search_Test extends WP_UnitTestCase {
 
 		// Force this request to be ratelimited
 		$es::$query_db_fallback_value = 11;
+		wp_cache_set( $this->search_instance::QUERY_COUNT_CACHE_KEY, 1, $this->search_instance::SEARCH_CACHE_GROUP );
 
 		// ep_skip_query_integration should be true if ratelimited
-		$this->assertTrue( $es->rate_limit_ep_query_integration( false ), 'should return true if the query is ratelimited' );
+		$this->assertTrue( $es->rate_limit_ep_query_integration( false ), 'should return true if the query is rate-limited' );
+		wp_cache_delete( $this->search_instance::QUERY_COUNT_CACHE_KEY, $this->search_instance::SEARCH_CACHE_GROUP );
 	}
 
 	public function test__rate_limit_ep_query_integration__handles_start_correctly() {
@@ -1291,10 +1293,10 @@ class Search_Test extends WP_UnitTestCase {
 			->getMock();
 		$partially_mocked_search->init();
 
-		// Force ratelimiting to apply
+		// Force rate-limiting to apply
 		$partially_mocked_search::$max_query_count = 0;
 
-		// Force this request to be ratelimited
+		// Force this request to be rate-limited
 		$partially_mocked_search::$query_db_fallback_value = 11;
 
 		$partially_mocked_search->expects( $this->once() )->method( 'handle_query_limiting_start_timestamp' );
@@ -1310,9 +1312,12 @@ class Search_Test extends WP_UnitTestCase {
 			->getMock();
 		$partially_mocked_search->init();
 
+		wp_cache_set( $this->search_instance::QUERY_COUNT_CACHE_KEY, 1, $this->search_instance::SEARCH_CACHE_GROUP );
+
 		$partially_mocked_search->expects( $this->once() )->method( 'clear_query_limiting_start_timestamp' );
 
 		$partially_mocked_search->rate_limit_ep_query_integration( false );
+		wp_cache_delete( $this->search_instance::QUERY_COUNT_CACHE_KEY, $this->search_instance::SEARCH_CACHE_GROUP );
 	}
 
 	public function test__record_ratelimited_query_stat__records_statsd() {
@@ -2493,7 +2498,7 @@ class Search_Test extends WP_UnitTestCase {
 			$this->expectWarning();
 			$this->expectWarningMessage(
 				sprintf(
-					'Application 123 - http://example.org has had its Elasticsearch queries rate limited for %d seconds. Half of traffic is diverted to the database when queries are rate limited.',
+					'Application 123 - http://example.org has had its Elasticsearch queries rate-limited for %d seconds. Half of traffic is diverted to the database when queries are rate-limited.',
 					$difference
 				)
 			);
@@ -2883,7 +2888,7 @@ class Search_Test extends WP_UnitTestCase {
 					$this->equalTo( 'warning' ),
 					$this->equalTo( 'search_query_rate_limiting' ),
 					$this->equalTo(
-						'Application 123 - http://example.org has triggered Elasticsearch query rate limiting, which will last up to 300 seconds. Subsequent or repeat occurrences are possible. Half of traffic is diverted to the database when queries are rate limited.'
+						'Application 123 - http://example.org has triggered Elasticsearch query rate-limiting, which will last up to 300 seconds. Subsequent or repeat occurrences are possible. Half of traffic is diverted to the database when queries are rate-limited.'
 					),
 					$this->anything()
 				);

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -1298,11 +1298,13 @@ class Search_Test extends WP_UnitTestCase {
 
 		// Force this request to be rate-limited
 		$partially_mocked_search::$query_db_fallback_value = 11;
+		wp_cache_set( $this->search_instance::QUERY_COUNT_CACHE_KEY, 1, $this->search_instance::SEARCH_CACHE_GROUP );
 
 		$partially_mocked_search->expects( $this->once() )->method( 'handle_query_limiting_start_timestamp' );
 		$partially_mocked_search->expects( $this->once() )->method( 'maybe_alert_for_prolonged_query_limiting' );
 
 		$partially_mocked_search->rate_limit_ep_query_integration( false );
+		wp_cache_delete( $this->search_instance::QUERY_COUNT_CACHE_KEY, $this->search_instance::SEARCH_CACHE_GROUP );
 	}
 
 	public function test__rate_limit_ep_query_integration__clears_start_correctly() {


### PR DESCRIPTION
## Description

Current logic is faulty - it increments the value on every filter call, which may lead to an artificially increased counter number, which would trigger rate-limiting logic and send some queries to DB. This may lead to random spikes in SQL.

The new approach only increments the counter AFTER the request is made, whether it was successful or not. 


## Changelog Description

### Plugin Updated: Enterprise Search

We've reworked query rate-limiting logic to avoid potential over-counting of number of queries made to Enterprise Search backend.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Before applying this PR, run a search query on the site, make note of total number of remote requests in QM or Search Dev Tools
2. `wp cache get query_count vip_search` - make note that this number is bigger
3. Apply the PR
4. Flush memcached
5. Do steps 1, 2 and verify the counter is `1`