### PR TITLE
[CANTINA-889] Change the way the collectors are loaded

### DIFF
--- a/prometheus.php
+++ b/prometheus.php
@@ -15,12 +15,15 @@ if ( defined( 'ABSPATH' ) ) {
 		require_once __DIR__ . '/prometheus-collectors/class-apcu-collector.php';
 		require_once __DIR__ . '/prometheus-collectors/class-opcache-collector.php';
 
-		add_filter( 'vip_prometheus_collectors', function ( array $collectors ): array {
-			$collectors[] = new Cache_Collector();
-			$collectors[] = new APCu_Collector();
-			$collectors[] = new OpCache_Collector();
+		add_filter( 'vip_prometheus_collectors', function ( array $collectors, string $hook ): array {
+			if ( 'vipgo_mu_plugins_loaded' === $hook ) {
+				$collectors[] = new Cache_Collector();
+				$collectors[] = new APCu_Collector();
+				$collectors[] = new OpCache_Collector();
+			}
+
 			return $collectors;
-		} );
+		}, 10, 2 );
 	}
 }
 // @codeCoverageIgnoreEnd

--- a/prometheus/inc/class-collectorinterface.php
+++ b/prometheus/inc/class-collectorinterface.php
@@ -5,7 +5,7 @@ namespace Automattic\VIP\Prometheus;
 use Prometheus\RegistryInterface;
 
 interface CollectorInterface {
-	public function initialize( RegistryInterface $registry );
+	public function initialize( RegistryInterface $registry ): void;
 
 	/**
 	 * Last chance to collect metrics before sending them to the scraper.

--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -12,7 +12,7 @@ use WP;
 use WP_Query;
 
 class Plugin {
-	private static ?Plugin $instance       = null;
+	protected static ?Plugin $instance     = null;
 	protected ?RegistryInterface $registry = null;
 	/** @var CollectorInterface[] */
 	protected array $collectors = [];
@@ -22,7 +22,7 @@ class Plugin {
 	 */
 	public static function get_instance(): self {
 		if ( ! self::$instance ) {
-			self::$instance = new self();
+			self::$instance = new static();
 		}
 
 		return self::$instance;
@@ -32,27 +32,36 @@ class Plugin {
 	 * @codeCoverageIgnore -- invoked before the tests start
 	 */
 	protected function __construct() {
-		add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
+		add_action( 'vipgo_mu_plugins_loaded', [ $this, 'init_registry' ], 9 );
+
+		add_action( 'vipgo_mu_plugins_loaded', [ $this, 'load_collectors' ] );
+		add_action( 'mu_plugins_loaded', [ $this, 'load_collectors' ] );
+		add_action( 'plugins_loaded', [ $this, 'load_collectors' ] );
+
 		add_action( 'init', [ $this, 'init' ] );
 	}
 
-	public function plugins_loaded(): void {
+	public function init_registry() {
 		$this->registry = self::create_registry();
+	}
 
-		$available_collectors = apply_filters( 'vip_prometheus_collectors', [] );
+	public function load_collectors(): void {
+		$available_collectors = apply_filters( 'vip_prometheus_collectors', [], current_action() );
 		if ( ! is_array( $available_collectors ) ) {
 			$available_collectors = [];
 		}
 
-		foreach ( $available_collectors as $key => $collector ) {
-			if ( is_object( $collector ) && $collector instanceof CollectorInterface ) {
-				$collector->initialize( $this->registry );
-			} else {
-				unset( $available_collectors[ $key ] );
-			}
-		}
+		$available_collectors = array_filter( $available_collectors, fn ( $collector ) => $collector instanceof CollectorInterface );
 
-		$this->collectors = $available_collectors;
+		$available_collectors = array_udiff(
+			$available_collectors,
+			$this->collectors,
+			fn ( $a, $b ) => spl_object_id( $a ) - spl_object_id( $b )
+		);
+
+		array_walk( $available_collectors, fn ( CollectorInterface $collector ) => $collector->initialize( $this->registry ) );
+
+		$this->collectors = array_merge( $this->collectors, $available_collectors );
 	}
 
 	public function init(): void {

--- a/tests/prometheus/class-plugin-helper.php
+++ b/tests/prometheus/class-plugin-helper.php
@@ -5,14 +5,8 @@ namespace Automattic\VIP\Prometheus;
 use Prometheus\RegistryInterface;
 
 class Plugin_Helper extends Plugin {
-	private static ?Plugin_Helper $instance = null;
-
-	public static function get_instance(): self {
-		if ( ! self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
+	public static function clear_instance(): void {
+		self::$instance = null;
 	}
 
 	public function get_registry(): RegistryInterface {

--- a/tests/prometheus/test-prometheus.php
+++ b/tests/prometheus/test-prometheus.php
@@ -11,6 +11,22 @@ require_once __DIR__ . '/class-plugin-helper.php';
 class Test_Prometheus extends WP_UnitTestCase {
 	use ExpectPHPException;
 
+	public function setUp(): void {
+		parent::setUp();
+
+		remove_all_actions( 'vipgo_mu_plugins_loaded' );
+		remove_all_actions( 'mu_plugins_loaded' );
+		remove_all_actions( 'plugins_loaded' );
+		remove_all_actions( 'init' );
+
+		Plugin_Helper::clear_instance();
+	}
+
+	public function tearDown(): void {
+		Plugin::get_instance();
+		parent::tear_down();
+	}
+
 	public function test_collectors_filter(): void {
 		$plugin = Plugin_Helper::get_instance();
 		self::assertInstanceOf( Plugin_Helper::class, $plugin );
@@ -24,7 +40,7 @@ class Test_Prometheus extends WP_UnitTestCase {
 		};
 
 		add_filter( 'vip_prometheus_collectors', $available_collectors_filter );
-		$plugin->plugins_loaded();
+		do_action( 'vipgo_mu_plugins_loaded' );
 
 		self::assertTrue( $filter_invoked );
 		self::assertIsArray( $plugin->get_collectors() );
@@ -42,7 +58,7 @@ class Test_Prometheus extends WP_UnitTestCase {
 		};
 
 		add_filter( 'vip_prometheus_collectors', $available_collectors_filter, PHP_INT_MAX );
-		$plugin->plugins_loaded();
+		do_action( 'vipgo_mu_plugins_loaded' );
 
 		self::assertTrue( $filter_invoked );
 		self::assertIsArray( $plugin->get_collectors() );
@@ -61,7 +77,7 @@ class Test_Prometheus extends WP_UnitTestCase {
 		};
 
 		add_filter( 'vip_prometheus_collectors', $available_collectors_filter, PHP_INT_MAX );
-		$plugin->plugins_loaded();
+		do_action( 'vipgo_mu_plugins_loaded' );
 
 		self::assertTrue( $filter_invoked );
 		self::assertEmpty( $plugin->get_collectors() );
@@ -69,19 +85,73 @@ class Test_Prometheus extends WP_UnitTestCase {
 
 	public function test_create_registry(): void {
 		$plugin = Plugin_Helper::get_instance();
-		$plugin->plugins_loaded();
+		do_action( 'vipgo_mu_plugins_loaded' );
 
 		self::assertInstanceOf( RegistryInterface::class, $plugin->get_registry() );
 	}
 
 	public function test_create_registry_wrong_backend(): void {
-		$plugin = Plugin_Helper::get_instance();
+		Plugin_Helper::get_instance();
 
 		add_filter( 'vip_prometheus_storage_backend', function () {
 			return new \stdClass();
 		} );
 
 		$this->expectWarning();
-		$plugin->plugins_loaded();
+		do_action( 'vipgo_mu_plugins_loaded' );
+	}
+
+	public function test_merge_collectors(): void {
+		$plugin = Plugin_Helper::get_instance();
+
+		$collector1 = new class() implements CollectorInterface {
+			public $initialize_called = 0;
+
+			public function initialize( RegistryInterface $registry ): void {
+				++$this->initialize_called;
+			}
+
+			public function collect_metrics(): void {
+				// Do nothing
+			}
+		};
+
+		$collector2 = clone $collector1;
+		$collector3 = clone $collector1;
+
+		add_filter( 'vip_prometheus_collectors', function ( array $collectors, string $hook ) use ( $collector1, $collector2, $collector3 ): array {
+			switch ( $hook ) {
+				case 'vipgo_mu_plugins_loaded':
+					return [ $collector1 ];
+
+				case 'mu_plugins_loaded':
+					return [ $collector1, $collector2 ];
+
+				case 'plugins_loaded':
+					return [ $collector2, $collector3 ];
+
+				default:
+					WP_UnitTestCase::assertFalse( true );
+					return $collectors;
+			}
+		}, 10, 2 );
+
+		do_action( 'vipgo_mu_plugins_loaded' );
+		self::assertEquals( 1, $collector1->initialize_called );
+		self::assertEquals( 0, $collector2->initialize_called );
+		self::assertEquals( 0, $collector3->initialize_called );
+
+		do_action( 'mu_plugins_loaded' );
+		self::assertEquals( 1, $collector1->initialize_called );
+		self::assertEquals( 1, $collector2->initialize_called );
+		self::assertEquals( 0, $collector3->initialize_called );
+
+		do_action( 'plugins_loaded' );
+		self::assertEquals( 1, $collector1->initialize_called );
+		self::assertEquals( 1, $collector2->initialize_called );
+		self::assertEquals( 1, $collector3->initialize_called );
+
+		$expected = [ $collector1, $collector2, $collector3 ];
+		self::assertEquals( $expected, $plugin->get_collectors() );
 	}
 }

--- a/tests/prometheus/test-prometheus.php
+++ b/tests/prometheus/test-prometheus.php
@@ -24,7 +24,7 @@ class Test_Prometheus extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		Plugin::get_instance();
-		parent::tear_down();
+		parent::tearDown();
 	}
 
 	public function test_collectors_filter(): void {

--- a/z-client-mu-plugins.php
+++ b/z-client-mu-plugins.php
@@ -112,6 +112,7 @@ function wpcom_vip_filter_client_mu_plugins_url( $url, $url_path, $plugin_path )
 }
 add_filter( 'plugins_url', 'wpcom_vip_filter_client_mu_plugins_url', 10, 3 );
 
+do_action( 'vipgo_mu_plugins_loaded' );
 
 if ( wpcom_vip_should_load_plugins() ) {
 	// Let's load the plugins


### PR DESCRIPTION
## Description

This PR changes the way how Prometheus collectors are loaded.

Now there are three different points when collectors can be loaded:
1. `vipgo_mu_plugins_loaded`: happens after all our MU plugins have been loaded and before `z-client-mu-plugins.php` loads MU plugins from the `client-mu-plugins` directory. This is when we should load *our* collectors;
2. `mu_plugins_loaded`: gives a chance for client MU plugins to set up their collectors;
3. `plugins_loaded`: gives a chance to client plugins to set up their collectors.

For now, (2) and (3) exist in case we will ever want to allow for user-provided collectors. In other words, these extension points exist, but we do not advertise them nor provide any user-visible feedback if they want to use them.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
