### PR TITLE
[CANTINA-889] Add login stats collector

### DIFF
--- a/prometheus-collectors/class-login-stats-collector.php
+++ b/prometheus-collectors/class-login-stats-collector.php
@@ -50,19 +50,19 @@ class Login_Stats_Collector implements CollectorInterface {
 	}
 
 	public function login_limit_exceeded(): void {
-		$this->login_limit_exceeded_counter->inc( [ 'site_id' => (string) get_current_blog_id() ] );
+		$this->login_limit_exceeded_counter->inc( [ (string) get_current_blog_id() ] );
 	}
 
 	public function password_reset_limit_exceeded(): void {
-		$this->password_reset_limit_exceeded_counter->inc( [ 'site_id' => (string) get_current_blog_id() ] );
+		$this->password_reset_limit_exceeded_counter->inc( [ (string) get_current_blog_id() ] );
 	}
 
 	public function wp_login(): void {
-		$this->successful_login_counter->inc( [ 'site_id' => (string) get_current_blog_id() ] );
+		$this->successful_login_counter->inc( [ (string) get_current_blog_id() ] );
 	}
 
 	public function wp_login_failed(): void {
-		$this->failed_login_counter->inc( [ 'site_id' => (string) get_current_blog_id() ] );
+		$this->failed_login_counter->inc( [ (string) get_current_blog_id() ] );
 	}
 
 	public function collect_metrics(): void {

--- a/prometheus-collectors/class-login-stats-collector.php
+++ b/prometheus-collectors/class-login-stats-collector.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Automattic\VIP\Prometheus;
+
+use Prometheus\Counter;
+use Prometheus\RegistryInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class Login_Stats_Collector implements CollectorInterface {
+	private Counter $login_limit_exceeded_counter;
+	private Counter $password_reset_limit_exceeded_counter;
+	private Counter $successful_login_counter;
+	private Counter $failed_login_counter;
+
+	public function initialize( RegistryInterface $registry ): void {
+		$this->login_limit_exceeded_counter = $registry->getOrRegisterCounter(
+			'security',
+			'login_limit_exceeded_total',
+			'Number of rate-limited login requests',
+			[ 'site_id' ]
+		);
+
+		$this->password_reset_limit_exceeded_counter = $registry->getOrRegisterCounter(
+			'security',
+			'password_reset_limit_exceeded_total',
+			'Number of rate-limited password reset requests',
+			[ 'site_id' ]
+		);
+
+		$this->successful_login_counter = $registry->getOrRegisterCounter(
+			'security',
+			'successful_logins_total',
+			'Number of successful login attempts',
+			[ 'site_id' ]
+		);
+
+		$this->failed_login_counter = $registry->getOrRegisterCounter(
+			'security',
+			'failed_logins_total',
+			'Number of failed login attempts',
+			[ 'site_id' ]
+		);
+
+		add_action( 'login_limit_exceeded', [ $this, 'login_limit_exceeded' ] );
+		add_action( 'password_reset_limit_exceeded', [ $this, 'password_reset_limit_exceeded' ] );
+		add_action( 'wp_login', [ $this, 'wp_login' ] );
+		add_action( 'wp_login_failed', [ $this, 'wp_login_failed' ] );
+	}
+
+	public function login_limit_exceeded(): void {
+		$this->login_limit_exceeded_counter->inc( [ 'site_id' => (string) get_current_blog_id() ] );
+	}
+
+	public function password_reset_limit_exceeded(): void {
+		$this->password_reset_limit_exceeded_counter->inc( [ 'site_id' => (string) get_current_blog_id() ] );
+	}
+
+	public function wp_login(): void {
+		$this->successful_login_counter->inc( [ 'site_id' => (string) get_current_blog_id() ] );
+	}
+
+	public function wp_login_failed(): void {
+		$this->failed_login_counter->inc( [ 'site_id' => (string) get_current_blog_id() ] );
+	}
+
+	public function collect_metrics(): void {
+		// Do nothing
+	}
+}

--- a/prometheus.php
+++ b/prometheus.php
@@ -2,6 +2,7 @@
 
 use Automattic\VIP\Prometheus\APCu_Collector;
 use Automattic\VIP\Prometheus\Cache_Collector;
+use Automattic\VIP\Prometheus\Login_Stats_Collector;
 use Automattic\VIP\Prometheus\OpCache_Collector;
 
 // @codeCoverageIgnoreStart -- this file is loaded before tests start
@@ -14,12 +15,14 @@ if ( defined( 'ABSPATH' ) ) {
 		require_once __DIR__ . '/prometheus-collectors/class-cache-collector.php';
 		require_once __DIR__ . '/prometheus-collectors/class-apcu-collector.php';
 		require_once __DIR__ . '/prometheus-collectors/class-opcache-collector.php';
+		require_once __DIR__ . '/prometheus-collectors/class-login-stats-collector.php';
 
 		add_filter( 'vip_prometheus_collectors', function ( array $collectors, string $hook ): array {
 			if ( 'vipgo_mu_plugins_loaded' === $hook ) {
 				$collectors[] = new Cache_Collector();
 				$collectors[] = new APCu_Collector();
 				$collectors[] = new OpCache_Collector();
+				$collectors[] = new Login_Stats_Collector();
 			}
 
 			return $collectors;


### PR DESCRIPTION
## Description

This PR adds a Prometheus collector for login stats.

It introduces the following counters:
* `security_login_limit_exceeded_total`: number of rate-limited login requests;
* `security_password_reset_limit_exceeded_total`: number of rate-limited password reset requests;
* `security_successful_logins_total`: number of successful logins;
* `security_failed_logins_total`: number of failed logins.

All counters have the `site_id` label with the value equal to the return value of `get_current_blog_id()`.