### PR TITLE
Change debug_bar_panels filter priority

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -63,5 +63,5 @@ add_action( 'init', function() {
 		$panels[] = new WPCOM_Debug_Bar_Apcu_Hotcache();
 
 		return $panels;
-	}, 99);
+	}, 5 );
 }, 1 ); // Priority must be lower than that of Query Monitor


### PR DESCRIPTION

## Description

The filter we have is running too late for the newer versions of Debug Bar, it seems--meaning we're missing out on some panels.

## Changelog Description

### Bugfix: Debug Bar Loader

Fix a fitler priority issue in our Debug Bar loader that caused some panels to be missing.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Go to a site, open Debug Bar, and notice the Memcache panel is visible.
