### PR TITLE
Add vip_prometheus_loaded hook

### DIFF
--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -39,6 +39,8 @@ class Plugin {
 		add_action( 'plugins_loaded', [ $this, 'load_collectors' ] );
 
 		add_action( 'init', [ $this, 'init' ] );
+
+		do_action( 'vip_prometheus_loaded' );
 	}
 
 	public function init_registry() {


### PR DESCRIPTION
Because other MU plugins might depend on the `CollectorInterface` interface, this PR provides a hook to signal that the interface is available.

Usage example:

```php
if ( did_action( 'vip_prometheus_loaded' ) ) {
    load_collector();
} else {
    add_action( 'vip_prometheus_loaded', 'load_collector' );
}
```
