### PR TITLE
Lockout Plugin: Add `VIP_ACCOUNT_STATUS` constant to display notice/lock site.

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -43,7 +43,7 @@ class Lockout {
 
 	private function get_lockout_state() {
 		// VIP_ACCOUNT_STATUS has precedence over VIP_LOCKOUT_STATE
-		if ( defined( 'VIP_ACCOUNT_STATUS' ) && VIP_ACCOUNT_STATUS !== self::ACCOUNT_STATUS_NORMAL ) {
+		if ( defined( 'VIP_ACCOUNT_STATUS' ) && constant( 'VIP_ACCOUNT_STATUS' ) !== self::ACCOUNT_STATUS_NORMAL ) {
 			return constant( 'VIP_ACCOUNT_STATUS' );
 		}
 
@@ -52,7 +52,7 @@ class Lockout {
 
 	private function get_lockout_message() {
 		// If the account is locked, use the proper lockout message
-		if ( defined( 'VIP_ACCOUNT_STATUS' ) && VIP_ACCOUNT_STATUS !== self::ACCOUNT_STATUS_NORMAL ) {
+		if ( defined( 'VIP_ACCOUNT_STATUS' ) && constant( 'VIP_ACCOUNT_STATUS' ) !== self::ACCOUNT_STATUS_NORMAL ) {
 			switch ( $this->get_lockout_state() ) {
 				case self::ACCOUNT_STATUS_WARNING:
 					return 'Payment for this WordPress VIP account is overdue and it will be disabled.<br />

--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -14,10 +14,10 @@ class Lockout {
 
 	const USER_SEEN_WARNING_TIME_KEY = 'seen_lockout_warning_time';
 
-    const ACCOUNT_STATUS_NORMAL = 'normal';
-    const ACCOUNT_STATUS_WARNING = 'warned';
-    const ACCOUNT_STATUS_LOCK = 'locked';
-    const ACCOUNT_STATUS_SHUTDOWN = 'shutdown';
+	const ACCOUNT_STATUS_NORMAL   = 'normal';
+	const ACCOUNT_STATUS_WARNING  = 'warned';
+	const ACCOUNT_STATUS_LOCK     = 'locked';
+	const ACCOUNT_STATUS_SHUTDOWN = 'shutdown';
 
 	/**
 	 * @var array Default user capabilities for locked state
@@ -31,7 +31,7 @@ class Lockout {
 	 * Lockout constructor.
 	 */
 	public function __construct() {
-		if ( $this->getLockoutState() ) {
+		if ( $this->get_lockout_state() ) {
 			add_action( 'admin_notices', [ $this, 'add_admin_notice' ], 1 );
 			add_action( 'user_admin_notices', [ $this, 'add_admin_notice' ], 1 );
 
@@ -41,36 +41,38 @@ class Lockout {
 		}
 	}
 
-    private function getLockoutState() {
-        // VIP_ACCOUNT_STATUS has precedence over VIP_LOCKOUT_STATE
-        if ( defined( 'VIP_ACCOUNT_STATUS' ) && VIP_ACCOUNT_STATUS !== self::ACCOUNT_STATUS_NORMAL ) {
-            return VIP_ACCOUNT_STATUS;
-        }
+	private function get_lockout_state() {
+		// VIP_ACCOUNT_STATUS has precedence over VIP_LOCKOUT_STATE
+		if ( defined( 'VIP_ACCOUNT_STATUS' ) && VIP_ACCOUNT_STATUS !== self::ACCOUNT_STATUS_NORMAL ) {
+			return constant( 'VIP_ACCOUNT_STATUS' );
+		}
 
-        return defined( 'VIP_LOCKOUT_STATE' ) ? VIP_LOCKOUT_STATE : false;
-    }
+		return defined( 'VIP_LOCKOUT_STATE' ) ? constant( 'VIP_LOCKOUT_STATE' ) : false;
+	}
 
-    private function getLockoutMessage() {
-        // If the account is locked, use the proper lockout message
-        if ( defined( 'VIP_ACCOUNT_STATUS') && VIP_ACCOUNT_STATUS !== self::ACCOUNT_STATUS_NORMAL ) {
-	        switch ( $this->getLockoutState() ) {
-		        case self::ACCOUNT_STATUS_WARNING:
-			        return 'Payment for this WordPress VIP account is overdue and it will be disabled.<br />
+	private function get_lockout_message() {
+		// If the account is locked, use the proper lockout message
+		if ( defined( 'VIP_ACCOUNT_STATUS' ) && VIP_ACCOUNT_STATUS !== self::ACCOUNT_STATUS_NORMAL ) {
+			switch ( $this->get_lockout_state() ) {
+				case self::ACCOUNT_STATUS_WARNING:
+					return 'Payment for this WordPress VIP account is overdue and it will be disabled.<br />
 Contact accounts@wpvip.com to pay your bill.';
-                case self::ACCOUNT_STATUS_LOCK:
-                case self::ACCOUNT_STATUS_SHUTDOWN:
-			        return 'Payment for this WordPress VIP account is overdue and it has been disabled.<br />
-Contact accounts@wpvip.com to pay your bill.';	        }
-        }
-        // Otherwise, read it from VIP_LOCKOUT_MESSAGE constant
-        return defined( 'VIP_LOCKOUT_MESSAGE' ) ? VIP_LOCKOUT_MESSAGE : false;
-    }
+				case self::ACCOUNT_STATUS_LOCK:
+				case self::ACCOUNT_STATUS_SHUTDOWN:
+					return 'Payment for this WordPress VIP account is overdue and it has been disabled.<br />
+Contact accounts@wpvip.com to pay your bill.';
+			}
+		}
+		// Otherwise, read it from VIP_LOCKOUT_MESSAGE constant
+		return defined( 'VIP_LOCKOUT_MESSAGE' ) ? constant( 'VIP_LOCKOUT_MESSAGE' ) : false;
+	}
 
 	/**
 	 * Add warnings to admin page
 	 */
 	public function add_admin_notice() {
-		if ( $lockout_state = $this->getLockoutState() ) {
+		$lockout_state = $this->get_lockout_state();
+		if ( $lockout_state ) {
 			$user = wp_get_current_user();
 
 			switch ( $lockout_state ) {
@@ -85,9 +87,9 @@ Contact accounts@wpvip.com to pay your bill.';	        }
 
 					break;
 
-                case self::ACCOUNT_STATUS_LOCK:
+				case self::ACCOUNT_STATUS_LOCK:
 				case self::ACCOUNT_STATUS_SHUTDOWN:
-				    $has_caps    = isset( $user->allcaps['edit_posts'] ) && true === $user->allcaps['edit_posts'];
+					$has_caps    = isset( $user->allcaps['edit_posts'] ) && true === $user->allcaps['edit_posts'];
 					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, $lockout_state, $user );
 					if ( $show_notice ) {
 						$this->render_locked_notice();
@@ -109,7 +111,7 @@ Contact accounts@wpvip.com to pay your bill.';	        }
 		$seen_warning = get_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, true );
 
 		if ( ! $seen_warning ) {
-			add_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, $this->getLockoutState(), true );
+			add_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, $this->get_lockout_state(), true );
 			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- not sure if it is safe to replace with gmdate()
 			add_user_meta( $user->ID, self::USER_SEEN_WARNING_TIME_KEY, date( 'Y-m-d H:i:s' ), true );
 		}
@@ -120,7 +122,7 @@ Contact accounts@wpvip.com to pay your bill.';	        }
 		<div id="lockout-warning" class="notice-warning wrap clearfix" style="align-items: center;background: #ffffff;border-left-width:4px;border-left-style:solid;border-radius: 6px;display: flex;margin-top: 30px;padding: 30px;line-height: 2em;">
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#ffb900;"></div>
 			<div style="display: flex;align-items: center;" >
-				<h3><?php echo wp_kses_post( $this->getLockoutMessage() ); ?></h3>
+				<h3><?php echo wp_kses_post( $this->get_lockout_message() ); ?></h3>
 			</div>
 		</div>
 		<?php
@@ -131,7 +133,7 @@ Contact accounts@wpvip.com to pay your bill.';	        }
 		<div id="lockout-warning" class="notice-error wrap clearfix" style="align-items: center;background: #ffffff;border-left-width:4px;border-left-style:solid;border-radius: 6px;display: flex;margin-top: 30px;padding: 30px;line-height: 2em;">
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#dc3232;"></div>
 			<div style="display: flex;align-items: center;" >
-				<h3><?php echo wp_kses_post( $this->getLockoutMessage() ); ?></h3>
+				<h3><?php echo wp_kses_post( $this->get_lockout_message() ); ?></h3>
 			</div>
 		</div>
 		<?php
@@ -150,7 +152,7 @@ Contact accounts@wpvip.com to pay your bill.';	        }
 	 * @return array
 	 */
 	public function filter_user_has_cap( $user_caps, $caps, $args, $user ) {
-        $lockout_state = $this->getLockoutState();
+		$lockout_state = $this->get_lockout_state();
 		if ( $lockout_state && in_array( $lockout_state, [ self::ACCOUNT_STATUS_LOCK, self::ACCOUNT_STATUS_SHUTDOWN ] ) ) {
 			if ( is_automattician( $user->ID ) ) {
 				return $user_caps;
@@ -180,7 +182,7 @@ Contact accounts@wpvip.com to pay your bill.';	        }
 	 * @return  array
 	 */
 	public function filter_site_admin_option( $pre_option ) {
-		$lockout_state = $this->getLockoutState();
+		$lockout_state = $this->get_lockout_state();
 		if ( $lockout_state && in_array( $lockout_state, [ self::ACCOUNT_STATUS_LOCK, self::ACCOUNT_STATUS_SHUTDOWN ] ) ) {
 			if ( is_automattician() ) {
 				return $pre_option;
@@ -202,9 +204,9 @@ Contact accounts@wpvip.com to pay your bill.';	        }
 	 * Instead, just block updates to the option if a site is locked.
 	 */
 	public function filter_prevent_site_admin_option_updates( $value, $old_value ) {
-		$lockout_state = $this->getLockoutState();
+		$lockout_state = $this->get_lockout_state();
 		if ( $lockout_state && in_array( $lockout_state, [ self::ACCOUNT_STATUS_LOCK, self::ACCOUNT_STATUS_SHUTDOWN ] ) ) {
-            return $old_value;
+			return $old_value;
 		}
 
 		return $value;

--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -14,6 +14,11 @@ class Lockout {
 
 	const USER_SEEN_WARNING_TIME_KEY = 'seen_lockout_warning_time';
 
+    const ACCOUNT_STATUS_NORMAL = 'normal';
+    const ACCOUNT_STATUS_WARNING = 'warned';
+    const ACCOUNT_STATUS_LOCK = 'locked';
+    const ACCOUNT_STATUS_SHUTDOWN = 'shutdown';
+
 	/**
 	 * @var array Default user capabilities for locked state
 	 */
@@ -26,7 +31,7 @@ class Lockout {
 	 * Lockout constructor.
 	 */
 	public function __construct() {
-		if ( defined( 'VIP_LOCKOUT_STATE' ) && defined( 'VIP_LOCKOUT_MESSAGE' ) ) {
+		if ( $this->getLockoutState() ) {
 			add_action( 'admin_notices', [ $this, 'add_admin_notice' ], 1 );
 			add_action( 'user_admin_notices', [ $this, 'add_admin_notice' ], 1 );
 
@@ -36,17 +41,42 @@ class Lockout {
 		}
 	}
 
+    private function getLockoutState() {
+        // VIP_ACCOUNT_STATUS has precedence over VIP_LOCKOUT_STATE
+        if ( defined( 'VIP_ACCOUNT_STATUS' ) && VIP_ACCOUNT_STATUS !== self::ACCOUNT_STATUS_NORMAL ) {
+            return VIP_ACCOUNT_STATUS;
+        }
+
+        return defined( 'VIP_LOCKOUT_STATE' ) ? VIP_LOCKOUT_STATE : false;
+    }
+
+    private function getLockoutMessage() {
+        // If the account is locked, use the proper lockout message
+        if ( defined( 'VIP_ACCOUNT_STATUS') && VIP_ACCOUNT_STATUS !== self::ACCOUNT_STATUS_NORMAL ) {
+	        switch ( $this->getLockoutState() ) {
+		        case self::ACCOUNT_STATUS_WARNING:
+			        return 'Payment for this WordPress VIP account is overdue and it will be disabled.<br />
+Contact accounts@wpvip.com to pay your bill.';
+                case self::ACCOUNT_STATUS_LOCK:
+                case self::ACCOUNT_STATUS_SHUTDOWN:
+			        return 'Payment for this WordPress VIP account is overdue and it has been disabled.<br />
+Contact accounts@wpvip.com to pay your bill.';	        }
+        }
+        // Otherwise, read it from VIP_LOCKOUT_MESSAGE constant
+        return defined( 'VIP_LOCKOUT_MESSAGE' ) ? VIP_LOCKOUT_MESSAGE : false;
+    }
+
 	/**
 	 * Add warnings to admin page
 	 */
 	public function add_admin_notice() {
-		if ( defined( 'VIP_LOCKOUT_STATE' ) ) {
+		if ( $lockout_state = $this->getLockoutState() ) {
 			$user = wp_get_current_user();
 
-			switch ( constant( 'VIP_LOCKOUT_STATE' ) ) {
-				case 'warning':
+			switch ( $lockout_state ) {
+				case self::ACCOUNT_STATUS_WARNING:
 					$has_caps    = isset( $user->allcaps['manage_options'] ) && true === $user->allcaps['manage_options'];
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, constant( 'VIP_LOCKOUT_STATE' ), $user );
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, $lockout_state, $user );
 					if ( $show_notice ) {
 						$this->render_warning_notice();
 
@@ -55,9 +85,10 @@ class Lockout {
 
 					break;
 
-				case 'locked':
-					$has_caps    = isset( $user->allcaps['edit_posts'] ) && true === $user->allcaps['edit_posts'];
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, constant( 'VIP_LOCKOUT_STATE' ), $user );
+                case self::ACCOUNT_STATUS_LOCK:
+				case self::ACCOUNT_STATUS_SHUTDOWN:
+				    $has_caps    = isset( $user->allcaps['edit_posts'] ) && true === $user->allcaps['edit_posts'];
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, $lockout_state, $user );
 					if ( $show_notice ) {
 						$this->render_locked_notice();
 
@@ -78,7 +109,7 @@ class Lockout {
 		$seen_warning = get_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, true );
 
 		if ( ! $seen_warning ) {
-			add_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, constant( 'VIP_LOCKOUT_STATE' ), true );
+			add_user_meta( $user->ID, self::USER_SEEN_WARNING_KEY, $this->getLockoutState(), true );
 			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- not sure if it is safe to replace with gmdate()
 			add_user_meta( $user->ID, self::USER_SEEN_WARNING_TIME_KEY, date( 'Y-m-d H:i:s' ), true );
 		}
@@ -89,7 +120,7 @@ class Lockout {
 		<div id="lockout-warning" class="notice-warning wrap clearfix" style="align-items: center;background: #ffffff;border-left-width:4px;border-left-style:solid;border-radius: 6px;display: flex;margin-top: 30px;padding: 30px;line-height: 2em;">
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#ffb900;"></div>
 			<div style="display: flex;align-items: center;" >
-				<h3><?php echo wp_kses_post( constant( 'VIP_LOCKOUT_MESSAGE' ) ); ?></h3>
+				<h3><?php echo wp_kses_post( $this->getLockoutMessage() ); ?></h3>
 			</div>
 		</div>
 		<?php
@@ -100,7 +131,7 @@ class Lockout {
 		<div id="lockout-warning" class="notice-error wrap clearfix" style="align-items: center;background: #ffffff;border-left-width:4px;border-left-style:solid;border-radius: 6px;display: flex;margin-top: 30px;padding: 30px;line-height: 2em;">
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#dc3232;"></div>
 			<div style="display: flex;align-items: center;" >
-				<h3><?php echo wp_kses_post( constant( 'VIP_LOCKOUT_MESSAGE' ) ); ?></h3>
+				<h3><?php echo wp_kses_post( $this->getLockoutMessage() ); ?></h3>
 			</div>
 		</div>
 		<?php
@@ -119,7 +150,8 @@ class Lockout {
 	 * @return array
 	 */
 	public function filter_user_has_cap( $user_caps, $caps, $args, $user ) {
-		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === constant( 'VIP_LOCKOUT_STATE' ) ) {
+        $lockout_state = $this->getLockoutState();
+		if ( $lockout_state && in_array( $lockout_state, [ self::ACCOUNT_STATUS_LOCK, self::ACCOUNT_STATUS_SHUTDOWN ] ) ) {
 			if ( is_automattician( $user->ID ) ) {
 				return $user_caps;
 			}
@@ -148,7 +180,8 @@ class Lockout {
 	 * @return  array
 	 */
 	public function filter_site_admin_option( $pre_option ) {
-		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === constant( 'VIP_LOCKOUT_STATE' ) ) {
+		$lockout_state = $this->getLockoutState();
+		if ( $lockout_state && in_array( $lockout_state, [ self::ACCOUNT_STATUS_LOCK, self::ACCOUNT_STATUS_SHUTDOWN ] ) ) {
 			if ( is_automattician() ) {
 				return $pre_option;
 			}
@@ -169,8 +202,9 @@ class Lockout {
 	 * Instead, just block updates to the option if a site is locked.
 	 */
 	public function filter_prevent_site_admin_option_updates( $value, $old_value ) {
-		if ( defined( 'VIP_LOCKOUT_STATE' ) && 'locked' === constant( 'VIP_LOCKOUT_STATE' ) ) {
-			return $old_value;
+		$lockout_state = $this->getLockoutState();
+		if ( $lockout_state && in_array( $lockout_state, [ self::ACCOUNT_STATUS_LOCK, self::ACCOUNT_STATUS_SHUTDOWN ] ) ) {
+            return $old_value;
 		}
 
 		return $value;


### PR DESCRIPTION
## Description
This PR changes the functionality of the Lockout plugin a bit, by using the `VIP_ACCOUNT_STATUS` to decide whether if the WordPress site should display a notice, or if it should be locked. The messaging is also "hard coded", and changes depending on the value of `VIP_ACCOUNT_STATUS`.

This constant can have four values:
 * `normal` - should be present on all sites without any overdue.
 * `warned` - slightly overdue, show a warning
 * `locked` - next overdue stage, where all the access is locked
 * `shutdown` - the application is shutdown (handled differently, see #3431)

I tried to maintain retro-compatibility with the current lockout architecture, so if `VIP_ACCOUNT_STATUS` is `normal`, it will fallback to the original logic: if `VIP_LOCKOUT_STATE` and `VIP_LOCKOUT_MESSAGE` are set, that message will be shown with the correct state. However, if at any time `VIP_ACCOUNT_STATUS` is changed to a state other than `normal`, it will bypass and override any of the values set in `VIP_LOCKOUT_STATE` and `VIP_LOCKOUT_MESSAGE`.

## Changelog Description

### Lockout: Adds VIP_ACCOUNT_STATUS constant to control the notice/locking functionalities

Adds a new `VIP_ACCOUNT_STATUS` that can be used to set the site's account status, and warn/lock the application, if required.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Validate the original logic: Set `VIP_LOCKOUT_STATE` environment variable to `warning` and `VIP_LOCKOUT_MESSAGE` to some string. 
1. Access `wp-admin` and you should the notice on every page. 
2. Now, add `define('VIP_ACCOUNT_STATUS', 'locked');`. The admin dashboard should be locked, and a red notice should be visible in all pages. This should override what was set in step 2.