### PR TITLE
[CANTINA-889] Add ES Prometheus Collector

### DIFF
--- a/search/includes/classes/class-prometheus-collector.php
+++ b/search/includes/classes/class-prometheus-collector.php
@@ -84,7 +84,7 @@ class Prometheus_Collector implements CollectorInterface {
 			$instance->request_times_histogram->observe(
 				$time,
 				[
-					(string) get_current_network_id(),
+					(string) get_current_blog_id(),
 					$host,
 					$mode,
 					$type,
@@ -100,7 +100,7 @@ class Prometheus_Collector implements CollectorInterface {
 			$mode = $instance->get_mode( $url, $method );
 			$instance->query_counter->inc(
 				[
-					(string) get_current_network_id(),
+					(string) get_current_blog_id(),
 					$host,
 					$mode,
 				]
@@ -115,7 +115,7 @@ class Prometheus_Collector implements CollectorInterface {
 			$mode = $instance->get_mode( $url, $method );
 			$instance->failed_query_counter->inc(
 				[
-					(string) get_current_network_id(),
+					(string) get_current_blog_id(),
 					$host,
 					$mode,
 					$reason,
@@ -130,7 +130,7 @@ class Prometheus_Collector implements CollectorInterface {
 			$host = $instance->get_host( $url );
 			$instance->ratelimited_query_counter->inc(
 				[
-					(string) get_current_network_id(),
+					(string) get_current_blog_id(),
 					$host,
 				]
 			);

--- a/search/includes/classes/class-prometheus-collector.php
+++ b/search/includes/classes/class-prometheus-collector.php
@@ -162,6 +162,10 @@ class Prometheus_Collector implements CollectorInterface {
 
 	private function get_mode( string $url, string $method ): string {
 		$parsed = wp_parse_url( $url );
+		if ( empty( $parsed['path'] ) ) {
+			return 'unknown';
+		}
+
 		$path   = explode( '/', $parsed['path'] );
 		$method = strtolower( $method );
 

--- a/search/includes/classes/class-prometheus-collector.php
+++ b/search/includes/classes/class-prometheus-collector.php
@@ -90,8 +90,6 @@ class Prometheus_Collector implements CollectorInterface {
 					$type,
 				]
 			);
-		} else {
-			_doing_it_wrong( __METHOD__, 'Cannot observe request time because the collector is not yet initialized', '' );
 		}
 	}
 
@@ -107,8 +105,6 @@ class Prometheus_Collector implements CollectorInterface {
 					$mode,
 				]
 			);
-		} else {
-			_doing_it_wrong( __METHOD__, 'Cannot increment query counter because the collector is not yet initialized', '' );
 		}
 	}
 
@@ -125,8 +121,6 @@ class Prometheus_Collector implements CollectorInterface {
 					$reason,
 				]
 			);
-		} else {
-			_doing_it_wrong( __METHOD__, 'Cannot increment failed query counter because the collector is not yet initialized', '' );
 		}
 	}
 
@@ -140,8 +134,6 @@ class Prometheus_Collector implements CollectorInterface {
 					$host,
 				]
 			);
-		} else {
-			_doing_it_wrong( __METHOD__, 'Cannot increment rate-limited query counter because the collector is not yet initialized', '' );
 		}
 	}
 

--- a/search/includes/classes/class-prometheus-collector.php
+++ b/search/includes/classes/class-prometheus-collector.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+use Automattic\VIP\Prometheus\CollectorInterface;
+use Prometheus\Counter;
+use Prometheus\Histogram;
+use Prometheus\RegistryInterface;
+
+class Prometheus_Collector implements CollectorInterface {
+	public const QUERY_FAILED_ERROR   = 'error';
+	public const QUERY_FAILED_TIMEOUT = 'timeout';
+
+	public const OBSERVATION_TYPE_ENGINE  = 'engine';
+	public const OBSERVATION_TYPE_REQUEST = 'request';
+	public const OBSERVATION_TYPE_PER_DOC = 'per_doc';
+
+	protected static ?self $instance = null;
+
+	private ?Histogram $request_times_histogram = null;
+	private ?Counter $query_counter             = null;
+	private ?Counter $failed_query_counter      = null;
+	private ?Counter $ratelimited_query_counter = null;
+
+	/**
+	 * @return static
+	 */
+	public static function get_instance(): self {
+		if ( ! self::$instance ) {
+			self::$instance = new static();
+		}
+
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_filter( 'vip_prometheus_collectors', [ $this, 'vip_prometheus_collectors' ] );
+	}
+
+	public function vip_prometheus_collectors( array $collectors ): array {
+		$collectors[] = $this;
+		return $collectors;
+	}
+
+	public function initialize( RegistryInterface $registry ): void {
+		$this->request_times_histogram = $registry->getOrRegisterHistogram(
+			'es',
+			'request_times',
+			'Request times',
+			[ 'site_id', 'host', 'mode', 'type' ]
+		);
+
+		$this->query_counter = $registry->getOrRegisterCounter(
+			'es',
+			'queries_total',
+			'Query count',
+			[ 'site_id', 'host', 'mode' ]
+		);
+
+		$this->failed_query_counter = $registry->getOrRegisterCounter(
+			'es',
+			'faled_queries_total',
+			'Failed query count',
+			[ 'site_id', 'host', 'mode', 'reason' ]
+		);
+
+		$this->ratelimited_query_counter = $registry->getOrRegisterCounter(
+			'es',
+			'ratelimited_queries_total',
+			'Ratelimited query count',
+			[ 'site_id', 'host' ]
+		);
+	}
+
+	public function collect_metrics(): void {
+		// Do nothing
+	}
+
+	public static function observe_request_time( string $method, string $url, string $type, float $time ): void {
+		$instance = self::get_instance();
+		if ( $instance->request_times_histogram ) {
+			$host = $instance->get_host( $url );
+			$mode = $instance->get_mode( $url, $method );
+			$instance->request_times_histogram->observe(
+				$time,
+				[
+					(string) get_current_network_id(),
+					$host,
+					$mode,
+					$type,
+				]
+			);
+		} else {
+			_doing_it_wrong( __METHOD__, 'Cannot observe request time because the collector is not yet initialized', '' );
+		}
+	}
+
+	public static function increment_query_counter( string $method, string $url ): void {
+		$instance = self::get_instance();
+		if ( $instance->query_counter ) {
+			$host = $instance->get_host( $url );
+			$mode = $instance->get_mode( $url, $method );
+			$instance->query_counter->inc(
+				[
+					(string) get_current_network_id(),
+					$host,
+					$mode,
+				]
+			);
+		} else {
+			_doing_it_wrong( __METHOD__, 'Cannot increment query counter because the collector is not yet initialized', '' );
+		}
+	}
+
+	public static function increment_failed_query_counter( string $method, string $url, string $reason ): void {
+		$instance = self::get_instance();
+		if ( $instance->failed_query_counter ) {
+			$host = $instance->get_host( $url );
+			$mode = $instance->get_mode( $url, $method );
+			$instance->failed_query_counter->inc(
+				[
+					(string) get_current_network_id(),
+					$host,
+					$mode,
+					$reason,
+				]
+			);
+		} else {
+			_doing_it_wrong( __METHOD__, 'Cannot increment failed query counter because the collector is not yet initialized', '' );
+		}
+	}
+
+	public static function increment_ratelimited_query_counter( string $url ): void {
+		$instance = self::get_instance();
+		if ( $instance->ratelimited_query_counter ) {
+			$host = $instance->get_host( $url );
+			$instance->ratelimited_query_counter->inc(
+				[
+					(string) get_current_network_id(),
+					$host,
+				]
+			);
+		} else {
+			_doing_it_wrong( __METHOD__, 'Cannot increment rate-limited query counter because the collector is not yet initialized', '' );
+		}
+	}
+
+	private function get_host( string $url ): string {
+		$host = wp_parse_url( $url, \PHP_URL_HOST );
+		$port = wp_parse_url( $url, \PHP_URL_PORT );
+
+		if ( empty( $host ) ) {
+			$host = 'unknown';
+		}
+
+		if ( ! empty( $port ) ) {
+			$host .= ':' . $port;
+		}
+
+		return $host;
+	}
+
+	private function get_mode( string $url, string $method ): string {
+		$parsed = wp_parse_url( $url );
+		$path   = explode( '/', $parsed['path'] );
+		$method = strtolower( $method );
+
+		$last   = empty( $path ) ? '' : $path[ count( $path ) - 1 ];
+		$penult = count( $path ) < 2 ? '' : $path[ count( $path ) - 2 ];
+
+		if ( '_search' === $last ) {
+			return 'search';
+		}
+
+		if ( '_doc' === $penult && ( 'delete' === $method || 'get' === $method ) ) {
+			return $method;
+		}
+
+		if ( '_mget' === $last ) {
+			return 'get';
+		}
+
+		if ( ( '_create' === $penult && ( 'put' === $method || 'post' === $method ) )
+			|| ( '_update' === $penult )
+			|| ( '_doc' === $last && 'post' === $method )
+			|| ( '_doc' === $penult && 'put' === $method )
+			|| ( '_bulk' === $last )
+		) {
+			return 'index';
+		}
+
+		return 'other';
+	}
+}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2423,7 +2423,7 @@ class Search {
 		}
 	}
 
-	private function load_collector(): void {
+	public function load_collector(): void {
 		require_once __DIR__ . '/class-prometheus-collector.php';
 		Prometheus_Collector::get_instance();
 	}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -202,6 +202,7 @@ class Search {
 	 * Initialize the VIP Search plugin
 	 */
 	public function init() {
+		$this->setup_collector();
 		$this->apply_settings(); // Applies filters for tweakable Search settings and should run first.
 		$this->setup_constants();
 		$this->maybe_enable_ep_query_logging();
@@ -943,6 +944,7 @@ class Search {
 		$duration = ( $end_time - $start_time ) * 1000;
 
 		$this->maybe_increment_stat( $statsd_prefix . '.total' );
+		Prometheus_Collector::increment_query_counter( $args['method'] ?? 'post', $query['url'] );
 
 		$response_code = (int) wp_remote_retrieve_response_code( $response );
 
@@ -950,7 +952,7 @@ class Search {
 		 * If request resulted in an error flag it as such but try to return the fallback value if available.
 		 */
 		if ( is_wp_error( $response ) || $response_code >= 400 ) {
-			$this->ep_handle_failed_request( $request, $response, $query, $statsd_prefix, $type, $cached_response );
+			$this->ep_handle_failed_request( $request, $response, $query, $statsd_prefix, $type, $cached_response, $args['method'] ?? 'post' );
 			if ( isset( $cached_response['response'] ) ) {
 				return $cached_response['response'];
 			}
@@ -961,12 +963,15 @@ class Search {
 
 			if ( $response_body && isset( $response_body['took'] ) && is_int( $response_body['took'] ) ) {
 				$this->maybe_send_timing_stat( $statsd_prefix . '.engine', $response_body['took'] );
+				Prometheus_Collector::observe_request_time( $args['method'] ?? 'post', $query['url'], Prometheus_Collector::OBSERVATION_TYPE_ENGINE, (float) $response_body['took'] );
 			}
 			$this->maybe_send_timing_stat( $statsd_prefix . '.total', $duration );
+			Prometheus_Collector::observe_request_time( $args['method'] ?? 'post', $query['url'], Prometheus_Collector::OBSERVATION_TYPE_REQUEST, (float) $duration );
 
 			if ( $collect_per_doc_metric && $response_body && isset( $response_body['items'] ) && is_array( $response_body['items'] ) ) {
 				$doc_count = count( $response_body['items'] );
 				$this->maybe_send_timing_stat( $statsd_prefix . '.per_doc', $duration / $doc_count );
+				Prometheus_Collector::observe_request_time( $args['method'] ?? 'post', $query['url'], Prometheus_Collector::OBSERVATION_TYPE_PER_DOC, (float) $duration / $doc_count );
 			}
 
 			$response_headers = wp_remote_retrieve_headers( $response );
@@ -1052,9 +1057,10 @@ class Search {
 	 * @param string $statsd_prefix
 	 * @param string $type
 	 * @param mixed $cached_request
+	 * @param string $query_method
 	 * @return void
 	 */
-	public function ep_handle_failed_request( $request, $response, $query, $statsd_prefix, $type, $cached_request = null ) {
+	public function ep_handle_failed_request( $request, $response, $query, $statsd_prefix, $type, $cached_request, $query_method ) {
 		// Not real failed requests, we should not be logging.
 		$skiplist = [
 			'index_exists',
@@ -1081,9 +1087,11 @@ class Search {
 			$response_failure_code = $response->get_error_code();
 
 			foreach ( $error_messages as $error_message ) {
-				$stat = $this->is_curl_timeout( $error_message ) ? '.timeout' : '.error';
+				$stat   = $this->is_curl_timeout( $error_message ) ? '.timeout' : '.error';
+				$reason = $this->is_curl_timeout( $error_message ) ? Prometheus_Collector::QUERY_FAILED_TIMEOUT : Prometheus_Collector::QUERY_FAILED_ERROR;
 
 				$this->maybe_increment_stat( $statsd_prefix . $stat );
+				Prometheus_Collector::increment_failed_query_counter( $query_method, $query['url'], $reason );
 			}
 
 			$error_message = implode( ';', $error_messages );
@@ -1101,6 +1109,7 @@ class Search {
 			}
 
 			$this->maybe_increment_stat( $statsd_prefix . '.error' );
+			Prometheus_Collector::increment_failed_query_counter( $query_method, $query['url'], Prometheus_Collector::QUERY_FAILED_ERROR );
 
 			$error_type = 'search_query_error';
 		}
@@ -1311,6 +1320,7 @@ class Search {
 		$stat = $this->get_statsd_prefix( $url, $statsd_mode );
 
 		$this->maybe_increment_stat( $stat );
+		Prometheus_Collector::increment_ratelimited_query_counter( $url );
 	}
 
 	public function maybe_alert_for_average_queue_time() {
@@ -2403,5 +2413,18 @@ class Search {
 	public function filter__blog_option_ep_indexable( $value, $blog_id ) {
 		$index_exists = \ElasticPress\Indexables::factory()->get( 'post' )->index_exists( $blog_id );
 		return false === $index_exists ? 'no' : 'yes';
+	}
+
+	public function setup_collector(): void {
+		if ( did_action( 'vip_prometheus_loaded' ) ) {
+			$this->load_collector();
+		} else {
+			add_action( 'vip_prometheus_loaded', [ $this, 'load_collector' ] );
+		}
+	}
+
+	private function load_collector(): void {
+		require_once __DIR__ . '/class-prometheus-collector.php';
+		Prometheus_Collector::get_instance();
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1320,7 +1320,7 @@ class Search {
 		$stat = $this->get_statsd_prefix( $url, $statsd_mode );
 
 		$this->maybe_increment_stat( $stat );
-		Prometheus_Collector::increment_ratelimited_query_counter( $url );
+		Prometheus_Collector::increment_ratelimited_query_counter( is_wp_error( $url ) ? 'unknown' : $url );
 	}
 
 	public function maybe_alert_for_average_queue_time() {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1109,7 +1109,7 @@ class Search {
 			}
 
 			$this->maybe_increment_stat( $statsd_prefix . '.error' );
-			Prometheus_Collector::increment_failed_query_counter( $query_method, $query['url'], Prometheus_Collector::QUERY_FAILED_ERROR );
+			Prometheus_Collector::increment_failed_query_counter( $query_method, $query['url'] ?? '', Prometheus_Collector::QUERY_FAILED_ERROR );
 
 			$error_type = 'search_query_error';
 		}

--- a/tests/search/includes/classes/test-class-cache.php
+++ b/tests/search/includes/classes/test-class-cache.php
@@ -34,6 +34,8 @@ class Cache_Test extends WP_UnitTestCase {
 
 		$this->es = new \Automattic\VIP\Search\Search();
 		$this->es->init();
+		\Automattic\VIP\Prometheus\Plugin::get_instance()->load_collectors();
+
 		\ElasticPress\register_indexable_posts();
 
 		add_filter( 'ep_skip_query_integration', '__return_false', 100 );

--- a/tests/search/includes/classes/test-class-cache.php
+++ b/tests/search/includes/classes/test-class-cache.php
@@ -19,7 +19,8 @@ class Cache_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		require_once __DIR__ . '/../../../../search/search.php';
-		include_once __DIR__ . '/../../../../advanced-post-cache/advanced-post-cache.php';
+		require_once __DIR__ . '/../../../../advanced-post-cache/advanced-post-cache.php';
+		require_once __DIR__ . '/../../../../prometheus.php';
 
 		$this->apc_filters = [
 			'posts_request',
@@ -28,6 +29,8 @@ class Cache_Test extends WP_UnitTestCase {
 			'found_posts_query',
 			'found_posts',
 		];
+
+		\Automattic\VIP\Prometheus\Plugin::get_instance()->init_registry();
 
 		$this->es = new \Automattic\VIP\Search\Search();
 		$this->es->init();

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2786,7 +2786,7 @@ class Search_Test extends WP_UnitTestCase {
 					$this->anything()
 				);
 
-		$this->search_instance->ep_handle_failed_request( null, $response, [], '', null, '' );
+		$this->search_instance->ep_handle_failed_request( null, $response, [], '', null, null, '' );
 	}
 
 	/**
@@ -2807,7 +2807,7 @@ class Search_Test extends WP_UnitTestCase {
 		];
 
 		foreach ( $skiplist as $item ) {
-			$this->search_instance->ep_handle_failed_request( null, 404, [], 0, $item, '' );
+			$this->search_instance->ep_handle_failed_request( null, 404, [], 0, $item, null, '' );
 		}
 	}
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2786,7 +2786,7 @@ class Search_Test extends WP_UnitTestCase {
 					$this->anything()
 				);
 
-		$this->search_instance->ep_handle_failed_request( null, $response, [], '', null );
+		$this->search_instance->ep_handle_failed_request( null, $response, [], '', null, '' );
 	}
 
 	/**
@@ -2807,7 +2807,7 @@ class Search_Test extends WP_UnitTestCase {
 		];
 
 		foreach ( $skiplist as $item ) {
-			$this->search_instance->ep_handle_failed_request( null, 404, [], 0, $item );
+			$this->search_instance->ep_handle_failed_request( null, 404, [], 0, $item, '' );
 		}
 	}
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/mock-header.php';
 require_once __DIR__ . '/../../../../search/search.php';
 require_once __DIR__ . '/../../../../search/includes/classes/class-versioning.php';
 require_once __DIR__ . '/../../../../search/elasticpress/elasticpress.php';
+require_once __DIR__ . '/../../../../prometheus.php';
 
 /**
  * @runTestsInSeparateProcesses
@@ -22,9 +23,16 @@ class Search_Test extends WP_UnitTestCase {
 	public static $mock_global_functions;
 	public $test_index_name = 'vip-1234-post-0-v3';
 
+	/** @var Search */
+	private $search_instance;
+
 	public function setUp(): void {
 		parent::setUp();
+
+		\Automattic\VIP\Prometheus\Plugin::get_instance()->init_registry();
 		$this->search_instance = new \Automattic\VIP\Search\Search();
+		$this->search_instance->load_collector();
+		\Automattic\VIP\Prometheus\Plugin::get_instance()->load_collectors();
 
 		self::$mock_global_functions = $this->getMockBuilder( self::class )
 			->setMethods( [ 'mock_vip_safe_wp_remote_request', 'mock_wp_remote_request' ] )

--- a/tests/search/includes/classes/test-class-settingshealthjob.php
+++ b/tests/search/includes/classes/test-class-settingshealthjob.php
@@ -6,6 +6,7 @@ use WP_UnitTestCase;
 use Automattic\Test\Constant_Mocker;
 
 class SettingsHealthJob_Test extends WP_UnitTestCase {
+	/** @var \Automattic\VIP\Search\Search */
 	public static $search;
 	public static $version_instance;
 
@@ -13,6 +14,7 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 		parent::setUpBeforeClass();
 		require_once __DIR__ . '/../../../../search/search.php';
 		require_once __DIR__ . '/../../../../search/includes/classes/class-settingshealthjob.php';
+		require_once __DIR__ . '/../../../../prometheus.php';
 
 		self::$search = \Automattic\VIP\Search\Search::instance();
 		self::$search->init();
@@ -29,6 +31,14 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 		// Required so that EP registers the Indexables
 		do_action( 'plugins_loaded' );
 		do_action( 'init' );
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		\Automattic\VIP\Prometheus\Plugin::get_instance()->init_registry();
+		self::$search->load_collector();
+		\Automattic\VIP\Prometheus\Plugin::get_instance()->load_collectors();
 	}
 
 	public function test__process_indexables_settings_health_results__reports_error() {


### PR DESCRIPTION
## Description

Add Prometheus Collector for ElasticSearch.

## Changelog Description

### Plugin Updated: Enterprise Search 

Add Prometheus collector.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
