### PR TITLE
[CANTINA-889] Add post stats collector

### DIFF
--- a/prometheus-collectors/class-post-stats-collector.php
+++ b/prometheus-collectors/class-post-stats-collector.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Automattic\VIP\Prometheus;
+
+use Prometheus\Gauge;
+use Prometheus\RegistryInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class Post_Stats_Collector implements CollectorInterface {
+	private Gauge $post_gauge;
+
+	public function initialize( RegistryInterface $registry ): void {
+		$this->post_gauge = $registry->getOrRegisterGauge(
+			'post',
+			'count',
+			'Number of posts by type and status',
+			[ 'site_id', 'post_type', 'post_status' ]
+		);
+	}
+
+	public function collect_metrics(): void {
+		$site_id = (string) get_current_blog_id();
+		$types   = get_post_types();
+		foreach ( $types as $type ) {
+			$posts = wp_count_posts( $type );
+			foreach ( $posts as $status => $count ) {
+				$this->post_gauge->set( $count, [ $site_id, $type, $status ] );
+			}
+		}
+	}
+}

--- a/prometheus.php
+++ b/prometheus.php
@@ -4,6 +4,7 @@ use Automattic\VIP\Prometheus\APCu_Collector;
 use Automattic\VIP\Prometheus\Cache_Collector;
 use Automattic\VIP\Prometheus\Login_Stats_Collector;
 use Automattic\VIP\Prometheus\OpCache_Collector;
+use Automattic\VIP\Prometheus\Post_Stats_Collector;
 
 // @codeCoverageIgnoreStart -- this file is loaded before tests start
 if ( defined( 'ABSPATH' ) ) {
@@ -16,6 +17,7 @@ if ( defined( 'ABSPATH' ) ) {
 		require_once __DIR__ . '/prometheus-collectors/class-apcu-collector.php';
 		require_once __DIR__ . '/prometheus-collectors/class-opcache-collector.php';
 		require_once __DIR__ . '/prometheus-collectors/class-login-stats-collector.php';
+		require_once __DIR__ . '/prometheus-collectors/class-post-stats-collector.php';
 
 		add_filter( 'vip_prometheus_collectors', function ( array $collectors, string $hook ): array {
 			if ( 'vip_mu_plugins_loaded' === $hook ) {
@@ -23,6 +25,7 @@ if ( defined( 'ABSPATH' ) ) {
 				$collectors[] = new APCu_Collector();
 				$collectors[] = new OpCache_Collector();
 				$collectors[] = new Login_Stats_Collector();
+				$collectors[] = new Post_Stats_Collector();
 			}
 
 			return $collectors;


### PR DESCRIPTION
## Description

Add post stats collector for Prometheus.

Exposed metrics:
* `posts_count{site_id,post_type,post_status}`: `gauge` - number of posts by type and status.

## Changelog Description

### Plugin Updated: VIP Prometheus

Added a collector for post statistics.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
