### PR TITLE
Debug bar: Change to earlier hook to utilize remote request logging

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -23,7 +23,7 @@ add_filter( 'debug_bar_enable', function( $enable ) {
 }, PHP_INT_MAX );
 
 // We only need to load the files if it's enabled
-add_action( 'init', function() {
+add_action( 'set_current_user', function() {
 	$enable = apply_filters( 'debug_bar_enable', false );
 
 	if ( ! $enable ) {


### PR DESCRIPTION
## Description
Fixes https://github.com/Automattic/vip-go-mu-plugins/issues/544.

## Changelog Description

### Plugin Updated: Debug Bar

Change to load at earlier hook to utilize remote request logging

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Add in theme:
```
$url = 'http://www.wordpress.com';
$args = array(
    'method' => 'GET'
);
$response = wp_remote_request( $url, $args );
```
2) Go to Debug Bar and notice "WP_http" panel does not exist
3) Apply PR
4) Repeat step 2 and notice the panel now
