### PR TITLE
Update Jetpack submodule to use the current repo and set its version to 10.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "advanced-post-cache"]
 	path = advanced-post-cache
 	url = https://github.com/Automattic/advanced-post-cache.git
-[submodule "jetpack"]
-	path = jetpack
-	url = https://github.com/Automattic/jetpack.git
 [submodule "rewrite-rules-inspector"]
 	path = rewrite-rules-inspector
 	url = https://github.com/Automattic/rewrite-rules-inspector

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "search/debug-bar-elasticpress"]
 	path = search/debug-bar-elasticpress
 	url = https://github.com/10up/debug-bar-elasticpress.git
+[submodule "jetpack"]
+	path = jetpack
+	url = https://github.com/Automattic/jetpack-production.git


### PR DESCRIPTION
## Description

This PR switches the Jetpack submodule from the legacy approach (source repo) to the current one - the built copy in https://github.com/Automattic/jetpack-production)

This PR bumps to 10.4 (follow-up to #3287 )

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Merge and hope on CI breaks 🗡️ 
