### PR TITLE
Search: Fully roll out filter_ep_enable_do_weighting

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -18,7 +18,7 @@ class Feature {
 	 * @var array
 	 */
 	public static $feature_percentages = [
-		'force-es-timeout'          => 0.75,
+		'force-es-timeout' => 0.75,
 	];
 
 	/**

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -18,7 +18,6 @@ class Feature {
 	 * @var array
 	 */
 	public static $feature_percentages = [
-		'reduce-default-es-payload' => 0.75,
 		'force-es-timeout'          => 0.75,
 	];
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2362,12 +2362,6 @@ class Search {
 	 * @return bool $should_do_weighting New value on whether to enable weight config
 	 */
 	public function filter__ep_enable_do_weighting( $should_do_weighting, $weight_config, $args, $formatted_args ) {
-		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( 'VIP_GO_APP_ENVIRONMENT' ) &&
-		! \Automattic\VIP\Feature::is_enabled_by_percentage( 'reduce-default-es-payload' ) ) {
-			// Rollout to non-prod and 25% of production
-			return $should_do_weighting;
-		}
-
 		if ( ! empty( $weight_config ) ) {
 			return true;
 		}


### PR DESCRIPTION
## Description
Continuing onto https://github.com/Automattic/vip-go-mu-plugins/pull/3482, let's bring it up to 100%.

## Changelog Description

### Plugin Updated: Enterprise Search

Add filter__ep_enable_do_weighting to optimize search requests not utilizing weighting