### PR TITLE
Removed unprefixed environment variables (Once more; with feeling!)

### DIFF
--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -20,14 +20,8 @@ class Environment {
 		$key       = strtoupper( $key );
 		$env_const = sprintf( '%s_%s', self::VAR_PREFIX, $key );
 
-		// First check to see if the VIP_ENV_VAR constant exists and return it
-		// If constant does not exist fallback to const without the prefix
-		// If neither constant exist, return default
 		if ( defined( $env_const ) ) {
 			return constant( $env_const );
-		} elseif ( defined( $key ) ) {
-			// interim migration step
-			return constant( $key );
 		}
 
 		// The call was not able to retrieve an env variable

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -30,25 +30,12 @@ class Environment_Test extends TestCase {
 		Constant_Mocker::define( 'VIP_ENV_VAR_MY_VAR', 'VIP_ENV_VAR_MY_VAR' );
 	}
 
-	public function get_var_legacy_env() {
-		Constant_Mocker::define( 'MY_VAR', 'MY_VAR' );
-	}
-
 	// tests the use-case where $key parameter is not found
 	public function test_get_default_var() {
 		error_reporting( $this->error_reporting & ~E_USER_NOTICE );
 
 		$val = Environment::get_var( 'MY_VAR', 'default_value' );
 		$this->assertEquals( 'default_value', $val );
-	}
-
-	// tests the use-case where $key parameter does not have the prefix
-	public function test_get_var_legacy_key() {
-		error_reporting( $this->error_reporting & ~E_USER_NOTICE );
-
-		$this->get_var_legacy_env();
-		$val = Environment::get_var( 'MY_VAR', 'default_value' );
-		$this->assertEquals( 'MY_VAR', $val );
 	}
 
 	// tests the use-case where $key parameter is lower case

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -38,15 +38,6 @@ class Environment_Test extends TestCase {
 		$this->assertEquals( 'default_value', $val );
 	}
 
-	// tests the use-case where $key parameter is lower case
-	public function test_get_var_lower_key() {
-		error_reporting( $this->error_reporting & ~E_USER_NOTICE );
-
-		$this->get_var_standard_env();
-		$val = Environment::get_var( 'vip_env_var_my_var', 'VIP_ENV_VAR_MY_VAR' );
-		$this->assertEquals( 'VIP_ENV_VAR_MY_VAR', $val );
-	}
-
 	// tests the use-case where $key parameter is ''
 	public function test_get_var_empty_key() {
 		error_reporting( $this->error_reporting & ~E_USER_NOTICE );

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -43,7 +43,7 @@ class Environment_Test extends TestCase {
 		error_reporting( $this->error_reporting & ~E_USER_NOTICE );
 
 		$this->get_var_standard_env();
-		$val = Environment::get_var( 'vip_env_var_my_var', 'default_value' );
+		$val = Environment::get_var( 'vip_env_var_my_var', 'VIP_ENV_VAR_MY_VAR' );
 		$this->assertEquals( 'VIP_ENV_VAR_MY_VAR', $val );
 	}
 

--- a/tests/lib/helpers/test-environment.php
+++ b/tests/lib/helpers/test-environment.php
@@ -33,24 +33,6 @@ class Environment_Test extends TestCase {
 	}
 
 	/**
-	 * tests the use-case where $key parameter does not have the prefix
-	 */
-	public function test_get_var_legacy_key() {
-		$this->get_var_legacy_env();
-		$val = vip_get_env_var( 'MY_VAR', 'BAR' );
-		$this->assertEquals( 'FOO', $val );
-	}
-
-	/**
-	 * tests the use-case where $key parameter is lower case
-	 */
-	public function test_get_var_lower_key() {
-		$this->get_var_standard_env();
-		$val = vip_get_env_var( 'vip_env_var_my_var', 'BAR' );
-		$this->assertEquals( 'FOO', $val );
-	}
-
-	/**
 	 * tests the use-case where $key parameter is ''
 	 */
 	public function test_get_var_empty_key() {


### PR DESCRIPTION
## Description
Removes the use of unprefixed environment variables in the VIP mu-plugins

## Changelog Description

### Removed the retrieval of unprefixed VIP environment variables

VIP environment variables, enabled through the dashboard or CLI, will now always be prefixed with a VIP string. This will not affect the use of environment variables currently used, but aims to prevent collisions between VIP environment variables and constants that may be defined elsewhere.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Check out PR.
1. Define a constant in wp-config like `define('MY_CONSTANT', 'foo');`
1. Define an environment variable with the same name, through the dashboard or VIP CLI: `MY_CONSTANT = 'bar'`
1. echo the constant in the code like: `echo MY_CONSTANT`.
2. verify the environment variable did not change the constant to 'bar'