### PR TITLE
Update jetpack_is_mobile() to account for X-Mobile-Class header

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -17,7 +17,9 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = [];
+	public static $feature_percentages = [
+		'jetpack-is-mobile' => 0.1,
+	];
 
 	/**
 	 * Holds feature slug and then, key of ids with bool value to enable E.g.

--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -199,9 +199,13 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 	public function test_vip_jetpack_is_mobile_rma(): void {
 		$_SERVER['HTTP_X_MOBILE_CLASS'] = 'tablet';
 
-		$expected = 'xxx';
-		$actual   = vip_jetpack_is_mobile( $expected, 'tablet', true );
-		self::assertEquals( $expected, $actual );
+		try {
+			$expected = 'xxx';
+			$actual   = vip_jetpack_is_mobile( $expected, 'tablet', true );
+			self::assertEquals( $expected, $actual );
+		} finally {
+			unset( $_SERVER['HTTP_X_MOBILE_CLASS'] );
+		}
 	}
 
 	/**
@@ -210,8 +214,12 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 	public function test_vip_jetpack_is_mobile( string $x_mobile_class, string $wanted, bool $expected ): void {
 		$_SERVER['HTTP_X_MOBILE_CLASS'] = $x_mobile_class;
 
-		$actual = vip_jetpack_is_mobile( false, $wanted, false );
-		self::assertSame( $expected, $actual );
+		try {
+			$actual = vip_jetpack_is_mobile( false, $wanted, false );
+			self::assertSame( $expected, $actual );
+		} finally {
+			unset( $_SERVER['HTTP_X_MOBILE_CLASS'] );
+		}
 	}
 
 	public function data_vip_jetpack_is_mobile(): iterable {

--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -224,6 +224,7 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 
 	public function data_vip_jetpack_is_mobile(): iterable {
 		return [
+			[ 'desktop', 'smart', false ],
 			[ 'smart', 'desktop', false ],
 			[ 'tablet', 'any', true ],
 			[ 'smart', 'smart', true ],

--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -1,5 +1,8 @@
 <?php
 
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use PHPUnit\Framework\ExpectationFailedException;
+
 class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 	public function get_jp_sync_settings_data() {
 		return [
@@ -187,5 +190,37 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 		$other_value_direct = get_option( 'jetpack_site_icon_id' );
 
 		$this->assertEquals( $other_value, $other_value_direct, 'Unexpected value for unfiltered Jetpack option' );
+	}
+
+	public function test_vip_jetpack_is_mobile_no_x_mobile_class(): void {
+		self::assertFalse( vip_jetpack_is_mobile( false, 'any', false ) );
+	}
+
+	public function test_vip_jetpack_is_mobile_rma(): void {
+		$_SERVER['HTTP_X_MOBILE_CLASS'] = 'tablet';
+
+		$expected = 'xxx';
+		$actual   = vip_jetpack_is_mobile( $expected, 'tablet', true );
+		self::assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @dataProvider data_vip_jetpack_is_mobile
+	 */
+	public function test_vip_jetpack_is_mobile( string $x_mobile_class, string $wanted, bool $expected ): void {
+		$_SERVER['HTTP_X_MOBILE_CLASS'] = $x_mobile_class;
+
+		$actual = vip_jetpack_is_mobile( false, $wanted, false );
+		self::assertSame( $expected, $actual );
+	}
+
+	public function data_vip_jetpack_is_mobile(): iterable {
+		return [
+			[ 'smart', 'desktop', false ],
+			[ 'tablet', 'any', true ],
+			[ 'smart', 'smart', true ],
+			[ 'dumb', 'dumb', true ],
+			[ 'smart', 'dumb', false ],
+		];
 	}
 }

--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -220,6 +220,7 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 			[ 'tablet', 'any', true ],
 			[ 'smart', 'smart', true ],
 			[ 'dumb', 'dumb', true ],
+			[ 'tablet', 'tablet', true ],
 			[ 'smart', 'dumb', false ],
 		];
 	}

--- a/tests/test-vip-jetpack.php
+++ b/tests/test-vip-jetpack.php
@@ -220,7 +220,6 @@ class VIP_Go_Jetpack_Test extends WP_UnitTestCase {
 			[ 'tablet', 'any', true ],
 			[ 'smart', 'smart', true ],
 			[ 'dumb', 'dumb', true ],
-			[ 'tablet', 'tablet', true ],
 			[ 'smart', 'dumb', false ],
 		];
 	}

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -749,4 +749,8 @@ function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
 
 	return $matches;
 }
-add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );
+$is_rolled_out = ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) || \Automattic\VIP\Feature::is_enabled_by_percentage( 'jetpack-is-mobile' );
+
+if ( $is_rolled_out ) {
+	add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );
+}

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -716,3 +716,37 @@ function vip_remove_jetpack_search_menu_page() {
 	);
 }
 add_action( 'admin_menu', 'vip_remove_jetpack_search_menu_page', PHP_INT_MAX );
+
+/**
+ * Account for X-Mobile-Class header in jetpack_is_mobile()
+ *
+ * @param bool|string $matches Boolean if current UA matches $kind or not. If
+ * $return_matched_agent is true, should return the UA string
+ * @param string      $kind Category of mobile device being checked. Can be 'any', 'smart' or 'dumb'.
+ * @param bool        $return_matched_agent Boolean indicating if the UA should be returned
+ *
+ * @return bool|string $matches Boolean if current UA matches $kind or not. If
+ * $return_matched_agent is true, should return the UA string
+ */
+function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
+	if ( ! isset( $_SERVER['HTTP_X_MOBILE_CLASS'] ) ) {
+		// No value set, return early.
+		return $matches;
+	}
+
+	// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+	$x_mobile_class = sanitize_text_field( $_SERVER['HTTP_X_MOBILE_CLASS'] ); // "desktop", "smart", "dumb", "tablet"
+
+	if ( 'desktop' === $x_mobile_class ) {
+		return false;
+	}
+
+	if ( 'smart' === $kind || 'dumb' === $kind ) {
+		$matches = $kind === $x_mobile_class;
+	} elseif ( 'any' === $kind ) {
+		$matches = true;
+	}
+
+	return $matches;
+}
+add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -722,7 +722,7 @@ add_action( 'admin_menu', 'vip_remove_jetpack_search_menu_page', PHP_INT_MAX );
  *
  * @param bool|string $matches Boolean if current UA matches $kind or not. If
  * $return_matched_agent is true, should return the UA string
- * @param string      $kind Category of mobile device being checked. Can be 'desktop', 'any', 'smart', tablet' or 'dumb'.
+ * @param string      $kind Category of mobile device being checked. Can be 'any', 'smart' or 'dumb'.
  * @param bool        $return_matched_agent Boolean indicating if the UA should be returned
  *
  * @return bool|string $matches Boolean if current UA matches $kind or not. If
@@ -741,7 +741,7 @@ function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
 		return false;
 	}
 
-	if ( 'smart' === $kind || 'dumb' === $kind || 'tablet' === $kind ) {
+	if ( 'smart' === $kind || 'dumb' === $kind ) {
 		$matches = $kind === $x_mobile_class;
 	} elseif ( 'any' === $kind ) {
 		$matches = true;

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -749,7 +749,7 @@ function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
 
 	return $matches;
 }
-$is_rolled_out = ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) || \Automattic\VIP\Feature::is_enabled_by_percentage( 'jetpack-is-mobile' );
+$is_rolled_out = ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) || \Automattic\VIP\Feature::is_enabled_by_percentage( 'jetpack-is-mobile' );
 
 if ( $is_rolled_out ) {
 	add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -741,7 +741,7 @@ function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
 		return false;
 	}
 
-	if ( 'smart' === $kind || 'dumb' === $kind ) {
+	if ( 'smart' === $kind || 'dumb' === $kind || 'tablet' === $kind ) {
 		$matches = $kind === $x_mobile_class;
 	} elseif ( 'any' === $kind ) {
 		$matches = true;

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -729,8 +729,8 @@ add_action( 'admin_menu', 'vip_remove_jetpack_search_menu_page', PHP_INT_MAX );
  * $return_matched_agent is true, should return the UA string
  */
 function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
-	if ( ! isset( $_SERVER['HTTP_X_MOBILE_CLASS'] ) ) {
-		// No value set, return early.
+	if ( ! isset( $_SERVER['HTTP_X_MOBILE_CLASS'] ) || $return_matched_agent ) {
+		// No value set or expectation to return matched agent, return early.
 		return $matches;
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -722,7 +722,7 @@ add_action( 'admin_menu', 'vip_remove_jetpack_search_menu_page', PHP_INT_MAX );
  *
  * @param bool|string $matches Boolean if current UA matches $kind or not. If
  * $return_matched_agent is true, should return the UA string
- * @param string      $kind Category of mobile device being checked. Can be 'any', 'smart' or 'dumb'.
+ * @param string      $kind Category of mobile device being checked. Can be 'desktop', 'any', 'smart', tablet' or 'dumb'.
  * @param bool        $return_matched_agent Boolean indicating if the UA should be returned
  *
  * @return bool|string $matches Boolean if current UA matches $kind or not. If


### PR DESCRIPTION
## Description
Fixes #363.

## Changelog Description

### Plugin Updated: Jetpack: VIP Specific Changes

Changed the behavior of jetpack_is_mobile() to account for X-Mobile-Class header.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Fake coming from a desktop:
```
add_action( 'init', function() {
	$_SERVER['HTTP_X_MOBILE_CLASS'] = 'desktop';
}, 998);
```

2) Test out `jetpack_is_mobile()`:
```
add_action( 'init', function() {
	var_dump( jetpack_is_mobile() );
}, 999);
```
Expect it to return `false`.
4) Fake coming from a tablet:
```
add_action( 'init', function() {
	$_SERVER['HTTP_X_MOBILE_CLASS'] = 'tablet';
}, 998);
```
5) Repeat step 2) but expect it to return `true`
6) Fake coming from a smartphone:
```
add_action( 'init', function() {
	$_SERVER['HTTP_X_MOBILE_CLASS'] = 'smart';
}, 998);
```
7) Repeat step 2) but expect it to return `true`
8) Use `jetpack_is_mobile()` to check if request is coming from a non-smartphone:
```
add_action( 'init', function() {
	var_dump( jetpack_is_mobile( 'dumb' ) );
}, 999);
```
Expect it to return `false` b/c step 6)
