### PR TITLE
Open the vip_files_acl_file_visibility filter

### DIFF
--- a/files/acl/endpoint-check-file-acl.php
+++ b/files/acl/endpoint-check-file-acl.php
@@ -35,11 +35,7 @@ if ( ! $vip_files_acl_is_path_allowed ) {
 }
 
 /**
- * Hook in here to adjust the visibility of a given file.
- *
- * Note: this is currently for VIP internal use only.
- *
- * @access private 
+ * Adjust the visibility of a given file.
  *
  * @param string|boolean $file_visibility Return one of Automattic\VIP\Files\Acl\(FILE_IS_PUBLIC | FILE_IS_PRIVATE_AND_ALLOWED | FILE_IS_PRIVATE_AND_DENIED) to set visibility.
  * @param string $sanitized_file_path The requested file path (note: This does not include `/wp-content/uploads/`. And, on multisite subdirectory installs, this does not includes the subdirectory).


### PR DESCRIPTION
## Description

Removes comments indicating that the `vip_files_acl_file_visibility` filter is private - this functionality has proven to be stable and the filter is now open for use.

## Changelog Description

### Mark the vip_files_acl_file_visibility` filter as available for use

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

This is a comment-only change and doesn't affect any functionality.