### PR TITLE
VIP Support: Add more validation checks and account for existing user with different e-mail

### DIFF
--- a/tests/vip-support/test-user.php
+++ b/tests/vip-support/test-user.php
@@ -115,7 +115,7 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 		] );
 
 		$instance = User::init();
-		
+
 		$instance->mark_user_email_verified( $user_id, 'admin@automattic.com' );
 
 		$this->assertTrue( $instance->is_verified_automattician( $user_id ) );
@@ -127,14 +127,14 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	 */
 	public function test_is_verified_automattician_for_disallowed_user(): void {
 		define( 'VIP_SUPPORT_USER_ALLOWED_EMAILS', array( 'admin@automattic.com' ) );
-	
+
 		$user_id = $this->factory->user->create( [
 			'user_email' => 'foo@automattic.com',
 			'user_login' => 'vip_foo',
 		] );
 
 		$instance = User::init();
-		
+
 		$instance->mark_user_email_verified( $user_id, 'foo@automattic.com' );
 
 		$this->assertFalse( $instance->is_verified_automattician( $user_id ) );
@@ -190,7 +190,7 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 		] );
 
 		$new_user_id = User::add( [
-			'user_email'   => 'existing456@automattic.com',
+			'user_email'   => 'existing456+test@automattic.com',
 			'user_login'   => 'vip-support-user-456',
 			'display_name' => 'New User',
 			'user_pass'    => 'password',
@@ -201,7 +201,21 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 		$this->assertEquals( $existing_user_id, $new_user_id, 'Existing and new IDs are not the same. Existing account was not updated.' );
 
 		$new_user_obj = get_userdata( $new_user_id );
-		$this->assertEquals( 'existing456@automattic.com', $new_user_obj->user_email, 'Email for new user was changed but should not have.' );
+		$this->assertEquals( 'existing456+test@automattic.com', $new_user_obj->user_email, 'Email for user was not updated.' );
 		$this->assertEquals( 'New User', $new_user_obj->display_name, 'Display name for new user was not updated.' );
+	}
+
+	public function test__remove__existing_vip_support_user(): void {
+		$new_user_id = User::add( [
+			'user_email' => 'existing1234@automattic.com',
+			'user_login' => 'new-vip-support-user-123',
+			'user_pass'  => 'password',
+		] );
+
+		User::remove( 'existing1234@automattic.com' );
+
+		$removed_user_obj = get_userdata( $new_user_id );
+
+		$this->assertFalse( $removed_user_obj, 'User was not deleted' );
 	}
 }

--- a/tests/vip-support/test-user.php
+++ b/tests/vip-support/test-user.php
@@ -39,8 +39,10 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 			'someuser+test@a8c.com',
 		);
 
+		$user_instance = User::init();
+
 		foreach ( $a8c_emails as $a8c_email ) {
-			$this->assertTrue( User::init()->is_a8c_email( $a8c_email ) );
+			$this->assertTrue( $user_instance::is_a8c_email( $a8c_email ) );
 		}
 
 		$non_a8c_emails = array(
@@ -55,7 +57,7 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 		);
 
 		foreach ( $non_a8c_emails as $non_a8c_email ) {
-			$this->assertFalse( User::init()->is_a8c_email( $non_a8c_email ) );
+			$this->assertFalse( $user_instance::is_a8c_email( $non_a8c_email ) );
 		}
 
 	}

--- a/vip-support/class-vip-support-user.php
+++ b/vip-support/class-vip-support-user.php
@@ -770,7 +770,7 @@ class User {
 
 	/**
 	 * Is a provided email address allowed to be a support user on this site?
-	 * 
+	 *
 	 * On certain sites with tight access restrictions, only certain support users are allowed
 	 *
 	 * @param string $email An email address to check
@@ -782,7 +782,7 @@ class User {
 		if ( ! defined( 'VIP_SUPPORT_USER_ALLOWED_EMAILS' ) ) {
 			return true;
 		}
-		
+
 		// Incorrectly formatted constant, fail fast + closed
 		if ( ! is_array( VIP_SUPPORT_USER_ALLOWED_EMAILS ) ) {
 			return false;
@@ -998,16 +998,19 @@ class User {
 			] );
 			remove_filter( 'send_password_change_email', '__return_false' );
 
-			// Force create a new user below.
+			// Force create new user if no existing user by login
 			$user = false;
-		} elseif ( $user && $user->ID ) {
-			// If the user exists, let's update it.
-			$user_data['ID'] = $user->ID;
+		}
+
+		if ( false === $user ) {
+			// Re-try to see if there is an existing user by login.
+			$user = get_user_by( 'login', $user_data['user_login'] );
 		}
 
 		if ( false === $user ) {
 			$user_id = wp_insert_user( $user_data );
 		} else {
+			$user_data['ID'] = $user->ID;
 			add_filter( 'send_password_change_email', '__return_false' );
 			$user_id = wp_update_user( $user_data );
 			remove_filter( 'send_password_change_email', '__return_false' );

--- a/vip-support/class-vip-support-user.php
+++ b/vip-support/class-vip-support-user.php
@@ -244,7 +244,7 @@ class User {
 	 * @param object $user The WP_User object representing the user being edited
 	 */
 	public function action_personal_options( $user ) {
-		if ( ! $this->is_a8c_email( $user->user_email ) ) {
+		if ( ! self::is_a8c_email( $user->user_email ) ) {
 			return;
 		}
 
@@ -316,7 +316,7 @@ class User {
 				$user_id     = get_current_user_id();
 				$user        = get_user_by( 'id', $user_id );
 				$resend_link = $this->get_trigger_resend_verification_url();
-				if ( $this->is_a8c_email( $user->user_email ) && ! $this->user_has_verified_email( $user->ID ) ) {
+				if ( self::is_a8c_email( $user->user_email ) && ! $this->user_has_verified_email( $user->ID ) ) {
 					// translators: 1 - link to resemd the email
 					$error_html = sprintf( __( 'Your Automattic email address is not verified, <a href="%s">re-send verification email</a>.', 'vip-support' ), esc_url( $resend_link ) );
 				}
@@ -333,7 +333,7 @@ class User {
 				$user_id     = absint( $_GET['user_id'] ?? 0 );
 				$user        = get_user_by( 'id', $user_id );
 				$resend_link = $this->get_trigger_resend_verification_url();
-				if ( $this->is_a8c_email( $user->user_email ) && ! $this->user_has_verified_email( $user->ID ) && self::user_has_vip_support_role( $user->ID ) ) {
+				if ( self::is_a8c_email( $user->user_email ) && ! $this->user_has_verified_email( $user->ID ) && self::user_has_vip_support_role( $user->ID ) ) {
 					// translators: 1 - link to resend the email
 					$error_html = sprintf( __( 'This user’s Automattic email address is not verified, <a href="%s">re-send verification email</a>.', 'vip-support' ), esc_url( $resend_link ) );
 				}
@@ -370,13 +370,13 @@ class User {
 
 		// Try to make the conditional checks clearer
 		$becoming_support         = ( Role::VIP_SUPPORT_ROLE == $role );
-		$valid_and_verified_email = ( $this->is_a8c_email( $user->user_email ) && $this->user_has_verified_email( $user_id ) );
+		$valid_and_verified_email = ( self::is_a8c_email( $user->user_email ) && $this->user_has_verified_email( $user_id ) );
 
 		if ( $becoming_support && ! $valid_and_verified_email ) {
 			$this->reverting_role = true;
 			// @FIXME This could be expressed more simply, probably :|
 			if ( ! is_array( $old_roles ) || ! isset( $old_roles[0] ) ) {
-				if ( $this->is_a8c_email( $user->user_email ) ) {
+				if ( self::is_a8c_email( $user->user_email ) ) {
 					$revert_role_to = Role::VIP_SUPPORT_INACTIVE_ROLE;
 				} else {
 					$revert_role_to = 'subscriber';
@@ -385,7 +385,7 @@ class User {
 				$revert_role_to = $old_roles[0];
 			}
 			$this->demote_user_from_vip_support_to( $user->ID, $revert_role_to );
-			if ( $this->is_a8c_email( $user->user_email ) && ! $this->user_has_verified_email( $user_id ) ) {
+			if ( self::is_a8c_email( $user->user_email ) && ! $this->user_has_verified_email( $user_id ) ) {
 				$this->message_replace = self::MSG_BLOCK_UPGRADE_VERIFY_EMAIL;
 				$this->send_verification_email( $user_id );
 			} else {
@@ -433,7 +433,7 @@ class User {
 	 * @return string
 	 */
 	public function filter_vip_support_email_aliases( $email, $id ) {
-		if ( is_admin() && $this->is_a8c_email( $email ) && $this->has_vip_support_meta( $id ) ) {
+		if ( is_admin() && self::is_a8c_email( $email ) && $this->has_vip_support_meta( $id ) ) {
 			return self::VIP_SUPPORT_EMAIL_ADDRESS;
 		}
 
@@ -472,7 +472,7 @@ class User {
 			$user_email = $id_or_email->user_email;
 		}
 
-		if ( isset( $user_email ) && $this->is_a8c_email( $user_email ) && ( ! $user || $this->has_vip_support_meta( $user->ID ) ) ) {
+		if ( isset( $user_email ) && self::is_a8c_email( $user_email ) && ( ! $user || $this->has_vip_support_meta( $user->ID ) ) ) {
 			return self::VIP_SUPPORT_EMAIL_ADDRESS_GRAVATAR . '?d=mm&r=g&s=' . $args['size'];
 		}
 
@@ -511,7 +511,7 @@ class User {
 	 */
 	public function action_user_register( $user_id ) {
 		$user = new WP_User( $user_id );
-		if ( $this->is_a8c_email( $user->user_email ) && self::user_has_vip_support_role( $user->ID ) ) {
+		if ( self::is_a8c_email( $user->user_email ) && self::user_has_vip_support_role( $user->ID ) ) {
 			$this->demote_user_from_vip_support_to( $user->ID, Role::VIP_SUPPORT_INACTIVE_ROLE );
 			$this->registering_a11n = true;
 			// @TODO Abstract this into an UNVERIFY method
@@ -575,7 +575,7 @@ class User {
 			wp_die( esc_html( $rebuffal_message ), esc_html( $rebuffal_title ), array( 'response' => 403 ) );
 		}
 
-		if ( ! $this->is_a8c_email( $user->user_email ) ) {
+		if ( ! self::is_a8c_email( $user->user_email ) ) {
 			wp_die( esc_html( $rebuffal_message ), esc_html( $rebuffal_title ), array( 'response' => 403 ) );
 		}
 
@@ -600,7 +600,7 @@ class User {
 
 		// If the user is an A12n, add them to the support role
 		// Only promotes the user if from the inactive user role
-		if ( $this->is_a8c_email( $user->user_email ) ) {
+		if ( self::is_a8c_email( $user->user_email ) ) {
 			$this->promote_user_to_vip_support( $user->ID );
 		}
 
@@ -752,7 +752,7 @@ class User {
 	 *
 	 * @return bool True if the string is an email with an A8c domain
 	 */
-	public function is_a8c_email( $email ) {
+	public static function is_a8c_email( $email ) {
 		if ( ! is_email( $email ) ) {
 			return false;
 		}
@@ -812,7 +812,7 @@ class User {
 
 		$instance = self::init();
 
-		$is_a8c_email     = $instance->is_a8c_email( $user->user_email );
+		$is_a8c_email     = self::is_a8c_email( $user->user_email );
 		$is_allowed_email = $instance->is_allowed_email( $user->user_email );
 		$email_verified   = $instance->user_has_verified_email( $user->ID );
 


### PR DESCRIPTION
## Description
Fixes https://github.com/Automattic/vip-go-mu-plugins/issues/1048.

This PR:
- changes the `is_a8c_email()` to a static method so that it can be used outside
- adds a validation check for an a8c e-mail before adding the support user
- adds a validation check for a username prefixed with "vip_" before adding the support user
- `add_support_user()`: accounts for an existing support user that has a different e-mail but same login and updates the e-mail

## Changelog Description

### Plugin Updated: VIP Support

Add additional validation checks before adding support user and account for existing support user with different e-mail

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Attempt to create a user without an A8C email
```
wp vipsupport create-user vip_testuser testing.user@gmail.com test123
```
Expect to see:
```
Error: User cannot be added as 'testing.user@gmail.com', not a valid email address.
```
2) Attempt to create a user without `vip_` prefix:
```
wp vipsupport create-user testuser_vip testing.user@automattic.com test123
```
Expect to see:
```
Error: User cannot be added as 'testuser_vip', not pre-fixed with "vip_".
```
3) Create user:
```
wp vipsupport create-user vip_testuser testing.user@automattic.com test123
```
4) Attempt to update user with different e-mail
```
wp vipsupport create-user vip_testuser tu@automattic.com test123
```
Verify user has been updated with new e-mail via `wp user list`