### PR TITLE
WPCOM_VIP_CLI_Command: Add deprecation notice for stop_the_insanity()

### DIFF
--- a/vip-helpers/vip-wp-cli.php
+++ b/vip-helpers/vip-wp-cli.php
@@ -4,8 +4,19 @@ class WPCOM_VIP_CLI_Command extends WP_CLI_Command {
 
 	/**
 	 *  Clear all of the caches for memory management
+	 *
+	 * @deprecated Use vip_inmemory_cleanup() instead
 	 */
 	protected function stop_the_insanity() {
+		_deprecated_function( __METHOD__, '2.0.0', 'vip_inmemory_cleanup' );
+		$this->vip_inmemory_cleanup();
+	}
+
+	/**
+	 * Clear in-memory local object cache (global $wp_object_cache) without affecting memcache
+	 * and reset in-memory database query log.
+	 */
+	protected function vip_inmemory_cleanup() {
 		vip_reset_db_query_log();
 		vip_reset_local_object_cache();
 	}


### PR DESCRIPTION
## Description
It's 2022, let's be a little less insensitive. Fixes https://github.com/Automattic/vip-go-mu-plugins/issues/1170.

Right now, I have it as `vip_inmemory_cleanup()`, but open to other ideas on what to rename it.

Not sure what the likeliness of removing `stop_the_insanity()` since it is still widely used but at least this will get us started on migrating and updating our docs.

## Changelog Description

### Plugin Updated: WPCOM_VIP_CLI_Command

Deprecate `stop_the_insanity()` in favour of `vip_inmemory_cleanup()`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) In `vip-config.php`:

```
error_reporting( E_ALL );
define( 'WP_DEBUG', true );
```
2) Add the below CLI test command:
```
<?php
class Test_CLI_Command extends WPCOM_VIP_CLI_Command {

	/**
	 * Test command bla bla bla.
	 *
	 * @subcommand subcommand
	 */
	public function subcommand( $args, $assoc_args ) {
		$this->stop_the_insanity();
	}
}

WP_CLI::add_command( 'test-command', 'Test_CLI_Command' );
```
3) Run `wp test-command subcommand` and expect to see:
```
Deprecated: Function WPCOM_VIP_CLI_Command::stop_the_insanity is <strong>deprecated</strong> since version 2.0.0! Use manage_memory instead. in /chroot/var/www/wp-includes/functions.php on line 5379 [$ /usr/local/bin/wp test-command subcommand] [/chrootwp-includes/functions.php:5379 trigger_error(), /chrootwp-content/mu-plugins/vip-helpers/vip-wp-cli.php:11 _deprecated_function(), /chroot/client-repo/client-mu-plugins/test-cron.php:10 WPCOM_VIP_CLI_Command->stop_the_insanity(), Test_CLI_Command->subcommand(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:417 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:440 WP_CLI\Runner->run_command(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1237 WP_CLI\Runner->run_command_and_exit(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28 WP_CLI\Runner->start(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php:78 WP_CLI\Bootstrap\LaunchRunner->process(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/bin/wp/php/boot-phar.php:11 include('phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/bin/wp/php/boot-phar.php')]
```