### PR TITLE
GH-3509: fix 'foreach() argument must be of type array|object, null given' warning

### DIFF
--- a/codebase-manager/plugins/plugins-manager.php
+++ b/codebase-manager/plugins/plugins-manager.php
@@ -42,13 +42,15 @@ class PluginsManager {
 	public function display_update_count_bubble_in_menu(): void {
 		global $menu;
 
-		foreach ( $menu as $menu_key => $menu_data ) {
-			if ( 'plugins.php' === $menu_data[2] ) {
-				$count         = count( $this->update_data );
-				$update_bubble = sprintf( '<span class="vip-update-plugins count-%s"><span class="vip-plugin-count">%s</span></span>', $count, number_format_i18n( $count ) );
+		if ( isset( $menu ) && is_array( $menu ) ) {
+			foreach ( $menu as $menu_key => $menu_data ) {
+				if ( 'plugins.php' === $menu_data[2] ) {
+					$count         = count( $this->update_data );
+					$update_bubble = sprintf( '<span class="vip-update-plugins count-%s"><span class="vip-plugin-count">%s</span></span>', $count, number_format_i18n( $count ) );
 
-				/* translators: Number of available plugin updates */
-				$menu[ $menu_key ][0] = sprintf( __( 'Plugins %s' ), $update_bubble ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+					/* translators: Number of available plugin updates */
+					$menu[ $menu_key ][0] = sprintf( __( 'Plugins %s' ), $update_bubble ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Fixes: GH-3509

## Changelog Description

### Plugin Updated: VIP Codebase Manager

Fix PHP warning when `$menu` is not initialized.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
