### PR TITLE
GH-2358: respect WPMU_PLUGIN_DIR/WPMU_PLUGIN_URL

### DIFF
--- a/lib/sunrise/sunrise.php
+++ b/lib/sunrise/sunrise.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) || ! is_multisite() ) {
 	return;
 }
 
-$mu_plugin_dir = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : WP_CONTENT_DIR . '/mu-plugins';
+$mu_plugin_dir = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : constant( 'WP_CONTENT_DIR' ) . '/mu-plugins';
 require_once $mu_plugin_dir . '/lib/utils/class-context.php';
 unset( $mu_plugin_dir );
 
@@ -68,7 +68,7 @@ function handle_not_found_error( $error_type ) {
 
 	$is_web_request = Context::is_web_request();
 	if ( $is_web_request ) {
-		$mu_plugin_dir       = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : WP_CONTENT_DIR . '/mu-plugins';
+		$mu_plugin_dir       = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : constant( 'WP_CONTENT_DIR' ) . '/mu-plugins';
 		$is_maintenance_mode = Context::is_maintenance_mode();
 		if ( $is_maintenance_mode ) {
 			// 503 prevents page from being cached.

--- a/lib/sunrise/sunrise.php
+++ b/lib/sunrise/sunrise.php
@@ -9,7 +9,9 @@ if ( ! defined( 'ABSPATH' ) || ! is_multisite() ) {
 	return;
 }
 
-require_once WP_CONTENT_DIR . '/mu-plugins/lib/utils/class-context.php';
+$mu_plugin_dir = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : WP_CONTENT_DIR . '/mu-plugins';
+require_once $mu_plugin_dir . '/lib/utils/class-context.php';
+unset( $mu_plugin_dir );
 
 use Automattic\VIP\Utils\Context;
 
@@ -66,16 +68,17 @@ function handle_not_found_error( $error_type ) {
 
 	$is_web_request = Context::is_web_request();
 	if ( $is_web_request ) {
+		$mu_plugin_dir       = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : WP_CONTENT_DIR . '/mu-plugins';
 		$is_maintenance_mode = Context::is_maintenance_mode();
 		if ( $is_maintenance_mode ) {
 			// 503 prevents page from being cached.
 			// We handle healthchecks earlier and don't have to worry about them.
 			$status_code = 503;
 			header( 'X-VIP-Go-Maintenance: true' );
-			$error_doc = sprintf( '%s/mu-plugins/errors/site-maintenance.html', WP_CONTENT_DIR );
+			$error_doc = sprintf( '%s/errors/site-maintenance.html', $mu_plugin_dir );
 		} else {
 			$status_code = 404;
-			$error_doc   = sprintf( '%s/mu-plugins/errors/%s-not-found.html', WP_CONTENT_DIR, $error_type );
+			$error_doc   = sprintf( '%s/errors/%s-not-found.html', $mu_plugin_dir, $error_type );
 		}
 
 		http_response_code( $status_code );

--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -348,7 +348,7 @@ class Logger {
 			 */
 
 			$index = 1;
-			if ( isset( $backtrace[ $index ]['file'] ) && wp_endswith( $backtrace[ $index ]['file'], '/mu-plugins/logstash/logstash.php' ) ) {
+			if ( isset( $backtrace[ $index ]['file'] ) && wp_endswith( $backtrace[ $index ]['file'], '/logstash/logstash.php' ) ) {
 				$index = 2;
 			}
 

--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -58,8 +58,8 @@ class WPCOM_VIP_Jetpack_Mandatory {
 	// =====
 
 	public function action_load_jetpack_modules() {
-		$mu_plugin_dir      = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : WP_CONTENT_DIR . '/mu-plugins';
-		$mu_plugin_url      = defined( 'WPMU_PLUGIN_URL' ) ? constant( 'WPMU_PLUGIN_URL' ) : WP_CONTENT_URL . '/mu-plugins';
+		$mu_plugin_dir      = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : constant( 'WP_CONTENT_DIR' ) . '/mu-plugins';
+		$mu_plugin_url      = defined( 'WPMU_PLUGIN_URL' ) ? constant( 'WPMU_PLUGIN_URL' ) : constant( 'WP_CONTENT_URL' ) . '/mu-plugins';
 		$mandatory_css_url  = $mu_plugin_url . '/' . basename( __DIR__ ) . '/css/mandatory-settings.css';
 		$mandatory_css_file = $mu_plugin_dir . '/' . basename( __DIR__ ) . '/css/mandatory-settings.css';
 		$mtime              = filemtime( $mandatory_css_file );

--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -58,8 +58,10 @@ class WPCOM_VIP_Jetpack_Mandatory {
 	// =====
 
 	public function action_load_jetpack_modules() {
-		$mandatory_css_url  = WP_CONTENT_URL . '/mu-plugins/' . basename( __DIR__ ) . '/css/mandatory-settings.css';
-		$mandatory_css_file = WP_CONTENT_DIR . '/mu-plugins/' . basename( __DIR__ ) . '/css/mandatory-settings.css';
+		$mu_plugin_dir      = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : WP_CONTENT_DIR . '/mu-plugins';
+		$mu_plugin_url      = defined( 'WPMU_PLUGIN_URL' ) ? constant( 'WPMU_PLUGIN_URL' ) : WP_CONTENT_URL . '/mu-plugins';
+		$mandatory_css_url  = $mu_plugin_url . '/' . basename( __DIR__ ) . '/css/mandatory-settings.css';
+		$mandatory_css_file = $mu_plugin_dir . '/' . basename( __DIR__ ) . '/css/mandatory-settings.css';
 		$mtime              = filemtime( $mandatory_css_file );
 		wp_enqueue_style( 'vip-jetpack-mandatory-settings', $mandatory_css_url, array(), $mtime );
 	}


### PR DESCRIPTION
## Description

Fixes: #2358

If `WPMU_PLUGIN_DIR`/`WPMU_PLUGIN_URL` constants are defined early, use them instead of `WP_CONTENT_{DIR,URL}/mu_plugins`.

## Changelog Description

### Plugin Updated: VIP Init

Respect `WPMU_PLUGIN_DIR`/`WPMU_PLUGIN_URL` constants if they are defined early, before the sunrise code is loaded.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Deploy and pray 😆 