### PR TITLE
Misc: Move priority up for _vip_filter_rest_url_for_ssl()

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -118,12 +118,11 @@ add_action( 'add_option', '_vip_maybe_clear_notoptions_cache' );
  * that HTTPS is enforced at the web server level in production,
  * meaning non-HTTPS API calls will result in a 406 error.
  */
-if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
-	add_filter( 'rest_url', '_vip_filter_rest_url_for_ssl' );
-}
-
+add_filter( 'rest_url', '_vip_filter_rest_url_for_ssl', 100 );
 function _vip_filter_rest_url_for_ssl( $url ) {
-	$url = set_url_scheme( $url, 'https' );
+	if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
+		$url = set_url_scheme( $url, 'https' );
+	}
 
 	return $url;
 }


### PR DESCRIPTION
## Description
Fixes #969. We could even move it to `PHP_INT_MAX`?

## Changelog Description
### Filter Updated: _vip_filter_rest_url_for_ssl

Moves the priority up to 100.
## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Ensure URL schema is https no matter what.
```
add_filter( 'rest_url', function( $url ) {
    $url = set_url_scheme( $url, 'http' );

    return $url;
} );

var_dump( get_rest_url() );
```

