### PR TITLE
Show where the constant was defined previously

### DIFF
--- a/tests/mock-constants.php
+++ b/tests/mock-constants.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Automattic\Test {
+
+	use Exception;
 	use InvalidArgumentException;
 
 	abstract class Constant_Mocker {
@@ -16,10 +18,12 @@ namespace Automattic\Test {
 
 		public static function define( string $constant, $value ): void {
 			if ( isset( self::$constants[ $constant ] ) ) {
-				throw new InvalidArgumentException( sprintf( 'Constant "%s" is already defined', $constant ) );
+				throw new InvalidArgumentException( sprintf( "Constant \"%s\" is already defined. Stacktrace:\n%s", $constant, self::$constants[ $constant ][1] ) );
 			}
 
-			self::$constants[ $constant ] = $value;
+			$e = new Exception();
+
+			self::$constants[ $constant ] = [ $value, $e->getTraceAsString() ];
 		}
 
 		public static function defined( string $constant ): bool {
@@ -31,7 +35,7 @@ namespace Automattic\Test {
 				throw new InvalidArgumentException( sprintf( 'Constant "%s" is not defined', $constant ) );
 			}
 
-			return self::$constants[ $constant ];
+			return self::$constants[ $constant ][0];
 		}
 	}
 }


### PR DESCRIPTION
When `Constant_Mocker` is used incorrectly (for example, a call to `clear()` is missing), it is hard to tell where the constant was defined previously (like in [this case](https://github.com/Automattic/vip-go-mu-plugins/runs/7812748512?check_suite_focus=true#step:5:306))

This PR adds functionality to store the stack trace along with the constant's value. The stack trace is then shown when `define()` throws `InvalidArgumentException`.