### PR TITLE
Clean up mocked constants in test-class-healthjob.php

### DIFF
--- a/tests/search/includes/classes/test-class-healthjob.php
+++ b/tests/search/includes/classes/test-class-healthjob.php
@@ -32,6 +32,10 @@ class HealthJob_Test extends WP_UnitTestCase {
 		\ElasticPress\Indexables::factory()->register( new \ElasticPress\Indexable\User\User() );
 	}
 
+	public static function tearDownAfterClass(): void {
+		Constant_Mocker::clear();
+	}
+
 	public function setUp(): void {
 		parent::setUp();
 		require_once __DIR__ . '/../../../../search/includes/classes/class-healthjob.php';


### PR DESCRIPTION
This fixes the "InvalidArgumentException: Constant "VIP_GO_ENV" is already defined." error.

Ref: https://github.com/Automattic/vip-go-mu-plugins/runs/7812748512?check_suite_focus=true#step:5:306

```
1) Automattic\VIP\Files\WP_Filesystem_VIP_Test::test__get_transport_for_path__non_vip_go_env
InvalidArgumentException: Constant "VIP_GO_ENV" is already defined. Stacktrace:
#0 /home/circleci/project/tests/search/includes/classes/test-class-healthjob.php(22): Automattic\Test\Constant_Mocker::define()
#1 /home/circleci/project/vendor/phpunit/phpunit/src/Framework/TestSuite.php(614): Automattic\VIP\Search\HealthJob_Test::setUpBeforeClass()
#2 /home/circleci/project/vendor/phpunit/phpunit/src/Framework/TestSuite.php(670): PHPUnit\Framework\TestSuite->run()
#3 /home/circleci/project/vendor/phpunit/phpunit/src/Framework/TestSuite.php(670): PHPUnit\Framework\TestSuite->run()
#4 /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(673): PHPUnit\Framework\TestSuite->run()
#5 /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/Command.php(143): PHPUnit\TextUI\TestRunner->run()
#6 /home/circleci/project/vendor/phpunit/phpunit/src/TextUI/Command.php(96): PHPUnit\TextUI\Command->run()
#7 phpvfscomposer:///home/circleci/project/vendor/phpunit/phpunit/phpunit(97): PHPUnit\TextUI\Command::main()
#8 /home/circleci/project/vendor/bin/phpunit(118): include('phpvfscomposer:...')
#9 {main}

/home/circleci/project/tests/mock-constants.php:21
/home/circleci/project/tests/files/test-wp-filesystem-vip.php:294
phpvfscomposer:///home/circleci/project/vendor/phpunit/phpunit/phpunit:97
```
