### PR TITLE
GH-1066: do not override SMTP server if it has already been set

### DIFF
--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -1,7 +1,6 @@
 <?php
 
-use PHPUnit\Framework\ExpectationFailedException;
-use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use PHPMailer\PHPMailer\PHPMailer;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- PHPMailer does not follow the conventions
@@ -109,5 +108,24 @@ class VIP_Mail_Test extends WP_UnitTestCase {
 		$mailer = tests_retrieve_phpmailer_instance();
 
 		$this->assertThat( $mailer->get_sent()->body, $this->logicalNot( $this->stringContains( 'Content-Disposition: attachment; filename=' ) ) );
+	}
+
+	/**
+	 * @ticket GH-1066
+	 */
+	public function test_smtp_servers_not_overwritten(): void {
+		$GLOBALS['all_smtp_servers'] = [ 'server1', 'server2' ];
+
+		$expected = 'preset-server';
+
+		add_action( 'phpmailer_init', function ( PHPMailer &$phpmailer ) use ( $expected ) {
+			$phpmailer->isSMTP();
+			$phpmailer->Host = $expected;
+		} );
+
+		wp_mail( 'test@example.com', 'Test', 'Test' );
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		self::assertEquals( $expected, $mailer->Host );
 	}
 }


### PR DESCRIPTION
## Description

Fixes: #1066

## Changelog Description

### Plugin Updated: VIP Mail

Do not override the SMTP server in `phpmailer_init` if it has already been set by another plugin.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
