### PR TITLE
Use deterministic test order for coverage generation

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -112,8 +112,10 @@ runs:
         OPTIONS=
         if [ "${{ steps.coverage.outputs.coverage }}" != 'none' ]; then
           OPTIONS="${OPTIONS} --coverage-clover=clover.xml"
+        else
+          OPTIONS="${OPTIONS} --order-by=random"
         fi
-        "${PHPUNIT}" --order-by=random ${OPTIONS}
+        "${PHPUNIT}" ${OPTIONS}
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
Run tests in the deterministic order if we generate a coverage report. This is to make sure that we don't have random fluctuations because of the order of the tests and the inner machinery of PHPUnit.
