### PR TITLE
Search: Change default search character length limit to 80

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -143,6 +143,7 @@ class Search {
 
 	private static $query_count_ttl;
 
+	private const DEFAULT_SEARCH_LENGTH          = 80;
 	private const MAX_SEARCH_LENGTH              = 255;
 	private const DISABLE_POST_META_ALLOW_LIST   = array();
 	private const STALE_QUEUE_WAIT_LIMIT         = 3600; // 1 hour in seconds
@@ -1769,7 +1770,13 @@ class Search {
 		if ( $query->is_search() ) {
 			$search = $query->get( 's' );
 
-			$truncated_search = substr( $search, 0, self::MAX_SEARCH_LENGTH );
+			$search_length = ! current_user_can( 'edit_posts' ) ? apply_filters( 'vip_search_char_length', self::DEFAULT_SEARCH_LENGTH ) : self::MAX_SEARCH_LENGTH;
+
+			if ( $search_length > self::MAX_SEARCH_LENGTH ) {
+				$search_length = self::MAX_SEARCH_LENGTH;
+			}
+
+			$truncated_search = substr( $search, 0, $search_length );
 
 			$query->set( 's', $truncated_search );
 		}

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -1434,7 +1434,7 @@ class Search_Test extends WP_UnitTestCase {
 			'role'       => 'administrator',
 		] );
 
-		set_current_user( $admin_user );
+		wp_set_current_user( $admin_user );
 
 		$es = new \Automattic\VIP\Search\Search();
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -1411,12 +1411,35 @@ class Search_Test extends WP_UnitTestCase {
 		}
 	}
 
-	public function test__truncate_search_string_length() {
+	public function test__truncate_search_string_length__user_no_cap() {
+		$es = new \Automattic\VIP\Search\Search();
+
+		$expected_search_string = '1nAtu5t4QRo9XmU5VeKFOCTfQN62FrbvvoQXkU1782KOThAlt50NipM7V4dZNGG4eO54HsOQlJaBPStX';
+		$provided_search_string = '1nAtu5t4QRo9XmU5VeKFOCTfQN62FrbvvoQXkU1782KOThAlt50NipM7V4dZNGG4eO54HsOQlJaBPStXPRoxWPHqdrHGsGkNQJJshYseaePxCJuGmY7kYp941TUoNF3GhSBEzjajNu0iwdCWrPMLxSJ5XXBltNM9of2LKvwa1hNPOXLka1tyAi8PSZlS53RbGhv7egKOYPyyPpR6mZlzJhx6nXXlZ5t3BtRdQOIvGho6HjdYwdd1hMyHHv1qpggg5oMk1nWsx5fJ0B3bAFYKt1Y5dOA0Q4lQUqj8mf1LjcmR73wQwujc1GQfgCKj9X9Ktr6LrDtN5zAJFQboAJa7fZ9AiGxbJqUrLFs';
+
+		$wp_query_mock = new \WP_Query();
+
+		$wp_query_mock->set( 's', $provided_search_string );
+		$wp_query_mock->is_search = true;
+
+		$this->search_instance->truncate_search_string_length( $wp_query_mock );
+
+		$this->assertEquals( $expected_search_string, $wp_query_mock->get( 's' ) );
+	}
+
+	public function test__truncate_search_string_length__user_with_cap() {
+		$admin_user = $this->factory->user->create( [
+			'user_email' => 'admin@automattic.com',
+			'user_login' => 'vip_admin',
+			'role'       => 'administrator',
+		] );
+
+		set_current_user( $admin_user );
+
 		$es = new \Automattic\VIP\Search\Search();
 
 		$expected_search_string = '1nAtu5t4QRo9XmU5VeKFOCTfQN62FrbvvoQXkU1782KOThAlt50NipM7V4dZNGG4eO54HsOQlJaBPStXPRoxWPHqdrHGsGkNQJJshYseaePxCJuGmY7kYp941TUoNF3GhSBEzjajNu0iwdCWrPMLxSJ5XXBltNM9of2LKvwa1hNPOXLka1tyAi8PSZlS53RbGhv7egKOYPyyPpR6mZlzJhx6nXXlZ5t3BtRdQOIvGho6HjdYwdd1hMyHHv1qpgg';
-		$provided_search_string = '1nAtu5t4QRo9XmU5VeKFOCTfQN62FrbvvoQXkU1782KOThAlt50NipM7V4dZNGG4eO54HsOQlJaBPStXPRoxWPHqdrHGsGkNQJJshYseaePxCJuGmY7kYp941TUoNF3GhSBEzjajNu0iwdCWrPMLxSJ5XXBltNM9of2LKvwa1hNPOXLka1tyAi8PSZlS53RbGhv7egKOYPyyPpR6mZlzJhx6nXXlZ5t3BtRdQOIvGho6HjdYwdd1hMyHHv1qpgg' .
-			'g5oMk1nWsx5fJ0B3bAFYKt1Y5dOA0Q4lQUqj8mf1LjcmR73wQwujc1GQfgCKj9X9Ktr6LrDtN5zAJFQboAJa7fZ9AiGxbJqUrLFs';
+		$provided_search_string = '1nAtu5t4QRo9XmU5VeKFOCTfQN62FrbvvoQXkU1782KOThAlt50NipM7V4dZNGG4eO54HsOQlJaBPStXPRoxWPHqdrHGsGkNQJJshYseaePxCJuGmY7kYp941TUoNF3GhSBEzjajNu0iwdCWrPMLxSJ5XXBltNM9of2LKvwa1hNPOXLka1tyAi8PSZlS53RbGhv7egKOYPyyPpR6mZlzJhx6nXXlZ5t3BtRdQOIvGho6HjdYwdd1hMyHHv1qpggg5oMk1nWsx5fJ0B3bAFYKt1Y5dOA0Q4lQUqj8mf1LjcmR73wQwujc1GQfgCKj9X9Ktr6LrDtN5zAJFQboAJa7fZ9AiGxbJqUrLFs';
 
 		$wp_query_mock = new \WP_Query();
 


### PR DESCRIPTION
## Description
The maximum length still remains at 255, but let's change the default search character length to 80 for users without the `edit_post` capability. Most search lengths shouldn't be longer than that. However, I added the filter `vip_search_char_length` if one wanted to change it to anything from 0-255.

## Changelog Description

### Plugin Updated: Enterprise Search

Search term character length limit has changed to 80 for users without the edit_post cap.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Use `used-4x4-premier-4dr-suv-mega-cab-4x4-awd-sl-4dr-crossover-4x4-z71-4dr-extended-cab-6-ft-lb-20t-luxury-4dr-sedan-sports-activity-vehicle-used-4x4-premier-4dr-suv-mega-cab-4x4-awd-sl-4dr-crossover-4x4-z71-4dr-extended-cab-6-ft-lb-20t-luxury-4dr-sedan-sports-activity-vehicle` as the search term
2) Go to Search Dev Tools and notice that it only requested `used-4x4-premier-4dr-suv-mega-cab-4x4-awd-sl-4dr-crossover-4x4-z71-4dr-extended-cab-6-ft-lb-20t-luxury-4dr-sedan-sports-activity-vehicle-use`