### PR TITLE
Update e2e eslintrc for breaking changes in @automattic/eslint-plugin-wpvip

### DIFF
--- a/__tests__/e2e/.eslintrc.js
+++ b/__tests__/e2e/.eslintrc.js
@@ -1,10 +1,7 @@
 module.exports = {
-    env: {
-        node: true,
-    },
     extends: [
-        'plugin:@wordpress/eslint-plugin/recommended',
         'plugin:@automattic/wpvip/base',
+        'plugin:@automattic/wpvip/testing',
         'plugin:@automattic/wpvip/typescript',
         'plugin:playwright/playwright-test',
     ],

--- a/__tests__/e2e/lib/global-setup.ts
+++ b/__tests__/e2e/lib/global-setup.ts
@@ -25,7 +25,6 @@ async function globalSetup( config: FullConfig ) {
     await context.tracing.start( { name: 'global-setup', screenshots: true, snapshots: true } );
 
     try {
-
         // Log in to wp-admin
         await page.goto( baseURL + '/wp-login.php', { waitUntil: 'networkidle' } );
         const loginPage = new LoginPage( page );
@@ -48,7 +47,6 @@ async function globalSetup( config: FullConfig ) {
         await page.goto( baseURL + '/wp-admin/post-new.php', { waitUntil: 'networkidle' } );
         const editorPage = new EditorPage( page );
         await editorPage.dismissWelcomeTour();
-
     } catch ( error ) {
         // eslint-disable-next-line no-console
         console.log( error );
@@ -66,7 +64,7 @@ async function globalSetup( config: FullConfig ) {
         fs.rmSync( artifactsDir, { recursive: true, force: true } );
     } else {
         // Stop test run if login fails
-        throw new Error( 'Setup unsuccessful - Tests will not run' )
+        throw new Error( 'Setup unsuccessful - Tests will not run' );
     }
 }
 


### PR DESCRIPTION
## Description

v0.3.0 of `@automattic/eslint-plugin-wpvip` introduced a breaking change (that was not handled well by semver or in the README). The preset `plugin:@wordpress/eslint-plugin/recommended` is no longer required, as it is provided by the `plugin:@automattic/wpvip/base` preset.

This also introduces a few lint fixes, and the use of the (mostly empty) new `plugin:@automattic/wpvip/testing` preset.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

`npm run lint-e2e`
