### PR TITLE
Prometheus: Wrap each class in `file_exists()` to ensure no race conditions occur during deploys

### DIFF
--- a/prometheus.php
+++ b/prometheus.php
@@ -8,28 +8,33 @@ use Automattic\VIP\Prometheus\Post_Stats_Collector;
 
 // @codeCoverageIgnoreStart -- this file is loaded before tests start
 if ( defined( 'ABSPATH' ) ) {
-	if ( file_exists( __DIR__ . '/prometheus/index.php' ) ) {
-		require_once __DIR__ . '/prometheus/index.php';
+	$files = [
+		'/prometheus/index.php',
+		'/prometheus-collectors/class-cache-collector.php',
+		'/prometheus-collectors/class-apcu-collector.php',
+		'/prometheus-collectors/class-opcache-collector.php',
+		'/prometheus-collectors/class-login-stats-collector.php',
+		'/prometheus-collectors/class-post-stats-collector.php',
+	];
+
+	foreach( $files as $file ) {
+		if ( ! file_exists( __DIR__ . $file ) ) {
+			return; // Bail early if one of the files doesn't exist.
+		} else {
+			require_once( __DIR__ . $file );
+		}
 	}
 
-	if ( file_exists( __DIR__ . '/prometheus-collectors/class-cache-collector.php' ) ) {
-		require_once __DIR__ . '/prometheus-collectors/class-cache-collector.php';
-		require_once __DIR__ . '/prometheus-collectors/class-apcu-collector.php';
-		require_once __DIR__ . '/prometheus-collectors/class-opcache-collector.php';
-		require_once __DIR__ . '/prometheus-collectors/class-login-stats-collector.php';
-		require_once __DIR__ . '/prometheus-collectors/class-post-stats-collector.php';
+	add_filter( 'vip_prometheus_collectors', function ( array $collectors, string $hook ): array {
+		if ( 'vip_mu_plugins_loaded' === $hook ) {
+			$collectors[] = new Cache_Collector();
+			$collectors[] = new APCu_Collector();
+			$collectors[] = new OpCache_Collector();
+			$collectors[] = new Login_Stats_Collector();
+			$collectors[] = new Post_Stats_Collector();
+		}
 
-		add_filter( 'vip_prometheus_collectors', function ( array $collectors, string $hook ): array {
-			if ( 'vip_mu_plugins_loaded' === $hook ) {
-				$collectors[] = new Cache_Collector();
-				$collectors[] = new APCu_Collector();
-				$collectors[] = new OpCache_Collector();
-				$collectors[] = new Login_Stats_Collector();
-				$collectors[] = new Post_Stats_Collector();
-			}
-
-			return $collectors;
-		}, 10, 2 );
-	}
+		return $collectors;
+	}, 10, 2 );
 }
 // @codeCoverageIgnoreEnd

--- a/prometheus.php
+++ b/prometheus.php
@@ -17,11 +17,11 @@ if ( defined( 'ABSPATH' ) ) {
 		'/prometheus-collectors/class-post-stats-collector.php',
 	];
 
-	foreach( $files as $file ) {
+	foreach ( $files as $file ) {
 		if ( ! file_exists( __DIR__ . $file ) ) {
 			return; // Bail early if one of the files doesn't exist.
 		} else {
-			require_once( __DIR__ . $file );
+			require_once __DIR__ . $file;
 		}
 	}
 


### PR DESCRIPTION
## Description
To avoid the fatal of the class not existing.

Edit: It doesn't help now, but it just adds a convention to follow if new classes are added.