### PR TITLE
Adjust VIP Jetpack loader to safe-guard against an edge-case where Jetpack is present in active_plugins

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -164,7 +164,7 @@ function vip_jetpack_load() {
 					return $option;
 				}
 
-				foreach( $option as $i => $plugin ) {
+				foreach ( $option as $i => $plugin ) {
 					if ( wp_endswith( $plugin, '/jetpack.php' ) ) {
 						unset( $option[ $i ] );
 						break;

--- a/jetpack.php
+++ b/jetpack.php
@@ -160,8 +160,12 @@ function vip_jetpack_load() {
 			// That would lead to Jetpack Autoloader Guard trying to load autoloaders for `jetpack` and `jetpack-$version`
 			// This in turn would lead to a fatal error, when jetpack and jetpack-$version are the same version.
 			add_filter( 'option_active_plugins', function( $option ) {
+				if ( ! is_array( $option ) ) {
+					return $option;
+				}
+
 				foreach( $option as $i => $plugin ) {
-					if ( 'jetpack/jetpack.php' === $plugin ) {
+					if ( wp_endswith( $plugin, '/jetpack.php' ) ) {
 						unset( $option[ $i ] );
 						break;
 					}

--- a/jetpack.php
+++ b/jetpack.php
@@ -156,6 +156,19 @@ function vip_jetpack_load() {
 		}
 
 		if ( file_exists( $path ) ) {
+			// In a rare edge case, the plugin could be present in `active_plugins` option,
+			// That would lead to Jetpack Autoloader Guard trying to load autoloaders for `jetpack` and `jetpack-$version`
+			// This in turn would lead to a fatal error, when jetpack and jetpack-$version are the same version.
+			add_filter( 'option_active_plugins', function( $option ) {
+				foreach( $option as $i => $plugin ) {
+					if ( 'jetpack/jetpack.php' === $plugin ) {
+						unset( $option[ $i ] );
+						break;
+					}
+				}
+				return $option;
+			} );
+
 			require_once $path;
 			define( 'VIP_JETPACK_LOADED_VERSION', $version );
 			break;


### PR DESCRIPTION
## Description

VIP loads Jetpack via a custom bootstrap function vip_jetpack_load(). Jetpack's [Autoloader](https://github.com/Automattic/jetpack-autoloader/blob/trunk/src/class-plugin-locator.php#L54) tries to determine plugin paths based on `active_plugins`. 

In case `jetpack/jetpack.php` is present in the option, Jetpack's autoloader would try to load both. In the best-case scenario, nothing happens except loading a bunch of Jetpack classes for a different version, but in the worst-case scenario (where the current global deployed version matches the one in `jetpack`, it results in a fatal.

<img width="842" alt="Screen Shot 2022-08-16 at 1 45 04 PM" src="https://user-images.githubusercontent.com/459254/184967867-ef87df5c-d719-473f-b6f1-e789eadbc6d7.png">

This PR addresses that by explicitly removing entries for Jetpack via the `option_active_plugins` filter. 


## Changelog Description

### Plugin Updated: VIP Jetpack Loader

We implemented a safeguard against potentially loading Jetpack classes from different paths.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The easiest way to test is to step through XDebug.

Before applying the PR: 
1. In `wp shell`: `update_option( 'active_plugins', [ 'jetpack/jetpack.php' ] );`
2. Verify the site is now fataling
3. Apply the PR
4. Verify site is not fataling anymore
5. For a good measure go to `jetpack/vendor/jetpack-autoloader/class-autoloader` and set a breakpoint at `class Autoloader`
6. Run a request with Xdebug and verify the breakpoint doesn't trigger. 
