### PR TITLE
Fix phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,11 @@
-<phpunit
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	disableCodeCoverageIgnore="false"
 	cacheResult="false"
 	>
 	<testsuites>


### PR DESCRIPTION
This PR fixes this warning:

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 10:
  - Element 'phpunit', attribute 'disableCodeCoverageIgnore': The attribute 'disableCodeCoverageIgnore' is not allowed.

  Test results may not be as expected.
```
