### PR TITLE
CANTINA-903: add workarounds for Yoast SEO

### DIFF
--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -13,6 +13,7 @@ $files = [
 	'/lib/class-vip-request-block.php',
 	'/lib/environment/class-environment.php',
 	'/lib/helpers/environment.php',
+	'/lib/helpers/php-compat.php',
 	'/lib/utils/class-context.php',
 ];
 

--- a/lib/helpers/php-compat.php
+++ b/lib/helpers/php-compat.php
@@ -62,3 +62,18 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 		return 0 === substr_compare( $haystack, $needle, -$len, $len );
 	}
 }
+
+if ( ! function_exists( 'array_is_list' ) ) {
+	function array_is_list( array $array ): bool {
+		$idx = 0;
+		foreach ( $array as $key => $_ ) {
+			if ( $key !== $idx ) {
+				return false;
+			}
+
+			++$idx;
+		}
+
+		return true;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,7 @@ define( 'WPCOM_VIP_MAIL_TRACKING_KEY', 'key' );
 define( 'WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING', true );
 
 function _manually_load_plugin() {
+	require_once __DIR__ . '/../lib/helpers/php-compat.php';
 	require_once __DIR__ . '/../000-vip-init.php';
 	require_once __DIR__ . '/../001-core.php';
 	require_once __DIR__ . '/../a8c-files.php';

--- a/tests/vip-helpers/test-vip-roles.php
+++ b/tests/vip-helpers/test-vip-roles.php
@@ -15,4 +15,29 @@ class Test_VIP_Roles extends WP_UnitTestCase {
 
 		self::assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * @ticket CANTINA-920
+	 */
+	public function test_wpcom_vip_add_role_yoast_style(): void {
+		// See https://github.com/Yoast/wordpress-seo/blob/0742e9b6ba4c0d6ae9d65223267a106b92a6a4a1/admin/roles/class-role-manager-vip.php#L22-L37
+		$capabilities = [
+			'moderate_comments' => true,
+			'manage_categories' => true,
+			'manage_links'      => true,
+		];
+
+		$enabled_capabilities = [];
+		foreach ( $capabilities as $capability => $_ ) {
+			$enabled_capabilities[] = $capability;
+		}
+
+		$role = 'test_role';
+		wpcom_vip_add_role( $role, 'Test Role', $enabled_capabilities );
+
+		$actual   = wpcom_vip_get_role_caps( $role );
+		$expected = $capabilities;
+
+		self::assertEquals( $expected, $actual );
+	}
 }

--- a/vip-helpers/vip-roles.php
+++ b/vip-helpers/vip-roles.php
@@ -30,6 +30,11 @@ function wpcom_vip_get_role_caps( $role ) {
  * @param array $capabilities Key/value array of capabilities for the role
  */
 function wpcom_vip_add_role( $role, $name, $capabilities ) {
+	if ( array_is_list( $capabilities ) && ! array_filter( $capabilities, 'is_bool' ) ) {
+		$capabilities = array_flip( $capabilities );
+		$capabilities = array_map( '__return_true', $capabilities );
+	}
+
 	$role_obj = get_role( $role );
 
 	if ( ! $role_obj ) {


### PR DESCRIPTION
## Description

`WPSEO_Role_Manager_VIP::add_role()` invokes `wpcom_vip_add_role()` incorrectly. This PR adds a workaround to make sure that roles added by Yoast have the correct capabilities.

Related: Yoast/wordpress-seo#16993

## Changelog Description

### Plugin Updated: VIP Helpers

Add a workaround for Yoast SEO's `WPSEO_Role_Manager_VIP::add_role()`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
