### PR TITLE
VIP_Files_CLI_Command: Use vip_inmemory_cleanup over deprecated stop_the_insanity

### DIFF
--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -115,7 +115,7 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 			}
 
 			// Pause.
-			$this->stop_the_insanity();
+			$this->vip_inmemory_cleanup();
 			sleep( 1 );
 
 			$start_index = $end_index + 1;


### PR DESCRIPTION
## Description
In https://github.com/Automattic/vip-go-mu-plugins/pull/3505, we deprecated `stop_the_insanity` in favour of `vip_inmemory_cleanup`. We should reference that in `VIP_Files_CLI_Command` now.

## Changelog Description

### Plugin Updated: VIP_Files_CLI_Command

Use vip_inmemory_cleanup over deprecated stop_the_insanity

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
