### PR TITLE
Fix fatal error when Jetpack network active

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -173,20 +173,22 @@ function vip_jetpack_load() {
 				return $option;
 			} );
 
-		    	// The same edge case as above, but for when Jetpack is network activated.
-			add_filter( 'site_option_active_sitewide_plugins', function( $option ) {
-				if ( ! is_array( $option ) ) {
-					return $option;
-				}
-
-				foreach ( $option as $plugin => $i ) {
-					if ( wp_endswith( $plugin, '/jetpack.php' ) ) {
-						unset( $option[ $plugin ] );
-						break;
+			if ( is_multisite() ) {
+			    	// The same edge case as above, but for when Jetpack is network activated.
+				add_filter( 'site_option_active_sitewide_plugins', function( $option ) {
+					if ( ! is_array( $option ) ) {
+						return $option;
 					}
-				}
-				return $option;
-			} );
+
+					foreach ( $option as $plugin => $i ) {
+						if ( wp_endswith( $plugin, '/jetpack.php' ) ) {
+							unset( $option[ $plugin ] );
+							break;
+						}
+					}
+					return $option;
+				} );
+			}
 			
 			require_once $path;
 			define( 'VIP_JETPACK_LOADED_VERSION', $version );

--- a/jetpack.php
+++ b/jetpack.php
@@ -173,6 +173,21 @@ function vip_jetpack_load() {
 				return $option;
 			} );
 
+		    	// The same edge case as above, but for when Jetpack is network activated.
+			add_filter( 'site_option_active_sitewide_plugins', function( $option ) {
+				if ( ! is_array( $option ) ) {
+					return $option;
+				}
+
+				foreach ( $option as $plugin => $i ) {
+					if ( wp_endswith( $plugin, '/jetpack.php' ) ) {
+						unset( $option[ $plugin ] );
+						break;
+					}
+				}
+				return $option;
+			} );
+			
 			require_once $path;
 			define( 'VIP_JETPACK_LOADED_VERSION', $version );
 			break;


### PR DESCRIPTION
## Description
This corrects a fatal error where Jetpack attempts to autoload the same class when it has been network activated previously.

The existing work around makes sure that if Jetpack is in the `active_plugins` array that it is ignored, however network activated plugins are stored in a different option, which isn't impacted by this filter.

## Changelog Description
Updates the Jetpack loader to account for network activated installations of Jetpack.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [X] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Create a new local Multisite
1. Install Jetpack
1. Network activate Jetpack
1. Without disabling Jetpack, remove Jetpack from the plugins
1. Install the vip-go-mu-plugins-built to your local site
1. Attempt to load your site.
