### PR TITLE
Roll out filter pre_jetpack_is_mobile to 50% of production sites, which accounts for X-Mobile-Class header in jetpack_is_mobile()

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -174,7 +174,7 @@ function vip_jetpack_load() {
 			} );
 
 			if ( is_multisite() ) {
-			    	// The same edge case as above, but for when Jetpack is network activated.
+				// The same edge case as above, but for when Jetpack is network activated.
 				add_filter( 'site_option_active_sitewide_plugins', function( $option ) {
 					if ( ! is_array( $option ) ) {
 						return $option;
@@ -189,7 +189,7 @@ function vip_jetpack_load() {
 					return $option;
 				} );
 			}
-			
+
 			require_once $path;
 			define( 'VIP_JETPACK_LOADED_VERSION', $version );
 			break;

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -18,7 +18,7 @@ class Feature {
 	 * @var array
 	 */
 	public static $feature_percentages = [
-		'jetpack-is-mobile' => 0.25,
+		'jetpack-is-mobile' => 0.5,
 	];
 
 	/**


### PR DESCRIPTION
## Description
Continuing on https://github.com/Automattic/vip-go-mu-plugins/pull/3549

## Changelog Description

### Plugin Updated: Jetpack: VIP Specific Changes

Roll out filter pre_jetpack_is_mobile to 50% of production sites, which accounts for X-Mobile-Class header in `jetpack_is_mobile()`