### PR TITLE
Debug Bar: Fix fatal "Cannot declare class Debug_Bar, because the name is already in use"

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -30,7 +30,9 @@ add_action( 'set_current_user', function() {
 		return;
 	}
 
-	require_once __DIR__ . '/debug-bar/debug-bar.php';
+	if ( ! class_exists( 'Debug_Bar' ) ) {
+		require_once __DIR__ . '/debug-bar/debug-bar.php';
+	}
 
 	// Load additional plugins
 	if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) ) {


### PR DESCRIPTION
## Description
The fatal occurs when `wp_set_current_user()` is called after https://github.com/Automattic/vip-go-mu-plugins/pull/3490, so we should add a check that the class doesn't already exist before attempting to require it. Stack trace found:

```
 in require_once called at /var/www/wp-content/mu-plugins/debug-bar.php (33)
 in {closure} called at /var/www/wp-includes/class-wp-hook.php (307)
 in WP_Hook::apply_filters called at /var/www/wp-includes/class-wp-hook.php (331)
 in WP_Hook::do_action called at /var/www/wp-includes/plugin.php (476)
 in do_action called at /var/www/wp-includes/pluggable.php (48)
 in wp_set_current_user called at /var/www/wp-content/mu-plugins/jetpack-11.2/jetpack_vendor/automattic/jetpack-sync/src/modules/class-callables.php (215)
 in Automattic\Jetpack\Sync\Modules\Callables::get_all_callables called at /var/www/wp-content/mu-plugins/jetpack-11.2/jetpack_vendor/automattic/jetpack-sync/src/modules/class-callables.php (456)
 in Automattic\Jetpack\Sync\Modules\Callables::maybe_sync_callables called at /var/www/wp-includes/class-wp-hook.php (307)
 in WP_Hook::apply_filters called at /var/www/wp-includes/class-wp-hook.php (331)
 in WP_Hook::do_action called at /var/www/wp-includes/plugin.php (476)
 in do_action called at /var/www/wp-content/mu-plugins/jetpack-11.2/jetpack_vendor/automattic/jetpack-sync/src/class-sender.php (534)
 in Automattic\Jetpack\Sync\Sender::do_sync_for_queue called at /var/www/wp-content/mu-plugins/jetpack-11.2/jetpack_vendor/automattic/jetpack-sync/src/class-sender.php (428)
 in Automattic\Jetpack\Sync\Sender::do_sync_and_set_delays called at /var/www/wp-content/mu-plugins/jetpack-11.2/jetpack_vendor/automattic/jetpack-sync/src/class-sender.php (325)
 in Automattic\Jetpack\Sync\Sender::do_sync called at /var/www/wp-includes/class-wp-hook.php (307)
 in WP_Hook::apply_filters called at /var/www/wp-includes/class-wp-hook.php (331)
 in WP_Hook::do_action called at /var/www/wp-includes/plugin.php (476)
 in do_action called at /var/www/wp-includes/load.php (1102)
 in shutdown_action_hook called at ? (?)
```

## Changelog Description

### Plugin Updated: Debug Bar

Fix fatal "Cannot declare class Debug_Bar, because the name is already in use"

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Couldn't reproduce the issue at hand, but our logs indicate that it's occurring (unclear what circumstances though).