### PR TITLE
Roll out filter pre_jetpack_is_mobile to 75% of production sites, which accounts for X-Mobile-Class header in jetpack_is_mobile()

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -18,7 +18,7 @@ class Feature {
 	 * @var array
 	 */
 	public static $feature_percentages = [
-		'jetpack-is-mobile' => 0.5,
+		'jetpack-is-mobile' => 0.75,
 	];
 
 	/**


### PR DESCRIPTION
## Description
Continuing on https://github.com/Automattic/vip-go-mu-plugins/pull/3579.

## Changelog Description

### Plugin Updated: Jetpack: VIP Specific Changes

Roll out pre_jetpack_is_mobile filter to 75% of production sites, which accounts for X-Mobile-Class header in jetpack_is_mobile()
