### PR TITLE
Search: When a weighting config exists, do not assume we should be applying weighting

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2369,7 +2369,7 @@ class Search {
 	 */
 	public function filter__ep_enable_do_weighting( $should_do_weighting, $weight_config, $args, $formatted_args ) {
 		if ( ! empty( $weight_config ) ) {
-			return true;
+			return $should_do_weighting;
 		}
 
 		global $wp_filter;
@@ -2386,11 +2386,11 @@ class Search {
 				foreach ( $wp_filter[ $ep_filter ]->callbacks as $callback ) {
 					foreach ( $callback as $el ) {
 						if ( $el['function'] instanceof \Closure ) {
-							return true;
+							return $should_do_weighting;
 						} else {
 							$class = get_class( $el['function'][0] );
 							if ( false === strpos( $class, 'ElasticPress\Feature' ) ) {
-								return true;
+								return $should_do_weighting;
 							}
 						}
 					}


### PR DESCRIPTION
## Description
Fixes #3599.

The issue is that we were hardcoding the `$should_do_weighting` return value to `true` under the assumption that it should be applied no matter what under the circumstances that a weighting-related filter or a weighting configuration existed...when it's possible that it could be `false`. 

## Changelog Description

### Plugin Updated: Enterprise Search

When a weighting config exists, do not assume we should be applying weighting via filter__ep_enable_do_weighting.

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Reproduction steps laid out in #3599.