### PR TITLE
Add filter vip_jetpack_is_mobile which accounts for X-Mobile-Class header in jetpack_is_mobile()

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -17,9 +17,7 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = [
-		'jetpack-is-mobile' => 0.75,
-	];
+	public static $feature_percentages = [];
 
 	/**
 	 * Holds feature slug and then, key of ids with bool value to enable E.g.

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -749,8 +749,5 @@ function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
 
 	return $matches;
 }
-$is_rolled_out = ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) || \Automattic\VIP\Feature::is_enabled_by_percentage( 'jetpack-is-mobile' );
 
-if ( $is_rolled_out ) {
-	add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );
-}
+add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );


### PR DESCRIPTION
## Description
Finish https://github.com/Automattic/vip-go-mu-plugins/pull/3600.

## Changelog Description

### Plugin Updated: Jetpack: VIP Specific Changes

Add filter vip_jetpack_is_mobile which accounts for X-Mobile-Class header in jetpack_is_mobile()

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
