### PR TITLE
Disable phpMyAdmin for E2E

### DIFF
--- a/__tests__/e2e/bin/setup-env.sh
+++ b/__tests__/e2e/bin/setup-env.sh
@@ -17,7 +17,7 @@ done
 vip dev-env destroy --slug=e2e-test-site
 
 # Create and run test site
-vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --phpmyadmin --mu-plugins="${pluginPath}" --wordpress="5.9" --multisite=false --client-code="${clientCodePath}"
+vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --wordpress="5.9" --multisite=false --client-code="${clientCodePath}"
 vip --slug=e2e-test-site dev-env start
 
 # Enable Enterprise Search


### PR DESCRIPTION
This reduces the time needed to complete the "Setup test environment" stage by not downloading a pretty large image that is not used anyway.

In theory, this could improve the overall run time because of the reduced memory pressure.
