### PR TITLE
Fix Soft 404 error on "metrics" endpoint

### DIFF
--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -98,6 +98,8 @@ class Plugin {
 		if ( '/metrics' === $request_uri && is_proxied_request() ) {
 			$query_vars['metrics'] = true;
 			unset( $query_vars['error'] );
+
+			add_filter( 'pre_handle_404', [ $this, 'pre_handle_404' ], 10, 2 );
 		}
 
 		return $query_vars;
@@ -114,6 +116,11 @@ class Plugin {
 		}
 
 		return $headers;
+	}
+
+	public function pre_handle_404( $_result, WP_Query $query ): bool {
+		unset( $query->query_vars['error'] );
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Description

When the permalink structure is set to `/%postname%`, hits to `/metrics` endpoint generate a soft 404 error because WP is unable to find a page matching the `/metrics` pattern.

This PR handles the situation by setting a `pre_handle_404` hook that unsets the `error` query variable.

## Changelog Description

### Plugin Updated: VIP Prometheus

Bug fix: fix soft 404 on `/metrics` endpoint

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

If testing this in a dev env, you may need to update [this line](https://github.com/Automattic/vip-go-mu-plugins/blob/7eade2ddfd30142496d16c3cb45d84c3315f8b1a/prometheus/inc/class-plugin.php#L98) to

```php
if ( '/metrics' === $request_uri ) {
```
