### PR TITLE
Allow for running `wp db` CLI commands in a sandbox

### DIFF
--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -16,8 +16,26 @@ $files = [
 	'/lib/utils/class-context.php',
 ];
 
+$cli_files = [
+	'/lib/helpers/wp-cli-db.php',
+];
+
 foreach ( $files as $file ) {
 	if ( file_exists( $mu_plugins_base . $file ) ) {
 		require_once $mu_plugins_base . $file;
 	}
 }
+
+unset( $files );
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	foreach ( $cli_files as $file ) {
+		if ( file_exists( $mu_plugins_base . $file ) ) {
+			require_once $mu_plugins_base . $file;
+		}
+	}
+}
+
+unset( $cli_files );
+unset( $file );
+unset( $mu_plugins_base );

--- a/lib/helpers/wp-cli-db/class-config.php
+++ b/lib/helpers/wp-cli-db/class-config.php
@@ -11,7 +11,7 @@ class Config {
 	private bool $is_sandbox   = false;
 
 	public function __construct() {
-		$this->is_sandbox   = class_exists( Environment::class ) && Environment::is_sandbox_container( gethostname(), getenv() );
+		$this->is_sandbox   = class_exists( Environment::class ) && Environment::is_sandbox_container( gethostname(), [] );
 		$this->enabled      = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
 		$this->allow_writes = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
 	}

--- a/lib/helpers/wp-cli-db/class-config.php
+++ b/lib/helpers/wp-cli-db/class-config.php
@@ -2,15 +2,18 @@
 
 namespace Automattic\VIP\Helpers\WP_CLI_DB;
 
+use Automattic\VIP\Environment;
 use Exception;
 
 class Config {
 	private bool $enabled      = false;
 	private bool $allow_writes = false;
+	private bool $is_sandbox   = false;
 
 	public function __construct() {
-		$this->enabled      = defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
-		$this->allow_writes = defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
+		$this->is_sandbox   = class_exists( Environment::class ) && Environment::is_sandbox_container( gethostname(), getenv() );
+		$this->enabled      = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
+		$this->allow_writes = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
 	}
 
 	public function enabled(): bool {
@@ -19,6 +22,10 @@ class Config {
 
 	public function allow_writes(): bool {
 		return $this->allow_writes;
+	}
+
+	public function is_sandbox(): bool {
+		return $this->is_sandbox;
 	}
 
 	/**

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -4,9 +4,10 @@ namespace Automattic\VIP\Helpers\WP_CLI_DB;
 
 use Exception;
 use WP_CLI;
-use Automattic\VIP\Environment;
 
 class Wp_Cli_Db {
+	private Config $config;
+
 	public function __construct( Config $config ) {
 		$this->config = $config;
 	}
@@ -60,8 +61,10 @@ class Wp_Cli_Db {
 		// This will throw an exception if db commands are not enabled for this env:
 		$server = $this->config->get_database_server();
 
-		// This will throw an exception if the db subcommand is not valid:
-		$this->validate_subcommand( $command );
+		if ( ! $this->config->is_sandbox() ) {
+			// This will throw an exception if the db subcommand is not valid:
+			$this->validate_subcommand( $command );
+		}
 
 		$server->define_variables();
 	}


### PR DESCRIPTION
## Description

This PR allows us to use all sorts of `wp db` commands in a sandboxed environment.

<!-- ## Changelog Description -->

Omitting changelog description, as this feature is for internal use only.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out this branch in a sandbox
2. Run `wp db cli` and make sure it works.
