### PR TITLE
GH-3638: allow for removal of wp_mail_from filter

### DIFF
--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -116,4 +116,23 @@ class VIP_Mail_Test extends WP_UnitTestCase {
 
 		self::assertEquals( $expected, $mailer->Host );
 	}
+
+	/**
+	 * @ticket GH-3638
+	 */
+	public function test_filter_removal(): void {
+		$instance = VIP_SMTP::instance();
+
+		self::assertEquals( 1, has_filter( 'wp_mail_from', [ $instance, 'filter_wp_mail_from' ] ) );
+
+		remove_filter( 'wp_mail_from', [ $instance, 'filter_wp_mail_from' ], 1 );
+		self::assertFalse( has_filter( 'wp_mail_from', [ $instance, 'filter_wp_mail_from' ] ) );
+
+		$expected = 'test-gh-3638@example.com';
+		add_filter( 'wp_mail_from', fn () => $expected, 0 );
+
+		$actual = apply_filters( 'wp_mail_from', 'bad@example.com' );
+
+		self::assertEquals( $expected, $actual );
+	}
 }

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -56,8 +56,18 @@ class VIP_Noop_Mailer {
 	}
 }
 
-class VIP_SMTP {
-	public function init() {
+final class VIP_SMTP {
+	private static ?VIP_SMTP $instance = null;
+
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	private function __construct() {
 		add_action( 'phpmailer_init', array( $this, 'phpmailer_init' ), 99 );
 		add_action( 'bp_phpmailer_init', array( $this, 'phpmailer_init' ), 99 );
 
@@ -81,7 +91,7 @@ class VIP_SMTP {
 
 		global $all_smtp_servers;
 
-		if ( ! is_array( $all_smtp_servers ) || empty( $all_smtp_servers ) ) {
+		if ( empty( $all_smtp_servers ) || ! is_array( $all_smtp_servers ) ) {
 			return;
 		}
 
@@ -178,4 +188,4 @@ class VIP_SMTP {
 	}
 }
 
-( new VIP_SMTP() )->init();
+VIP_SMTP::instance();


### PR DESCRIPTION
## Description

Fixes: #3638

## Changelog Description

### Plugin Updated: VIP Mailer

Add the ability to remove the `wp_mail_from` filter.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

The CI should pass.
