### PR TITLE
Fix is_sandbox_container() to work with k8s sandboxes

### DIFF
--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -39,7 +39,7 @@ class Environment {
 	}
 
 	public static function is_sandbox_container( $hostname, $env = array() ) {
-		if ( false !== strpos( $hostname, '_web_dev_' ) ) {
+		if ( false !== strpos( $hostname, '_web_dev_' ) || false !== strpos( $hostname, '-sbx-u' ) ) {
 			return true;
 		}
 

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -108,6 +108,11 @@ class Environment_Test extends TestCase {
 				// Expected result
 				true,
 			),
+			array(
+				'somesite-sbx-u666-abcdefabcd-efabc',
+				array(),
+				true,
+			),
 		);
 	}
 


### PR DESCRIPTION
`is_sandbox_container()`'s hostname check worked only for VIPd sandboxes. This PR adds support for k8s sandboxes.

Required for #3645 