### PR TITLE
BB8-9678: fix PHP warnings in image_resize()

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -316,8 +316,8 @@ class A8C_Files {
 
 			$imagedata = wp_get_attachment_metadata( $id );
 			if ( $imagedata ) {
-				$w = $imagedata['width'];
-				$h = $imagedata['height'];
+				$w = $imagedata['width'] ?? 0;
+				$h = $imagedata['height'] ?? 0;
 			}
 
 			if ( empty( $w ) ) {


### PR DESCRIPTION
## Description

Sometimes, `wp_get_attachment_metadata()` returns an array without `width` and/or `height` keys. Such situations upset PHP, and it spits warnings. This PR fixes that.

## Changelog Description

### Plugin Updated: VIP File Service

Fix bugs in the code which generate PHP warnings.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
