### PR TITLE
Remove 2FA phone placeholder

### DIFF
--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -195,7 +195,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 					value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>"/>
 			<?php else : ?>
 				<label>Phone Number
-					<input name="vip-two-factor-phone" type="tel" placeholder="+14158675309"
+					<input name="vip-two-factor-phone" type="tel"
 						value="<?php echo esc_attr( $sms ); ?>"/>
 				</label>
 				<input type="submit" class="button" name="vip-two-factor-phone-send-code"


### PR DESCRIPTION
## Description

Removes the placeholder from the two-factor phone number field. This field could be seen as misleading as being populated with an existing unknown number. It is also US-centric which isn't friendly for non-US users.

While there are [better solutions](https://github.com/Automattic/vip-go-mu-plugins/issues/2433#issuecomment-921732670) to improve the experience for everyone, just removing the placeholder stops it from being worse than a default implementation.

Fixes #2433.

## Changelog Description

### Two-factor phone number field

We removed the misleading placeholder attribute value from the phone number field.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. View the two-factor settings on a user profile inside wp-admin. Empty the phone number field if not already.
2. Apply patch, and reload the user profile page, and check the placeholder value has been removed.
