### PR TITLE
Check if ALLOW_UNFILTERED_UPLOADS is defined

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -22,7 +22,9 @@ define( 'LOCAL_UPLOADS', '/tmp/uploads' );
 
 if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
 	// User capabilities tests do not want this constant to be defined
-	define( 'ALLOW_UNFILTERED_UPLOADS', false );
+	if ( ! defined( 'ALLOW_UNFILTERED_UPLOADS' ) ) {
+		define( 'ALLOW_UNFILTERED_UPLOADS', false );
+	}
 }
 
 require_once __DIR__ . '/files/class-path-utils.php';


### PR DESCRIPTION
If `ALLOW_UNFILTERED_UPLOADS` is defined higher up in the boot order this code previously caused a PHP warning:

```
Warning: Constant ALLOW_UNFILTERED_UPLOADS already defined
```

Checking whether or not the constant is already defined quietens the warning.
