### PR TITLE
add vip admin notice filter

### DIFF
--- a/admin-notice/class-admin-notice-controller.php
+++ b/admin-notice/class-admin-notice-controller.php
@@ -19,8 +19,8 @@ class Admin_Notice_Controller {
 		$dismissed_notices = get_user_meta( get_current_user_id(), self::DISMISS_USER_META );
 
 		$filtered_notices = array_filter( $this->all_notices, function ( $notice ) use ( $dismissed_notices ) {
-			$is_dismissed = in_array( $notice->dismiss_identifier, $dismissed_notices );
-			$is_hidden_with_filter = apply_filters('vip_admin_notice_hide_'.$notice->dismiss_identifier, false);
+			$is_dismissed          = in_array( $notice->dismiss_identifier, $dismissed_notices );
+			$is_hidden_with_filter = apply_filters( 'vip_admin_notice_hide_' . $notice->dismiss_identifier, false );
 			if ( $notice->dismiss_identifier && ( $is_dismissed || $is_hidden_with_filter ) ) {
 				return false;
 			}

--- a/admin-notice/class-admin-notice-controller.php
+++ b/admin-notice/class-admin-notice-controller.php
@@ -19,7 +19,9 @@ class Admin_Notice_Controller {
 		$dismissed_notices = get_user_meta( get_current_user_id(), self::DISMISS_USER_META );
 
 		$filtered_notices = array_filter( $this->all_notices, function ( $notice ) use ( $dismissed_notices ) {
-			if ( $notice->dismiss_identifier && in_array( $notice->dismiss_identifier, $dismissed_notices ) ) {
+			$is_dismissed = in_array( $notice->dismiss_identifier, $dismissed_notices );
+			$is_hidden_with_filter = apply_filters('vip_admin_notice_hide_'.$notice->dismiss_identifier, false);
+			if ( $notice->dismiss_identifier && ( $is_dismissed || $is_hidden_with_filter ) ) {
 				return false;
 			}
 			return $notice->should_render();


### PR DESCRIPTION
## Description

Make it easier to conditionally not show specific VIP admin notices.

Useful for anyone wanting to dynamically suppress our messages for certain caps, or any other reason. Ex hiding php notice from non super admins:

```php
add_filter('vip_admin_notice_hide_php8-migrations-3', function($show) {
	return ! is_super_admin();
});
```

Might be better to have just `vip_hide_admin_notice` to blanket hide all VIP admin_notices as an option instead of requiring the optional ID for each new message.


<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
