### PR TITLE
Revert "Allow for running `wp db` CLI commands in a sandbox (#3645)"

### DIFF
--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -16,26 +16,8 @@ $files = [
 	'/lib/utils/class-context.php',
 ];
 
-$cli_files = [
-	'/lib/helpers/wp-cli-db.php',
-];
-
 foreach ( $files as $file ) {
 	if ( file_exists( $mu_plugins_base . $file ) ) {
 		require_once $mu_plugins_base . $file;
 	}
 }
-
-unset( $files );
-
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	foreach ( $cli_files as $file ) {
-		if ( file_exists( $mu_plugins_base . $file ) ) {
-			require_once $mu_plugins_base . $file;
-		}
-	}
-}
-
-unset( $cli_files );
-unset( $file );
-unset( $mu_plugins_base );

--- a/lib/helpers/wp-cli-db/class-config.php
+++ b/lib/helpers/wp-cli-db/class-config.php
@@ -2,18 +2,15 @@
 
 namespace Automattic\VIP\Helpers\WP_CLI_DB;
 
-use Automattic\VIP\Environment;
 use Exception;
 
 class Config {
 	private bool $enabled      = false;
 	private bool $allow_writes = false;
-	private bool $is_sandbox   = false;
 
 	public function __construct() {
-		$this->is_sandbox   = class_exists( Environment::class ) && Environment::is_sandbox_container( gethostname(), [] );
-		$this->enabled      = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
-		$this->allow_writes = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
+		$this->enabled      = defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
+		$this->allow_writes = defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
 	}
 
 	public function enabled(): bool {
@@ -22,10 +19,6 @@ class Config {
 
 	public function allow_writes(): bool {
 		return $this->allow_writes;
-	}
-
-	public function is_sandbox(): bool {
-		return $this->is_sandbox;
 	}
 
 	/**

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -4,10 +4,9 @@ namespace Automattic\VIP\Helpers\WP_CLI_DB;
 
 use Exception;
 use WP_CLI;
+use Automattic\VIP\Environment;
 
 class Wp_Cli_Db {
-	private Config $config;
-
 	public function __construct( Config $config ) {
 		$this->config = $config;
 	}
@@ -61,10 +60,8 @@ class Wp_Cli_Db {
 		// This will throw an exception if db commands are not enabled for this env:
 		$server = $this->config->get_database_server();
 
-		if ( ! $this->config->is_sandbox() ) {
-			// This will throw an exception if the db subcommand is not valid:
-			$this->validate_subcommand( $command );
-		}
+		// This will throw an exception if the db subcommand is not valid:
+		$this->validate_subcommand( $command );
 
 		$server->define_variables();
 	}


### PR DESCRIPTION
## Description

This reverts commit 2f591840e44b8c8b1e7abf9b7838c70b5b039284.

Change in #3645 made db import in dev-env fail. We are reverting now to unblock the imports.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Run: `vip dev-env import sql ~/Downloads/test.sql`

And don't get:
```
$ dev-env import sql ~/Downloads/test.sql --slug faster -S
PHP Fatal error:  Uncaught Exception: The db command is not currently supported in this environment. in /wp/wp-content/mu-plugins/lib/helpers/wp-cli-db/class-config.php:38
Stack trace:
#0 /wp/wp-content/mu-plugins/lib/helpers/wp-cli-db/class-wp-cli-db.php(62): Automattic\VIP\Helpers\WP_CLI_DB\Config->get_database_server()
#1 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/class-wp-cli.php(332): Automattic\VIP\Helpers\WP_CLI_DB\Wp_Cli_Db->before_run_command(Array, Array, Array)
#2 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(395): WP_CLI::do_hook('before_run_comm...', Array, Array, Array)
#3 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(440): WP_CLI\Runner->run_command(Array, Array)
#4 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(125): WP_CLI\Runner->run_command_and_exit()
#5 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1292): WP_CLI\Runner->do_early_invoke('after_wp_config...')
#6 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1235): WP_CLI\Runner->load_wordpress()
#7 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#8 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(78): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#9 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#10 phar:///usr/local/bin/wp/php/boot-phar.php(11): include('phar:///usr/loc...')
#11 /usr/local/bin/wp(4): include('phar:///usr/loc...')
#12 {main}
  thrown in /wp/wp-content/mu-plugins/lib/helpers/wp-cli-db/class-config.php on line 38
```