### PR TITLE
Reverting wp-cli-db

### DIFF
--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -17,7 +17,7 @@ $files = [
 ];
 
 $cli_files = [
-	'/lib/helpers/wp-cli-db.php',
+	// '/lib/helpers/wp-cli-db.php', - Reverting as it breaks dev-env import
 ];
 
 foreach ( $files as $file ) {


### PR DESCRIPTION
## Description

This reverts part of commit 2f591840e44b8c8b1e7abf9b7838c70b5b039284.

Change in #3645 made db import in dev-env fail. We are reverting part of it to unblock the imports.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Run: `vip dev-env import sql ~/Downloads/test.sql`

And don't get:
```
$ dev-env import sql ~/Downloads/test.sql --slug faster -S
PHP Fatal error:  Uncaught Exception: The db command is not currently supported in this environment. in /wp/wp-content/mu-plugins/lib/helpers/wp-cli-db/class-config.php:38
Stack trace:
#0 /wp/wp-content/mu-plugins/lib/helpers/wp-cli-db/class-wp-cli-db.php(62): Automattic\VIP\Helpers\WP_CLI_DB\Config->get_database_server()
#1 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/class-wp-cli.php(332): Automattic\VIP\Helpers\WP_CLI_DB\Wp_Cli_Db->before_run_command(Array, Array, Array)
#2 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(395): WP_CLI::do_hook('before_run_comm...', Array, Array, Array)
#3 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(440): WP_CLI\Runner->run_command(Array, Array)
#4 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(125): WP_CLI\Runner->run_command_and_exit()
#5 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1292): WP_CLI\Runner->do_early_invoke('after_wp_config...')
#6 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1235): WP_CLI\Runner->load_wordpress()
#7 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#8 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(78): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#9 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#10 phar:///usr/local/bin/wp/php/boot-phar.php(11): include('phar:///usr/loc...')
#11 /usr/local/bin/wp(4): include('phar:///usr/loc...')
#12 {main}
  thrown in /wp/wp-content/mu-plugins/lib/helpers/wp-cli-db/class-config.php on line 38
```