### PR TITLE
Expand function parameters according to WP Core

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -361,17 +361,17 @@ function wpcom_vip_old_slug_redirect() {
  * if it's called several times per request. This allows bypassing the db queries in favor of
  * the cache
  */
-function wpcom_vip_count_user_posts( $user_id ) {
+function wpcom_vip_count_user_posts( $user_id, $post_type = 'post', $public_only = false ) {
 	if ( ! is_numeric( $user_id ) ) {
 		return 0;
 	}
 
-	$cache_key   = 'vip_' . (int) $user_id;
+	$cache_key   = 'vip_' .  md5(wp_json_encode($post_type)) . '_' . (int) $user_id;
 	$cache_group = 'user_posts_count';
-	
+
 	$count = wp_cache_get( $cache_key, $cache_group );
 	if ( false === $count ) {
-		$count = count_user_posts( $user_id );
+		$count = count_user_posts( $user_id, $post_type, $public_only );
 
 		wp_cache_set( $cache_key, $count, $cache_group, 5 * MINUTE_IN_SECONDS );
 	}
@@ -510,7 +510,7 @@ function wpcom_vip_get_adjacent_post( $in_same_term = false, $excluded_terms = '
 	$join              = '';
 	$where             = '';
 	$current_post_date = $post->post_date;
-	
+
 	/** @var string[] */
 	$excluded_terms = empty( $excluded_terms ) ? [] : explode( ',', $excluded_terms );
 

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -360,6 +360,11 @@ function wpcom_vip_old_slug_redirect() {
  * count_user_posts is generally fast, but it can be easy to end up with many redundant queries
  * if it's called several times per request. This allows bypassing the db queries in favor of
  * the cache
+ *
+ * @param int          $user_id      User ID.
+ * @param array|string $post_type   Optional. Single post type or array of post types to count the number of posts for. Default 'post'.
+ * @param bool         $public_only Optional. Whether to only return counts for public posts. Default false.
+ * @return string Number of posts the user has written in this post type.
  */
 function wpcom_vip_count_user_posts( $user_id, $post_type = 'post', $public_only = false ) {
 	if ( ! is_numeric( $user_id ) ) {

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -361,7 +361,7 @@ function wpcom_vip_old_slug_redirect() {
  * if it's called several times per request. This allows bypassing the db queries in favor of
  * the cache
  *
- * @param int          $user_id      User ID.
+ * @param int          $user_id     User ID.
  * @param array|string $post_type   Optional. Single post type or array of post types to count the number of posts for. Default 'post'.
  * @param bool         $public_only Optional. Whether to only return counts for public posts. Default false.
  * @return string Number of posts the user has written in this post type.

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -366,7 +366,7 @@ function wpcom_vip_count_user_posts( $user_id, $post_type = 'post', $public_only
 		return 0;
 	}
 
-	$cache_key   = 'vip_' .  md5(wp_json_encode($post_type)) . '_' . (int) $user_id;
+	$cache_key   = 'vip_' .  md5( wp_json_encode( $post_type ) ) . '_' . (int) $user_id;
 	$cache_group = 'user_posts_count';
 
 	$count = wp_cache_get( $cache_key, $cache_group );


### PR DESCRIPTION
Added default WordPress parameters to `wpcom_vip_count_user_posts` function to allow using with custom post types