### PR TITLE
Tweak account lockout wording

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -55,12 +55,12 @@ class Lockout {
 		if ( defined( 'VIP_ACCOUNT_STATUS' ) && constant( 'VIP_ACCOUNT_STATUS' ) !== self::ACCOUNT_STATUS_NORMAL ) {
 			switch ( $this->get_lockout_state() ) {
 				case self::ACCOUNT_STATUS_WARNING:
-					return 'Payment for this WordPress VIP account is overdue and it will be disabled.<br />
-Contact accounts@wpvip.com to pay your bill.';
+					return 'Payment for this WordPress VIP account is overdue and access will be disabled.<br />
+Please contact accounts@wpvip.com to settle your bill.';
 				case self::ACCOUNT_STATUS_LOCK:
 				case self::ACCOUNT_STATUS_SHUTDOWN:
-					return 'Payment for this WordPress VIP account is overdue and it has been disabled.<br />
-Contact accounts@wpvip.com to pay your bill.';
+					return 'Payment for this WordPress VIP account is overdue and access has been disabled.<br />
+Please contact accounts@wpvip.com to settle your bill.';
 			}
 		}
 		// Otherwise, read it from VIP_LOCKOUT_MESSAGE constant


### PR DESCRIPTION
## Description

Minor editorial changes to the account lockout messaging for WP-Admin.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

If you really want to...

1. Check out PR.
2. Add this early (vip-config.php) `define( 'VIP_ACCOUNT_STATUS', 'warned' );` 
1. Go to `wp-admin`
2. Should see updated warning message
1. Switch to `define( 'VIP_ACCOUNT_STATUS', 'locked' );` 
2. Should see updated lockout message