### PR TITLE
Debug Bar: Enable for local VIP dev environments and require debug-bar.php outside of set_current_user

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -9,13 +9,18 @@ Author URI: https://wordpress.org/
 Text Domain: debug-bar
 */
 
-// If the user is an Automattician (typically a vip_support user), then force-enable Debug Bar.
+if ( file_exists( __DIR__ . '/debug-bar/debug-bar.php' ) ) {
+	require_once __DIR__ . '/debug-bar/debug-bar.php';
+}
+
+// If the user is an Automattician (typically a vip_support user) or local environment, then force-enable Debug Bar.
 add_filter( 'debug_bar_enable', function( $enable ) {
 	if ( is_automattician() ) {
 		return true;
 	}
 
-	if ( defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === WP_ENVIRONMENT_TYPE ) {
+	if ( ( defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === WP_ENVIRONMENT_TYPE ) ||
+		( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'local' === VIP_GO_APP_ENVIRONMENT ) ) {
 		return true;
 	}
 
@@ -28,10 +33,6 @@ add_action( 'set_current_user', function() {
 
 	if ( ! $enable ) {
 		return;
-	}
-
-	if ( ! class_exists( 'Debug_Bar' ) ) {
-		require_once __DIR__ . '/debug-bar/debug-bar.php';
 	}
 
 	// Load additional plugins


### PR DESCRIPTION
## Description
This PR does two things:
1. Enables the debug bar for local VIP dev envs automatically
2. Requires the debug bar file no matter what since it will only display if user has the correct permissions: https://github.com/Automattic/vip-go-mu-plugins/blob/a5fc7b9add9d6f2615764cde5fca7fbe8877b4a1/debug-bar/debug-bar.php#L52-L54

For 2, I know we initially decided to not load it if the user doesn't have the correct permissions (for performance reasons I reckon), but the fatal mentioned in https://github.com/Automattic/vip-go-mu-plugins/pull/3581 is triggered on certain use cases (e.g. when `wp_set_current_user()` is called). Unfortunately, the `class_exists()` check was counter-productive because it will always return `true` due to https://github.com/Automattic/vip-go-mu-plugins/blob/develop/query-monitor/classes/debug_bar.php and therefore, it was not getting required when needed.

## Changelog Description

### Plugin Updated: Debug Bar

Enable for local VIP dev environments and require debug-bar.php outside of set_current_user hook

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Go to local develop environment and look for Debug bar panel showing up automatically
2) For testing what will appear in production, login as a subscriber and comment out the below lines:
```
	if ( ( defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === WP_ENVIRONMENT_TYPE ) ||
		( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'local' === VIP_GO_APP_ENVIRONMENT ) ) {
		return true;
	}
```
Notice Debug bar panel disappear
3) Login as admin and see debug bar panel re-appear