### PR TITLE
Wp-admin: Display notices only for super admins

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -36,6 +36,7 @@ add_action(
 			new Admin_Notice(
 				$message,
 				[
+					new Expression_Condition( is_super_admin() ),
 					new Expression_Condition( version_compare( PHP_VERSION, '8.0', '<' ) ),
 				],
 				'php8-migrations-3',
@@ -56,7 +57,7 @@ add_action(
 			new Admin_Notice(
 				$message,
 				[
-					new Capability_Condition( 'administrator' ),
+					new Expression_Condition( is_super_admin() ),
 					new Expression_Condition( version_compare( $wp_version, '5.9', '<' ) ),
 					new Expression_Condition( ! defined( 'VIP_JETPACK_PINNED_VERSION' ) ),
 				],


### PR DESCRIPTION
## Description
Display current wp-admin notices only for super admins.

## Changelog Description

### Plugin Updated: wp-admin

Display current wp-admin notices only for users with super administrator capability.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Log in as super admin
2) Verify notice displays
3) Log in as subscriber
3) Verify no notice