### PR TITLE
Search: Do not use filter__ep_enable_do_weighting if Custom Search Results present

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2359,7 +2359,7 @@ class Search {
 	}
 
 	/**
-	 * A filter that only enables weighting if it is needed. E.g. When weightings are set by UI or filtered.
+	 * A filter that only enables weighting if it is needed. E.g. When weightings are set by UI or filtered, or custom results are used.
 	 *
 	 * @param bool  Whether to enable weight config, defaults to true for search requests that are public or REST
 	 * @param array $weight_config Current weight config
@@ -2369,6 +2369,18 @@ class Search {
 	 */
 	public function filter__ep_enable_do_weighting( $should_do_weighting, $weight_config, $args, $formatted_args ) {
 		if ( ! empty( $weight_config ) ) {
+			return $should_do_weighting;
+		}
+
+		$custom_results = new \WP_Query( [
+			'post_type'           => 'ep-pointer',
+			'post_status'         => 'publish',
+			'fields'              => 'ids',
+			'posts_per_page'      => 1,
+			'no_found_rows'       => true,
+			'ignore_sticky_posts' => true,
+		] );
+		if ( ! empty( $custom_results->posts ) ) {
 			return $should_do_weighting;
 		}
 


### PR DESCRIPTION
## Description
Currently, filter__ep_enable_do_weighting breaks Custom Search Results, so we need to bow out of the filter if there are any present. The addition of a query in the filter is sub-par but APC should make it lickety split.

## Changelog Description

### Plugin Updated: Enterprise Search

Do not use filter__ep_enable_do_weighting if Custom Search Results present

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) On a fresh install with no weighting, add a custom search result.
2) Search for the custom search result and notice it doesn't return as expected.
3) Apply PR and repeat step 2.