### PR TITLE
E2E: Get rid of unnecessary awaits

### DIFF
--- a/__tests__/e2e/lib/components/wp-admin-sidebar-component.ts
+++ b/__tests__/e2e/lib/components/wp-admin-sidebar-component.ts
@@ -25,8 +25,8 @@ export class WPAdminSidebarComponent {
      *
      * @param {string} itemName Name of the item to be hovered over
      */
-    async hoverMenuItem( itemName: string ): Promise<void> {
-        await this.page.hover( selectors.menuItem( itemName ) );
+    hoverMenuItem( itemName: string ): Promise<void> {
+        return this.page.hover( selectors.menuItem( itemName ) );
     }
 
     /**
@@ -34,8 +34,8 @@ export class WPAdminSidebarComponent {
      *
      * @param {string} itemName Name of the item to be clicked
      */
-    async clickMenuItem( itemName: string ): Promise<void> {
-        await this.page.click( selectors.menuItem( itemName ) );
+    clickMenuItem( itemName: string ): Promise<void> {
+        return this.page.click( selectors.menuItem( itemName ) );
     }
 
     /**
@@ -43,8 +43,8 @@ export class WPAdminSidebarComponent {
      *
      * @param {string} itemName Name of the item to be hovered over
      */
-    async hoverSubMenuItem( itemName: string ): Promise<void> {
-        await this.page.hover( selectors.submenuItem( itemName ) );
+    hoverSubMenuItem( itemName: string ): Promise<void> {
+        return this.page.hover( selectors.submenuItem( itemName ) );
     }
 
     /**
@@ -52,7 +52,7 @@ export class WPAdminSidebarComponent {
      *
      * @param {string} itemName Name of the item to be clicked
      */
-    async clickSubMenuItem( itemName: string ): Promise<void> {
-        await this.page.click( selectors.submenuItem( itemName ) );
+    clickSubMenuItem( itemName: string ): Promise<void> {
+        return this.page.click( selectors.submenuItem( itemName ) );
     }
 }

--- a/__tests__/e2e/lib/pages/media-upload-page.ts
+++ b/__tests__/e2e/lib/pages/media-upload-page.ts
@@ -32,15 +32,16 @@ export class MediaUploadPage {
             this.page.waitForEvent( 'filechooser' ),
             this.page.click( selectors.selectFilesButton ),
         ] );
-        await fileChooser.setFiles( mediaFile );
+
+        return fileChooser.setFiles( mediaFile );
     }
 
     /**
      * Get Meduia URL
      *
-     * @return { string } Url of uploaded media
+     * @return { Promise<string | null> } Url of uploaded media
      */
-    async getMediaUrl(): Promise<string> {
+    async getMediaUrl(): Promise<string | null> {
         await this.page.waitForSelector( selectors.attachedMediaDetails );
         return this.page.locator( selectors.copyURLButton ).getAttribute( 'data-clipboard-text' );
     }

--- a/__tests__/e2e/lib/pages/page-list-page.ts
+++ b/__tests__/e2e/lib/pages/page-list-page.ts
@@ -22,8 +22,8 @@ export class PageListPage {
     /**
      * Navigate to Page List page
      */
-    async visit(): Promise<void> {
-        await this.page.goto( '/wp-admin/edit.php?post_type=page' );
+    visit(): Promise<unknown> {
+        return this.page.goto( '/wp-admin/edit.php?post_type=page' );
     }
 
     /**
@@ -31,7 +31,7 @@ export class PageListPage {
      *
      * @param { string } pageID ID of the page to be edited
      */
-    async editPageByID( pageID: string ): Promise<void> {
-        await this.page.click( selectors.pageLink( pageID ) );
+    editPageByID( pageID: string ): Promise<void> {
+        return this.page.click( selectors.pageLink( pageID ) );
     }
 }

--- a/__tests__/e2e/lib/pages/post-list-page.ts
+++ b/__tests__/e2e/lib/pages/post-list-page.ts
@@ -22,8 +22,8 @@ export class PostListPage {
     /**
      * Navigate to Post List page
      */
-    async visit(): Promise<void> {
-        await this.page.goto( '/wp-admin/edit.php' );
+    visit(): Promise<unknown> {
+        return this.page.goto( '/wp-admin/edit.php' );
     }
 
     /**
@@ -31,7 +31,7 @@ export class PostListPage {
      *
      * @param {string} postID ID of the post to be edited
      */
-    async editPostByID( postID: string ): Promise<void> {
-        await this.page.click( selectors.postLink( postID ) );
+    editPostByID( postID: string ): Promise<void> {
+        return this.page.click( selectors.postLink( postID ) );
     }
 }

--- a/__tests__/e2e/lib/pages/published-page-page.ts
+++ b/__tests__/e2e/lib/pages/published-page-page.ts
@@ -48,9 +48,9 @@ export class PublishedPagePage {
     /**
      * Returns boolean of whether or not image was found in page
      *
-     * @return {boolean} True if image is found, otherwise false
+     * @return {Promise<boolean>} True if image is found, otherwise false
      */
-    async isImageDisplayed(): Promise<boolean> {
+    isImageDisplayed(): Promise<boolean> {
         return this.page.isVisible( selectors.pageImage );
     }
 }

--- a/__tests__/e2e/lib/pages/published-post-page.ts
+++ b/__tests__/e2e/lib/pages/published-post-page.ts
@@ -48,9 +48,9 @@ export class PublishedPostPage {
     /**
      * Returns boolean of whether or not image was found in post
      *
-     * @return {boolean} True if image is found, otherwise false
+     * @return {Promise<boolean>} True if image is found, otherwise false
      */
-    async isImageDisplayed(): Promise<boolean> {
+    isImageDisplayed(): Promise<boolean> {
         return this.page.isVisible( selectors.postImage );
     }
 }

--- a/__tests__/e2e/lib/pages/search-page.ts
+++ b/__tests__/e2e/lib/pages/search-page.ts
@@ -127,7 +127,7 @@ export class SearchPage {
      *
      * @return {Promise<string>} Parameters as a string
      */
-    async getWPQuery(): Promise<string> {
+    getWPQuery(): Promise<string> {
         return this.getQueryExtrasHelper( 0 );
     }
 
@@ -136,7 +136,7 @@ export class SearchPage {
      *
      * @return {Promise<string>} Backtrace as a string
      */
-    async getTrace(): Promise<string> {
+    getTrace(): Promise<string> {
         return this.getQueryExtrasHelper( 1 );
     }
 
@@ -145,7 +145,7 @@ export class SearchPage {
      *
      * @return {Promise<string>} Query
      */
-    async getQuery(): Promise<string> {
+    getQuery(): Promise<string> {
         return this.sourceQueryLocator.inputValue();
     }
 
@@ -155,7 +155,7 @@ export class SearchPage {
      * @param {string} newQuery New Query
      * @return {Promise<*>} Resolves on success
      */
-    async editQuery( newQuery: string ): Promise<unknown> {
+    editQuery( newQuery: string ): Promise<unknown> {
         return this.sourceQueryLocator.fill( newQuery );
     }
 

--- a/__tests__/e2e/lib/pages/settings-writing-page.ts
+++ b/__tests__/e2e/lib/pages/settings-writing-page.ts
@@ -24,14 +24,14 @@ export class SettingsWritingPage {
     /**
      * Navigate to Writing Settings page
      */
-    async visit(): Promise<void> {
-        await this.page.goto( '/wp-admin/options-writing.php' );
+    visit(): Promise<unknown> {
+        return this.page.goto( '/wp-admin/options-writing.php' );
     }
 
     /**
      * Checks to see if Classic Editor Settings are available
      *
-     * @return { boolean } Whether classic editor settings are visible
+     * @return { Promise<boolean> } Whether classic editor settings are visible
      */
     async hasClassicEditor(): Promise<boolean> {
         const editorSettings = await this.page.locator( selectors.classicEditorBlock );

--- a/__tests__/e2e/lib/pages/wp-admin-page.ts
+++ b/__tests__/e2e/lib/pages/wp-admin-page.ts
@@ -24,7 +24,7 @@ export class WPAdminPage {
     /**
      * Navigate to WP Admin
      */
-    async visit(): Promise<void> {
-        await this.page.goto( '/wp-admin' );
+    visit(): Promise<unknown> {
+        return this.page.goto( '/wp-admin' );
     }
 }

--- a/__tests__/e2e/lib/pages/wp-classic-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-classic-editor-page.ts
@@ -92,8 +92,8 @@ export class ClassicEditorPage {
      *
      * @param { string } url URL of post to visit
      */
-    private async visitPublishedPost( url: string ): Promise<void> {
-        await Promise.all( [
+    private visitPublishedPost( url: string ): Promise<unknown> {
+        return Promise.all( [
             this.page.waitForNavigation( { waitUntil: 'networkidle', url } ),
             this.page.click( selectors.viewButton ),
         ] );

--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -190,8 +190,8 @@ export class EditorPage {
     /**
      * Updates the post or page.
      */
-    async update(): Promise<void> {
-        await this.page.click( selectors.updateButton );
+    update(): Promise<void> {
+        return this.page.click( selectors.updateButton );
     }
 
     /**
@@ -199,8 +199,8 @@ export class EditorPage {
      *
      * @param {string} url Url to visit
      */
-    private async visitPublishedPost( url: string ): Promise<void> {
-        await Promise.all( [
+    private visitPublishedPost( url: string ): Promise<unknown> {
+        return Promise.all( [
             this.page.waitForNavigation( { waitUntil: 'networkidle', url } ),
             this.page.click( selectors.viewButton ),
         ] );

--- a/__tests__/e2e/lib/pages/wp-login-page.ts
+++ b/__tests__/e2e/lib/pages/wp-login-page.ts
@@ -25,8 +25,8 @@ export class LoginPage {
      * Navigate to login page
      *
      */
-    async visit(): Promise<void> {
-        await this.page.goto( '/wp-login.php' );
+    visit(): Promise<unknown> {
+        return this.page.goto( '/wp-login.php' );
     }
 
     /**
@@ -35,9 +35,9 @@ export class LoginPage {
      * @param {string} username Username to login as
      * @param {string} password Password for account
      */
-    async login( username: string, password: string ): Promise<void> {
+    async login( username: string, password: string ): Promise<unknown> {
         await this.page.fill( selectors.userField, username );
         await this.page.fill( selectors.passwordField, password );
-        await Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.submitButton ) ] );
+        return Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.submitButton ) ] );
     }
 }

--- a/__tests__/e2e/lib/wp-api-helper.ts
+++ b/__tests__/e2e/lib/wp-api-helper.ts
@@ -16,15 +16,14 @@ type PostData = {
  * @param {APIRequestContext} request  The Playwright API Request context
  * @param {string}            id       Id of the post to be deleted
  * @param {PostType}          postType Type of the post to be deleted
- * @return {APIResponse} The response of the api call.
+ * @return {Promise<APIResponse>} The response of the api call.
  */
-export async function deletePost( request: APIRequestContext, id: string, postType: PostType ): Promise<APIResponse> {
-    const response = await request.delete( `/wp-json/wp/v2/${ postType }s/${ id }`, {
+export function deletePost( request: APIRequestContext, id: string, postType: PostType ): Promise<APIResponse> {
+    return request.delete( `/wp-json/wp/v2/${ postType }s/${ id }`, {
         headers: {
-            'X-WP-Nonce': process.env.WP_E2E_NONCE,
+            'X-WP-Nonce': `${ process.env.WP_E2E_NONCE }`,
         },
     } );
-    return response;
 }
 
 /**
@@ -32,12 +31,12 @@ export async function deletePost( request: APIRequestContext, id: string, postTy
  *
  * @param {APIRequestContext} request  The Playwright API Request context
  * @param {PostData}          postData Object containing title, body and type of post
- * @return {APIResponse} The response of the api call.
+ * @return {Promise<APIResponse>} The response of the api call.
  */
-export async function createPost( request: APIRequestContext, postData: PostData ): Promise<APIResponse> {
-    const response = await request.post( `/wp-json/wp/v2/${ postData.postType }s/?force=true`, {
+export function createPost( request: APIRequestContext, postData: PostData ): Promise<APIResponse> {
+    return request.post( `/wp-json/wp/v2/${ postData.postType }s/?force=true`, {
         headers: {
-            'X-WP-Nonce': process.env.WP_E2E_NONCE,
+            'X-WP-Nonce': `${ process.env.WP_E2E_NONCE }`,
         },
         data: {
             title: postData.title,
@@ -45,5 +44,4 @@ export async function createPost( request: APIRequestContext, postData: PostData
             content: postData.body,
         },
     } );
-    return response;
 }

--- a/__tests__/e2e/specs/media__add.spec.ts
+++ b/__tests__/e2e/specs/media__add.spec.ts
@@ -16,7 +16,7 @@ test( 'Add Media', async ( { page } ) => {
     await test.step( 'Go to WP-admin', async () => {
         const wpAdminPage = new WPAdminPage( page );
         await wpAdminPage.visit();
-        await expect( wpAdminPage.adminBar ).toBeVisible();
+        return expect( wpAdminPage.adminBar ).toBeVisible();
     } );
 
     await test.step( 'Select add new media', async () => {
@@ -25,13 +25,13 @@ test( 'Add Media', async ( { page } ) => {
         await wpAdminSidebarComponent.clickSubMenuItem( 'Add New' );
     } );
 
-    await test.step( 'Upload Image', async () => {
+    await test.step( 'Upload Image', () => {
         mediaUploadPage = new MediaUploadPage( page );
-        await mediaUploadPage.uploadFile( 'test_media/image_02.jpg' );
+        return mediaUploadPage.uploadFile( 'test_media/image_02.jpg' );
     } );
 
-    await test.step( 'Verify image url', async () => {
-        const imageURL = await mediaUploadPage.getMediaUrl();
-        expect( imageURL ).toContain( 'image_02' );
+    await test.step( 'Verify image url', () => {
+        const imageURL = mediaUploadPage.getMediaUrl();
+        return expect( imageURL ).resolves.toContain( 'image_02' );
     } );
 } );

--- a/__tests__/e2e/specs/page__edit.spec.ts
+++ b/__tests__/e2e/specs/page__edit.spec.ts
@@ -42,13 +42,13 @@ test( 'edit a Page', async ( { page } ) => {
     let editorPage: EditorPage;
     let pageListPage: PageListPage;
 
-    await test.step( 'Go to Page List page', async () => {
+    await test.step( 'Go to Page List page', () => {
         pageListPage = new PageListPage( page );
-        await pageListPage.visit();
+        return pageListPage.visit();
     } );
 
-    await test.step( 'Select post to edit', async () => {
-        pageListPage.editPageByID( postID );
+    await test.step( 'Select post to edit', () => {
+        return pageListPage.editPageByID( postID );
     } );
 
     await test.step( 'Edit Page', async () => {
@@ -65,11 +65,11 @@ test( 'edit a Page', async ( { page } ) => {
 
     await test.step( 'Publish changes and visit page', async () => {
         await editorPage.update();
-        await page.goto( postURL );
+        return page.goto( postURL );
     } );
 
     await test.step( 'Validate published page', async () => {
         const publishedPagePage = new PublishedPagePage( page );
-        await publishedPagePage.validateTextInPost( titleText );
+        return publishedPagePage.validateTextInPost( titleText );
     } );
 } );

--- a/__tests__/e2e/specs/page__publish.spec.ts
+++ b/__tests__/e2e/specs/page__publish.spec.ts
@@ -41,12 +41,12 @@ test( 'publish a Page', async ( { page } ) => {
 
     await test.step( 'Publish and visit page', async () => {
         const publishedURL = await editorPage.publish( { visit: true } );
-        expect( publishedURL ).toBe( page.url() );
+        return expect( publishedURL ).toBe( page.url() );
     } );
 
     await test.step( 'Validate published page', async () => {
         const publishedPagePage = new PublishedPagePage( page );
         await publishedPagePage.validateTextInPost( titleText );
-        expect( await publishedPagePage.isImageDisplayed() ).toBeTruthy();
+        return expect( publishedPagePage.isImageDisplayed() ).resolves.toBeTruthy();
     } );
 } );

--- a/__tests__/e2e/specs/page_classic__publish.spec.ts
+++ b/__tests__/e2e/specs/page_classic__publish.spec.ts
@@ -25,11 +25,11 @@ test( 'publish a Page', async ( { page } ) => {
     await test.step( 'Go to WP-admin', async () => {
         const wpAdminPage = new WPAdminPage( page );
         await wpAdminPage.visit();
-        await expect( wpAdminPage.adminBar ).toBeVisible();
+        return expect( wpAdminPage.adminBar ).toBeVisible();
     } );
 
-    await test.step( 'Add new page in classic editor', async () => {
-        await page.goto( '/wp-admin/post-new.php?post_type=page&classic-editor&classic-editor__forget' );
+    await test.step( 'Add new page in classic editor', () => {
+        return page.goto( '/wp-admin/post-new.php?post_type=page&classic-editor&classic-editor__forget' );
     } );
 
     await test.step( 'Write Page', async () => {
@@ -41,11 +41,11 @@ test( 'publish a Page', async ( { page } ) => {
 
     await test.step( 'Publish and visit page', async () => {
         const publishedURL = await classicEditorPage.publish( { visit: true } );
-        expect( publishedURL ).toBe( page.url() );
+        return expect( publishedURL ).toBe( page.url() );
     } );
 
     await test.step( 'Validate published page', async () => {
         const publishedPagePage = new PublishedPagePage( page );
-        await publishedPagePage.validateTextInPost( titleText );
+        return publishedPagePage.validateTextInPost( titleText );
     } );
 } );

--- a/__tests__/e2e/specs/post__edit.spec.ts
+++ b/__tests__/e2e/specs/post__edit.spec.ts
@@ -42,13 +42,13 @@ test( 'edit a Post', async ( { page } ) => {
     let editorPage: EditorPage;
     let postListPage: PostListPage;
 
-    await test.step( 'Go to Post List page', async () => {
+    await test.step( 'Go to Post List page', () => {
         postListPage = new PostListPage( page );
-        await postListPage.visit();
+        return postListPage.visit();
     } );
 
-    await test.step( 'Select post to edit', async () => {
-        postListPage.editPostByID( postID );
+    await test.step( 'Select post to edit', () => {
+        return postListPage.editPostByID( postID );
     } );
 
     await test.step( 'Edit Post', async () => {
@@ -65,11 +65,11 @@ test( 'edit a Post', async ( { page } ) => {
 
     await test.step( 'Publish changes and visit post', async () => {
         await editorPage.update();
-        await page.goto( postURL );
+        return page.goto( postURL );
     } );
 
-    await test.step( 'Validate published post', async () => {
+    await test.step( 'Validate published post', () => {
         const publishedPostPage = new PublishedPostPage( page );
-        await publishedPostPage.validateTextInPost( titleText );
+        return publishedPostPage.validateTextInPost( titleText );
     } );
 } );

--- a/__tests__/e2e/specs/post__publish.spec.ts
+++ b/__tests__/e2e/specs/post__publish.spec.ts
@@ -23,7 +23,7 @@ test( 'publish a Post', async ( { page } ) => {
     await test.step( 'Go to WP-admin', async () => {
         const wpAdminPage = new WPAdminPage( page );
         await wpAdminPage.visit();
-        await expect( wpAdminPage.adminBar ).toBeVisible();
+        return expect( wpAdminPage.adminBar ).toBeVisible();
     } );
 
     await test.step( 'Select add new post', async () => {
@@ -41,12 +41,12 @@ test( 'publish a Post', async ( { page } ) => {
 
     await test.step( 'Publish and visit post', async () => {
         const publishedURL = await editorPage.publish( { visit: true } );
-        expect( publishedURL ).toBe( page.url() );
+        return expect( publishedURL ).toBe( page.url() );
     } );
 
     await test.step( 'Validate published post', async () => {
         const publishedPostPage = new PublishedPostPage( page );
         await publishedPostPage.validateTextInPost( titleText );
-        expect( await publishedPostPage.isImageDisplayed() ).toBeTruthy();
+        return expect( publishedPostPage.isImageDisplayed() ).resolves.toBeTruthy();
     } );
 } );

--- a/__tests__/e2e/specs/post_classic__publish.spec.ts
+++ b/__tests__/e2e/specs/post_classic__publish.spec.ts
@@ -25,11 +25,11 @@ test( 'publish a Post', async ( { page } ) => {
     await test.step( 'Go to WP-admin', async () => {
         const wpAdminPage = new WPAdminPage( page );
         await wpAdminPage.visit();
-        await expect( wpAdminPage.adminBar ).toBeVisible();
+        return expect( wpAdminPage.adminBar ).toBeVisible();
     } );
 
-    await test.step( 'Add new post in classic editor', async () => {
-        await page.goto( '/wp-admin/post-new.php?classic-editor&classic-editor__forget' );
+    await test.step( 'Add new post in classic editor', () => {
+        return page.goto( '/wp-admin/post-new.php?classic-editor&classic-editor__forget' );
     } );
 
     await test.step( 'Write Post', async () => {
@@ -41,11 +41,11 @@ test( 'publish a Post', async ( { page } ) => {
 
     await test.step( 'Publish and visit post', async () => {
         const publishedURL = await classicEditorPage.publish( { visit: true } );
-        expect( publishedURL ).toBe( page.url() );
+        return expect( publishedURL ).toBe( page.url() );
     } );
 
-    await test.step( 'Validate published post', async () => {
+    await test.step( 'Validate published post', () => {
         const publishedPostPage = new PublishedPostPage( page );
-        await publishedPostPage.validateTextInPost( titleText );
+        return publishedPostPage.validateTextInPost( titleText );
     } );
 } );


### PR DESCRIPTION
Every `await` creates and enqueues a microtask. Unnecessary awaits consume memory and decrease performance.

In this PR we get rid of such awaits.