### PR TITLE
Hotfix: Bump down the Jetpack version to 10.7 as 10.9.1 is not actually loadable on WordPress 5.8

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -25,7 +25,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.8', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.4' );
 	} elseif ( version_compare( $wp_version, '5.9', '<' ) ) {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.9' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.7' );
 	} else {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.3' );
 	}


### PR DESCRIPTION
## Description

Today's production release caused issues on a small subset of sites, the issue is a compound one and involved the changes we have in the build pipeline, but the bug manifested because 10.9 required 5.8, but 10.9.1 required 5.9, and that basically prevented the loading. 


Omitting changelog on purpose.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
