### PR TITLE
Update jetpack loader

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -191,7 +191,10 @@ function vip_jetpack_load() {
 			}
 
 			require_once $path;
-			define( 'VIP_JETPACK_LOADED_VERSION', $version );
+			if ( class_exists( 'Jetpack' ) ) {
+				define( 'VIP_JETPACK_LOADED_VERSION', $version );
+			}
+			// We should break even if we failed to load Jetpack, because some constants like JETPACK_VERSION were probably already set
 			break;
 		}
 	}


### PR DESCRIPTION
## Description
Adds extra validation before we set `VIP_JETPACK_LOADED_VERSION`. That way if Jetpack fails to load we don't end up in broken state but "only" with site without Jetpack.

`VIP_JETPACK_LOADED_VERSION` is then later used to load internal plugins that rely on Jetpack which would cause a fatal error if Jetpack wasn't loaded.

## Changelog Description

### Plugin Updated: Jetpack loader

We made Jetpack loader more resilient as it now validates existence of `Jetpack` class, before proceeding to load more related logic.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1) Add a return statement at the top of jetpack.php you are loading (similar to as if the version requirements weren't met)
2) Navigate to wp-admin
3) Page still works (although no JP is loaded)
