### PR TITLE
Lockout: Show notices to VIP Support users and updated copy

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -55,12 +55,12 @@ class Lockout {
 		if ( defined( 'VIP_ACCOUNT_STATUS' ) && constant( 'VIP_ACCOUNT_STATUS' ) !== self::ACCOUNT_STATUS_NORMAL ) {
 			switch ( $this->get_lockout_state() ) {
 				case self::ACCOUNT_STATUS_WARNING:
-					return 'Payment for this WordPress VIP account is overdue and access will be disabled.<br />
+					return 'Payment for this WordPress VIP account is overdue and access will be suspended soon.<br />
 Please contact accounts@wpvip.com to settle your bill.';
 				case self::ACCOUNT_STATUS_LOCK:
 				case self::ACCOUNT_STATUS_SHUTDOWN:
-					return 'Payment for this WordPress VIP account is overdue and access has been disabled.<br />
-Please contact accounts@wpvip.com to settle your bill.';
+					return 'Payment for this WordPress VIP account is overdue and access has been suspended.<br />
+Please contact accounts@wpvip.com to settle your bill and restore access.';
 			}
 		}
 		// Otherwise, read it from VIP_LOCKOUT_MESSAGE constant

--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -78,7 +78,8 @@ Please contact accounts@wpvip.com to settle your bill.';
 			switch ( $lockout_state ) {
 				case self::ACCOUNT_STATUS_WARNING:
 					$has_caps    = isset( $user->allcaps['manage_options'] ) && true === $user->allcaps['manage_options'];
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, $lockout_state, $user );
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps || is_automattician(), $lockout_state, $user );
+
 					if ( $show_notice ) {
 						$this->render_warning_notice();
 
@@ -90,7 +91,8 @@ Please contact accounts@wpvip.com to settle your bill.';
 				case self::ACCOUNT_STATUS_LOCK:
 				case self::ACCOUNT_STATUS_SHUTDOWN:
 					$has_caps    = isset( $user->allcaps['edit_posts'] ) && true === $user->allcaps['edit_posts'];
-					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps, $lockout_state, $user );
+					$show_notice = apply_filters( 'vip_lockout_show_notice', $has_caps || is_automattician(), $lockout_state, $user );
+
 					if ( $show_notice ) {
 						$this->render_locked_notice();
 

--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -56,11 +56,11 @@ class Lockout {
 			switch ( $this->get_lockout_state() ) {
 				case self::ACCOUNT_STATUS_WARNING:
 					return 'Payment for this WordPress VIP account is overdue and access will be suspended soon.<br />
-Please contact accounts@wpvip.com to settle your bill.';
+Please contact <a href="mailto:accounts@wpvip.com">accounts@wpvip.com</a> to settle your bill.';
 				case self::ACCOUNT_STATUS_LOCK:
 				case self::ACCOUNT_STATUS_SHUTDOWN:
 					return 'Payment for this WordPress VIP account is overdue and access has been suspended.<br />
-Please contact accounts@wpvip.com to settle your bill and restore access.';
+Please contact <a href="mailto:accounts@wpvip.com">accounts@wpvip.com</a> to settle your bill and restore access.';
 			}
 		}
 		// Otherwise, read it from VIP_LOCKOUT_MESSAGE constant


### PR DESCRIPTION
## Description

This PR  updates the copy of the wp-admin notices, and changes the display logic of these notices to also show them to VIP Support users.

The validation was made with `is_automattician()` to be consistent with the class implementation. Another alternative would be to check if the user role is VIP Support.

VIP Support users will retain all the capabilities, while regular users will be reduced to Subscriber capabilities.

## Changelog Description

### Lockout Update

Updated the copy of the admin notices and made them visible to VIP Support users.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Set `VIP_ACCOUNT_STATUS` environment variable to `warning`. 
1. Access `wp-admin` and you should the notice on every page. 
2. Now, change it to `locked`. The admin dashboard should be locked, and a red notice should be visible in all pages.
