### PR TITLE
Admin notice: Add is_super_admin() condition by default if no Capability_Condition defined

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -36,7 +36,6 @@ add_action(
 			new Admin_Notice(
 				$message,
 				[
-					new Expression_Condition( is_super_admin() ),
 					new Expression_Condition( version_compare( PHP_VERSION, '8.0', '<' ) ),
 				],
 				'php8-migrations-3',
@@ -57,7 +56,6 @@ add_action(
 			new Admin_Notice(
 				$message,
 				[
-					new Expression_Condition( is_super_admin() ),
 					new Expression_Condition( version_compare( $wp_version, '5.9', '<' ) ),
 					new Expression_Condition( ! defined( 'VIP_JETPACK_PINNED_VERSION' ) ),
 				],

--- a/admin-notice/class-admin-notice.php
+++ b/admin-notice/class-admin-notice.php
@@ -61,6 +61,11 @@ class Admin_Notice {
 	 * @return bool
 	 */
 	public function should_render() : bool {
+		if ( ! $this->cap_condition_exist() && ! is_super_admin() ) {
+			// If there's no Capability_Condition defined, default to not showing the notices for non-super admins
+			return false;
+		}
+
 		foreach ( $this->conditions as $condition ) {
 			if ( ! $condition->evaluate() ) {
 				return false;
@@ -68,5 +73,18 @@ class Admin_Notice {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Whether a Capability_Condition is explicitly defined
+	 */
+	public function cap_condition_exist() {
+		foreach ( $this->conditions as $condition ) {
+			if ( $condition instanceof \Automattic\VIP\Admin_Notice\Capability_Condition ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/tests/admin-notice/test-class-admin-notice.php
+++ b/tests/admin-notice/test-class-admin-notice.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Admin_Notice;
 
+use PHPUnit\Framework\MockObject\MockObject;
+
 require_once __DIR__ . '/../../admin-notice/class-admin-notice.php';
 require_once __DIR__ . '/../../admin-notice/conditions/interface-condition.php';
 
@@ -72,6 +74,7 @@ class Admin_Notice_Class_Test extends \PHPUnit\Framework\TestCase {
 		wp_set_current_user( self::$super_admin_id );
 
 		$conditions = array_map( function ( $result_to_return ) {
+			/** @var Condition&MockObject */
 			$condition_stub = $this->createMock( Condition::class );
 			$condition_stub->method( 'evaluate' )->willReturn( $result_to_return );
 			return $condition_stub;
@@ -88,5 +91,27 @@ class Admin_Notice_Class_Test extends \PHPUnit\Framework\TestCase {
 		$result = $notice->should_render();
 
 		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @dataProvider data_cap_condition_exist
+	 */
+	public function test_cap_condition_exist( array $conditions, bool $xpected ): void {
+		$notice = new Admin_Notice( 'notice', $conditions );
+		$actual = $notice->cap_condition_exist();
+		self::assertSame( $xpected, $actual );
+	}
+
+	public function data_cap_condition_exist(): iterable {
+		return [
+			'no conditions'        => [
+				[],
+				false,
+			],
+			'capability condition' => [
+				[ new Capability_Condition( 'delete_users' ) ],
+				true,
+			],
+		];
 	}
 }

--- a/tests/admin-notice/test-class-admin-notice.php
+++ b/tests/admin-notice/test-class-admin-notice.php
@@ -19,6 +19,7 @@ class Admin_Notice_Class_Test extends \PHPUnit\Framework\TestCase {
 			'role'       => 'admin',
 		]);
 		$super_admin    = get_user_by( 'id', $super_admin_id );
+		grant_super_admin( $super_admin_id );
 		$super_admin->add_cap( 'delete_users' ); // Fake super admin
 		self::$super_admin_id = $super_admin_id;
 


### PR DESCRIPTION
## Description
Notices are displayed only for super admins if no Capability_Conditions have been defined.

## Changelog Description

### Plugin Updated: Admin Notice

Notices are displayed only for super admins if no Capability_Conditions have been defined.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Start up a PHP 7.4 environment to see the current deprecation warning
2) Log in as super admin user, see deprecation warning on wp-admin
3) Log out and log in as an author and see deprecation warning not appear on wp-admin