### PR TITLE
Search: Add better error handling for list_indexes()

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -100,11 +100,14 @@ class CoreCommand extends \ElasticPress\Command {
 		$path = '_cat/indices?format=json';
 
 		$response = Elasticsearch::factory()->remote_request( $path );
-		$body     = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error( 'list-indexes-error', $response->get_error_message() );
+		}
 
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
 		if ( ! is_array( $body ) ) {
 			$message = property_exists( $body, 'error' ) ? $body->error : 'Something went wrong during list_indexes().';
-			return new WP_Error( 'list-indexes-error', $message );
+			return new \WP_Error( 'list-indexes-error', $message );
 		}
 
 		$indexes = array_column( $body, 'index' );


### PR DESCRIPTION
## Description
This adds better error handling in `list_indexes()` since `remote_request()` can return a WP_Error so we should bubble that up.

## Changelog Description

### Plugin Updated: Enterprise Search

Better error handling in `list_indexes()` since `remote_request()` can return a WP_Error.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
