### PR TITLE
Search: Add e2e tests to CI

### DIFF
--- a/.github/workflows/search-e2e.yml
+++ b/.github/workflows/search-e2e.yml
@@ -39,7 +39,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Install dependencies
-      run: npm ci --include=dev
+      run: npm ci
 
     - name: Set up WP environment with Elasticsearch
       run: npm run search-env:start

--- a/.github/workflows/search-e2e.yml
+++ b/.github/workflows/search-e2e.yml
@@ -1,0 +1,68 @@
+name: Enterprise Search e2e tests
+env:
+  NODE_VERSION: "16"
+  NODE_CACHE: "${{ github.workspace }}/node_modules_cache"
+
+on:
+  push:
+    branches:
+      - develop
+      - production
+      - staging
+  pull_request:
+    branches:
+      - develop
+      - production
+      - staging
+
+jobs:
+  cypress_local:
+    name: Cypress - Local
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Prepare npm cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.NODE_CACHE }}
+        key: npm-${{ env.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          npm-${{ env.NODE_VERSION }}-
+    - name: "Install node v${{ env.NODE_VERSION }}"
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Install dependencies
+      run: npm ci --include=dev
+
+    - name: Set up WP environment with Elasticsearch
+      run: npm run search-env:start
+
+    - name: Build asset
+      run: npm run search-build
+
+    - name: Set up database
+      run: npm run cypress:setup
+
+    - name: Test
+      run: npm run cypress:run
+
+    - name: Make artifacts available
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: cypress-artifact
+        retention-days: 2
+        path: |
+          ${{ github.workspace }}/tests/cypress/screenshots/
+          ${{ github.workspace }}/tests/cypress/videos/
+          ${{ github.workspace }}/tests/cypress/logs/
+    - name: Stop Elasticsearch
+      if: always()
+      run: cd bin/search/es-docker/ && docker-compose down

--- a/.github/workflows/search-e2e.yml
+++ b/.github/workflows/search-e2e.yml
@@ -26,17 +26,11 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Prepare npm cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.NODE_CACHE }}
-        key: npm-${{ env.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          npm-${{ env.NODE_VERSION }}-
     - name: "Install node v${{ env.NODE_VERSION }}"
       uses: actions/setup-node@v3
       with:
         node-version: ${{ env.NODE_VERSION }}
+        cache: npm
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/search-e2e.yml
+++ b/.github/workflows/search-e2e.yml
@@ -1,7 +1,6 @@
 name: Enterprise Search e2e tests
 env:
   NODE_VERSION: "16"
-  NODE_CACHE: "${{ github.workspace }}/node_modules_cache"
 
 on:
   push:

--- a/bin/search/es-docker/Dockerfile
+++ b/bin/search/es-docker/Dockerfile
@@ -1,4 +1,6 @@
 ARG ES_VERSION=7.17.2
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+ENV ELECTRON_EXTRA_LAUNCH_ARGS=--disable-gpu
+ENV LIBVA_DRIVER_NAME=--disable-software-rasterizer
 
 RUN if [ -d plugins/ingest-attachment ]; then true ; else ./bin/elasticsearch-plugin install ingest-attachment -b; fi

--- a/bin/search/setup-cypress-env.sh
+++ b/bin/search/setup-cypress-env.sh
@@ -59,7 +59,7 @@ if [ ! -z $EP_INDEX_PREFIX ]; then
 	./bin/search/wp-env-cli tests-wordpress "wp --allow-root config set EP_INDEX_PREFIX ${EP_INDEX_PREFIX}"
 fi
 
-./bin/search/wp-env-cli tests-wordpress "wp --allow-root config set VIP_ELASTICSEARCH_ENDPOINTS --raw \"['http://host.docker.internal:8890/','http://host.docker.internal:8890/']\""
+./bin/search/wp-env-cli tests-wordpress "wp --allow-root config set VIP_ELASTICSEARCH_ENDPOINTS --raw \"['${EP_HOST}','${EP_HOST}']\""
 
 ./bin/search/wp-env-cli tests-wordpress "wp --allow-root core multisite-convert"
 


### PR DESCRIPTION
## Description
Adds the Search e2e tests from https://github.com/Automattic/vip-go-mu-plugins/pull/3727 into the CI pipeline. 

Note: Currently failing because of https://github.com/Automattic/vip-go-mu-plugins/pull/3731
