### PR TITLE
Jetpack 11.4 release

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.2
+ * Version: 11.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -27,7 +27,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '5.9', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.9' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.3' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.4' );
 	}
 }
 


### PR DESCRIPTION
## Description
This Change makes Jetpack 11.4 the default version on the VIP platform.

## Changelog Description
### Plugin Updated: Jetpack 11.4

We made Jetpack 11.4 the default Jetpack version on the VIP platform

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Jetpack`
1. Verify the version is 11.4.
