### PR TITLE
Cancel previous E2E workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,10 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/search-e2e.yml
+++ b/.github/workflows/search-e2e.yml
@@ -13,6 +13,11 @@ on:
       - develop
       - production
       - staging
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   cypress_local:


### PR DESCRIPTION
This PR allows for canceling already running E2E workflows when a new workflow is about to run.

This help to reduce the load on GHA workers and decrease waiting time.