### PR TITLE
Jetpack: Fix bug where pinned/local Jetpack weren't displaying the correct version in plugins UI

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -751,3 +751,28 @@ function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
 }
 
 add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );
+
+/**
+ * Display correct Jetpack version in wp-admin plugins UI for pinned or local versions.
+ *
+ * @param string[] $plugin_meta An array of the plugin's metadata, including
+ *                              the version, author, author URI, and plugin URI.
+ * @param string   $plugin_file Path to the plugin file relative to the plugins directory.
+ * @param array    $plugin_data An array of plugin data.
+ * @param string   $status      Status filter currently applied to the plugin list.
+ * @return string[] $plugin_meta Updated plugin's metadata.
+ */
+function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file, $plugin_data, $status ) {
+	if ( ! defined( 'VIP_JETPACK_PINNED_VERSION' ) && ! defined( 'WPCOM_VIP_JETPACK_LOCAL' ) ) {
+		return $plugin_meta;
+	}
+
+	if ( 'jetpack.php' === $plugin_file ) {
+		$version = defined( 'VIP_JETPACK_LOADED_VERSION' ) ? VIP_JETPACK_LOADED_VERSION : JETPACK__VERSION;
+		/* translators: Loaded Jetpack version number */
+		$plugin_meta[0] = sprintf( esc_html__( 'Version %s' ), $version );
+	}
+
+	return $plugin_meta;
+}
+add_filter( 'plugin_row_meta', 'vip_filter_plugin_version_jetpack', PHP_INT_MAX, 4 );


### PR DESCRIPTION
## Description
When Jetpack is loaded from a pinned version or locally, it doesn't display the correct plugin version when going to wp-admin > Plugins > Must-Use. Fixes CANTINA-899.

## Changelog Description

### Plugin Updated: Jetpack 

Fix bug where pinned/local Jetpack weren't displaying the correct version in plugins UI

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Pin Jetpack to an older version, e.g. 11.0: `define( 'VIP_JETPACK_PINNED_VERSION', '11.0' );`
2) Go to wp-admin > Plugins > Must-Use
3) See that it displays the latest @ 11.4
4) Apply PR
5) Repeat step 2)
6) See it displays @ 11.0