### PR TITLE
(WIP) Block automatic loading of wp-parsely and Jetpack for FedRAMP sites.

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -128,6 +128,8 @@ docker run \
     -e MYSQL_HOST \
     -e DISABLE_XDEBUG=1 \
     -e PRETEST_SCRIPT=/home/circleci/project/bin/pretest.sh \
+    -e WPVIP_PARSELY_INTEGRATION_TEST_MODE="${WPVIP_PARSELY_INTEGRATION_TEST_MODE}" \
+    -e WPVIP_PARSELY_INTEGRATION_PLUGIN_VERSION="${WPVIP_PARSELY_INTEGRATION_PLUGIN_VERSION}" \
     ${DOCKER_OPTIONS} \
     -v "$(pwd):/home/circleci/project" \
     ghcr.io/automattic/vip-container-images/wp-test-runner:latest \

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -153,6 +153,16 @@ switch ( getenv( 'WPVIP_PARSELY_INTEGRATION_TEST_MODE' ) ) {
 		break;
 }
 
+tests_add_filter( 'muplugins_loaded', function () {
+	echo "[WP_PARSELY_INTEGRATION] Removing autoload (so we can manually test)\n";
+	$removed = remove_action( 'plugins_loaded', 'Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin', 1 );
+	if ( ! $removed ) {
+		throw new Exception( '[WP_PARSELY_INTEGRATION] Failed to remove autoload' );
+	}
+	echo "[WP_PARSELY_INTEGRATION] Disabling the telemetry backend\n";
+	add_filter( 'wp_parsely_enable_telemetry_backend', '__return_false' );
+} );
+
 require_once __DIR__ . '/mock-constants.php';
 require_once __DIR__ . '/mock-header.php';
 require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -141,6 +141,40 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_bootstrap_modes_for_fedramp() {
+		define( 'VIP_IS_FEDRAMP', '1' );
+		maybe_load_plugin();
+
+		switch ( self::$test_mode ) {
+			case 'disabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_NONE, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'filter_enabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				$this->assertTrue( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_MUPLUGINS, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'option_enabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_NONE, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'filter_and_option_enabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
+				$this->assertTrue( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_MUPLUGINS, Parsely_Loader_Info::get_integration_type() );
+				break;
+			default:
+				$this->fail( 'Invalid test mode specified: ' . self::$test_mode );
+		}
+	}
+
 	public function test_parsely_ui_hooks() {
 		maybe_load_plugin();
 

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -26,7 +26,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
-		self::$test_mode = test_mode();
+		self::$test_mode     = test_mode();
 		self::$major_version = test_version();
 	}
 
@@ -195,8 +195,8 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 			'post_status'  => 'publish',
 		];
 
-		$post_id  = wp_insert_post( $post, true );
-		$option = get_option( 'parsely' ) ?: [];
+		$post_id = wp_insert_post( $post, true );
+		$option  = get_option( 'parsely' ) ?: [];
 		update_option( 'parsely', array_merge( $option, [ 'apikey' => 'testing123' ] ) );
 
 		$metadata = $this->get_post_metadata( $post_id );
@@ -224,8 +224,8 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 			'post_password' => 'hunter2',
 		];
 
-		$post_id  = wp_insert_post( $post, true );
-		$option = get_option( 'parsely' ) ?: [];
+		$post_id = wp_insert_post( $post, true );
+		$option  = get_option( 'parsely' ) ?: [];
 		update_option( 'parsely', array_merge( $option, [ 'apikey' => 'testing123' ] ) );
 
 		$metadata = $this->get_post_metadata( $post_id );

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -2,7 +2,6 @@
 
 namespace Automattic\VIP\WP_Parsely_Integration;
 
-use Automattic\VIP\WP_Parsely_Integration\Parsely_Loader_Info;
 use Parsely\UI\Row_Actions;
 use WP_UnitTestCase;
 
@@ -11,17 +10,22 @@ function test_mode() {
 	return $mode ?: 'disabled';
 }
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 	protected static $test_mode;
 
 	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
 		self::$test_mode = test_mode();
-		if ( 'disabled' !== self::$test_mode ) {
-			echo 'Running Parsely Integration Tests in mode: ' . esc_html( self::$test_mode ) . "\n";
-		}
 	}
 
 	public function test_parsely_loader_info_defaults() {
+		maybe_load_plugin();
+
 		// Can only reliably test the defaults in "disabled" mode.
 		if ( 'disabled' === self::$test_mode ) {
 			$this->assertFalse( Parsely_Loader_Info::is_active() );
@@ -37,73 +41,90 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		set_current_screen( 'plugins' );
 
 		$this->set_get_globals_for_parsely_activation();
-		$this->assertTrue( \Automattic\VIP\WP_Parsely_Integration\is_queued_for_activation() );
+		$this->assertTrue( is_queued_for_activation() );
 	}
 
 	public function test_is_queued_for_activation_post() {
 		set_current_screen( 'plugins' );
 
 		$this->set_post_globals_for_parsely_activation();
-		$this->assertTrue( \Automattic\VIP\WP_Parsely_Integration\is_queued_for_activation() );
+		$this->assertTrue( is_queued_for_activation() );
 	}
 
 	public function test_is_not_queued_for_activation() {
 		set_current_screen( 'plugins' );
 
-		$this->assertFalse( \Automattic\VIP\WP_Parsely_Integration\is_queued_for_activation() );
-	}
-
-	public function test_has_maybe_load_plugin_action() {
-		$this->assertSame(
-			1,
-			has_action( 'plugins_loaded', __NAMESPACE__ . '\maybe_load_plugin' )
-		);
+		$this->assertFalse( is_queued_for_activation() );
 	}
 
 	public function test_parsely_class_existance() {
-		$class_should_exist = 'disabled' !== self::$test_mode;
+		$this->assertFalse( class_exists( 'Parsely' ) );
+		$this->assertFalse( class_exists( 'Parsely\Parsely' ) );
 
-		if ( $class_should_exist ) {
+		maybe_load_plugin();
+
+		if ( 'disabled' !== self::$test_mode ) {
 			$this->assertTrue( class_exists( 'Parsely\Parsely' ) );
-		} else {
-			$this->assertFalse( class_exists( 'Parsely' ) );
-			$this->assertFalse( class_exists( 'Parsely\Parsely' ) );
+			return;
 		}
+
+		$this->assertFalse( class_exists( 'Parsely' ) );
+		$this->assertFalse( class_exists( 'Parsely\Parsely' ) );
 	}
 
-	public function test_parsely_global() {
-		global $parsely;
+	public function test_parsely_instance() {
+		maybe_load_plugin();
+		$this->assertFalse( isset( $GLOBALS['parsely'] ) );
 
-		$instance_should_exist = 'disabled' !== self::$test_mode;
-		$this->assertSame( $instance_should_exist, isset( $parsely ) );
+		if ( 'disabled' === self::$test_mode ) {
+			return;
+		}
+
+		\Parsely\parsely_initialize_plugin();
+
+		$classname = get_class( $GLOBALS['parsely'] );
+
+		$this->assertEquals( 'Parsely\Parsely', $classname );
 	}
 
 	public function test_bootstrap_modes() {
-		\Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin();
+		maybe_load_plugin();
 		switch ( self::$test_mode ) {
 			case 'disabled':
 				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertFalse(
+					Parsely_Loader_Info::is_active(),
+					'Expecting the plugin to be inactive'
+				);
 				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_NONE, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'filter_enabled':
 				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
-				$this->assertTrue( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_SELF_MANAGED, Parsely_Loader_Info::get_integration_type() );
+				$this->assertTrue(
+					Parsely_Loader_Info::is_active(),
+					'Expecting wp-parsely plugin to be enabled by the filter.'
+				);
+				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_MUPLUGINS, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'option_enabled':
 				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
-				$this->assertTrue( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_SELF_MANAGED, Parsely_Loader_Info::get_integration_type() );
+				$this->assertTrue(
+					Parsely_Loader_Info::is_active(),
+					'Expecting wp-parsely plugin to be enabled by the option.'
+				);
+				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_MUPLUGINS_SILENT, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'filter_and_option_enabled':
 				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
-				$this->assertTrue( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_SELF_MANAGED, Parsely_Loader_Info::get_integration_type() );
+				$this->assertTrue(
+					Parsely_Loader_Info::is_active(),
+					'Expecting wp-parsely plugin to be enabled by the filter overriding the option.'
+				);
+				$this->assertEquals( Parsely_Loader_Info::INTEGRATION_TYPE_MUPLUGINS, Parsely_Loader_Info::get_integration_type() );
 				break;
 			default:
 				$this->fail( 'Invalid test mode specified: ' . self::$test_mode );
@@ -111,21 +132,30 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_parsely_ui_hooks() {
-		$repeated_metas_expected = 'option_enabled' == self::$test_mode ? 10 : false;
-		$this->assertSame( $repeated_metas_expected, has_action( 'option_parsely', 'Automattic\VIP\WP_Parsely_Integration\alter_option_use_repeated_metas' ) );
+		maybe_load_plugin();
 
-		// Class should only exist if Parse.ly is enabled
-		if ( 'disabled' !== self::$test_mode ) {
-			$row_actions = new Row_Actions( $GLOBALS['parsely'] );
-			$row_actions->run();
+		$this->assertFalse( has_action( 'option_parsely', __NAMESPACE__ . '\alter_option_use_repeated_metas' ) );
 
-			$row_actions_expected = in_array( self::$test_mode, [ 'filter_enabled', 'filter_and_option_enabled' ] ) ? 10 : false;
-			$this->assertSame( $row_actions_expected, has_filter( 'page_row_actions', array( $row_actions, 'row_actions_add_parsely_link' ) ) );
-			$this->assertSame( $row_actions_expected, has_filter( 'post_row_actions', array( $row_actions, 'row_actions_add_parsely_link' ) ) );
+		if ( 'disabled' === self::$test_mode ) {
+			return;
 		}
+
+		\Parsely\parsely_initialize_plugin();
+		maybe_disable_some_features();
+
+		$repeated_metas_expected = 'option_enabled' === self::$test_mode ? 10 : false;
+		$this->assertSame( $repeated_metas_expected, has_action( 'option_parsely', __NAMESPACE__ . '\alter_option_use_repeated_metas' ) );
+
+		$row_actions = new Row_Actions( $GLOBALS['parsely'] );
+		$row_actions->run();
+
+		$row_actions_expected = in_array( self::$test_mode, [ 'filter_enabled', 'filter_and_option_enabled' ] ) ? 10 : false;
+		$this->assertSame( $row_actions_expected, has_filter( 'page_row_actions', array( $row_actions, 'row_actions_add_parsely_link' ) ) );
+		$this->assertSame( $row_actions_expected, has_filter( 'post_row_actions', array( $row_actions, 'row_actions_add_parsely_link' ) ) );
 	}
 
 	public function test_alter_option_use_repeated_metas() {
+		maybe_load_plugin();
 		$options = alter_option_use_repeated_metas();
 		$this->assertSame( array( 'meta_type' => 'repeated_metas' ), $options );
 
@@ -140,9 +170,14 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_unprotected_published_posts_show_meta() {
+		maybe_load_plugin();
+
 		if ( 'disabled' === self::$test_mode ) {
-			$this->markTestSkipped();
+			$this->assertFalse( is_callable( '\Parsely\parsely_initialize_plugin' ) );
+			return;
 		}
+
+		\Parsely\parsely_initialize_plugin();
 
 		$post = [
 			'post_title'   => 'Testing unprotected posts',
@@ -160,9 +195,14 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 	public function test_protected_post_do_not_show_meta() {
 		global $parsely;
 
+		maybe_load_plugin();
+
 		if ( 'disabled' === self::$test_mode ) {
-			$this->markTestSkipped();
+			$this->assertFalse( is_callable( '\Parsely\parsely_initialize_plugin' ) );
+			return;
 		}
+
+		\Parsely\parsely_initialize_plugin();
 
 		$post = [
 			'post_title'    => 'Testing protected posts',

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -156,6 +156,12 @@ function maybe_load_plugin() {
 
 	$should_load            = true === $filtered_load_status || '1' === $option_load_status;
 	$should_prevent_loading = false === $filtered_load_status || '0' === $option_load_status;
+	$vip_is_fedramp         = defined( 'VIP_IS_FEDRAMP' ) && constant( 'VIP_IS_FEDRAMP' );
+
+	if ( $vip_is_fedramp && ! $filtered_load_status ) {
+		// FedRAMP sites should only load the mu-plugins version of wp-parsely via the filter.
+		$should_prevent_loading = true;
+	}
 
 	// No integration: The site has not enabled parsely.
 	if ( ! $should_load || $should_prevent_loading ) {


### PR DESCRIPTION
## Description
WIP

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
