### PR TITLE
Fix infinite loop in custom results by removing ep_enable_do_weighting in is_custom_results_exist

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2474,6 +2474,7 @@ class Search {
 			'posts_per_page'      => 1,
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
+			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFiltersTrue
 			'suppress_filters'    => true,
 		];
 		$custom_results = new \WP_Query( $args );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2465,6 +2465,8 @@ class Search {
 	 * @return bool $exist If there are any Custom Search Results or not.
 	 */
 	public function is_custom_results_exist() {
+		remove_filter( 'ep_enable_do_weighting', [ $this, 'filter__ep_enable_do_weighting' ], 9999, 4 );
+
 		$args           = [
 			'post_type'           => 'ep-pointer',
 			'post_status'         => 'publish',
@@ -2472,8 +2474,11 @@ class Search {
 			'posts_per_page'      => 1,
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
+			'suppress_filters'    => true,
 		];
 		$custom_results = new \WP_Query( $args );
+
+		add_filter( 'ep_enable_do_weighting', [ $this, 'filter__ep_enable_do_weighting' ], 9999, 4 );
 
 		return ! empty( $custom_results->posts );
 	}


### PR DESCRIPTION
## Description

Explicitly disable the weighting filter before trying to check for whether any custom pointers exist.

## Changelog Description

### Plugin Updated: Enterprise Search

Bugfix: prevent potential recursion in Search::is_custom_results_exist

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
