### PR TITLE
Use a different approach to run WP Core Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,32 +72,6 @@ jobs:
           phpunit: ${{ matrix.config.phpunit }}
           coverage: ${{ matrix.config.coverage }}
 
-  wp-core:
-    name: "Run WP Core Tests (WordPress ${{ matrix.wp }}, multisite: ${{ matrix.multisite }})"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        wp:
-          - latest
-        multisite:
-          - "no"
-          - "yes"
-    steps:
-      - name: Check out source code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
-        with:
-          submodules: recursive
-
-      - name: Run tests
-        run: |
-          if [ "${{ matrix.multisite }}" = "yes" ]; then
-            MULTISITE=1
-          else
-            MULTISITE=0
-          fi
-          ./bin/run-core-tests.sh --wp ${{ matrix.wp }} --multisite ${MULTISITE}
-
   search-dev-tools:
     name: Build Search Dev Tools
     runs-on: ubuntu-latest

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -79,9 +79,10 @@ jobs:
       - name: Run tests
         run: |
           if [ "${{ matrix.multisite }}" = "yes" ]; then
-            PHPUNIT_ARGS="-c tests/phpunit/multisite.xml"
+            PHPUNIT_ARGS="-c tests/phpunit/multisite.xml --group ms-files"
           else
-            PHPUNIT_ARGS="-c phpuniut.xml.dist"
+            PHPUNIT_ARGS="-c phpunit.xml.dist"
           fi
           node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose ${PHPUNIT_ARGS}
         working-directory: wordpress
+

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -45,9 +45,10 @@ jobs:
           submodules: recursive
           path: wordpress/src/wp-content/mu-plugins
 
-      - name: Disable Jetpack
+      - name: Tweaks
         run: |
           echo "define( 'VIP_JETPACK_SKIP_LOAD', 'true' );" >> "wordpress/src/wp-content/mu-plugins/000-vip-init.php"
+          echo "GITHUB_EVENT_NAME=pull_request" >> "wordpress/.env"
 
       - name: Install NodeJS
         uses: actions/setup-node@v3

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -1,0 +1,82 @@
+name: CI (WP Core)
+
+on:
+  push:
+    branches-ignore:
+      - develop
+      - staging
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+
+jobs:
+  wp-core:
+    name: "Run WP Core Tests (WordPress ${{ matrix.wp }}, multisite: ${{ matrix.multisite }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        multisite:
+          - "no"
+          - "yes"
+    steps:
+      - name: Get the latest WP version
+        id: version
+        run: |
+          echo "::set-output name=latest::$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers | map(select( .response == "upgrade")) | .[0].version')"
+
+      - name: Check out WordPress
+        uses: actions/checkout@v3
+        with:
+          repository: wordpress/wordpress-develop
+          path: wordpress
+          ref: ${{ steps.version.outputs.latest }}
+
+      - name: Check out source code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          path: wordpress/src/wp-content/mu-plugins
+
+      - run: ls -lha wordpress/src/wp-content/mu-plugins
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'wordpress/.nvmrc'
+          cache: npm
+          cache-dependency-path: 'wordpress/package-lock.json'
+
+      - name: Install Dependencies
+        run: npm ci
+        working-directory: wordpress
+
+      - name: Install Composer dependencies
+        run: docker-compose run --rm php composer update
+        working-directory: wordpress
+
+      - name: Start Docker environment
+        run: npm run env:start
+        working-directory: wordpress
+
+      - name: Install WordPress
+        run: npm run env:install
+        working-directory: wordpress
+
+      - name: Run tests
+        run: |
+          if [ "${{ matrix.multisite }}" = "yes" ]; then
+            PHPUNIT_ARGS="-c tests/phpunit/multisite.xml"
+          else
+            PHPUNIT_ARGS="-c phpuniut.xml.dist"
+          fi
+          node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose ${PHPUNIT_ARGS}
+        working-directory: wordpress

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           echo "::set-output name=latest::$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers | map(select( .response == "upgrade")) | .[0].version')"
 
+      - name: Configure environment variables
+        run: |
+          echo "PHP_FPM_UID=$(id -u)" >> "${GITHUB_ENV}"
+          echo "PHP_FPM_GID=$(id -g)" >> "${GITHUB_ENV}"
+
       - name: Check out WordPress
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -19,14 +19,8 @@ env:
 
 jobs:
   wp-core:
-    name: "Run WP Core Tests (WordPress ${{ matrix.wp }}, multisite: ${{ matrix.multisite }})"
+    name: "Run WP Core Tests"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        multisite:
-          - "no"
-          - "yes"
     steps:
       - name: Get the latest WP version
         id: version
@@ -51,7 +45,9 @@ jobs:
           submodules: recursive
           path: wordpress/src/wp-content/mu-plugins
 
-      - run: ls -lha wordpress/src/wp-content/mu-plugins
+      - name: Disable Jetpack
+        run: |
+          echo "define( 'VIP_JETPACK_SKIP_LOAD', 'true' );" >> "wordpress/src/wp-content/mu-plugins/000-vip-init.php"
 
       - name: Install NodeJS
         uses: actions/setup-node@v3
@@ -76,13 +72,18 @@ jobs:
         run: npm run env:install
         working-directory: wordpress
 
-      - name: Run tests
-        run: |
-          if [ "${{ matrix.multisite }}" = "yes" ]; then
-            PHPUNIT_ARGS="-c tests/phpunit/multisite.xml --group ms-files"
-          else
-            PHPUNIT_ARGS="-c phpunit.xml.dist"
-          fi
-          node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose ${PHPUNIT_ARGS}
+      - name: Run PHPUnit tests
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist
         working-directory: wordpress
 
+      - name: Run AJAX tests
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group ajax
+        working-directory: wordpress
+
+      - name: Run ms-files tests as a multisite install
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c tests/phpunit/multisite.xml --group ms-files
+        working-directory: wordpress
+
+      - name: Run external HTTP tests
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group external-http
+        working-directory: wordpress


### PR DESCRIPTION
WP 6 changed the way how the tests should be run. This PR modified the workflow to run the tests properly.