### PR TITLE
CANTINA-911: add support for touch()

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -4,8 +4,8 @@ namespace Automattic\VIP\Files;
 
 use WP_Error;
 
-require __DIR__ . '/class-curl-streamer.php';
-require __DIR__ . '/class-api-cache.php';
+require_once __DIR__ . '/class-curl-streamer.php';
+require_once __DIR__ . '/class-api-cache.php';
 
 function new_api_client() {
 	return new API_Client(

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -105,7 +105,7 @@ class VIP_Filesystem_Stream_Wrapper {
 	/**
 	 * Flush empty file flag
 	 *
-	 * Flag to determine if an empty file should be flushed to the 
+	 * Flag to determine if an empty file should be flushed to the
 	 * Filesystem.
 	 *
 	 * @since   1.0.0
@@ -694,9 +694,25 @@ class VIP_Filesystem_Stream_Wrapper {
 	 * @return  bool
 	 */
 	public function stream_metadata( $path, $option, $value ) {
-		$this->debug( sprintf( 'stream_metadata =>  %s + %s + %s', $path, $option, $value ) );
+		$this->debug( sprintf( 'stream_metadata =>  %s + %s + %s', $path, $option, json_encode( $value ) ) );   // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 
-		return false;
+		switch ( $option ) {
+			case STREAM_META_TOUCH:
+				if ( false === file_exists( $path ) ) {
+					$file = fopen( $path, 'w' );    // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+					if ( is_resource( $file ) ) {
+						fclose( $file );
+						return true;
+					}
+
+					return false;
+				}
+
+				return true;
+
+			default:
+				return false;
+		}
 	}
 
 	/**

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -26,7 +26,7 @@ class VIP_Filesystem_Stream_Wrapper {
 	 *
 	 * @since   1.0.0
 	 * @access  public
-	 * @var     resource|nul    Stream context
+	 * @var     resource|null   Stream context
 	 */
 	public $context;
 
@@ -124,7 +124,7 @@ class VIP_Filesystem_Stream_Wrapper {
 	 */
 	public function __construct( API_Client $client = null, $protocol = null ) {
 		if ( is_null( $client ) ) {
-			$this->client = self::$default_client ?: new_api_client();
+			$this->client = static::$default_client ?: new_api_client();
 		} else {
 			$this->client = $client;
 		}

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -114,6 +114,8 @@ class VIP_Filesystem_Stream_Wrapper {
 	 */
 	private $should_flush_empty;
 
+	public static ?API_Client $default_client = null;
+
 	/**
 	 * Vip_Filesystem_Stream constructor.
 	 *
@@ -122,7 +124,7 @@ class VIP_Filesystem_Stream_Wrapper {
 	 */
 	public function __construct( API_Client $client = null, $protocol = null ) {
 		if ( is_null( $client ) ) {
-			$this->client = new_api_client();
+			$this->client = self::$default_client ?: new_api_client();
 		} else {
 			$this->client = $client;
 		}
@@ -154,8 +156,7 @@ class VIP_Filesystem_Stream_Wrapper {
 			stream_wrapper_unregister( $this->protocol );
 		}
 
-		return stream_wrapper_register(
-		$this->protocol, get_called_class(), STREAM_IS_URL );
+		return stream_wrapper_register( $this->protocol, get_called_class(), STREAM_IS_URL );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR adds support for the `touch()` function to our VIP Filesystem Wrapper.

## Changelog Description

### Plugin Updated: VIP File Service

Added support for the `touch()` function to the `vip://` filesystem wrapper,

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
