### PR TITLE
Update workflows

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -49,11 +49,11 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.coverage }}" = "yes" ] && [ -n "${{ inputs.coverage-file }}" ]; then
-          echo "::set-output name=coverage::pcov"
-          echo '::set-output name=ini::apc.enable_cli=1, pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|advanced-post-cache|akismet|cron-control|debug-bar|debug-bar-cron|drop-ins|http-concat|lightweight-term-count-update|query-monitor|(search/(elasticpress|debug-bar-elasticpress|es-wp-query))|shared-plugins|rewrite-rules-inspector|vaultpress|wordpress-importer)/~"'
+          echo "coverage=pcov" >> $GITHUB_OUTPUT
+          echo 'ini=apc.enable_cli=1, pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|advanced-post-cache|akismet|cron-control|debug-bar|debug-bar-cron|drop-ins|http-concat|lightweight-term-count-update|query-monitor|(search/(elasticpress|debug-bar-elasticpress|es-wp-query))|shared-plugins|rewrite-rules-inspector|vaultpress|wordpress-importer)/~"' >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=coverage::none"
-          echo "::set-output name=ini::apc.enable_cli=1, opcache.enable_cli=1"
+          echo "coverage=none" >> $GITHUB_OUTPUT
+          echo "ini=apc.enable_cli=1, opcache.enable_cli=1" >> $GITHUB_OUTPUT
         fi
 
     - name: Set up PHP

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get the latest WP version
         id: version
         run: |
-          echo "::set-output name=latest::$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers | map(select( .response == "upgrade")) | .[0].version')"
+          echo "latest=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers | map(select( .response == "upgrade")) | .[0].version')" >> $GITHUB_OUTPUT
 
       - name: Configure environment variables
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,9 +104,9 @@ jobs:
         id: wpver
         run: |
           if [ -z "${{ github.event.inputs.wpversion }}" ]; then
-            echo ::set-output name=wpversion::latest
+            echo "wpversion=latest" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=wpversion::${{ github.event.inputs.wpversion }}
+            echo "wpversion=${{ github.event.inputs.wpversion }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Setup test environment

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -38,7 +38,7 @@ jobs:
               minor_version=$(echo "${tag}" | awk -F. '{print $2+1}')
           fi
 
-          echo "::set-output name=id::${current_date}${minor_version}"
+          echo "id=${current_date}${minor_version}" >> $GITHUB_OUTPUT
 
       - name: Tag release
         run: git tag ${{ steps.id-generator.outputs.id }}


### PR DESCRIPTION
GitHub has [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the `set-output` and `save-state` commands. This PR updates our workflows to use the [suggested replacement](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).