### PR TITLE
Dependabot: Ignore cypress updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     package-ecosystem: npm
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "cypress"
     versioning-strategy: increase-if-necessary
 
   - directory: /


### PR DESCRIPTION
## Description
Ignore all updates to cypress, will manually increase it: https://github.com/Automattic/vip-go-mu-plugins/pull/3769