### PR TITLE
Disable JS concatenation for wp-admin

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -191,3 +191,10 @@ add_filter( 'site_search_columns', function( $cols ) {
 	$cols[] = 'domain';
 	return $cols;
 });
+
+/**
+ * Disable JS Concatenation for wp-admin.
+ */
+if ( is_admin() ) {
+	add_filter( 'js_do_concat', '__return_false' );
+}


### PR DESCRIPTION
## Description
Since it breaks plugins like Gravity Forms and the cons outweigh the pros. If one wanted to continue using concat, they could easily remove the filter.

## Changelog Description

### Plugin Updated: JS Concat

In wp-admin, JS assets will no longer be concatenated. 