### PR TITLE
Media: Account for 6.0.3 new filter wp_allow_query_attachment_by_filename

### DIFF
--- a/performance/media.php
+++ b/performance/media.php
@@ -3,7 +3,7 @@
 // Prevent core from doing filename lookups for media search.
 // https://core.trac.wordpress.org/ticket/39358
 function vip_filter_query_attachment_filenames() {
-	remove_filter( 'posts_clauses', '_filter_query_attachment_filenames' );
+	add_filter( 'wp_allow_query_attachment_by_filename', '__return_false', PHP_INT_MAX );
 }
 
 if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {


### PR DESCRIPTION
## Description

6.0.3 introduced a new filter `wp_allow_query_attachment_by_filename`. Let's account for that.