### PR TITLE
2FA: Fix warning generated on a site with no path in home_url()

### DIFF
--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -87,7 +87,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 	public function format_sms_message( $verification_code ) {
 		$site_title                = get_bloginfo();
 		$parse                     = wp_parse_url( home_url() );
-		$home_url_without_protocol = $parse['host'] . $parse['path'];
+		$home_url_without_protocol = $parse['host'] . ( $parse['path'] ?? '' );
 
 		$format = '%1$s is your %2$s verification code.' . "\n\n" . '@%3$s #%1$s';
 


### PR DESCRIPTION
## Description
This fixes the below warning:

```
Warning: Undefined array key "path" in /var/www/wp-content/mu-plugins/wpcom-vip-two-factor/sms-provider.php on line 90
[www.url.com/wp-login.php]
[wp-content/mu-plugins/wpcom-vip-two-factor/sms-provider.php:106 Two_Factor_SMS->format_sms_message(), wp-content/mu-plugins/wpcom-vip-two-factor/sms-provider.php:125 Two_Factor_SMS->generate_and_send_token(), wp-content/mu-plugins/shared-plugins/two-factor/class-two-factor-core.php:619 Two_Factor_SMS->authentication_page(), wp-content/mu-plugins/shared-plugins/two-factor/class-two-factor-core.php:530 Two_Factor_Core::login_html(), wp-content/mu-plugins/shared-plugins/two-factor/class-two-factor-core.php:439 Two_Factor_Core::show_two_factor_login(), wp-includes/class-wp-hook.php:307 Two_Factor_Core::wp_login(), wp-includes/class-wp-hook.php:331 WP_Hook->apply_filters(), wp-includes/plugin.php:476 WP_Hook->do_action(), wp-includes/user.php:110 do_action('wp_login'), wp-login.php:1221 wp_signon()]
```

## Changelog Description

### Plugin Updated: 2FA

2FA: Fix warning generated on a site with no path in home_url()

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Add 2FA SMS on an account on a site with a home_url without a path
2) Log out
3) Attempt to log back in and see the warning present itself