### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,19 @@ updates:
     schedule:
       interval: daily
     versioning-strategy: increase-if-necessary
+    ignore:
+      - dependency-name: "cypress"
+
+  - directory: /__tests__/e2e/
+    package-ecosystem: npm
+    schedule:
+      interval: daily
+    versioning-strategy: increase-if-necessary
 
   - directory: /search/search-dev-tools/
     package-ecosystem: npm
     schedule:
       interval: daily
-    ignore:
-      - dependency-name: "cypress"
     versioning-strategy: increase-if-necessary
 
   - directory: /


### PR DESCRIPTION
In #3799, we moved the E2E stuff to a separate directory. Now we need to update `dependabot.yml` so that Dependabot can watch for the outdated packages there.
