### PR TITLE
Site Details: Track block editor usage

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -83,6 +83,9 @@ class Site_Details_Index {
 		$site_details['jetpack'] = $this->get_jetpack_info();
 		$site_details['parsely'] = $this->get_parsely_info();
 
+		// `constants` is an inaccurrate name here. It's really just a key-value store.
+		$site_details['constants'] = $this->get_extra_blog_meta();
+
 		return $site_details;
 	}
 
@@ -242,6 +245,40 @@ class Site_Details_Index {
 		$parsely_info['version']          = ParselyInfo::get_version();
 
 		return $parsely_info;
+	}
+
+	public function get_extra_blog_meta() {
+		$blog_meta = [];
+
+		// Block Editor
+		$is_using_block_editor = $this->is_using_block_editor();
+		$blog_meta[] = [
+			'name' => 'using_block_editor',
+			'value' => $is_using_block_editor ? 1 : 0,
+		];
+		
+		return $blog_meta;
+	}
+
+	// Somewhat naive detection of block editor use
+	private function is_using_block_editor() {
+		// TODO: probably move this elsewhere
+		$default_post = get_default_post_to_edit();
+
+		$most_recent_post_array = get_posts( [
+			'post_type' => $default_post->post_type,
+			'post_status' => 'publish',
+			'posts_per_page' => 1,
+			'orderby' => 'post_date',
+			'order' => 'DESC',
+		] );
+
+		$is_using_block_editor = false;
+		if ( ! empty( $most_recent_post_lookup ) ) {
+			$is_using_block_editor = has_blocks( $most_recent_post_array[ 0 ] );
+		}
+
+		return $is_using_block_editor;
 	}
 
 	/**


### PR DESCRIPTION
This is somewhat basic / naive. Fetches the most recently published post of the default post_type and checks if it has blocks. It's not perfect and has lots of edge cases to consider.

Putting this draft out there to get discussion started on how we could make this better.

Context for this: https://wp.me/p9zhOE-2hY

## Changelog Description

TODO

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

TODO