### PR TITLE
Search: Add new version of ElasticPress

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "jetpack"]
 	path = jetpack
 	url = https://github.com/Automattic/jetpack-production.git
+[submodule "search/elasticpress-next"]
+	path = search/elasticpress-next
+	url = https://github.com/Automattic/ElasticPress.git

--- a/search/includes/classes/class-dashboard.php
+++ b/search/includes/classes/class-dashboard.php
@@ -31,7 +31,7 @@ class Dashboard {
 		$screen = get_current_screen();
 		if ( 'toplevel_page_elasticpress' === $screen->base ) {
 			echo '<style>
-			div.ep-feature.ep-feature-autosuggest, div.ep-feature.ep-feature-documents {
+			div.ep-feature.ep-feature-autosuggest, div.ep-feature.ep-feature-documents, div.ep-feature.ep-feature-instant-results {
 				display: none !important;
 			}
 			</style>';

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1003,7 +1003,12 @@ class Health {
 				return $actual_settings;
 			}
 
-			$desired_settings = $indexable->build_settings();
+			if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+				$mapping          = $indexable->generate_mapping();
+				$desired_settings = $mapping['settings'];
+			} else {
+				$desired_settings = $indexable->build_settings();
+			}
 
 			// We only monitor certain settings
 			$actual_settings_to_check  = self::limit_index_settings_to_keys( $actual_settings, self::INDEX_SETTINGS_HEALTH_MONITORED_KEYS );
@@ -1068,7 +1073,12 @@ class Health {
 			}
 		}
 
-		$desired_settings = $indexable->build_settings();
+		if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+			$mapping          = $indexable->generate_mapping();
+			$desired_settings = $mapping['settings'];
+		} else {
+			$desired_settings = $indexable->build_settings();
+		}
 
 		// Limit to only the settings that we auto-heal
 		$desired_settings_to_heal = self::limit_index_settings_to_keys( $desired_settings, self::INDEX_SETTINGS_HEALTH_AUTO_HEAL_KEYS );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2274,8 +2274,8 @@ class Search {
 	 * @return string
 	 */
 	public function filter__ep_search_algorithm_version() {
-		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) {
-			// Enable new algorithm for non-prods
+		if ( ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) || self::is_next_ep_constant_defined() ) {
+			// Enable new algorithm for non-prods & using the new constant
 			return '4.0';
 		}
 		return '3.5';

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -229,6 +229,15 @@ class Search {
 		return $endpoints_defined && $username_defined && $password_defined;
 	}
 
+	/**
+	 * Check if the constant needed for the next ElasticPress version to be loaded is defined
+	 *
+	 * @return bool true if constants are defined, false otherwise
+	 */
+	public static function is_next_ep_constant_defined() {
+		return defined( 'VIP_SEARCH_USE_NEXT_EP' ) && true === constant( 'VIP_SEARCH_USE_NEXT_EP' );
+	}
+
 	public static function instance() {
 		if ( ! ( static::$instance instanceof Search ) ) {
 			static::$instance = new Search();
@@ -240,7 +249,11 @@ class Search {
 
 	protected function load_dependencies() {
 		// Load ElasticPress
-		require_once __DIR__ . '/../../elasticpress/elasticpress.php';
+		if ( self::is_next_ep_constant_defined() ) {
+			require_once __DIR__ . '/../../elasticpress-next/elasticpress.php';
+		} else {
+			require_once __DIR__ . '/../../elasticpress/elasticpress.php';
+		}
 
 		// Load health check cron job
 		require_once __DIR__ . '/class-healthjob.php';

--- a/search/includes/functions/ep-get-query-log.php
+++ b/search/includes/functions/ep-get-query-log.php
@@ -1,5 +1,9 @@
 <?php
-require_once __DIR__ . '../../../elasticpress/elasticpress.php';
+if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+	require_once __DIR__ . '/../../elasticpress-next/elasticpress.php';
+} else {
+	require_once __DIR__ . '/../../elasticpress/elasticpress.php';
+}
 
 // Override query log to remove Authorization header.
 function ep_get_query_log() {

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Search;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
+use Automattic\Test\Constant_Mocker;
 
 require_once __DIR__ . '/../../../../search/search.php';
 require_once __DIR__ . '/../../../../search/includes/classes/class-health.php';
@@ -15,6 +16,38 @@ require_once __DIR__ . '/../../../../search/elasticpress/includes/classes/Elasti
  * @preserveGlobalState disabled
  */
 class Health_Test extends WP_UnitTestCase {
+	/** @var array */
+	private static $indexable_methods = [
+		'query_es',
+		'query_db',
+		'format_args',
+		'prepare_document',
+		'put_mapping',
+		'build_mapping',
+		'index_exists',
+		'get_index_name',
+		'get_index_settings',
+		'update_index_settings',
+	];
+
+	/** @var Search */
+	private static $search_instance;
+
+	public static function setUpBeforeClass(): void {
+		self::$search_instance = new \Automattic\VIP\Search\Search();
+		self::$search_instance->init();
+
+		if ( method_exists( \ElasticPress\Indexable::class, 'build_settings' ) ) {
+			self::$indexable_methods[] = 'build_settings';
+		} else {
+			self::$indexable_methods[] = 'generate_mapping';
+		}
+	}
+
+	public function use_constant() {
+		return [ [ true ], [ false ] ];
+	}
+
 	public function test_get_missing_docs_or_posts_diff() {
 		$found_post_ids     = array( 1, 3, 5 );
 		$found_document_ids = array( 1, 3, 7 );
@@ -431,13 +464,20 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertEquals( $diff, $expected_diff );
 	}
 
-	public function test_get_index_entity_count_from_elastic_search__returns_result() {
-		$health         = new \Automattic\VIP\Search\Health( Search::instance() );
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_get_index_entity_count_from_elastic_search__returns_result( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
+		$health         = new \Automattic\VIP\Search\Health( self::$search_instance );
 		$expected_count = 42;
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexable->slug = 'foo';
@@ -454,12 +494,19 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertEquals( $result, $expected_count );
 	}
 
-	public function test_get_index_entity_count_from_elastic_search__exception() {
-		$health = new \Automattic\VIP\Search\Health( Search::instance() );
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_get_index_entity_count_from_elastic_search__exception( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
+		$health = new \Automattic\VIP\Search\Health( self::$search_instance );
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexable->slug = 'foo';
@@ -472,12 +519,19 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertTrue( is_wp_error( $result ) );
 	}
 
-	public function test_get_index_entity_count_from_elastic_search__failed_query() {
-		$health = new \Automattic\VIP\Search\Health( Search::instance() );
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_get_index_entity_count_from_elastic_search__failed_query( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
+		$health = new \Automattic\VIP\Search\Health( self::$search_instance );
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_es', 'format_args', 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexable->slug = 'foo';
@@ -490,12 +544,19 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertTrue( is_wp_error( $result ) );
 	}
 
-	public function test_validate_index_entity_count__failed_ES_should_pass_error() {
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_validate_index_entity_count__failed_ES_should_pass_error( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
 		$error = new \WP_Error( 'test error' );
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings', 'index_exists' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexable->slug = 'foo';
@@ -503,7 +564,7 @@ class Health_Test extends WP_UnitTestCase {
 
 		/** @var \Automattic\VIP\Search\Health&MockObject */
 		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
-			->setConstructorArgs( [ Search::instance() ] )
+			->setConstructorArgs( [ self::$search_instance ] )
 			->setMethods( [ 'get_index_entity_count_from_elastic_search' ] )
 			->getMock();
 
@@ -515,7 +576,14 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertEquals( $result, $error );
 	}
 
-	public function test_validate_index_entity_count__returns_all_data() {
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_validate_index_entity_count__returns_all_data( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
 		$expected_result = [
 			'entity'   => 'foo',
 			'type'     => 'N/A',
@@ -528,7 +596,7 @@ class Health_Test extends WP_UnitTestCase {
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings', 'index_exists' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexable->slug = $expected_result['entity'];
@@ -540,7 +608,7 @@ class Health_Test extends WP_UnitTestCase {
 
 		/** @var \Automattic\VIP\Search\Health&MockObject */
 		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
-			->setConstructorArgs( [ Search::instance() ] )
+			->setConstructorArgs( [ self::$search_instance ] )
 			->setMethods( [ 'get_index_entity_count_from_elastic_search' ] )
 			->getMock();
 
@@ -552,7 +620,14 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertEquals( $result, $expected_result );
 	}
 
-	public function test_validate_index_entity_count__skipping_non_initialized_indexes() {
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_validate_index_entity_count__skipping_non_initialized_indexes( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
 		$expected_result = [
 			'entity'   => 'foo',
 			'type'     => 'N/A',
@@ -565,14 +640,14 @@ class Health_Test extends WP_UnitTestCase {
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings', 'index_exists' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 		$mocked_indexable->method( 'index_exists' )->willReturn( true );
 		$mocked_indexable->slug = $expected_result['entity'];
 
 		/** @var \Automattic\VIP\Search\Health&MockObject */
 		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
-			->setConstructorArgs( [ Search::instance() ] )
+			->setConstructorArgs( [ self::$search_instance ] )
 			->setMethods( [ 'get_index_entity_count_from_elastic_search' ] )
 			->getMock();
 
@@ -597,12 +672,12 @@ class Health_Test extends WP_UnitTestCase {
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings', 'index_exists' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 		$mocked_indexable->method( 'index_exists' )->willReturn( false );
 		$mocked_indexable->slug = $expected_result['entity'];
 
-		$health = new \Automattic\VIP\Search\Health( Search::instance() );
+		$health = new \Automattic\VIP\Search\Health( self::$search_instance );
 		$result = $health->validate_index_entity_count( [], $mocked_indexable );
 
 		$this->assertEquals( $result, $expected_result );
@@ -637,7 +712,7 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->indexables = $mocked_indexables;
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
@@ -668,7 +743,7 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->indexables = $mocked_indexables;
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
@@ -683,7 +758,14 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->validate_index_posts_content( $options );
 	}
 
-	public function test_validate_index_posts_content__should_not_interact_with_process_if_paralel_run() {
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_validate_index_posts_content__should_not_interact_with_process_if_parallel_run( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
 		/** @var \Automattic\VIP\Search\Health&MockObject */
 		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
 			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'validate_index_posts_content_batch' ] )
@@ -697,7 +779,7 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->indexables = $mocked_indexables;
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
@@ -710,7 +792,14 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->validate_index_posts_content( [ 'force_parallel_execution' => true ] );
 	}
 
-	public function test_validate_index_posts_content__should_not_interact_with_process_if_non_default_start_id_is_sent_in() {
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_validate_index_posts_content__should_not_interact_with_process_if_non_default_start_id_is_sent_in( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
 		/** @var \Automattic\VIP\Search\Health&MockObject */
 		$patrtially_mocked_health = $this->getMockBuilder( \Automattic\VIP\Search\Health::class )
 			->setMethods( [ 'update_validate_content_process', 'remove_validate_content_process', 'validate_index_posts_content_batch' ] )
@@ -724,7 +813,7 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->indexables = $mocked_indexables;
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
@@ -737,7 +826,14 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->validate_index_posts_content( [ 'start_post_id' => 25 ] );
 	}
 
-	public function test_validate_index_posts_content__pick_up_after_interuption() {
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_validate_index_posts_content__pick_up_after_interuption( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
 		$interrupted_post_id = 5;
 		$start_post_id       = 1;
 
@@ -755,7 +851,7 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->indexables = $mocked_indexables;
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
@@ -768,7 +864,14 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->validate_index_posts_content( $start_post_id, null, null, null, false, false, false );
 	}
 
-	public function test_validate_index_posts_content__do_not_pick_up_after_interuption_when_running_in_parallel() {
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_validate_index_posts_content__do_not_pick_up_after_interuption_when_running_in_parallel( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
 		$interrupted_post_id = 5;
 		$start_post_id       = 1;
 
@@ -786,7 +889,7 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->indexables = $mocked_indexables;
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
@@ -801,7 +904,14 @@ class Health_Test extends WP_UnitTestCase {
 		] );
 	}
 
-	public function test_validate_index_posts_content__do_not_pick_up_after_interuption_when_non_default_start_post_id() {
+	/**
+	 * @dataProvider use_constant
+	 */
+	public function test_validate_index_posts_content__do_not_pick_up_after_interuption_when_non_default_start_post_id( $define ) {
+		if ( $define ) {
+			Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+		}
+
 		$interrupted_post_id = 5;
 		$start_post_id       = 2;
 
@@ -819,7 +929,7 @@ class Health_Test extends WP_UnitTestCase {
 		$patrtially_mocked_health->indexables = $mocked_indexables;
 
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'build_settings' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexables->method( 'get' )->willReturn( $mocked_indexable );
@@ -978,7 +1088,7 @@ class Health_Test extends WP_UnitTestCase {
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'get_index_settings', 'build_settings', 'index_exists', 'get_index_name' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexable->slug = 'post';
@@ -988,8 +1098,13 @@ class Health_Test extends WP_UnitTestCase {
 		$mocked_indexable->method( 'get_index_settings' )
 			->willReturn( $actual );
 
-		$mocked_indexable->method( 'build_settings' )
-			->willReturn( $desired );
+		if ( method_exists( $mocked_indexable, 'build_settings' ) ) {
+			$mocked_indexable->method( 'build_settings' )
+				->willReturn( $desired );
+		} else {
+			$mocked_indexable->method( 'generate_mapping' )
+				->willReturn( [ 'settings' => $desired ] );
+		}
 
 		$actual_result = $health->get_index_settings_diff_for_indexable( $mocked_indexable, $options );
 
@@ -1021,7 +1136,7 @@ class Health_Test extends WP_UnitTestCase {
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'get_index_settings', 'build_settings', 'index_exists' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexable->slug = 'post';
@@ -1030,8 +1145,13 @@ class Health_Test extends WP_UnitTestCase {
 		$mocked_indexable->method( 'get_index_settings' )
 			->willReturn( $actual );
 
-		$mocked_indexable->method( 'build_settings' )
-			->willReturn( $desired );
+		if ( method_exists( $mocked_indexable, 'build_settings' ) ) {
+			$mocked_indexable->method( 'build_settings' )
+				->willReturn( $desired );
+		} else {
+			$mocked_indexable->method( 'generate_mapping' )
+				->willReturn( [ 'settings' => $desired ] );
+		}
 
 		$actual_diff = $health->get_index_settings_diff_for_indexable( $mocked_indexable, $options );
 
@@ -1112,7 +1232,7 @@ class Health_Test extends WP_UnitTestCase {
 
 		/** @var \ElasticPress\Indexable&MockObject */
 		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
-			->setMethods( [ 'query_db', 'prepare_document', 'put_mapping', 'build_mapping', 'update_index_settings', 'build_settings', 'get_index_name' ] )
+			->setMethods( self::$indexable_methods )
 			->getMock();
 
 		$mocked_indexable->slug = 'post';
@@ -1120,8 +1240,13 @@ class Health_Test extends WP_UnitTestCase {
 		$mocked_indexable->method( 'get_index_name' )
 			->willReturn( 'foo-index-name' );
 
-		$mocked_indexable->method( 'build_settings' )
-			->willReturn( $desired_settings );
+		if ( method_exists( $mocked_indexable, 'build_settings' ) ) {
+			$mocked_indexable->method( 'build_settings' )
+				->willReturn( $desired_settings );
+		} else {
+			$mocked_indexable->method( 'generate_mapping' )
+				->willReturn( [ 'settings' => $desired_settings ] );
+		}
 
 		$mocked_indexable->method( 'update_index_settings' )
 			->willReturn( true );
@@ -1171,7 +1296,7 @@ class Health_Test extends WP_UnitTestCase {
 	 * @dataProvider limit_index_settings_to_keys_data
 	 */
 	public function test_limit_index_settings_to_keys( $input, $keys, $expected ) {
-		$health = new Health( Search::instance() );
+		$health = new Health( self::$search_instance );
 
 		$limited_settings = $health->limit_index_settings_to_keys( $input, $keys );
 
@@ -1316,7 +1441,7 @@ class Health_Test extends WP_UnitTestCase {
 	 * @dataProvider get_index_settings_diff_data
 	 */
 	public function test_get_index_settings_diff( $actual, $desired, $expected_diff ) {
-		$health = new Health( Search::instance() );
+		$health = new Health( self::$search_instance );
 
 		$actual_diff = $health->get_index_settings_diff( $actual, $desired );
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -341,7 +341,12 @@ class Search_Test extends WP_UnitTestCase {
 
 		add_filter( 'wp_count_posts', $return_big_count );
 
-		$settings = $indexable->build_settings();
+		if ( method_exists( $indexable, 'build_settings' ) ) {
+			$settings = $indexable->build_settings();
+		} else {
+			$mapping  = $indexable->generate_mapping();
+			$settings = $mapping['settings'];
+		}
 
 		$this->assertEquals( 4, $settings['index.number_of_shards'] );
 
@@ -369,7 +374,12 @@ class Search_Test extends WP_UnitTestCase {
 		add_filter( 'pre_count_users', $return_big_count );
 
 		$indexable = \ElasticPress\Indexables::factory()->get( 'user' );
-		$settings  = $indexable->build_settings();
+		if ( method_exists( $indexable, 'build_settings' ) ) {
+			$settings = $indexable->build_settings();
+		} else {
+			$mapping  = $indexable->generate_mapping();
+			$settings = $mapping['settings'];
+		}
 		$this->assertEquals( 4, $settings['index.number_of_shards'] );
 
 		remove_filter( 'pre_count_users', $return_big_count );
@@ -1783,7 +1793,12 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $indexables, 'Indexables array was empty' );
 
 		foreach ( $indexables as $indexable ) {
-			$settings = $indexable->build_settings();
+			if ( method_exists( $indexable, 'build_settings' ) ) {
+				$settings = $indexable->build_settings();
+			} else {
+				$mapping  = $indexable->generate_mapping();
+				$settings = $mapping['settings'];
+			}
 
 			$this->assertEquals( 'dfw', $settings['index.routing.allocation.include.dc'], 'Indexable ' . $indexable->slug . ' has the wrong routing allocation' );
 		}
@@ -1804,7 +1819,12 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $indexables, 'Indexables array was empty' );
 
 		foreach ( $indexables as $indexable ) {
-			$settings = $indexable->build_settings();
+			if ( method_exists( $indexable, 'build_settings' ) ) {
+				$settings = $indexable->build_settings();
+			} else {
+				$mapping  = $indexable->generate_mapping();
+				$settings = $mapping['settings'];
+			}
 
 			// Datacenter was invalid, so it should not have added the allocation settings
 			$this->assertArrayNotHasKey( 'index.routing.allocation.include.dc', $settings, 'Indexable ' . $indexable->slug . ' incorrectly defined the allocation settings' );


### PR DESCRIPTION
## Description
This adds the newest version of EP via a constant `VIP_SEARCH_USE_NEXT_EP`. Plan is to set a deadline to change the default EP to the newest version.

## Changelog Description

### Plugin Updated: Enterprise Search

Adds the newest version of ElasticPress. Can be tested by defining constant VIP_SEARCH_USE_NEXT_EP to true.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Add to vip-config: `define( 'VIP_SEARCH_USE_NEXT_EP', true );`
2) Test search