### PR TITLE
PHP 8: Fix warnings about undefined array key in image_resize()

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -260,8 +260,8 @@ class A8C_Files {
 			$_max_w = get_option( 'large_size_w' );
 			$_max_h = get_option( 'large_size_h' );
 		} elseif ( is_array( $size ) ) {
-			$_max_w = $size[0];
-			$_max_h = $size[1];
+			$_max_w = $size[0] ?? 0;
+			$_max_h = $size[1] ?? 0;
 			$w      = $_max_w;
 			$h      = $_max_h;
 		} elseif ( ! empty( $_wp_additional_image_sizes[ $size ] ) ) {


### PR DESCRIPTION
## Description
Fixes the below warning:

```
PHP message: PHP Warning: Undefined array key 1 in /var/www/wp-content/mu-plugins/a8c-files.php on line 264
```

## Changelog Description
### Plugin Updated: VIP File Service

Fix PHP 8 warning in image_resize()

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.