### PR TITLE
Suppress codebase manager

### DIFF
--- a/codebase-manager/codebase-manager.php
+++ b/codebase-manager/codebase-manager.php
@@ -11,6 +11,7 @@ add_action( 'admin_init', function() {
 		return;
 	}
 
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( ! isset( $_REQUEST['s'] ) ) {
 		// Avoid loading stuff due to bug in plugin manager list for search requests.
 		$plugins_manager = new PluginsManager();

--- a/codebase-manager/codebase-manager.php
+++ b/codebase-manager/codebase-manager.php
@@ -11,5 +11,9 @@ add_action( 'admin_init', function() {
 		return;
 	}
 
-	( new PluginsManager() )->init();
+	if ( ! isset( $_REQUEST['s'] ) ) {
+		// Avoid loading stuff due to bug in plugin manager list for search requests.
+		$plugins_manager = new PluginsManager();
+		$plugins_manager->init();
+	}
 } );

--- a/codebase-manager/codebase-manager.php
+++ b/codebase-manager/codebase-manager.php
@@ -11,10 +11,6 @@ add_action( 'admin_init', function() {
 		return;
 	}
 
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( ! isset( $_REQUEST['s'] ) ) {
-		// Avoid loading stuff due to bug in plugin manager list for search requests.
-		$plugins_manager = new PluginsManager();
-		$plugins_manager->init();
-	}
+	$plugins_manager = new PluginsManager();
+	$plugins_manager->init();
 } );

--- a/codebase-manager/plugins/plugins-manager.php
+++ b/codebase-manager/plugins/plugins-manager.php
@@ -4,7 +4,7 @@ namespace Automattic\VIP\CodebaseManager;
 
 class PluginsManager {
 	private $update_data;
-	private $column_count;
+	private $column_count = null;
 
 	public function init() {
 		if ( ! $this->user_can_manage_plugins() ) {
@@ -13,10 +13,6 @@ class PluginsManager {
 		}
 
 		$this->update_data = $this->fetch_plugins_with_updates();
-
-		// Check how many columns exist on the plugin's page.
-		$wp_list_table      = _get_list_table( 'WP_Plugins_List_Table', [ 'screen' => 'plugins' ] );
-		$this->column_count = method_exists( $wp_list_table, 'get_column_count' ) ? $wp_list_table->get_column_count() : 3;
 
 		add_action( 'after_plugin_row', [ $this, 'output_plugin_row_information' ], 10, 2 );
 		add_action( 'admin_init', [ $this, 'display_update_count_bubble_in_menu' ], 15 ); // Hook in early, but after PluginsManager is initialized.
@@ -30,6 +26,12 @@ class PluginsManager {
 	 * @param array  $plugin_data An array of plugin data. See `get_plugin_data()` & `plugin_row_meta` filter in WP core for the full list.
 	 */
 	public function output_plugin_row_information( $plugin_file, $plugin_data ) {
+		if ( null === $this->column_count ) {
+			// Check how many columns exist on the plugin's page.
+			$wp_list_table      = _get_list_table( 'WP_Plugins_List_Table', [ 'screen' => 'plugins' ] );
+			$this->column_count = method_exists( $wp_list_table, 'get_column_count' ) ? $wp_list_table->get_column_count() : 3;
+		}
+
 		$update_data = $this->update_data[ $plugin_file ] ?? new \stdClass();
 
 		$plugin = new Plugin( $plugin_file, $plugin_data, $update_data );


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
There is a bug in class-wp-plugins-list-table.php which makes the search parameter unescaped. CodebaseManager makes this bug more prevalent as it loads the problematic page on every admin_init (as opposed to only the plugin list). 

1) CodebaseManager during [init](https://github.com/Automattic/vip-go-mu-plugins/blob/2e00dd5111f6fa26fef54f1a776a34854b930849/codebase-manager/plugins/plugins-manager.php#L18) constructs WP_Plugins_List_Table
2) The [constructor](https://github.com/WordPress/wordpress-develop/blob/b71a7bfcfff6532d6f83b38dbe52bcb24208d37f/src/wp-admin/includes/class-wp-plugins-list-table.php#L57) of WP_Plugins_List_Table does the unencoding as a side effect

This workaround will avoid loading Codebase Manager when search parameter is present avoiding the problem.

## Changelog Description

### Plugin Updated: Codebase Manager

Workaround related to search unescaping in wp-admin.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Go to posts list
1) Search for `test&me` 
1) Search term changes to `test`