### PR TITLE
Fix fatal "Uncaught Error: Class "WP_Feed_Cache_Transient" not found"

### DIFF
--- a/vip-feed-cache/class-vip-go-feed-transient.php
+++ b/vip-feed-cache/class-vip-go-feed-transient.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! class_exists( 'WP_Feed_Cache_Transient' ) ) {
+	require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
+}
+
 class VIP_Go_Feed_Cache_Transient extends WP_Feed_Cache_Transient implements SimplePie_Cache_Base {
 	/**
 	 * Gets the transient.


### PR DESCRIPTION
## Description
This fixes the below fatal when the plugin `wp-rss-aggregator` is used on VIP:

```
 Fatal error: Uncaught Error: Class "WP_Feed_Cache_Transient" not found
in /var/www/wp-content/mu-plugins/vip-feed-cache/class-vip-go-feed-transient.php on line 7

Call stack:

require_once()
wp-content/mu-plugins/vip-feed-cache.php:19
vipgo_feed_options()
wp-includes/class-wp-hook.php:309
WP_Hook::apply_filters()
wp-includes/class-wp-hook.php:331
WP_Hook::do_action()
wp-includes/plugin.php:524
do_action_ref_array()
wp-content/plugins/wp-rss-aggregator/includes/feed-importing.php:406
wprss_fetch_feed()
wp-content/plugins/wp-rss-aggregator/includes/admin-metaboxes.php:502
wprss_preview_meta_box_callback()
wp-admin/includes/template.php:1401
do_meta_boxes()
wp-admin/edit-form-advanced.php:681
require()
wp-admin/post.php:206
```

## Changelog Description

### Plugin Updated: VIP Go Feed Cache

Fix incompatibility with wp-rss-aggregator plugin

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Use wp-rss-aggregator on VIP
2) Create a "Feed Source"
3) Go to edit "Feed Source" and see fatal crop up