### PR TITLE
Query Monitor: Add APCU Hot cache panel

### DIFF
--- a/qm-plugins/qm-apcu-cache/class-qm-apcu-cache-collector.php
+++ b/qm-plugins/qm-apcu-cache/class-qm-apcu-cache-collector.php
@@ -1,0 +1,9 @@
+<?php
+
+class QM_Apcu_Cache_Collector extends \QM_Collector {
+	public $id = 'qm-apcu-cache';
+
+	public function name() {
+		return esc_html__( 'APCU Hot-Cache', 'query-monitor' );
+	}
+}

--- a/qm-plugins/qm-apcu-cache/class-qm-apcu-cache-output-html.php
+++ b/qm-plugins/qm-apcu-cache/class-qm-apcu-cache-output-html.php
@@ -1,0 +1,38 @@
+<?php
+
+class QM_Apcu_Cache_Output extends \QM_Output_Html {
+
+	public function __construct( \QM_Collector $collector ) {
+		parent::__construct( $collector );
+
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 110 );
+	}
+
+	public function admin_menu( array $menu ) {
+
+		$menu[] = $this->menu( array(
+			'id'    => 'qm-apcu-cache',
+			'href'  => '#qm-apcu-cache',
+			'title' => esc_html__( 'APCU Hot-Cache', 'query-monitor' ),
+		));
+
+		return $menu;
+	}
+
+	public function output() {
+		?>
+		<div class="qm" id="<?php echo esc_attr( $this->collector->id ); ?>">
+			<div id="apcu-cache-stats">
+				<?php
+				global $apc_cache_interceptor;
+				if ( ! isset( $apc_cache_interceptor ) || ! is_object( $apc_cache_interceptor ) ) {
+					echo '<h2>APCU Hot-Caching is currently disabled</h2>';
+					return;
+				}
+				$apc_cache_interceptor->stats();
+				?>
+			</div>
+		</div>
+		<?php
+	}
+}

--- a/qm-plugins/qm-apcu-cache/qm-apcu-cache.php
+++ b/qm-plugins/qm-apcu-cache/qm-apcu-cache.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Plugin Name: Query Monitor APCu Cache Collector
+ * Description: Additional collector for Query Monitor for APCu Cache
+ * Version: 1.0
+ * Author: Automattic, Rebecca Hum
+ */
+
+add_action( 'plugins_loaded', 'register_qm_apcu_cache_collector' );
+function register_qm_apcu_cache_collector() {
+	if ( ! class_exists( 'QM_Collectors' ) ) {
+		return;
+	}
+
+	require_once __DIR__ . '/class-qm-apcu-cache-collector.php';
+
+	QM_Collectors::add( new QM_Apcu_Cache_Collector() );
+	add_filter( 'qm/outputter/html', 'register_qm_apcu_cache_output', 120, 2 );
+}
+
+function register_qm_apcu_cache_output( array $output, \QM_Collectors $collectors ) {
+	$collector = \QM_Collectors::get( 'qm-apcu-cache' );
+	if ( $collector ) {
+		require_once __DIR__ . '/class-qm-apcu-cache-output-html.php';
+
+		$output['qm-apcu-cache'] = new QM_Apcu_Cache_Output( $collector );
+	}
+	return $output;
+}

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -159,3 +159,4 @@ add_filter( 'qm/dispatchers', 'change_dispatchers_shutdown_priority', PHP_INT_MA
  */
 require_once __DIR__ . '/qm-plugins/qm-alloptions/qm-alloptions.php';
 require_once __DIR__ . '/qm-plugins/qm-object-cache/qm-object-cache.php';
+require_once __DIR__ . '/qm-plugins/qm-apcu-cache/qm-apcu-cache.php';


### PR DESCRIPTION
## Description
This adds the APCU Cache panel to Query Monitor
<img width="1513" alt="Screenshot 2022-10-28 at 5 50 31 PM" src="https://user-images.githubusercontent.com/16962021/198751503-3596bbbb-e8bd-4e65-9952-b01aae32287a.png">

## Changelog Description

### Plugin Updated: Query Monitor

Add APCU Cache panel to Query Monitor

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Go to Query Monitor
2) Click on "APCu Hot-Cache" Panel and verify it matches Debug Bar's