### PR TITLE
chore(deps): Update dependencies in action.yml

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -57,7 +57,7 @@ runs:
         fi
 
     - name: Set up PHP
-      uses: shivammathur/setup-php@2.21.2
+      uses: shivammathur/setup-php@2.22.0
       with:
         coverage: ${{ steps.coverage.outputs.coverage }}
         ini-values: ${{ steps.coverage.outputs.ini }}
@@ -76,7 +76,7 @@ runs:
       uses: ramsey/composer-install@2.1.0
 
     - name: Set up WordPress and WordPress Test Library
-      uses: sjinks/setup-wordpress-test-library@1.1.7
+      uses: sjinks/setup-wordpress-test-library@1.1.11
       with:
         version: ${{ inputs.wordpress }}
 
@@ -122,7 +122,7 @@ runs:
         "${PHPUNIT}" ${OPTIONS}
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v3.1.0
+      uses: codecov/codecov-action@v3.1.1
       with:
         files: ${{ inputs.coverage-file }}
         flags: ${{ inputs.coverage-flags }}


### PR DESCRIPTION
This PR updates all outdated dependencies in `.github/actions/run-wp-tests/action.yml`, as Dependabot does not check that location (and it seems like it can't be configured to check it).
