### PR TITLE
fix(cache): Fix "Undefined array key" in `Vary_Cache::parse_group_cookie()`

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -419,7 +419,7 @@ class Vary_Cache {
 			$cookie_value = $_SERVER[ self::HEADER_AUTH ];
 		} elseif ( self::is_encryption_enabled() && ! empty( $_COOKIE[ self::COOKIE_AUTH ] ) && isset( $_SERVER['HTTP_COOKIE'] ) ) {
 			// If the header auth isn't set (in case of a logged-in user), fall back to decrypting the cookie itself.
-			$auth_cookie = null;
+			$auth_cookie = '';
 			// $_COOKIE is automatically urldecoded, so we need to search through the $_SERVER version to get the unencoded one.
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			foreach ( explode( '; ', $_SERVER['HTTP_COOKIE'] ) as $rawcookie ) {
@@ -449,7 +449,7 @@ class Vary_Cache {
 		$cookie_value = str_replace( self::VERSION_PREFIX, '', $cookie_value );
 		$groups       = explode( self::GROUP_SEPARATOR, $cookie_value );
 		foreach ( $groups as $group ) {
-			if ( empty( $group ) ) {
+			if ( empty( $group ) || false === strpos( $group, self::VALUE_SEPARATOR ) ) {
 				continue;
 			}
 			list( $group_name, $group_value ) = explode( self::VALUE_SEPARATOR, $group );

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -700,4 +700,18 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 		$get_parse_group_cookie_method->invokeArgs( null, [] );
 		$this->assertEquals( $expected_result, Vary_Cache::get_groups() );
 	}
+
+	/**
+	 * @ticket 157433-z
+	 */
+	public function test_parse_group_cookie_malformed(): void {
+		$this->expectNotToPerformAssertions();
+
+		try {
+			$_COOKIE[ Vary_Cache::COOKIE_SEGMENT ] = sprintf( '%s%s', Vary_Cache::VERSION_PREFIX, 'name' );
+			Vary_Cache::parse_cookies();
+		} finally {
+			$_COOKIE = [];
+		}
+	}
 }


### PR DESCRIPTION
## Description

This PR fixes the "Undefined array key 1 in cache/class-vary-cache.php on line 455" warning.

Ref: 157433-z

## Changelog Description

### Plugin Updated: VIP Cache Personalization

Fix "Undefined array key" in `Vary_Cache::parse_group_cookie()`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

This change has relevant unit tests; the CI should pass.
