### PR TITLE
Query Monitor: Add cron panel

### DIFF
--- a/qm-plugins/qm-cron/class-qm-cron-collector.php
+++ b/qm-plugins/qm-cron/class-qm-cron-collector.php
@@ -1,0 +1,168 @@
+<?php
+
+class QM_Cron_Collector extends \QM_Collector {
+
+	/**
+	 * @var string
+	 */
+	public $id = 'qm-cron';
+
+	/**
+	 * Lists all crons that are defined in WP Core.
+	 *
+	 * @var array
+	 *
+	 * @internal To find all, search WP trunk for `wp_schedule_(single_)?event`.
+	 */
+	private $core_cron_hooks = [
+		'do_pings',
+		'importer_scheduled_cleanup',     // WP 3.1+.
+		'publish_future_post',
+		'update_network_counts',          // WP 3.1+.
+		'upgrader_scheduled_cleanup',     // WP 3.3+.
+		'wp_maybe_auto_update',           // WP 3.7+.
+		'wp_scheduled_auto_draft_delete', // WP 3.4+.
+		'wp_scheduled_delete',            // WP 2.9+.
+		'wp_split_shared_term_batch',     // WP 4.3+.
+		'wp_update_plugins',
+		'wp_update_themes',
+		'wp_version_check',
+	];
+
+	/**
+	 * @return string
+	 */
+	public function name() {
+		return esc_html__( 'Cron', 'query-monitor' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function process() {
+		$this->process_crons();
+		$this->process_schedules();
+	}
+
+	/**
+	 * Processes the cron jobs.
+	 *
+	 * @return void
+	 */
+	private function process_crons() {
+		$this->data['doing_cron'] = get_transient( 'doing_cron' ) ? true : false;
+
+		$crons = _get_cron_array();
+		if ( is_array( $crons ) && ! empty( $crons ) ) {
+			$this->data['crons'] = $crons;
+			$this->sort_count_crons( $crons );
+			$this->process_next_event_time( $crons );
+		}
+	}
+
+	/**
+	 * Sort and count crons.
+	 *
+	 * This function sorts the cron jobs into core crons, and custom crons. It also tallies
+	 * a total count for the crons as this number is otherwise tough to get.
+	 *
+	 * @param array $crons Cron events
+	 */
+	private function sort_count_crons( $crons ) {
+		$total_crons      = 0;
+		$total_core_crons = 0;
+		$total_user_crons = 0;
+		$core_crons       = [];
+		$user_crons       = [];
+		foreach ( $crons as $time => $time_cron_array ) {
+			foreach ( $time_cron_array as $hook => $data ) {
+				$total_crons += count( $data );
+
+				if ( in_array( $hook, $this->core_cron_hooks, true ) ) {
+					$core_crons[ $time ][ $hook ] = $data;
+					$total_core_crons            += count( $data );
+				} else {
+					$user_crons[ $time ][ $hook ] = $data;
+					$total_user_crons            += count( $data );
+				}
+			}
+		}
+
+		$this->data['total_crons']      = $total_crons;
+		$this->data['total_core_crons'] = $total_core_crons;
+		$this->data['core_crons']       = $core_crons;
+		$this->data['user_crons']       = $user_crons;
+		$this->data['total_user_crons'] = $total_user_crons;
+	}
+
+	/**
+	 * Process next cron event time
+	 *
+	 * @param array Cron events
+	 */
+	private function process_next_event_time( $crons ) {
+		$cron_times          = array_keys( $crons );
+		$unix_time_next_cron = (int) $cron_times[0];
+		$time_next_cron      = gmdate( 'Y-m-d H:i:s', $unix_time_next_cron );
+
+		$this->data['next_event_time']['human_time'] = $time_next_cron;
+		$this->data['next_event_time']['unix']       = $unix_time_next_cron;
+	}
+
+	/**
+	 * Sorting method for cron schedules. Order by schedules interval.
+	 *
+	 * @param array $schedule_a First element of comparison pair.
+	 * @param array $schedule_b Second element of comparison pair.
+	 *
+	 * @return int Return 1 if $schedule_a argument 'interval' greater then $schedule_b argument 'interval',
+	 *             0 if both intervals equivalent and -1 otherwise.
+	 */
+	private function schedules_sorting( $schedule_a, $schedule_b ) {
+		if ( (int) $schedule_a['interval'] === (int) $schedule_b['interval'] ) {
+			return 0;
+		} else {
+			return ( ( (int) $schedule_a['interval'] > (int) $schedule_b['interval'] ) ? 1 : -1 );
+		}
+	}
+
+	/**
+	 * Process cron schedules
+	 */
+	private function process_schedules() {
+		$schedules = wp_get_schedules();
+		ksort( $schedules );
+		uasort( $schedules, array( $this, 'schedules_sorting' ) );
+
+		foreach ( $schedules as $interval_hook => $data ) {
+			$interval = (int) $data['interval'];
+
+			$this->data['schedules'][ $interval_hook ] = [
+				'interval' => $interval,
+				'display'  => $data['display'],
+			];
+		}
+	}
+
+	/**
+	 * Transform a time in seconds to minutes rounded to 2 decimals.
+	 *
+	 * @param int $time Unix timestamp.
+	 *
+	 * @return float
+	 */
+	private function get_minutes( $time ) {
+		return round( ( (int) $time / 60 ), 2 );
+	}
+
+	/**
+	 * Transform a time in seconds to hours rounded to 2 decimals.
+	 *
+	 * @param int $time Unix timestamp.
+	 *
+	 * @return float
+	 */
+	private function get_hours( $time ) {
+		return round( ( (int) $time / 3600 ), 2 );
+	}
+}

--- a/qm-plugins/qm-cron/class-qm-cron-collector.php
+++ b/qm-plugins/qm-cron/class-qm-cron-collector.php
@@ -1,6 +1,6 @@
 <?php
 
-class QM_Cron_Collector extends \QM_Collector {
+class QM_Cron_Collector extends QM_Collector {
 
 	/**
 	 * @var string

--- a/qm-plugins/qm-cron/class-qm-cron-collector.php
+++ b/qm-plugins/qm-cron/class-qm-cron-collector.php
@@ -139,26 +139,4 @@ class QM_Cron_Collector extends QM_Collector {
 			];
 		}
 	}
-
-	/**
-	 * Transform a time in seconds to minutes rounded to 2 decimals.
-	 *
-	 * @param int $time Unix timestamp.
-	 *
-	 * @return float
-	 */
-	private function get_minutes( $time ) {
-		return round( ( (int) $time / 60 ), 2 );
-	}
-
-	/**
-	 * Transform a time in seconds to hours rounded to 2 decimals.
-	 *
-	 * @param int $time Unix timestamp.
-	 *
-	 * @return float
-	 */
-	private function get_hours( $time ) {
-		return round( ( (int) $time / 3600 ), 2 );
-	}
 }

--- a/qm-plugins/qm-cron/class-qm-cron-collector.php
+++ b/qm-plugins/qm-cron/class-qm-cron-collector.php
@@ -119,11 +119,7 @@ class QM_Cron_Collector extends QM_Collector {
 	 *             0 if both intervals equivalent and -1 otherwise.
 	 */
 	private function schedules_sorting( $schedule_a, $schedule_b ) {
-		if ( (int) $schedule_a['interval'] === (int) $schedule_b['interval'] ) {
-			return 0;
-		} else {
-			return ( ( (int) $schedule_a['interval'] > (int) $schedule_b['interval'] ) ? 1 : -1 );
-		}
+		return (int) $schedule_a['interval'] <=> (int) $schedule_b['interval'];
 	}
 
 	/**

--- a/qm-plugins/qm-cron/class-qm-cron-output-html.php
+++ b/qm-plugins/qm-cron/class-qm-cron-output-html.php
@@ -1,0 +1,333 @@
+<?php
+
+class QM_Cron_Output extends \QM_Output_Html {
+
+	private $doing_cron = false;
+
+	public function __construct( \QM_Collector $collector ) {
+		parent::__construct( $collector );
+
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 110 );
+	}
+
+	public function admin_menu( array $menu ) {
+		$menu[] = $this->menu( array(
+			'id'    => 'qm-cron',
+			'href'  => '#qm-cron',
+			'title' => esc_html__( 'Cron', 'query-monitor' ),
+		));
+
+		return $menu;
+	}
+
+	public function output() {
+		$data             = $this->collector->get_data();
+		$this->doing_cron = $data['doing_cron'];
+		?>
+		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
+		<table id="qm-cron-stats" style="width: 100%">
+			<thead>
+				<tr>
+					<th><h3><?php esc_html_e( 'Total Events', 'query-monitor' ); ?></h3></th>
+					<th><h3><?php esc_html_e( 'Core Events', 'query-monitor' ); ?></h3></th>
+					<th><h3><?php esc_html_e( 'Custom Events', 'query-monitor' ); ?></h3></th>
+					<th><h3><?php esc_html_e( 'Doing Cron', 'query-monitor' ); ?></h3></th>
+					<th><h3><?php esc_html_e( 'Next Event', 'query-monitor' ); ?></h3></th>
+					<th><h3><?php esc_html_e( 'Current Time', 'query-monitor' ); ?></h3></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><?php echo absint( $data['total_crons'] ); ?></td>
+					<td><?php echo absint( $data['total_core_crons'] ); ?></td>
+					<td><?php echo absint( $data['total_user_crons'] ); ?></td>
+					<td><?php true === $this->doing_cron ? esc_html_e( 'Yes', 'query-monitor' ) : esc_html_e( 'No', 'query-monitor' ); ?></td>
+					<td>
+						<?php
+						echo esc_html( $data['next_event_time']['human_time'] );
+						echo '<br>';
+						echo absint( $data['next_event_time']['unix'] );
+						echo '<br>';
+						echo '<i>' . esc_html( $this->display_past_time( human_time_diff( $data['next_event_time']['unix'] ), $data['next_event_time']['unix'] ) ) . '</i>';
+						?>
+					</td>
+					<td><?php echo esc_html( gmdate( 'H:i:s' ) ); ?></td>
+				</tr>
+			</tbody>
+		</table>
+		<br>
+		<h3><b>Schedules</b></h3>
+		<table id="qm-cron-schedules" style="width: 100%">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Interval Hook', 'query-monitor' ); ?></span></th>
+					<th><?php esc_html_e( 'Interval (S)', 'query-monitor' ); ?></th>
+					<th><?php esc_html_e( 'Interval (M)', 'query-monitor' ); ?></th>
+					<th><?php esc_html_e( 'Interval (H)', 'query-monitor' ); ?></th>
+					<th><?php esc_html_e( 'Display Name', 'query-monitor' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php
+				foreach ( $data['schedules'] as $schedule => $value ) {
+					echo '<tr>';
+					echo '<th>' . esc_html( $schedule ) . '</th>';
+					echo '<th>' . esc_html( $value['interval'] ) . '</th>';
+					echo '<th>' . esc_html( $this->get_minutes( $value['interval'] ) ) . '</th>';
+					echo '<th>' . esc_html( $this->get_hours( $value['interval'] ) ) . '</th>';
+					echo '<th>' . esc_html( $value['display'] ) . '</th>';
+					echo '</tr>';
+				}
+				?>
+			</tbody>
+		</table>
+		<br>
+		<h3><b>Custom Events</b></h3>
+		<?php $this->display_events( $data['user_crons'], 'qm-cron-user-crons' ); ?>
+		<br>
+		<h3><b>Core Events</b></h3>
+		<?php $this->display_events( $data['core_crons'], 'qm-cron-core-crons' ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Displays the events in an easy to read table.
+	 *
+	 * @param array  $events        Array of events.
+	 * @param string $no_events_msg Message to display if there are no events.
+	 */
+	private function display_events( $events, $html_table_id = '', $no_events_msg = 'No events found' ) {
+		// Exit early if no events found.
+		if ( ! is_array( $events ) || empty( $events ) ) {
+			echo '
+			<p>', esc_html( $no_events_msg ), '</p>';
+			return;
+		}
+
+		echo '
+			<table class="qm-cron-table qm-cron-event-table">
+				<thead><tr>
+					<th class="col1">', esc_html__( 'Next Execution', 'query-monitor' ), '</th>
+					<th class="col2">', esc_html__( 'Hook', 'query-monitor' ), '</th>
+					<th class="col3">', esc_html__( 'Interval Hook', 'query-monitor' ), '</th>
+					<th class="col4">', esc_html__( 'Interval Value', 'query-monitor' ), '</th>
+					<th class="col5">', esc_html__( 'Args', 'query-monitor' ), '</th>
+				</tr></thead>
+				<tbody>';
+
+		foreach ( $events as $time => $time_cron_array ) {
+			$time        = (int) $time;
+			$event_count = $this->get_arg_set_count( $time_cron_array );
+			$show_time   = true;
+
+			foreach ( $time_cron_array as $hook => $data ) {
+				$row_attributes = $this->get_event_row_attributes( $time, $hook );
+				$arg_set_count  = count( $data );
+				$show_hook      = true;
+
+				foreach ( $data as $hash => $info ) {
+					echo '<tr', $row_attributes, '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+					if ( true === $show_time ) {
+						$this->display_event_time( $time, $event_count );
+						$show_time = false;
+					}
+
+					if ( true === $show_hook ) {
+						$this->display_event_hook( $hook, $arg_set_count );
+						$show_hook = false;
+					}
+
+					// Report the schedule.
+					echo '<td>';
+					$this->display_event_schedule( $info );
+					echo '</td>';
+
+					// Report the interval.
+					echo '<td class="intervals">';
+					$this->display_event_intervals( $info );
+					echo '</td>';
+
+					// Report the args.
+					echo '<td>';
+					$this->display_event_cron_arguments( $info['args'] );
+					echo '</td></tr>';
+				}
+				unset( $hash, $info );
+			}
+			unset( $hook, $data, $row_attributes, $arg_set_count, $show_hook );
+		}
+		unset( $time, $time_cron_array, $show_time );
+
+		echo '</tbody></table>';
+	}
+
+	/**
+	 * Count the number of argument sets for a cron time.
+	 *
+	 * @param array $hook_array Array of hooks with argument sets.
+	 *
+	 * @return int
+	 */
+	private function get_arg_set_count( $hook_array ) {
+		$count = 0;
+		foreach ( $hook_array as $set ) {
+			$count += count( $set );
+		}
+		return $count;
+	}
+
+	/**
+	* Create a HTML attribute string for an event row.
+	*
+	* @param int    $time Unix timestamp.
+	* @param string $hook Action hook for the cron job.
+	*
+	* @return string
+	*/
+	private function get_event_row_attributes( $time, $hook ) {
+		$attributes = '';
+
+		// Verify if any events are hooked in.
+		if ( false === has_action( $hook ) ) {
+			/* translators: This text will display as a tooltip. %1$s will be replaced by a line break. */
+			$attributes .= ' title="' . sprintf( esc_attr__( 'No actions are hooked into this event at this time.%1$sThe most likely reason for this is that a plugin or theme was de-activated or uninstalled and didn\'t clean up after itself.%1$sHowever, a number of plugins also use the best practice of lean loading and only hook in conditionally, so check carefully if you intend to remove this event.', 'query-monitor' ), "\n" ) . '"';
+		}
+
+		return $attributes;
+	}
+
+	/**
+	* Display the timing for the event as a date, timestamp and human readable time difference.
+	*
+	* @param int $time        Timestamp.
+	* @param int $event_count Number of events running at this time.
+	*/
+	private function display_event_time( $time, $event_count ) {
+		$row_span = ( $event_count > 1 ) ? ' rowspan="' . esc_attr( $event_count ) . '"' : '';
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<td' . $row_span . '>
+		   ', esc_html( gmdate( 'Y-m-d H:i:s', $time ) ), '<br />
+		   ', esc_html( $time ), '<br />
+		   ', '<i>' . esc_html( $this->display_past_time( human_time_diff( $time ), $time ) ) . '</i>', '
+	   </td>';
+	}
+
+
+	/**
+	* Display the name of the cron job event hook.
+	*
+	* @param string $hook          Hook name.
+	* @param int    $arg_set_count Number of events running at this time and on this hook.
+	*/
+	private function display_event_hook( $hook, $arg_set_count ) {
+		$row_span = ( $arg_set_count > 1 ) ? ' rowspan="' . esc_attr( $arg_set_count ) . '"' : '';
+
+		echo '<td' . $row_span . '>', esc_html( $hook ), '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+
+	/**
+	* Displays the the event schedule name for recurring events or else 'single event'.
+	*
+	* @param array $info Event info array.
+	*/
+	private function display_event_schedule( $info ) {
+		if ( ! empty( $info['schedule'] ) ) {
+			echo esc_html( $info['schedule'] );
+		} else {
+			esc_html_e( 'Single Event', 'query-monitor' );
+		}
+	}
+
+
+	/**
+	* Displays the event interval in seconds, minutes and hours.
+	*
+	* @param array $info Event info array.
+	*/
+	private function display_event_intervals( $info ) {
+		if ( ! empty( $info['interval'] ) ) {
+			$interval = (int) $info['interval'];
+			/* translators: %s is number of seconds. */
+			printf( esc_html__( '%ss', 'query-monitor' ) . '<br />', esc_html( $interval ) );
+			/* translators: %s is number of minutes. */
+			printf( esc_html__( '%sm', 'query-monitor' ) . '<br />', esc_html( $this->get_minutes( $interval ) ) );
+			/* translators: %s is number of hours. */
+			printf( esc_html__( '%sh', 'query-monitor' ), esc_html( $this->get_hours( $interval ) ) );
+			unset( $interval );
+		} else {
+			esc_html_e( 'Single Event', 'query-monitor' );
+		}
+	}
+
+	/**
+	* Displays the cron arguments in a readable format.
+	*
+	* @param mixed $args Cron argument(s).
+	*
+	* @return void
+	*/
+	private function display_event_cron_arguments( $args ) {
+		// Arguments defaults to an empty array if no arguments are given.
+		if ( is_array( $args ) && array() === $args ) {
+			esc_html_e( 'No Args', 'query-monitor' );
+			return;
+		}
+
+		echo wp_json_encode( $args );
+	}
+
+	/**
+	 * Verify if a given timestamp is in the past or the future.
+	 *
+	 * @param int $time Unix timestamp.
+	 *
+	 * @return bool True if the time has passed, false otherwise.
+	 */
+	private function is_time_in_past( $time ) {
+		return ( time() > $time && false === $this->doing_cron );
+	}
+
+	/**
+	 * Compares time with current time and adds ' ago' if current time is greater than event time.
+	 *
+	 * @param string $human_time Human readable time difference.
+	 * @param int    $time       Unix time of event.
+	 *
+	 * @return string
+	 */
+	private function display_past_time( $human_time, $time ) {
+		if ( time() > $time ) {
+			/* translators: %s is a human readable time difference. */
+			return sprintf( esc_html__( '%s ago', 'query-monitor' ), $human_time );
+		} else {
+			return $human_time;
+		}
+	}
+
+	/**
+	 * Transform a time in seconds to minutes rounded to 2 decimals.
+	 *
+	 * @param int $time Unix timestamp.
+	 *
+	 * @return float
+	 */
+	private function get_minutes( $time ) {
+		return round( ( (int) $time / 60 ), 2 );
+	}
+
+
+	/**
+	 * Transform a time in seconds to hours rounded to 2 decimals.
+	 *
+	 * @param int $time Unix timestamp.
+	 *
+	 * @return float
+	 */
+	private function get_hours( $time ) {
+		return round( ( (int) $time / 3600 ), 2 );
+	}
+}

--- a/qm-plugins/qm-cron/class-qm-cron-output-html.php
+++ b/qm-plugins/qm-cron/class-qm-cron-output-html.php
@@ -272,7 +272,7 @@ class QM_Cron_Output extends QM_Output_Html {
 	*/
 	private function display_event_cron_arguments( $args ) {
 		// Arguments defaults to an empty array if no arguments are given.
-		if ( is_array( $args ) && array() === $args ) {
+		if ( is_array( $args ) && empty( $args ) ) {
 			esc_html_e( 'No Args', 'query-monitor' );
 			return;
 		}

--- a/qm-plugins/qm-cron/class-qm-cron-output-html.php
+++ b/qm-plugins/qm-cron/class-qm-cron-output-html.php
@@ -284,17 +284,6 @@ class QM_Cron_Output extends QM_Output_Html {
 	}
 
 	/**
-	 * Verify if a given timestamp is in the past or the future.
-	 *
-	 * @param int $time Unix timestamp.
-	 *
-	 * @return bool True if the time has passed, false otherwise.
-	 */
-	private function is_time_in_past( $time ) {
-		return ( time() > $time && false === $this->doing_cron );
-	}
-
-	/**
 	 * Compares time with current time and adds ' ago' if current time is greater than event time.
 	 *
 	 * @param string $human_time Human readable time difference.

--- a/qm-plugins/qm-cron/class-qm-cron-output-html.php
+++ b/qm-plugins/qm-cron/class-qm-cron-output-html.php
@@ -1,6 +1,6 @@
 <?php
 
-class QM_Cron_Output extends \QM_Output_Html {
+class QM_Cron_Output extends QM_Output_Html {
 
 	private $doing_cron = false;
 

--- a/qm-plugins/qm-cron/class-qm-cron-output-html.php
+++ b/qm-plugins/qm-cron/class-qm-cron-output-html.php
@@ -129,7 +129,7 @@ class QM_Cron_Output extends QM_Output_Html {
 				foreach ( $data as $hash => $info ) {
 					echo '<tr', $row_attributes, '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-					if ( true === $show_time ) {
+					if ( $show_time ) {
 						$this->display_event_time( $time, $event_count );
 						$show_time = false;
 					}

--- a/qm-plugins/qm-cron/class-qm-cron-output-html.php
+++ b/qm-plugins/qm-cron/class-qm-cron-output-html.php
@@ -26,6 +26,7 @@ class QM_Cron_Output extends QM_Output_Html {
 		?>
 		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
 		<table id="qm-cron-stats" style="width: 100%">
+			<caption>Cron event statistics</caption>
 			<thead>
 				<tr>
 					<th><h3><?php esc_html_e( 'Total Events', 'query-monitor' ); ?></h3></th>
@@ -56,8 +57,9 @@ class QM_Cron_Output extends QM_Output_Html {
 			</tbody>
 		</table>
 		<br />
-		<h3><b>Schedules</b></h3>
+		<h3><strong>Schedules</strong></h3>
 		<table id="qm-cron-schedules" style="width: 100%">
+			<caption>List of set schedules for cron events</caption>
 			<thead>
 				<tr>
 					<th><?php esc_html_e( 'Interval Hook', 'query-monitor' ); ?></span></th>
@@ -82,10 +84,10 @@ class QM_Cron_Output extends QM_Output_Html {
 			</tbody>
 		</table>
 		<br />
-		<h3><b>Custom Events</b></h3>
+		<h3><strong>Custom Events</strong></h3>
 		<?php $this->display_events( $data['user_crons'], 'qm-cron-user-crons' ); ?>
 		<br />
-		<h3><b>Core Events</b></h3>
+		<h3><strong>Core Events</strong></h3>
 		<?php $this->display_events( $data['core_crons'], 'qm-cron-core-crons' ); ?>
 		</div>
 		<?php
@@ -107,6 +109,7 @@ class QM_Cron_Output extends QM_Output_Html {
 
 		echo '
 			<table class="qm-cron-table qm-cron-event-table">
+			<caption>Cron Events Listing</caption>
 				<thead><tr>
 					<th class="col1">', esc_html__( 'Next Execution', 'query-monitor' ), '</th>
 					<th class="col2">', esc_html__( 'Hook', 'query-monitor' ), '</th>

--- a/qm-plugins/qm-cron/class-qm-cron-output-html.php
+++ b/qm-plugins/qm-cron/class-qm-cron-output-html.php
@@ -45,9 +45,9 @@ class QM_Cron_Output extends QM_Output_Html {
 					<td>
 						<?php
 						echo esc_html( $data['next_event_time']['human_time'] );
-						echo '<br>';
+						echo '<br />';
 						echo absint( $data['next_event_time']['unix'] );
-						echo '<br>';
+						echo '<br />';
 						echo '<i>' . esc_html( $this->display_past_time( human_time_diff( $data['next_event_time']['unix'] ), $data['next_event_time']['unix'] ) ) . '</i>';
 						?>
 					</td>
@@ -55,7 +55,7 @@ class QM_Cron_Output extends QM_Output_Html {
 				</tr>
 			</tbody>
 		</table>
-		<br>
+		<br />
 		<h3><b>Schedules</b></h3>
 		<table id="qm-cron-schedules" style="width: 100%">
 			<thead>
@@ -81,10 +81,10 @@ class QM_Cron_Output extends QM_Output_Html {
 				?>
 			</tbody>
 		</table>
-		<br>
+		<br />
 		<h3><b>Custom Events</b></h3>
 		<?php $this->display_events( $data['user_crons'], 'qm-cron-user-crons' ); ?>
-		<br>
+		<br />
 		<h3><b>Core Events</b></h3>
 		<?php $this->display_events( $data['core_crons'], 'qm-cron-core-crons' ); ?>
 		</div>

--- a/qm-plugins/qm-cron/qm-cron.php
+++ b/qm-plugins/qm-cron/qm-cron.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Plugin Name: Query Monitor Cron
+ * Description: Additional collector for Query Monitor for Cron. Adapted from Debug Bar Cron.
+ * Version: 1.0
+ * Author: Automattic
+ */
+
+add_action( 'plugins_loaded', 'register_qm_cron' );
+function register_qm_cron() {
+	if ( ! class_exists( 'QM_Collectors' ) ) {
+		return;
+	}
+
+	require_once __DIR__ . '/class-qm-cron-collector.php';
+
+	QM_Collectors::add( new QM_Cron_Collector() );
+	add_filter( 'qm/outputter/html', 'register_qm_cron_output', 120, 2 );
+}
+
+function register_qm_cron_output( array $output, \QM_Collectors $collectors ) {
+	$collector = \QM_Collectors::get( 'qm-cron' );
+	if ( $collector ) {
+		require_once __DIR__ . '/class-qm-cron-output-html.php';
+
+		$output['qm-cron'] = new QM_Cron_Output( $collector );
+	}
+	return $output;
+}

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -160,3 +160,4 @@ add_filter( 'qm/dispatchers', 'change_dispatchers_shutdown_priority', PHP_INT_MA
 require_once __DIR__ . '/qm-plugins/qm-alloptions/qm-alloptions.php';
 require_once __DIR__ . '/qm-plugins/qm-object-cache/qm-object-cache.php';
 require_once __DIR__ . '/qm-plugins/qm-apcu-cache/qm-apcu-cache.php';
+require_once __DIR__ . '/qm-plugins/qm-cron/qm-cron.php';

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -160,4 +160,6 @@ add_filter( 'qm/dispatchers', 'change_dispatchers_shutdown_priority', PHP_INT_MA
 require_once __DIR__ . '/qm-plugins/qm-alloptions/qm-alloptions.php';
 require_once __DIR__ . '/qm-plugins/qm-object-cache/qm-object-cache.php';
 require_once __DIR__ . '/qm-plugins/qm-apcu-cache/qm-apcu-cache.php';
-require_once __DIR__ . '/qm-plugins/qm-cron/qm-cron.php';
+if ( file_exists( __DIR__ . '/qm-plugins/qm-cron/qm-cron.php' ) ) {
+	require_once __DIR__ . '/qm-plugins/qm-cron/qm-cron.php';
+}


### PR DESCRIPTION
## Description
This adds the cron panel to query monitor.
<img width="1570" alt="Screenshot 2022-11-01 at 10 43 02 AM" src="https://user-images.githubusercontent.com/16962021/199288585-c1a053e5-74ee-4eb6-b9fe-d23d9d8dc0dc.png">


## Changelog Description
### Plugin Updated: Query Monitor

We added a panel to display cron events.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Go to query monitor > Cron and verify it matches with what is in Debug Bar