### PR TITLE
e2e: addImage() needs to click instead of tab

### DIFF
--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -153,7 +153,7 @@ export class EditorPage {
         if ( await this.page.isVisible( selectors.blockAppender ) ) {
             await this.page.click( selectors.blockAppender );
         } else {
-            await this.page.keyboard.press( 'Tab' );
+            await this.page.click( selectors.editorTitleContainer );
             await this.page.click( selectors.blockInserter );
         }
         await this.page.click( selectors.imageBlocks );


### PR DESCRIPTION
## Description
Fix failing e2e with the latest WP update. We should click elsewhere instead of tabbing over.

