### PR TITLE
ci: Fix core tests

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -177,9 +177,11 @@ if ( ! defined( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION' ) ) {
 	define( 'VIP_JETPACK_AUTO_MANAGE_CONNECTION', WPCOM_IS_VIP_ENV );
 }
 
-// Interaction with the filesystem will always be direct.
-// Avoids issues with `get_filesystem_method` which attempts to write to `WP_CONTENT_DIR` and fails.
-define( 'FS_METHOD', 'direct' );
+if ( ! defined( 'FS_METHOD' ) ) {
+	// Interaction with the filesystem will always be direct.
+	// Avoids issues with `get_filesystem_method` which attempts to write to `WP_CONTENT_DIR` and fails.
+	define( 'FS_METHOD', 'direct' );
+}
 
 if ( WPCOM_SANDBOXED ) {
 	require __DIR__ . '/vip-helpers/sandbox.php';
@@ -256,16 +258,19 @@ if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && ! defined( 'WP_ENVIRONMENT_TYPE' ) )
 	define( 'WP_ENVIRONMENT_TYPE', $environment_type );
 }
 
-// Load config related helpers
-require_once __DIR__ . '/config/class-sync.php';
+if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
+	// Load config related helpers
+	require_once __DIR__ . '/config/class-sync.php';
 
-add_action( 'init', [ Sync::class, 'instance' ] );
+	add_action( 'init', [ Sync::class, 'instance' ] );
 
-// Load _encloseme meta cleanup scheduler
-require_once __DIR__ . '/lib/class-vip-encloseme-cleanup.php';
 
-$encloseme_cleaner = new VIP_Encloseme_Cleanup();
-$encloseme_cleaner->init();
+	// Load _encloseme meta cleanup scheduler
+	require_once __DIR__ . '/lib/class-vip-encloseme-cleanup.php';
+
+	$encloseme_cleaner = new VIP_Encloseme_Cleanup();
+	$encloseme_cleaner->init();
+}
 
 // Add custom header for VIP
 add_filter( 'wp_headers', function( $headers ) {

--- a/files/init-filesystem.php
+++ b/files/init-filesystem.php
@@ -25,11 +25,11 @@ require_once __DIR__ . '/class-api-client.php';
 // it does a check for class_exists() of the filesystem method i.e. `WP_Filesystem_{type}`
 class WP_Filesystem_VIP extends Automattic\VIP\Files\WP_Filesystem_VIP {}
 
-$priority = ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) ? PHP_INT_MAX : 10;
-add_filter( 'filesystem_method', function() {
-	return VIP_FILESYSTEM_METHOD; // The VIP base class transparently handles using the direct filesystem as well as the VIP Go File API
-}, $priority );
-unset( $priority );
+if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
+	add_filter( 'filesystem_method', function() {
+		return VIP_FILESYSTEM_METHOD; // The VIP base class transparently handles using the direct filesystem as well as the VIP Go File API
+	}, PHP_INT_MAX );
+}
 
 add_filter( 'request_filesystem_credentials', function( $credentials, $form_post, $type ) {
 	// Handle the default `''` case which we'll override thanks to the `filesystem_method` filter.

--- a/vip-helpers/vip-notoptions-mitigation.php
+++ b/vip-helpers/vip-notoptions-mitigation.php
@@ -10,6 +10,10 @@ namespace Automattic\VIP;
 
 use Automattic\VIP\Utils\Alerts;
 
+if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
+	return;
+}
+
 define( 'USER_ROLE_BACKUP_LENGTH', 3 );
 
 if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {


### PR DESCRIPTION
WP 6.1 seems to handle filesystems differently, and we have to avoid setting up the `filesystem_method` filter.