### PR TITLE
Add vip_get_hyper_servers()

### DIFF
--- a/001-core/constants.php
+++ b/001-core/constants.php
@@ -15,13 +15,13 @@ function define_db_constants( $hyperdb ): void {
 	if ( defined( 'DB_NAME' ) || defined( 'DB_HOST' ) || defined( 'DB_PASSWORD' ) || defined( 'DB_USER' ) ) {
 		return;
 	}
-
-	if ( ! method_exists( $hyperdb, 'get_hyper_servers' ) ) {
+	require_once __DIR__ . '/../vip-helpers/vip-utils.php';
+	if ( ! function_exists( 'vip_get_hyper_servers' ) ) {
 		return;
 	}
 
-	$db_servers = $hyperdb->get_hyper_servers( 'write' );
-	if ( ! is_array( $db_servers ) ) {
+	$db_servers = vip_get_hyper_servers( $hyperdb, 'write' );
+	if ( ! is_array( $db_servers ) || empty( $db_servers ) ) {
 		return;
 	}
 

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -498,7 +498,7 @@ function vip_regex_redirects( $vip_redirects_array = array(), $with_querystring 
 
 /**
  * Internal helper function to log request failure.
- * 
+ *
  * @param string $url
  * @param WP_Error|array|false $response
  * @return void
@@ -651,7 +651,7 @@ function wpcom_vip_file_get_contents( $url, $timeout = 3, $cache_time = 900, $ex
 		} elseif ( $response ) {
 			// We were unable to fetch any content, so don't try again for another 60 seconds
 			wp_cache_set( $disable_get_key, 1, $cache_group, 60 );
-	
+
 			// If a remote request failed, log why it did
 			_wpcom_log_failed_request( $url, $response );
 
@@ -1597,4 +1597,25 @@ function wpcom_vip_irc( $channel_or_user, $message, $level = 0, $kind = '', $int
 	}
 
 	return true;
+}
+
+/**
+ * Get array of $hyper_servers
+ *
+ * @param $hyperdb Hyperdb object.
+ * @param $operation Returns servers with both 'read' and 'write' operations if none passed in.
+ * @param $dataset Defaults to 'global' if none passed in.
+ * @return array $hyper_servers
+ */
+function vip_get_hyper_servers( $hyperdb, $operation = 'all', $dataset = 'global' ) {
+	if ( ! is_object( $hyperdb ) || ! isset( $hyperdb->hyper_servers ) || ! isset( $hyperdb->hyper_servers[ $dataset ] ) ) {
+		return array();
+	}
+
+	$operations = array( 'read', 'write' );
+	if ( in_array( $operation, $operations, true ) ) {
+		return $hyperdb->hyper_servers[ $dataset ][ $operation ];
+	}
+
+	return $hyperdb->hyper_servers[ $dataset ];
 }


### PR DESCRIPTION
## Description
Since `$hyperdb->get_hyper_servers()` wasn't accepted upstream, this adds the VIP helper method instead. Should be returning the same result.

## Changelog Description

### Plugin Updated: VIP Utils

Add vip_get_hyper_servers() method.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Sandbox and compare the result between `vip_get_hyper_servers( $hyperdb, 'write' );` and `$hyperdb->get_hyper_servers( 'write' );` to ensure they are the same.