### PR TITLE
fix(files): `touch()` should fail if `fclose()` fails

### DIFF
--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -702,8 +702,7 @@ class VIP_Filesystem_Stream_Wrapper {
 				if ( false === file_exists( $path ) ) {
 					$file = fopen( $path, 'w' );    // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
 					if ( is_resource( $file ) ) {
-						fclose( $file );
-						return true;
+						return fclose( $file );
 					}
 
 					return false;


### PR DESCRIPTION
## Description

The `touch()` implementation introduced in #3776 assumed that `close()` could not fail. As always, assumptions and the truth dine at totally separate tables.

## Changelog Description

### Plugin Updated: VIP Filesystem Services

Fix `touch()` implementation to return `false` if `fclose()` fails.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

`touch("vip://wp-content/uploads/test.php");` in the WP Shell should return `false` if `stream_flush` fails.
