### PR TITLE
fix(files): Clear stats cache when upload of an empty file fails

### DIFF
--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -316,17 +316,22 @@ class VIP_Filesystem_Stream_Wrapper {
 
 		try {
 			// Upload to file service
-			$result                   = $this->client->upload_file( $this->uri, $this->path );
-			$this->should_flush_empty = false;
+			$result = $this->client->upload_file( $this->uri, $this->path );
 			if ( is_wp_error( $result ) ) {
 				trigger_error(
 					sprintf( 'stream_flush failed for %s with error: %s #vip-go-streams', esc_html( $this->path ), esc_html( $result->get_error_message() ) ),
 					E_USER_WARNING
 				);
 
+				if ( $this->should_flush_empty ) {
+					$this->should_flush_empty = false;
+					$this->client->cache_file_stats( $this->path, [] );
+				}
+
 				return false;
 			}
 
+			$this->should_flush_empty = false;
 			return fflush( $this->file );
 		} catch ( \Exception $e ) {
 			trigger_error(

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -702,8 +702,7 @@ class VIP_Filesystem_Stream_Wrapper {
 				if ( false === file_exists( $path ) ) {
 					$file = fopen( $path, 'w' );    // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
 					if ( is_resource( $file ) ) {
-						fclose( $file );
-						return true;
+						return fclose( $file );
 					}
 
 					return false;

--- a/files/class-vip-filesystem-stream-wrapper.php
+++ b/files/class-vip-filesystem-stream-wrapper.php
@@ -325,6 +325,14 @@ class VIP_Filesystem_Stream_Wrapper {
 
 				if ( $this->should_flush_empty ) {
 					$this->should_flush_empty = false;
+					/*
+					 * The API client does not have a method to clear file stats cache;
+					 * However, if we pass an empty array, this effectively clears the cache.
+					 * See API_Client::is_file(): if $stats is empty, it calls the API.
+					 *
+					 * We have to clear the cache because we have failed to upload the file;
+					 * as a result, it was not create on the remote end.
+					 */
 					$this->client->cache_file_stats( $this->path, [] );
 				}
 


### PR DESCRIPTION
## Description

If we create an empty file and then close it, and for some reason the upload fails, subsequent calls to the `stats` family pretend that the file exists:

```
wp> touch("vip://wp-content/uploads/test.php");
[08-Nov-2022 22:01:01 UTC] Warning: stream_flush failed for wp-content/uploads/test.php with error: Failed to upload file `/tmp/phpdimqHB` to `wp-content/uploads/test.php` (response code: 404) #vip-go-streams in /chroot/var/www/wp-content/mu-plugins/files/class-vip-filesystem-stream-wrapper.php on line 323
bool(false)
wp> is_file("vip://wp-content/uploads/test.php");
=> phar:///usr/local/bin/wp/vendor/wp-cli/shell-command/src/WP_CLI/Shell/REPL.php:52:
bool(true)
```

This happens because `stream_open()` calls `cache_file_stats()` on a temporary file, but `stream_close()` does not clear it if the upload fails (and file is not created).

This PR fixes that.

## Changelog Description

### Plugin Updated: VIP Filesystem Services

Fix the case when the upload of an empty file fails, but the cached stats are not cleared.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Follow the steps in the description; it is very hard to write meaningful tests because `call_api()` method is private.