### PR TITLE
ci: Update E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,7 +108,7 @@ jobs:
         working-directory: __tests__/e2e
 
       - name: Install VIP CLI
-        run: npm install -g @automattic/vip@2.20.0
+        run: npm install -g @automattic/vip@2.22.0
 
       - name: Determine WP version
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,8 +75,11 @@ jobs:
             packages.microsoft.com:443
             download.cypress.io:443
             cdn.cypress.io:443
-            foresight.service.thundra.io
-            foresight-cli-test-artifact-prod.s3-accelerate.amazonaws.com
+            foresight.service.thundra.io:443
+            foresight-cli-test-artifact-prod.s3-accelerate.amazonaws.com:443
+            upload.service.runforesight.com:443
+            api.service.runforesight.com:443
+            api.wpvip.com:443
 
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/__tests__/e2e/package.json
+++ b/__tests__/e2e/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --fix .",
     "pretest": "./bin/setup-env.sh",
     "test": "playwright test -c playwright.config.ts",
-    "posttest": "vip dev-env destroy --slug=e2e-test-site"
+    "posttest": "docker stats --no-stream; vip dev-env destroy --slug=e2e-test-site"
   },
   "author": "Automattic",
   "devDependencies": {

--- a/__tests__/e2e/package.json
+++ b/__tests__/e2e/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --fix .",
     "pretest": "./bin/setup-env.sh",
     "test": "playwright test -c playwright.config.ts",
-    "posttest": "docker stats --no-stream; vip dev-env destroy --slug=e2e-test-site"
+    "posttest": "vip dev-env destroy --slug=e2e-test-site"
   },
   "author": "Automattic",
   "devDependencies": {

--- a/__tests__/e2e/playwright.config.ts
+++ b/__tests__/e2e/playwright.config.ts
@@ -7,9 +7,9 @@ const config: PlaywrightTestConfig = {
     retries: 1,
     globalSetup: require.resolve( './lib/global-setup' ),
     timeout: 60000,
-    reporter: process.env.CI ? [['github'], [ 'junit', { outputFile: 'results.xml' } ]] : 'line',
+    reporter: process.env.CI ? [ [ 'github' ], [ 'junit', { outputFile: 'results.xml' } ] ] : 'line',
     reportSlowTests: null,
-    workers: process.env.CI ? 2 : undefined,
+    workers: process.env.CI ? 1 : undefined,
     use: {
         headless: process.env.DEBUG_TESTS !== 'true',
         viewport: { width: 1280, height: 1000 },


### PR DESCRIPTION
* Add Foresight domains to the list of the allowed endpoints ([ref](https://github.com/Automattic/vip-go-mu-plugins/actions/runs/3433244834))
* Reduce the number of workers to 1 for CI to reduce CPU/memory usage
* Bump @automattic/vip to 2.22.0
