### PR TITLE
ci: Fix coverage generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Rsync ext
         run: 'rsync -r --delete --exclude-from="vip-go-mu-plugins-ext/.dockerignore" vip-go-mu-plugins-ext/* ./'
 
+      - name: Delete mu-plugins-ext
+        run: rm -rf vip-go-mu-plugins-ext
+
       - name: Run tests
         uses: ./.github/actions/run-wp-tests
         with:


### PR DESCRIPTION
`mu-plugins-ext` checked out into the `vip-go-mu-plugins` tree breaks coverage generation and increases the CI time, as PHPUnit has to process a lot of not used files.

This PR fixes that.
