### PR TITLE
chore(deps): Bump ramsey/composer-install to 2.2.0

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -73,7 +73,7 @@ runs:
       if: inputs.phpunit != ''
 
     - name: Install PHP Dependencies
-      uses: ramsey/composer-install@2.1.0
+      uses: ramsey/composer-install@2.2.0
 
     - name: Set up WordPress and WordPress Test Library
       uses: sjinks/setup-wordpress-test-library@1.1.11


### PR DESCRIPTION
This PR bumps ramsey/composer-install to 2.2.0 to address GitHub's deprecations.

Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/3433849604/jobs/5724599992#step:7:74
