### PR TITLE
Search: Update get_index_settings_diff_for_indexable() and heal_index_settings_for_indexable() to account for next EP version

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -995,7 +995,13 @@ class Health {
 		$diff = [];
 
 		if ( $indexable->index_exists() ) {
-			$actual_settings = $indexable->get_index_settings();
+			if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+				$index_name      = $indexable->get_index_name();
+				$settings        = $this->elasticsearch->get_index_settings( $index_name );
+				$actual_settings = $settings[ $index_name ]['settings'] ?? [];
+			} else {
+				$actual_settings = $indexable->get_index_settings();
+			}
 
 			if ( is_wp_error( $actual_settings ) ) {
 				$this->search->versioning->reset_current_version_number( $indexable );
@@ -1082,10 +1088,13 @@ class Health {
 
 		// Limit to only the settings that we auto-heal
 		$desired_settings_to_heal = self::limit_index_settings_to_keys( $desired_settings, self::INDEX_SETTINGS_HEALTH_AUTO_HEAL_KEYS );
+		$index_name               = $indexable->get_index_name();
+		if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+			$result = $this->elasticsearch->update_index_settings( $index_name, $desired_settings_to_heal, true );
+		} else {
+			$result = $indexable->update_index_settings( $desired_settings_to_heal );
+		}
 
-		$result = $indexable->update_index_settings( $desired_settings_to_heal );
-
-		$index_name    = $indexable->get_index_name();
 		$index_version = $this->search->versioning->get_current_version_number( $indexable );
 
 		$this->search->versioning->reset_current_version_number( $indexable );

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -1330,6 +1330,80 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_result, $result );
 	}
 
+	/**
+	 * @dataProvider heal_index_settings_for_indexable_data
+	 * @processIsolation true
+	 */
+	public function test_heal_index_settings_for_indexable__next_ep_constant( $desired_settings, $options ) {
+		Constant_Mocker::define( 'VIP_SEARCH_USE_NEXT_EP', true );
+
+		self::$indexable_methods[] = 'generate_mapping';
+
+		$index_name = 'foo-index-name';
+		// Mock search and the versioning instance
+		/** @var Search&MockObject */
+		$mock_search = $this->createMock( Search::class );
+
+		/** @var Versioning&MockObject */
+		$versioning = $this->getMockBuilder( Versioning::class )
+			->enableProxyingToOriginalMethods()
+			->setMethods( [ 'get_current_version_number', 'set_current_version_number', 'reset_current_version_number' ] )
+			->getMock();
+
+		$mock_search->versioning = $versioning;
+
+		// If we're healing a specific version, make sure we actually switch
+		if ( isset( $options['index_version'] ) ) {
+			$mock_search->versioning->expects( $this->once() )
+				->method( 'set_current_version_number' )
+				->with( $options['index_version'] );
+
+			$mock_search->versioning->expects( $this->once() )
+				->method( 'reset_current_version_number' );
+		}
+
+		$versioning->method( 'get_current_version_number' )->willReturn( $options['index_version'] ?? 1 );
+
+		$health = new Health( $mock_search );
+
+		/** @var \ElasticPress\Indexable&MockObject */
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( self::$indexable_methods )
+			->getMock();
+
+		$mocked_indexable->slug = 'post';
+
+		$mocked_indexable->method( 'get_index_name' )
+			->willReturn( $index_name );
+
+		$mocked_indexable->method( 'generate_mapping' )
+			->willReturn( [ 'settings' => $desired_settings ] );
+
+		$health->elasticsearch = $this->getMockBuilder( \ElasticPress\Elasticsearch::class )
+			->setMethods( [ 'update_index_settings' ] )
+			->getMock();
+
+		$health->elasticsearch->method( 'update_index_settings' )
+			->willReturn( true );
+
+		// Expected updated settings
+		$expected_updated_settings = Health::limit_index_settings_to_keys( $desired_settings, Health::INDEX_SETTINGS_HEALTH_AUTO_HEAL_KEYS );
+
+		$health->elasticsearch->expects( $this->once() )
+			->method( 'update_index_settings' )
+			->with( $index_name, $expected_updated_settings, true );
+
+		$result = $health->heal_index_settings_for_indexable( $mocked_indexable, $options );
+
+		$expected_result = array(
+			'index_name'    => $index_name,
+			'index_version' => $options['index_version'] ?? 1,
+			'result'        => true,
+		);
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
 	public function limit_index_settings_to_keys_data() {
 		return array(
 			// Mix of monitored and not monitored keys


### PR DESCRIPTION
## Description
 `update_index_settings()` and `get_index_settings()` live in [the `ElasticPress\Elasticsearch` namespace](https://github.com/Automattic/ElasticPress/blob/5defd71bb2fd1a6b1a9be40aefcc0e35beb56668/includes/classes/Elasticsearch.php#L929) rather in an indexable in the next EP version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

0) Define `VIP_SEARCH_USE_NEXT_EP` to `true`

### Make a bad setting in the index via shell:
1) `$bad_settings = [ 'index.number_of_replicas' => 8, 'index.max_result_window' => 50 ];`
2) `$indexable = \ElasticPress\Indexables::factory()->get( 'post' );`
3) `$index_name = $indexable->get_index_name();`
4) `\ElasticPress\Elasticsearch::factory()->update_index_settings( $index_name, $bad_settings, true );`

### Verify the bad settings are in:
1) `$actual_mapping  = $indexable->get_mapping();`
2) `$actual_settings = $actual_mapping[ $index_name ]['settings'];`
3) Verify that you see the below properties:
```
    ["number_of_replicas"]=>
    string(1) "8"
    ["max_result_window"]=>
    string(2) "50"
```

### Now let's check to ensure it returns in the diff checker that the settings are bad
1) `$es = new \Automattic\VIP\Search\Search();`
2) `$es->init();`
3) `$health = new \Automattic\VIP\Search\Health( $es );`
4) `$health->get_index_settings_health_for_all_indexables();`
5) Verify the difference reported:
```
  ["post"]=>
  array(1) {
    [0]=>
    array(3) {
      ["index_version"]=>
      int(1)
      ["index_name"]=>
      string(17) "vip-200508-post-1"
      ["diff"]=>
      array(2) {
        ["index.number_of_replicas"]=>
        array(2) {
          ["expected"]=>
          int(1)
          ["actual"]=>
          string(1) "8"
        }
        ["index.max_result_window"]=>
        array(2) {
          ["expected"]=>
          int(10000)
          ["actual"]=>
          string(2) "50"
        }
      }
    }
  }
}
```

### Verify it "heals" it
1) `$hj = new \Automattic\VIP\Search\SettingsHealthJob( $es );`
2) `$hj->check_settings_health();`
3) `$health->get_index_settings_health_for_all_indexables();` should return an empty array
