### PR TITLE
refine alloptions alerting thresholds

### DIFF
--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -26,6 +26,14 @@ function run_alloptions_safeguard() {
 		return;
 	}
 
+	$home_url_parsed = wp_parse_url( home_url() );
+	if (
+		wp_endswith( $home_url_parsed['host'], '.go-vip.co' ) ||
+		wp_endswith( $home_url_parsed['host'], '.go-vip.net' )
+	) {
+		return;
+	}
+
 	// To avoid performing a potentially expensive calculation of the compressed size we use 4MB uncompressed (which is likely less than 1MB compressed)
 	$alloptions_size_worry_level = MB_IN_BYTES * 4;
 
@@ -115,7 +123,7 @@ function alloptions_safeguard_notify( $size, $size_compressed, $really_blocked =
 	$is_vip_env  = ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV );
 	$environment = ( ( defined( 'VIP_GO_ENV' ) && VIP_GO_ENV ) ? VIP_GO_ENV : 'unknown' );
 	$site_id     = defined( 'FILES_CLIENT_SITE_ID' ) ? FILES_CLIENT_SITE_ID : false;
-	$home_url    = get_home_url();
+	$home_url    = home_url();
 
 	// Send notices to VIP staff if this is happening on VIP-hosted sites
 	if (

--- a/alloptions-limit.php
+++ b/alloptions-limit.php
@@ -167,6 +167,7 @@ function alloptions_safeguard_notify( $size, $size_compressed, $really_blocked =
 
 	$description .= "\n\n`$cli_command`";
 
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	trigger_error( $subject, E_USER_WARNING );
 
 	// Send to OpsGenie


### PR DESCRIPTION
## Description

- do no monitor on convenience domains
- no action if uncompressed size is less than 4MB
- if greater than 4M: calculate the compressed size
- if *compressed* size is over 850K: log warning and send P2 alert
- if *compressed* size is over 1M: throw 503, log warning, and send P1 alert

## Changelog Description

Refined alloptions alerting thresholds

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Create large options for testing

```
# 3 copies of this option will put a basic site at alerting level without throwing 503
update_option( 'large_option_3', wp_remote_get( 'https://en.wikipedia.org/wiki/Language' ) );
```