### PR TITLE
Check earlier if display-name is set

### DIFF
--- a/vip-support/class-vip-support-cli.php
+++ b/vip-support/class-vip-support-cli.php
@@ -33,7 +33,7 @@ class Command extends WP_CLI_Command {
 		$user_login   = $args[0];
 		$user_email   = $args[1];
 		$user_pass    = $args[2];
-		$display_name = $assoc_args['display-name'] ?? $user_login;
+		$display_name = $assoc_args['display-name'] ?? '';
 
 		// Validation checks
 		if ( ! is_email( $user_email ) || ! User::is_a8c_email( $user_email ) ) {
@@ -49,7 +49,7 @@ class Command extends WP_CLI_Command {
 		$user_data['user_login']   = $user_login;
 		$user_data['user_email']   = $user_email;
 		$user_data['display_name'] = $display_name;
-		$user_data['first_name']   = $display_name;
+		$user_data['first_name']   = ! empty( $display_name ) ? $display_name : $user_login;
 		$user_data['last_name']    = '(VIP Support)';
 		$user_data['locale']       = 'en_US';
 

--- a/vip-support/class-vip-support-cli.php
+++ b/vip-support/class-vip-support-cli.php
@@ -33,7 +33,7 @@ class Command extends WP_CLI_Command {
 		$user_login   = $args[0];
 		$user_email   = $args[1];
 		$user_pass    = $args[2];
-		$display_name = $assoc_args['display-name'];
+		$display_name = $assoc_args['display-name'] ?? $user_login;
 
 		// Validation checks
 		if ( ! is_email( $user_email ) || ! User::is_a8c_email( $user_email ) ) {
@@ -49,7 +49,7 @@ class Command extends WP_CLI_Command {
 		$user_data['user_login']   = $user_login;
 		$user_data['user_email']   = $user_email;
 		$user_data['display_name'] = $display_name;
-		$user_data['first_name']   = ! empty( $display_name ) ? $display_name : $user_login;
+		$user_data['first_name']   = $display_name;
 		$user_data['last_name']    = '(VIP Support)';
 		$user_data['locale']       = 'en_US';
 


### PR DESCRIPTION
## Description
If `--display-name` is not set in the `vipsupport create-user` CLI, an "Undefined array key" warning is thrown. 

## Changelog Description

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
While sandboxed:
 - run `wp vipsupport create-user --prompt`, fill in required fields, but provide no value for display-name
 - or, `wp vipsupport create-user 'vip_yourusername' 'your.name@automattic.com' 'strongpasswordhereplease'`
