### PR TITLE
Make helper methods in WPCOM_VIP_CLI_Command public and static

### DIFF
--- a/vip-helpers/vip-wp-cli.php
+++ b/vip-helpers/vip-wp-cli.php
@@ -9,7 +9,7 @@ class WPCOM_VIP_CLI_Command extends WP_CLI_Command {
 	 */
 	protected function stop_the_insanity() {
 		_deprecated_function( __METHOD__, '2.0.0', 'vip_inmemory_cleanup' );
-		self::vip_inmemory_cleanup();
+		$this->vip_inmemory_cleanup();
 	}
 
 	/**

--- a/vip-helpers/vip-wp-cli.php
+++ b/vip-helpers/vip-wp-cli.php
@@ -9,14 +9,14 @@ class WPCOM_VIP_CLI_Command extends WP_CLI_Command {
 	 */
 	protected function stop_the_insanity() {
 		_deprecated_function( __METHOD__, '2.0.0', 'vip_inmemory_cleanup' );
-		$this->vip_inmemory_cleanup();
+		self::vip_inmemory_cleanup();
 	}
 
 	/**
 	 * Clear in-memory local object cache (global $wp_object_cache) without affecting memcache
 	 * and reset in-memory database query log.
 	 */
-	protected function vip_inmemory_cleanup() {
+	public static function vip_inmemory_cleanup() {
 		vip_reset_db_query_log();
 		vip_reset_local_object_cache();
 	}
@@ -24,7 +24,7 @@ class WPCOM_VIP_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Disable term counting so that terms are not all recounted after every term operation
 	 */
-	protected function start_bulk_operation() {
+	public static function start_bulk_operation() {
 		// Disable term count updates for speed
 		wp_defer_term_counting( true );
 	}
@@ -32,7 +32,7 @@ class WPCOM_VIP_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Re-enable Term counting and trigger a term counting operation to update all term counts
 	 */
-	protected function end_bulk_operation() {
+	public static function end_bulk_operation() {
 		// This will also trigger a term count.
 		wp_defer_term_counting( false );
 	}


### PR DESCRIPTION
## Description

Makes the helper methods in `WPCOM_VIP_CLI_Command` public and static so that they can be used by functions and classes that don't extend this class. This will have no impact on existing implementations, but allows developers more freedom in how they interact with this class.

Fixes #3886 

## Changelog Description

### Helper Updated: WPCOM_VIP_CLI_Command

Changed visibility and accessibility of helper methods in the WPCOM_VIP_CLI_Command class to enable them to be called statically.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [X] This change has relevant unit tests (if applicable).
- [X] This change has relevant documentation additions / updates (if applicable).
- [X] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Create a WP_CLI command and call `WPCOM_VIP_CLI_Command::vip_inmemory_cleanup()` and ensure that it runs.