### PR TITLE
ci: Fix Jetpack bootstrapping issue

### DIFF
--- a/.github/actions/prepare-source/action.yml
+++ b/.github/actions/prepare-source/action.yml
@@ -1,0 +1,19 @@
+name: Prpeare source code for testing
+description: Checks out and installs all dependencies
+runs:
+  using: composite
+  steps:
+    - name: Check out mu-plugins-ext
+      uses: actions/checkout@v3
+      with:
+        repository: 'Automattic/vip-go-mu-plugins-ext'
+        path: 'vip-go-mu-plugins-ext'
+
+    - name: Copy plugins into the source tree
+      shell: bash
+      run: 'rsync -r --delete --exclude-from="vip-go-mu-plugins-ext/.dockerignore" vip-go-mu-plugins-ext/* ./'
+
+    - name: Clean up
+      shell: bash
+      run: rm -rf vip-go-mu-plugins-ext
+

--- a/.github/actions/prepare-source/action.yml
+++ b/.github/actions/prepare-source/action.yml
@@ -1,4 +1,4 @@
-name: Prpeare source code for testing
+name: Prepare source code for testing
 description: Checks out and installs all dependencies
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Check out mu-plugins-ext
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
-        with:
-          repository: 'Automattic/vip-go-mu-plugins-ext'
-          path: 'vip-go-mu-plugins-ext'
-
-      - name: Rsync ext
-        run: 'rsync -r --delete --exclude-from="vip-go-mu-plugins-ext/.dockerignore" vip-go-mu-plugins-ext/* ./'
-
-      - name: Delete mu-plugins-ext
-        run: rm -rf vip-go-mu-plugins-ext
+      - name: Prepare source code
+        uses: ./.github/actions/prepare-source
 
       - name: Run tests
         uses: ./.github/actions/run-wp-tests

--- a/.github/workflows/coverage-develop.yml
+++ b/.github/workflows/coverage-develop.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Prepare source code
+        uses: ./.github/actions/prepare-source
+
       - name: Run tests
         uses: ./.github/actions/run-wp-tests
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,6 +86,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Prepare source code
+        uses: ./.github/actions/prepare-source
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Prepare source code
+        uses: ./.github/actions/prepare-source
+
       - name: Set up environment
         run: |
           echo WPVIP_PARSELY_INTEGRATION_PLUGIN_VERSION="${{ matrix.config.parsely }}" >> "${GITHUB_ENV}"

--- a/.github/workflows/search-e2e.yml
+++ b/.github/workflows/search-e2e.yml
@@ -33,6 +33,9 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Prepare source code
+      uses: ./.github/actions/prepare-source
+
     - name: "Install node v${{ env.NODE_VERSION }}"
       uses: actions/setup-node@v3.5.1
       with:


### PR DESCRIPTION
Because Jetpacks now live elsewhere, several workflows need to be updated to check them out from the other repository.

This fixes the "Jetpack could not be loaded and initialized due to a bootstrapping issue" warning.

Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/3447629250/jobs/5755529162#step:12:956
