### PR TITLE
ci: Fix a typo in tag-release.yml

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -44,7 +44,7 @@ jobs:
         run: git tag ${{ steps.id-generator.outputs.id }}
 
       - name: Push tags
-        run: git push --tag
+        run: git push --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: softprops/action-gh-release@v0.1.14


### PR DESCRIPTION
The [proper](https://git-scm.com/docs/git-push) command is `git push --tags`. `git push --tag` does seem to work, but it is an undocumented feature, and we'd better not rely upon it.