### PR TITLE
ci: Update deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       SOURCE_REPO_PATH: main
       TARGET_REPO_PATH: built
+      EXT_REPO_PATH: ext
     permissions:
       contents: write
     steps:
@@ -25,6 +26,12 @@ jobs:
         with:
           submodules: recursive
           path: ${{ env.SOURCE_REPO_PATH }}
+
+      - name: Check out Automattic/vip-go-mu-plugins-ext
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        with:
+          repository: Automattic/vip-go-mu-plugins-ext
+          path: ${{ env.EXT_REPO_PATH }}
 
       - name: Check out Automattic/vip-go-mu-plugins-built
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
@@ -41,16 +48,17 @@ jobs:
         working-directory: ${{ env.TARGET_REPO_PATH }}
 
       - name: Synchronize files
-        run: rsync --delete -a "${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/" "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/" --exclude='.git/'
+        run: |
+          rsync --delete -a "${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/" "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/" --exclude-from="${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/.dockerignore"
+          rsync --delete -a "${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/*" "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/" --exclude-from="${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/.dockerignore"
 
-      - name: Delete files
+      - name: Clean up
         run: |
           TARGET="${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}"
           find "${TARGET}" -name ".svn" -exec rm -rfv {} \; 2> /dev/null
           find "${TARGET}" -name ".git*" -not -name ".github" -not -name ".git" -exec rm -rfv {} \; 2> /dev/null
-          mv -vf "${TARGET}/README-PUBLIC.md" "${TARGET}/README.md"
-          mv -vf "${TARGET}/composer.json.tpl" "${TARGET}/composer.json"
-          rm -rvf "${TARGET}/ci" "${TARGET}/.github" "${TARGET}/renovate.json" "${TARGET}/tests" "${TARGET}/bin" "${TARGET}/.dockerignore" "${TARGET}/.ackrc" "${TARGET}/.lintstagedrc" "${TARGET}/.sonarcloud.properties" "${TARGET}/phpcs.xml.dist" "${TARGET}/phpunit-multisite.xml" "${TARGET}/phpunit.xml"
+          cp -vf "${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/README-PUBLIC.md" "${TARGET}/README.md"
+          cp -vf "${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/composer.json.tpl" "${TARGET}/composer.json"
 
       - name: Commit!
         run: |


### PR DESCRIPTION
This PR updates the deploy workflow:
  * `vip-go-mu-plugins-ext` are copied into `vip-go-mu-plugins-built`;
  * the copy step ignores all files listed in `.dockerignore`