### PR TITLE
Search: Auto re-build post index when mapping is bad

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -6,14 +6,19 @@ on:
       - staging
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Docker image
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Request to build Docker image
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.WPCOM_VIP_BOT_TOKEN }}
           script: |
             github.rest.repos.createDispatchEvent({
               owner: 'automattic',

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -13,7 +13,6 @@ jobs:
   build:
     name: Build Docker image
     runs-on: ubuntu-latest
-    permissions: write-all
     steps:
       - name: Request to build Docker image
         uses: actions/github-script@v6

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -2,8 +2,6 @@
 
 namespace Automattic\VIP\Search;
 
-use \ElasticPress\Indexables as Indexables;
-
 use \WP_Query as WP_Query;
 use \WP_User_Query as WP_User_Query;
 use \WP_Error as WP_Error;
@@ -1128,5 +1126,26 @@ class Health {
 		}
 
 		return $result;
+	}
+	/**
+	 * Verify if the post mapping is incorrect from running `wp vip-search index` without the --setup flag on initial indexing.
+	 *
+	 * @return bool Whether mapping is incorrect
+	 */
+	public function validate_incorrect_post_index_mapping() {
+		$indexable = $this->indexables->get( 'post' );
+		if ( ! $indexable ) {
+			// No post Indexable exists, bail early.
+			return false;
+		}
+
+		$index_name = $indexable->get_index_name();
+		$mapping    = $indexable->get_mapping( $index_name );
+
+		if ( ! isset( $mapping[ $index_name ]['mappings']['_meta']['mapping_version'] ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Search;
 
+use \ElasticPress\Indexables as Indexables;
+
 use \WP_Query as WP_Query;
 use \WP_User_Query as WP_User_Query;
 use \WP_Error as WP_Error;

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -2,8 +2,6 @@
 
 namespace Automattic\VIP\Search;
 
-use \ElasticPress\Indexables as Indexables;
-
 use \WP_Query as WP_Query;
 use \WP_User_Query as WP_User_Query;
 use \WP_Error as WP_Error;
@@ -1137,5 +1135,26 @@ class Health {
 		}
 
 		return $result;
+	}
+	/**
+	 * Verify if the post mapping is incorrect from running `wp vip-search index` without the --setup flag on initial indexing.
+	 *
+	 * @return bool Whether mapping is incorrect
+	 */
+	public function validate_incorrect_post_index_mapping() {
+		$indexable = $this->indexables->get( 'post' );
+		if ( ! $indexable ) {
+			// No post Indexable exists, bail early.
+			return false;
+		}
+
+		$index_name = $indexable->get_index_name();
+		$mapping    = $indexable->get_mapping( $index_name );
+
+		if ( ! isset( $mapping[ $index_name ]['mappings']['_meta']['mapping_version'] ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1139,22 +1139,17 @@ class Health {
 	/**
 	 * Verify if the post mapping is incorrect from running `wp vip-search index` without the --setup flag on initial indexing.
 	 *
-	 * @return bool Whether mapping is incorrect
+	 * @param mixed $indexable Instance of an ElasticPress post Indexable
+	 * @return bool Whether mapping is correct
 	 */
-	public function validate_incorrect_post_index_mapping() {
-		$indexable = $this->indexables->get( 'post' );
-		if ( ! $indexable ) {
-			// No post Indexable exists, bail early.
-			return false;
-		}
-
+	public function validate_post_index_mapping( $indexable ) {
 		$index_name = $indexable->get_index_name();
 		$mapping    = $indexable->get_mapping( $index_name );
 
 		if ( ! isset( $mapping[ $index_name ]['mappings']['_meta']['mapping_version'] ) ) {
-			return true;
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 }

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Search;
 
+use \ElasticPress\Indexables as Indexables;
+
 use \WP_Query as WP_Query;
 use \WP_User_Query as WP_User_Query;
 use \WP_Error as WP_Error;
@@ -1144,7 +1146,7 @@ class Health {
 	 */
 	public function validate_post_index_mapping( $indexable ) {
 		$index_name = $indexable->get_index_name();
-		$mapping    = $indexable->get_mapping( $index_name );
+		$mapping    = $this->elasticsearch->get_mapping( $index_name );
 
 		if ( ! isset( $mapping[ $index_name ]['mappings']['_meta']['mapping_version'] ) ) {
 			return false;

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -109,6 +109,10 @@ class SettingsHealthJob {
 		if ( ! empty( $unhealthy_indexables ) ) {
 			$this->process_indexables_settings_health_results( $unhealthy_indexables );
 		} else {
+			if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+				// Only do for non-prods for now
+				return;
+			}
 			$post_indexable = $this->indexables->get( 'post' );
 			if ( $post_indexable && ! \ElasticPress\Utils\is_indexing() ) {
 				$correct_mapping = $this->health->validate_post_index_mapping( $post_indexable );

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -109,9 +109,13 @@ class SettingsHealthJob {
 		if ( ! empty( $unhealthy_indexables ) ) {
 			$this->process_indexables_settings_health_results( $unhealthy_indexables );
 		} else {
-			// Eventually, $unhealthy_indexables will be empty -- that is when we should check the index mapping to prevent
-			// too many checks going on at the same time.
-			$this->health->validate_incorrect_post_index_mapping();
+			$post_indexable = $this->indexables->get( 'post' );
+			if ( $post_indexable && ! \ElasticPress\Utils\is_indexing() ) {
+				$correct_mapping = $this->health->validate_post_index_mapping( $post_indexable );
+				if ( ! $correct_mapping ) {
+					$this->maybe_process_build( $post_indexable );
+				}
+			}
 		}
 	}
 

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -106,11 +106,13 @@ class SettingsHealthJob {
 	public function check_settings_health() {
 		$unhealthy_indexables = $this->health->get_index_settings_health_for_all_indexables();
 
-		if ( empty( $unhealthy_indexables ) ) {
-			return;
+		if ( ! empty( $unhealthy_indexables ) ) {
+			$this->process_indexables_settings_health_results( $unhealthy_indexables );
+		} else {
+			// Eventually, $unhealthy_indexables will be empty -- that is when we should check the index mapping to prevent
+			// too many checks going on at the same time.
+			$this->health->validate_incorrect_post_index_mapping();
 		}
-
-		$this->process_indexables_settings_health_results( $unhealthy_indexables );
 	}
 
 	public function process_indexables_settings_health_results( $results ) {


### PR DESCRIPTION
## Description
This PR only executes the jobs for non-prods atm. When `wp vip-search index` is run on a new site without the `--setup` flag, we get the error message `field [post_date_gmt] is of type [org.elasticsearch.index.mapper.TextFieldMapper$TextFieldType@f663aff], but only numeric types are supported.` and thus, ES isn't run on it.

## Changelog Description

### Plugin Updated: Enterprise Search

Re-build index if incorrect post mapping found (non-prods only)

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create a new second site
2) Run `wp vip-search index`
3) Go do a search `?s=test` and check Search Dev Tools for the error being returned `field [post_date_gmt] is of type [org.elasticsearch.index.mapper.TextFieldMapper$TextFieldType@f663aff], but only numeric types are supported.`
4) Shell in:
```
$es = new \Automattic\VIP\Search\Search();
$es->init();
$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
$health = new \Automattic\VIP\Search\Health( $es );
$mapping = $health->validate_post_index_mapping( $indexable );
```
Ensure `$mapping` returns `false` to ensure that it is picking up the incorrect mapping
5) Run `wp vip-search index --setup`
6) Repeat step 4 and ensure it returns `true` instead
