### PR TITLE
Introduce Environment::has_var()

### DIFF
--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -9,19 +9,19 @@ class Environment {
 	 */
 	const VAR_PREFIX = 'VIP_ENV_VAR';
 
-    /**
-     * Checks existence of custom environment variable values based on the supplied key and return
-     * its name if it is set, null otherwise.
-     *
-     * @param string $key The name of the environment variable.
-     * @return string|null
-     */
-    public static function has_var( string $key ): ?string {
-        $key       = strtoupper( $key );
-        $env_const = sprintf( '%s_%s', self::VAR_PREFIX, $key );
+	/**
+	 * Checks existence of custom environment variable values based on the supplied key and return
+	 * its name if it is set, null otherwise.
+	 *
+	 * @param string $key The name of the environment variable.
+	 * @return string|null
+	 */
+	public static function has_var( string $key ): ?string {
+		$key       = strtoupper( $key );
+		$env_const = sprintf( '%s_%s', self::VAR_PREFIX, $key );
 
-        return defined( $env_const ) ? $env_const : null;
-    }
+		return defined( $env_const ) ? $env_const : null;
+	}
 
 	/**
 	 * Attempts to return custom environment variable values based on the supplied key
@@ -31,9 +31,9 @@ class Environment {
 	 * @return string
 	 */
 	public static function get_var( string $key, $default_value = '' ) {
-		$env_const = self::has_var( $key );
+		$env_const = static::has_var( $key );
 
-		if ( $env_const !== null ) {
+		if ( null !== $env_const ) {
 			return constant( $env_const );
 		}
 

--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -9,47 +9,38 @@ class Environment {
 	 */
 	const VAR_PREFIX = 'VIP_ENV_VAR';
 
-	/**
-	 * Checks existence of custom environment variable values based on the supplied key and return
-	 * its name if it is set, null otherwise.
-	 *
-	 * @param string $key The name of the environment variable.
-	 * @return string|null
-	 */
-	public static function has_var( string $key ): ?string {
-		$key       = strtoupper( $key );
-		$env_const = sprintf( '%s_%s', self::VAR_PREFIX, $key );
-
-		return defined( $env_const ) ? $env_const : null;
-	}
+    /**
+     * Checks existence of custom environment variable values based on the supplied key.
+     *
+     * @param string $key The name of the environment variable.
+     * @return bool
+     */
+    public static function has_var( string $key ): bool {
+        return defined( self::calculate_env_const_name( $key ) );
+    }
 
 	/**
-	 * Attempts to return custom environment variable values based on the supplied key
+	 * Attempts to return custom environment variable values based on the supplied key.
 	 *
 	 * @param string $key The name of the environment variable.
-	 * @param string $default_value The value to return if no environment variable matches the key
-	 * @return string
+	 * @param mixed $default_value The value to return if no environment variable matches the key
+	 * @return mixed
 	 */
 	public static function get_var( string $key, $default_value = '' ) {
-		$env_const = static::has_var( $key );
+		$env_const = self::calculate_env_const_name( $key );
 
-		if ( null !== $env_const ) {
-			return constant( $env_const );
-		}
-
-		// The call was not able to retrieve an env variable
-		// log this as an E_USER_NOTICE for debugging
-		trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			sprintf(
-				'The ENV variable: "%s" did not exist. %s::get_var returned the default value',
-				$key, // phpcs:ignore WordPress.Security.EscapeOutput
-				__CLASS__
-			),
-			\E_USER_NOTICE
-		);
-
-		return $default_value;
+		return defined( $env_const ) ? constant( $env_const ) : $default_value;
 	}
+
+	/**
+	 * Calculates environment variable constant name based on the supplied key.
+	 *
+	 * @param string $key
+	 * @return string
+	 */
+    private static function calculate_env_const_name( string $key ): string {
+        return sprintf( '%s_%s', self::VAR_PREFIX, strtoupper( $key ) );
+    }
 
 	public static function is_sandbox_container( $hostname, $env = array() ) {
 		if ( false !== strpos( $hostname, '_web_dev_' ) || false !== strpos( $hostname, '-sbx-u' ) ) {

--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -9,6 +9,20 @@ class Environment {
 	 */
 	const VAR_PREFIX = 'VIP_ENV_VAR';
 
+    /**
+     * Checks existence of custom environment variable values based on the supplied key and return
+     * its name if it is set, null otherwise.
+     *
+     * @param string $key The name of the environment variable.
+     * @return string|null
+     */
+    public static function has_var( string $key ): ?string {
+        $key       = strtoupper( $key );
+        $env_const = sprintf( '%s_%s', self::VAR_PREFIX, $key );
+
+        return defined( $env_const ) ? $env_const : null;
+    }
+
 	/**
 	 * Attempts to return custom environment variable values based on the supplied key
 	 *
@@ -17,10 +31,9 @@ class Environment {
 	 * @return string
 	 */
 	public static function get_var( string $key, $default_value = '' ) {
-		$key       = strtoupper( $key );
-		$env_const = sprintf( '%s_%s', self::VAR_PREFIX, $key );
+		$env_const = self::has_var( $key );
 
-		if ( defined( $env_const ) ) {
+		if ( $env_const !== null ) {
 			return constant( $env_const );
 		}
 

--- a/lib/helpers/environment.php
+++ b/lib/helpers/environment.php
@@ -24,5 +24,5 @@ function vip_get_env_var( $key, $default_value = '' ) {
  * @return bool
  */
 function vip_has_env_var( $key ) {
-    return Environment::has_var( $key ) !== null;
+	return Environment::has_var( $key ) !== null;
 }

--- a/lib/helpers/environment.php
+++ b/lib/helpers/environment.php
@@ -16,3 +16,13 @@ use Automattic\VIP\Environment;
 function vip_get_env_var( $key, $default_value = '' ) {
 	return Environment::get_var( $key, $default_value );
 }
+
+/**
+ * A wrapper for Automattic\VIP\Environment::has_var with boolean return value.
+ *
+ * @param string $key The name of the environment variable.
+ * @return bool
+ */
+function vip_has_env_var( $key ) {
+    return Environment::has_var( $key ) !== null;
+}

--- a/lib/helpers/environment.php
+++ b/lib/helpers/environment.php
@@ -11,18 +11,19 @@ use Automattic\VIP\Environment;
  * A wrapper for Automattic\VIP\Environment::get_var
  *
  * @param string $key The name of the environment variable.
- * @param string $default_value The value to return if no environment variable matches the key 
+ * @param mixed $default_value The value to return if no environment variable matches the key
+ * @return mixed
  */
-function vip_get_env_var( $key, $default_value = '' ) {
+function vip_get_env_var( string $key, $default_value = '' ) {
 	return Environment::get_var( $key, $default_value );
 }
 
 /**
- * A wrapper for Automattic\VIP\Environment::has_var with boolean return value.
+ * A wrapper for Automattic\VIP\Environment::has_var.
  *
  * @param string $key The name of the environment variable.
  * @return bool
  */
-function vip_has_env_var( $key ) {
-	return Environment::has_var( $key ) !== null;
+function vip_has_env_var( string $key ): bool {
+    return Environment::has_var( $key );
 }

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -30,6 +30,21 @@ class Environment_Test extends TestCase {
 		Constant_Mocker::define( 'VIP_ENV_VAR_MY_VAR', 'VIP_ENV_VAR_MY_VAR' );
 	}
 
+	public function test_has_var() {
+		error_reporting( $this->error_reporting & ~E_USER_NOTICE );
+
+		$this->get_var_standard_env();
+		$val = Environment::has_var( 'MY_VAR' );
+		$this->assertEquals( 'VIP_ENV_VAR_MY_VAR', $val );
+	}
+
+	public function test_has_var_missing() {
+		error_reporting( $this->error_reporting & ~E_USER_NOTICE );
+
+		$val = Environment::has_var( 'MY_VAR' );
+		$this->assertEquals( null, $val );
+	}
+
 	// tests the use-case where $key parameter is not found
 	public function test_get_default_var() {
 		error_reporting( $this->error_reporting & ~E_USER_NOTICE );

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -35,14 +35,14 @@ class Environment_Test extends TestCase {
 
 		$this->get_var_standard_env();
 		$val = Environment::has_var( 'MY_VAR' );
-		$this->assertEquals( 'VIP_ENV_VAR_MY_VAR', $val );
+		$this->assertEquals( true, $val );
 	}
 
 	public function test_has_var_missing() {
 		error_reporting( $this->error_reporting & ~E_USER_NOTICE );
 
 		$val = Environment::has_var( 'MY_VAR' );
-		$this->assertEquals( null, $val );
+		$this->assertEquals( false, $val );
 	}
 
 	// tests the use-case where $key parameter is not found

--- a/tests/lib/helpers/test-environment.php
+++ b/tests/lib/helpers/test-environment.php
@@ -26,7 +26,6 @@ class Environment_Test extends TestCase {
 
 	// tests the use-case that an environment has a defined env var
 	public function test_has_var() {
-
 		$this->get_var_standard_env();
 		$val = vip_has_env_var( 'MY_VAR' );
 		$this->assertEquals( true, $val );
@@ -34,7 +33,6 @@ class Environment_Test extends TestCase {
 
 	// tests the use-case that an environment is missing a defined env var
 	public function test_has_var_missing() {
-
 		$val = vip_has_env_var( 'MISSING_ENV_VAR' );
 		$this->assertEquals( false, $val );
 	}

--- a/tests/lib/helpers/test-environment.php
+++ b/tests/lib/helpers/test-environment.php
@@ -24,6 +24,21 @@ class Environment_Test extends TestCase {
 		Constant_Mocker::define( 'MY_VAR', 'FOO' );
 	}
 
+	// tests the use-case that an environment has a defined env var
+	public function test_has_var() {
+
+		$this->get_var_standard_env();
+		$val = vip_has_env_var( 'MY_VAR' );
+		$this->assertEquals( true, $val );
+	}
+
+	// tests the use-case that an environment is missing a defined env var
+	public function test_has_var_missing() {
+
+		$val = vip_has_env_var( 'MISSING_ENV_VAR' );
+		$this->assertEquals( false, $val );
+	}
+
 	// tests the use-case where $key parameter is not found
 	public function test_get_default_var() {
 		$this->expectNotice();

--- a/tests/lib/helpers/test-environment.php
+++ b/tests/lib/helpers/test-environment.php
@@ -39,8 +39,6 @@ class Environment_Test extends TestCase {
 
 	// tests the use-case where $key parameter is not found
 	public function test_get_default_var() {
-		$this->expectNotice();
-
 		$val = vip_get_env_var( 'MY_VAR', 'BAR' );
 		$this->assertEquals( 'BAR', $val );
 	}
@@ -49,8 +47,6 @@ class Environment_Test extends TestCase {
 	 * tests the use-case where $key parameter is ''
 	 */
 	public function test_get_var_empty_key() {
-		$this->expectNotice();
-
 		$this->get_var_standard_env();
 		$val = vip_get_env_var( '', 'BAR' );
 		$this->assertEquals( 'BAR', $val );


### PR DESCRIPTION
# Description

## The issue

`Environment::get_var()`, as described in [docs](https://docs.wpvip.com/how-tos/manage-environment-variables/#wordpress), allows us to retrieve the value of a custom environment variable set via VIP CLI.

We have found this particularly useful for feature flags. For example, a code like this:

```php
if (Environment::get_var('FEATURE_X_ENABLED')) {
  // Use feature X
}
```

The problem is that `Environment::get_var()` [triggers a notice](https://github.com/Automattic/vip-go-mu-plugins/blob/69e63d26f61fb4b5d152128dd796aacdce06acda/lib/environment/class-environment.php#L29-L36) whenever the target variable is not set.

This is annoying because, for feature flags, undefined variables are _expected_.


## The solution

This PR introduces the method `Environment::has_var()`, alongside its wrapper `vip_has_env_var()`, to check if a custom variable is defined before attempt accessing it.

Or snippet above now becomes:

```php
if (Environment::has_var('FEATURE_X_ENABLED') && Environment::get_var('FEATURE_X_ENABLED')) {
  // Use feature X
}
```

or, if we set it only if true, just:

```php
if (Environment::has_var('FEATURE_X_ENABLED')) {
  // Use feature X
}
```

as a result, the behavior is the same but now we don't have notice triggered.

## Notes

1. unchecked accesses to undefined variables _still_ trigger the notice after this PR
2. the wrapper `vip_has_env_var()` behaves differently from the wrapped method: it returns a boolean, whereas the method returns a string (the name of the constant). That is to avoid call `strtoupper` and `sprintf` in both methods, improving performance
3. The changes are 100% backward compatible



# Changelog Description

#### Introduce `Environment::has_var()` method and `vip_has_env_var()` wrapper function

They allow custom environment variables existence checks without triggering notices.

# Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

# Steps to Test

1. Check out PR.
4. Write a code that make use of the new class method
5. Verify that you can check existence of set environment variables without trigger notices