### PR TITLE
CI: Add WP 6.0 to matrix for single sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - { wp: 5.7.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
           - { wp: 5.8.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
           - { wp: 5.9.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
+          - { wp: 6.0.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
           - { wp: latest,  ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
           - { wp: nightly, ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
         # Jetpack, Multi-Site, PHP 7.4


### PR DESCRIPTION
## Description
6.1.1 is the latest version now, so let's add `6.0.x` to the matrix.