### PR TITLE
Prometheus: update the endpoint and query_var to be more unique, remove proxy restriction

### DIFF
--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -95,7 +95,7 @@ class Plugin {
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- the value is used only for strict comparison
 		$request_uri = $_SERVER['REQUEST_URI'] ?? '';
-		if ( '/vip-prom-metrics' === $request_uri && is_proxied_request() ) {
+		if ( '/vip-prom-metrics' === $request_uri ) {
 			$query_vars['vip-prom-metrics'] = true;
 			unset( $query_vars['error'] );
 

--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -84,7 +84,7 @@ class Plugin {
 			$vars = [];
 		}
 
-		$vars[] = 'metrics';
+		$vars[] = 'vip-prom-metrics';
 		return $vars;
 	}
 
@@ -95,8 +95,8 @@ class Plugin {
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- the value is used only for strict comparison
 		$request_uri = $_SERVER['REQUEST_URI'] ?? '';
-		if ( '/metrics' === $request_uri && is_proxied_request() ) {
-			$query_vars['metrics'] = true;
+		if ( '/vip-prom-metrics' === $request_uri && is_proxied_request() ) {
+			$query_vars['vip-prom-metrics'] = true;
 			unset( $query_vars['error'] );
 
 			add_filter( 'pre_handle_404', [ $this, 'pre_handle_404' ], 10, 2 );
@@ -110,7 +110,7 @@ class Plugin {
 			$headers = [];
 		}
 
-		if ( isset( $wp->query_vars['metrics'] ) ) {
+		if ( isset( $wp->query_vars['vip-prom-metrics'] ) ) {
 			$headers['Content-Type'] = RenderTextFormat::MIME_TYPE;
 			$headers                 = array_merge( $headers, wp_get_nocache_headers() );
 		}
@@ -130,7 +130,7 @@ class Plugin {
 		/** @var WP_Query $wp_query */
 		global $wp_query;
 
-		if ( isset( $wp_query->query_vars['metrics'] ) ) {
+		if ( isset( $wp_query->query_vars['vip-prom-metrics'] ) ) {
 			array_walk( $this->collectors, fn ( CollectorInterface $collector ) => $collector->collect_metrics() );
 
 			$renderer = new RenderTextFormat();


### PR DESCRIPTION
## Description

It was decided that `metrics` is way too generic;  to avoid any sort of collision with userland code this PR makes the slug/query variable more unique - `vip-prom-metrics`.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Merge the PR
2. Hit the https://vip-local.vipdev.lndo.site/vip-prom-metrics
3. Verify it's there. 
