### PR TITLE
Prometheus: switch rendering logic to only care about specific path, rather than a registered query var

### DIFF
--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -109,7 +109,7 @@ class Plugin {
 	 * @global WP_Query $wp_query
 	 */
 	public function template_redirect(): void {
-		if ( $this->is_prom_endpoint_request() ) {
+		if ( ! $this->is_prom_endpoint_request() ) {
 			return;
 		}
 

--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -77,6 +77,10 @@ class Plugin {
 	}
 
 	public function request( $query_vars ): array {
+		if ( ! is_array( $query_vars ) ) {
+			$query_vars = [];
+		}
+
 		if ( $this->is_prom_endpoint_request() ) {
 			unset( $query_vars['error'] );
 			add_filter( 'pre_handle_404', [ $this, 'pre_handle_404' ], 10, 2 );

--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -110,6 +110,10 @@ class Plugin {
 			$headers = [];
 		}
 
+		if ( ! $this->is_prom_endpoint_request() ) {
+			return $headers;
+		}
+
 		if ( isset( $wp->query_vars[ self::$query_var ] ) ) {
 			$headers['Content-Type'] = RenderTextFormat::MIME_TYPE;
 			$headers                 = array_merge( $headers, wp_get_nocache_headers() );

--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -18,7 +18,7 @@ class Plugin {
 	protected array $collectors = [];
 
 	private static string $endpoint_path = './vip-prom-metrics';
-	private static string $query_var = 'vip-prom-metrics';
+	private static string $query_var     = 'vip-prom-metrics';
 	/**
 	 * @return static
 	 */


### PR DESCRIPTION
## Description

- Change the request path to `/.vip-prom-metrics`
- Explicitly check the request path before injecting endpoint headers and template
- Upon further consideration, strip out the query var - we can put it back if need be, but without it the code is a bit simpler.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Hit http://what-mu.vipdev.lndo.site/?vip-prom-metrics - this should NOT render the endpoint anymore
2. Hit http://what-mu.vipdev.lndo.site/.vip-prom-metrics - this should render the endpoint.
