### PR TITLE
Query Monitor: Add panel for VIP-specifics

### DIFF
--- a/qm-plugins/qm-vip/class-qm-vip-collector.php
+++ b/qm-plugins/qm-vip/class-qm-vip-collector.php
@@ -35,8 +35,8 @@ class QM_VIP_Collector extends QM_Collector {
 
 		$info          = json_decode( $version );
 		$branch        = $info->tag ?? '';
-		$stack_version = $info->stack_version ?? [];
-		$version_info  = explode( '-', $stack_version );
+		$stack_version = $info->stack_version ?? null;
+		$version_info  = $stack_version ? explode( '-', $stack_version ) : [];
 		$date          = isset( $version_info[0] ) ? gmdate( 'F j, Y', strtotime( $version_info[0] ) ) : null;
 		$commit        = $version_info[1] ?? null;
 

--- a/qm-plugins/qm-vip/class-qm-vip-collector.php
+++ b/qm-plugins/qm-vip/class-qm-vip-collector.php
@@ -22,24 +22,38 @@ class QM_VIP_Collector extends QM_Collector {
 	}
 
 	private function process_version_file() {
-		$version_file = WP_CONTENT_DIR . '/mu-plugins/.version';
+		$version_file = WPMU_PLUGIN_DIR . '/.version';
 		if ( ! file_exists( $version_file ) ) {
-			return null;
+			$this->set_default_version_info();
+			return;
 		}
 		$version = file_get_contents( $version_file ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		if ( ! $version ) {
-			return null;
+			$this->set_default_version_info();
+			return;
 		}
 
 		$info          = json_decode( $version );
-		$tag           = $info->tag ?? null;
-		$stack_version = $info->stack_version ?? null;
+		$branch        = $info->tag ?? '';
+		$stack_version = $info->stack_version ?? [];
 		$version_info  = explode( '-', $stack_version );
 		$date          = isset( $version_info[0] ) ? gmdate( 'F j, Y', strtotime( $version_info[0] ) ) : null;
 		$commit        = $version_info[1] ?? null;
 
-		$this->data['mu-plugins-stack']  = $tag;
-		$this->data['version']['date']   = $date;
-		$this->data['version']['commit'] = $commit;
+		$this->data['mu-plugins'] = [
+			'branch' => $branch,
+			'commit' => $commit,
+			'date'   => $date,
+		];
+	}
+
+	/**
+	 * Return some default information if no .version file is found or if the file is empty.
+	 *
+	 */
+	private function set_default_version_info() {
+		$this->data['mu-plugins'] = [
+			'branch' => 'unbuilt',
+		];
 	}
 }

--- a/qm-plugins/qm-vip/class-qm-vip-collector.php
+++ b/qm-plugins/qm-vip/class-qm-vip-collector.php
@@ -1,0 +1,45 @@
+<?php
+
+class QM_VIP_Collector extends QM_Collector {
+
+	/**
+	 * @var string
+	 */
+	public $id = 'qm-vip';
+
+	/**
+	 * @return string
+	 */
+	public function name() {
+		return esc_html__( 'VIP', 'query-monitor' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function process() {
+		$this->process_version_file();
+	}
+
+	private function process_version_file() {
+		$version_file = WP_CONTENT_DIR . '/mu-plugins/.version';
+		if ( ! file_exists( $version_file ) ) {
+			return null;
+		}
+		$version = file_get_contents( $version_file ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		if ( ! $version ) {
+			return null;
+		}
+
+		$info          = json_decode( $version );
+		$tag           = $info->tag ?? null;
+		$stack_version = $info->stack_version ?? null;
+		$version_info  = explode( '-', $stack_version );
+		$date          = isset( $version_info[0] ) ? gmdate( 'F j, Y', strtotime( $version_info[0] ) ) : null;
+		$commit        = $version_info[1] ?? null;
+
+		$this->data['mu-plugins-stack']  = $tag;
+		$this->data['version']['date']   = $date;
+		$this->data['version']['commit'] = $commit;
+	}
+}

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -19,12 +19,18 @@ class QM_VIP_Output extends QM_Output_Html {
 	}
 
 	public function output() {
-		$data       = $this->collector->get_data();
-		$commit_url = 'https://github.com/automattic/vip-go-mu-plugins/commit/' . $data['version']['commit'];
+		$data = $this->collector->get_data();
+		if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
+			$commit_date_html = '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) . '" alt="GitHub URL of the commit that the stack was deployed from."><i><strong>Last modified: </strong>' . esc_html( $data['mu-plugins']['date'] ) . '</i></a></p>';
+		}
 		?>
 		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
-			<h3><strong>MU-Plugins Stack: </strong><?php echo esc_html( $data['mu-plugins-stack'] ); ?></h3>
-			<p><a href="<?php echo esc_url( $commit_url ); ?>" alt="GitHub URL of the commit that the stack was deployed from."><i><strong>Last modified: </strong><?php echo esc_html( $data['version']['date'] ); ?></i></a></p>
+			<h3><strong>MU-Plugins Branch: </strong><?php echo esc_html( $data['mu-plugins']['branch'] ); ?></h3>
+			<?php
+			if ( $commit_date_html ) {
+				echo wp_kses_post( $commit_date_html );
+			}
+			?>
 		</div>
 		<?php
 	}

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -20,15 +20,14 @@ class QM_VIP_Output extends QM_Output_Html {
 
 	public function output() {
 		$data = $this->collector->get_data();
-		if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
-			$commit_date_html = '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) . '" alt="GitHub URL of the commit that the stack was deployed from."><i><strong>Last modified: </strong>' . esc_html( $data['mu-plugins']['date'] ) . '</i></a></p>';
-		}
 		?>
 		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
 			<h3><strong>MU-Plugins Branch: </strong><?php echo esc_html( $data['mu-plugins']['branch'] ); ?></h3>
 			<?php
-			if ( $commit_date_html ) {
-				echo wp_kses_post( $commit_date_html );
+			if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
+				echo '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) .
+				'" alt="GitHub URL of the commit that the stack was deployed from."><i><strong>Last modified: </strong>' . esc_html( $data['mu-plugins']['date'] ) .
+				'</i></a></p>';
 			}
 			?>
 		</div>

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -1,0 +1,31 @@
+<?php
+
+class QM_VIP_Output extends QM_Output_Html {
+
+	public function __construct( \QM_Collector $collector ) {
+		parent::__construct( $collector );
+
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 1 );
+	}
+
+	public function admin_menu( array $menu ) {
+		$menu[] = $this->menu( array(
+			'id'    => 'qm-vip',
+			'href'  => '#qm-vip',
+			'title' => esc_html__( 'VIP', 'query-monitor' ),
+		));
+
+		return $menu;
+	}
+
+	public function output() {
+		$data       = $this->collector->get_data();
+		$commit_url = 'https://github.com/automattic/vip-go-mu-plugins/commit/' . $data['version']['commit'];
+		?>
+		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
+			<h3><strong>MU-Plugins Stack: </strong><?php echo esc_html( $data['mu-plugins-stack'] ); ?></h3>
+			<p><a href="<?php echo esc_url( $commit_url ); ?>" alt="GitHub URL of the commit that the stack was deployed from."><i><strong>Last modified: </strong><?php echo esc_html( $data['version']['date'] ); ?></i></a></p>
+		</div>
+		<?php
+	}
+}

--- a/qm-plugins/qm-vip/qm-vip.php
+++ b/qm-plugins/qm-vip/qm-vip.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Plugin Name: Query Monitor VIP
+ * Description: Additional collector for Query Monitor for VIP-specific information.
+ * Version: 1.0
+ * Author: Automattic, Rebecca Hum
+ */
+
+if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+	return;
+}
+
+add_action( 'plugins_loaded', 'register_qm_vip' );
+function register_qm_vip() {
+	if ( ! class_exists( 'QM_Collectors' ) ) {
+		return;
+	}
+
+	require_once __DIR__ . '/class-qm-vip-collector.php';
+
+	QM_Collectors::add( new QM_VIP_Collector() );
+	add_filter( 'qm/outputter/html', 'register_qm_vip_output', 120, 2 );
+}
+
+function register_qm_vip_output( array $output, \QM_Collectors $collectors ) {
+	$collector = \QM_Collectors::get( 'qm-vip' );
+	if ( $collector ) {
+		require_once __DIR__ . '/class-qm-vip-output-html.php';
+
+		$output['qm-vip'] = new QM_VIP_Output( $collector );
+	}
+	return $output;
+}

--- a/qm-plugins/qm-vip/qm-vip.php
+++ b/qm-plugins/qm-vip/qm-vip.php
@@ -7,7 +7,7 @@
  * Author: Automattic, Rebecca Hum
  */
 
-if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 	return;
 }
 

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -163,3 +163,6 @@ require_once __DIR__ . '/qm-plugins/qm-apcu-cache/qm-apcu-cache.php';
 if ( file_exists( __DIR__ . '/qm-plugins/qm-cron/qm-cron.php' ) ) {
 	require_once __DIR__ . '/qm-plugins/qm-cron/qm-cron.php';
 }
+if ( file_exists( __DIR__ . '/qm-plugins/qm-vip/qm-vip.php' ) ) {
+	require_once __DIR__ . '/qm-plugins/qm-vip/qm-vip.php';
+}


### PR DESCRIPTION
## Description
Adds a VIP panel in Query Monitor.
<img width="512" alt="screenshot_2022-11-18_at_12 13 38_pm" src="https://user-images.githubusercontent.com/16962021/202792862-45c43b12-121d-4bb3-a41f-d6dd5b1d2434.png">


## Changelog Description
### Plugin Updated: Query Monitor

Adds a "VIP" panel with display of stacks information
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create a `.version` in `vip-go-mu-plugins` if using VIP dev-env with content of `{ "tag": "staging", "stack_version": "20221115190626-cb35ffb7e-1234" }`
2) Log in and go to Query Monitor and expect to see screenshot in Description