### PR TITLE
Search: Update breakpoint time for stale indices

### DIFF
--- a/search/includes/classes/class-versioningcleanupjob.php
+++ b/search/includes/classes/class-versioningcleanupjob.php
@@ -22,6 +22,10 @@ class VersioningCleanupJob {
 	 * @access  public
 	 */
 	public function init() {
+		if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			return;
+		}
+
 		add_action( self::CRON_EVENT_NAME, [ $this, 'versioning_cleanup' ] );
 
 		$this->schedule_job();
@@ -78,7 +82,8 @@ class VersioningCleanupJob {
 			return [];
 		}
 
-		$time_ago_breakpoint    = time() - \MONTH_IN_SECONDS;
+		$breakpoint_time        = defined( 'VIP_GO_APP_ENVIRONMENT' ) && constant( 'VIP_GO_APP_ENVIRONMENT' ) === 'production' ? 2 * \WEEK_IN_SECONDS : 1 * \WEEK_IN_SECONDS;
+		$time_ago_breakpoint    = time() - $breakpoint_time;
 		$was_activated_recently = $active_version['activated_time'] > $time_ago_breakpoint;
 		if ( $was_activated_recently ) {
 			// We want to keep the old version for a period of time, even if it's older than the cutoff time period, while the new version proves stable


### PR DESCRIPTION
## Description
For stale inactive indexes that are production, let's delete them after 2 weeks and for non-production, let's delete them after 1 week.

## Changelog Description

### Plugin Updated: Enterprise Search

Update breakpoint times for job that cleans up stale inactive index
