### PR TITLE
Search: Add 'inactive' as an alias

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -185,7 +185,8 @@ class Versioning {
 	}
 
 	/**
-	 * Grab just the version number for the inactive version
+	 * Grab just the version number for the inactive version. If there is more than one inactive version, grab
+	 * the first one.
 	 *
 	 * @param \ElasticPress\Indexable $indexable The Indexable to get the inactive version number for
 	 * @return int|WP_Error The current inactive version number
@@ -195,10 +196,6 @@ class Versioning {
 
 		if ( empty( $inactive_versions ) ) {
 			return new WP_Error( 'no-inactive-versions-found', 'No inactive versions.' );
-		}
-
-		if ( count( $inactive_versions ) > 1 ) {
-			return new WP_Error( 'many-inactive-versions-found', 'More than one inactive version found.' );
 		}
 
 		return array_key_first( $inactive_versions ); // We only need the first key since there's only one.

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -187,7 +187,7 @@ class Versioning {
 	/**
 	 * Grab just the version number for the inactive version
 	 *
-	 * @param \ElasticPress\Indexable $indexable The Indexable to get the active version number for
+	 * @param \ElasticPress\Indexable $indexable The Indexable to get the inactive version number for
 	 * @return int|WP_Error The current inactive version number
 	 */
 	public function get_inactive_version_number( Indexable $indexable ) {

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -184,6 +184,26 @@ class Versioning {
 		return $active_version['number'];
 	}
 
+	/**
+	 * Grab just the version number for the inactive version
+	 *
+	 * @param \ElasticPress\Indexable $indexable The Indexable to get the active version number for
+	 * @return int|WP_Error The current inactive version number
+	 */
+	public function get_inactive_version_number( Indexable $indexable ) {
+		$inactive_versions = $this->get_inactive_versions( $indexable );
+
+		if ( empty( $inactive_versions ) ) {
+			return new WP_Error( 'no-inactive-versions-found', 'No inactive versions.' );
+		}
+
+		if ( count( $inactive_versions ) > 1 ) {
+			return new WP_Error( 'many-inactive-versions-found', 'More than one inactive version found.' );
+		}
+
+		return array_key_first( $inactive_versions ); // We only need the first key since there's only one.
+	}
+
 	public function get_inactive_versions( Indexable $indexable ) {
 		$versions              = $this->get_versions( $indexable );
 		$active_version_number = $this->get_active_version_number( $indexable );
@@ -223,7 +243,7 @@ class Versioning {
 				);
 			} else {
 				return [];
-			}       
+			}
 		}
 
 		// Normalize the versions to ensure consistency (have all fields, etc)
@@ -286,6 +306,9 @@ class Versioning {
 
 			case 'previous':
 				return $this->get_previous_existing_version_number( $indexable );
+
+			case 'inactive':
+				return $this->get_inactive_version_number( $indexable );
 
 			default:
 				// Was it a number, but passed through as a string? return it as an int
@@ -807,7 +830,7 @@ class Versioning {
 			if ( $indexable->get( $object_id ) ) {
 				$indexable->delete( $object_id );
 			}
-			
+
 			$this->reset_current_version_number( $indexable );
 		}
 

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -512,7 +512,7 @@ class Versioning_Test extends WP_UnitTestCase {
 				// Version string to be normalized
 				'inactive',
 				// Expected inactive version
-				new \WP_Error( 'many-inactive-versions-found' ),
+				4,
 			),
 			// No versions
 			array(

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -474,6 +474,57 @@ class Versioning_Test extends WP_UnitTestCase {
 				// Expected active version
 				new \WP_Error( 'active-index-not-found-in-versions-list' ), // NOTE - like above, this is because the default active version is 1, even if it doesn't exist in the list. Likely to change
 			),
+			// Regular, 'inactive'
+			array(
+				// Input array of versions
+				array(
+					4 => array(
+						'number' => 4,
+						'active' => true,
+					),
+					5 => array(
+						'number' => 5,
+						'active' => false,
+					),
+				),
+				// Indexable slug
+				'post',
+				// Version string to be normalized
+				'inactive',
+				// Expected inactive version
+				5,
+			),
+			// More than one inactive version
+			array(
+				// Input array of versions
+				array(
+					4 => array(
+						'number' => 4,
+						'active' => false,
+					),
+					5 => array(
+						'number' => 5,
+						'active' => false,
+					),
+				),
+				// Indexable slug
+				'post',
+				// Version string to be normalized
+				'inactive',
+				// Expected inactive version
+				new \WP_Error( 'many-inactive-versions-found' ),
+			),
+			// No versions
+			array(
+				// Input array of versions
+				array(),
+				// Indexable slug
+				'post',
+				// Version string to be normalized
+				'inactive',
+				// Expected inactive version
+				new \WP_Error( 'no-inactive-versions-found' ),
+			),
 		);
 	}
 


### PR DESCRIPTION
## Description
Currently, we have `next`, `previous`, `active` as aliases in versioning. It would be good to have `inactive` as one as well, especially so we could do something like `wp vip-search index-versions delete post inactive`.

## Changelog Description

### Plugin Updated: Enterprise Search

Add `inactive` as alias in versioning

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Spin up new environment and create an index `wp vip-search index --setup`
2) Add another version `wp vip-search index-versions add post`
3) Verify there are two versions `wp vip-search index-versions list post`, with one being active and one inactive:
```
+--------+--------+--------------+----------------+----------------+
| number | active | created_time | activated_time | document_count |
+--------+--------+--------------+----------------+----------------+
| 1      | 1      |              |                | 2              |
| 2      |        | 1669227879   |                | 0              |
+--------+--------+--------------+----------------+----------------+
```

### Testing the `get_inactive_version_number()` directly from shell:
1) `$v = new \Automattic\VIP\Search\Versioning();`
2) `$indexable = \ElasticPress\Indexables::factory()->get( 'post' );`
3) `$v->get_inactive_version_number( $indexable );`
Expect to see `2` returned

### Testing it as an alias in CLI context
1) `wp vip-search index-versions delete post inactive` and confirm
2) Expect to see `Success: Successfully deleted index version 2 for type post`


