### PR TITLE
Search: check response size before trying to cache the ES response to avoid potentially hammering Memcached

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1028,7 +1028,7 @@ class Search {
 			add_site_option( $index_exists_option_name, $response );
 		}
 
-		if ( $is_cacheable ) {
+		if ( $is_cacheable && isset( $response_body_json ) && strlen( $response_body_json ) < 6 * MB_IN_BYTES ) {
 			// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
 			wp_cache_set( $cache_key, $response, self::SEARCH_CACHE_GROUP, 5 * MINUTE_IN_SECONDS );
 		}


### PR DESCRIPTION
## Description

Previous approach didn't take the size of response into the account when making a decision whether to cache or not to cache. This PR adds a safeguard to not try to set large values.

The 6MB mark is rather arbitrary, with compression it'll likely fit in Memcached but since our goal is to reduce the chances of `wp_cache_set` barrages this felt like a good compromise.

## Changelog Description

### Plugin Updated: Enteprise Search

We modified the request cache behavior to not try to cache any responses over 6 megabytes in size to prevent potential negative impact on object cache.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
