### PR TITLE
CANTINA-914: Account for multisite in Feature rollout

### DIFF
--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -77,7 +77,7 @@ class Feature {
 		// Is the bucket enabled?
 		$threshold = $percentage * 100; // $percentage is decimal
 
-		if ( is_multisite() && ( $bucket < $threshold ) ) {
+		if ( is_multisite() && $bucket < $threshold ) {
 			// For multisites, we don't want to roll out for all subsites
 			$bucket = crc32( $feature . '-' . get_current_blog_id() ) % 100;
 		}

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -17,9 +17,7 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = [
-		'es-auto-rebuild-bad-index' => 0.25,
-	];
+	public static $feature_percentages = [];
 
 	/**
 	 * Holds feature slug and then, key of ids with bool value to enable E.g.
@@ -78,6 +76,11 @@ class Feature {
 
 		// Is the bucket enabled?
 		$threshold = $percentage * 100; // $percentage is decimal
+
+		if ( is_multisite() && ( $bucket < $threshold ) ) {
+			// For multisites, we don't want to roll out for all subsites
+			$bucket = crc32( $feature . '-' . get_current_blog_id() ) % 100;
+		}
 
 		return $bucket < $threshold; // If our 0-based bucket is inside our threshold, it's enabled
 	}

--- a/tests/lib/feature/test-class-feature-ms.php
+++ b/tests/lib/feature/test-class-feature-ms.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Automattic\VIP;
+
+use PHPUnit\Framework\TestCase;
+use Automattic\Test\Constant_Mocker;
+
+require_once __DIR__ . '/../../../lib/feature/class-feature.php';
+
+class Feature_Multisite_Test extends TestCase {
+
+	public static $site_id = 400; // Hashes to 13
+
+	public function setUp(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		parent::setUp();
+
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', self::$site_id );
+	}
+
+	public function tearDown(): void {
+		Constant_Mocker::clear();
+	}
+
+	/**
+	 * NOTE - since the Feature class uses crc32 on the feature + id (to distribute testing across sites), we have to
+	 * use something like this when generating test data:
+	 *
+	 * for( $i = 1; $i < 1000; $i++ ) {
+	 *     echo $i . ' - ' . crc32( 'foo-feature-' . $i ) % 100 . PHP_EOL;
+	 * }
+	 *
+	 * The above will give you a list of blog ids that fall above or below your target threshold
+	 */
+	public function is_enabled_by_percentage_data() {
+		return array(
+			// Blog ID bucketed within the percentage threshold, enabled
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				0.25,
+				// blog id
+				6, // hashes to 4
+				// Expected enabled/disabled
+				true,
+			),
+			// blog id bucketed within the percentage threshold, enabled
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				0.25,
+				// blog id
+				37, // hashes to 3
+				// Expected enabled/disabled
+				true,
+			),
+			// blog id is bucketed to exact percentage, not enabled, b/c buckets are 0-based
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				0.25,
+				// blog id
+				20, // hashes to 25
+				// Expected enabled/disabled
+				false,
+			),
+			// blog id is bucketed to "percentage - 1", enabled, b/c buckets are 0-based
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				0.63,
+				// blog id
+				99, // hashes to 62
+				// Expected enabled/disabled
+				true,
+			),
+			// blog id bucketed outside the threshold, not enabled
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				0.25,
+				// blog id
+				7, // hashes to 26
+				// Expected enabled/disabled
+				false,
+			),
+
+			// 100% enabled
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				1,
+				// blog id
+				100,
+				// Expected enabled/disabled
+				true,
+			),
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				1,
+				// blog id
+				5,
+				// Expected enabled/disabled
+				true,
+			),
+
+			// 0% enabled
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				0,
+				// blog id
+				22,
+				// Expected enabled/disabled
+				false,
+			),
+			array(
+				// Feature name
+				'foo-feature',
+				// Enabled percentage
+				0,
+				// blog id
+				1,
+				// Expected enabled/disabled
+				false,
+			),
+
+			// Different feature name, should _not_ have the same bucket as the same id from earlier
+			array(
+				// Feature name
+				'bar-feature',
+				// Enabled percentage
+				0.25,
+				// blog id
+				37, // hashes to 90
+				// Expected enabled/disabled
+				false,
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider is_enabled_by_percentage_data
+	 */
+	public function test_is_enabled_by_percentage( $feature, $percentage, $blogid, $expected ) {
+		Feature::$feature_percentages = array(
+			$feature => $percentage,
+		);
+
+		switch_to_blog( $blogid );
+
+		$enabled = Feature::is_enabled_by_percentage( $feature );
+
+		$this->assertEquals( $expected, $enabled );
+
+		restore_current_blog();
+	}
+
+	public function test_is_enabled_by_percentage_with_undefined_feature() {
+		Feature::$feature_percentages = array(
+			'foo' => 1,
+		);
+
+		switch_to_blog( wp_rand( 0, 20 ) );
+
+		$enabled = Feature::is_enabled_by_percentage( 'barzzz' );
+
+		$this->assertEquals( false, $enabled );
+
+		restore_current_blog();
+	}
+}


### PR DESCRIPTION
## Description
When we use the feature roll-out, it should be taking into account the subsites in multisites since we don't want all of the subsites to be enabled.

## Changelog Description

### Plugin Updated: Feature

Feature percentage roll out will take into account a multisite's subsites to ensure not all subsites are rolled out together at once.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
