### PR TITLE
Query Monitor (VIP): Open commit in new window

### DIFF
--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -26,7 +26,7 @@ class QM_VIP_Output extends QM_Output_Html {
 			<?php
 			if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
 				echo '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) .
-				'" alt="GitHub URL of the commit that the stack was deployed from."><i><strong>Last modified: </strong>' . esc_html( $data['mu-plugins']['date'] ) .
+				'" alt="GitHub URL of the commit that the stack was deployed from." target="_blank"><i><strong>Last modified: </strong>' . esc_html( $data['mu-plugins']['date'] ) .
 				'</i></a></p>';
 			}
 			?>

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -26,7 +26,7 @@ class QM_VIP_Output extends QM_Output_Html {
 			<?php
 			if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
 				echo '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) .
-				'"><i><strong><span class="screen-reader-text">Open in new tab </span>Last modified: </strong>' .
+				' target="_blank"><i><strong><span class="screen-reader-text">Open in new tab </span>Last modified: </strong>' .
 				esc_html( $data['mu-plugins']['date'] ) . '</i></a></p>';
 			}
 			?>

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -26,7 +26,7 @@ class QM_VIP_Output extends QM_Output_Html {
 			<?php
 			if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
 				echo '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) .
-				'" aria-label="GitHub URL of the commit that the stack was deployed from."><i><strong><span class="screen-reader-text">Open in new tab </span>Last modified: </strong>' .
+				'"><i><strong><span class="screen-reader-text">Open in new tab </span>Last modified: </strong>' .
 				esc_html( $data['mu-plugins']['date'] ) . '</i></a></p>';
 			}
 			?>

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -26,8 +26,8 @@ class QM_VIP_Output extends QM_Output_Html {
 			<?php
 			if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
 				echo '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) .
-				'" alt="GitHub URL of the commit that the stack was deployed from." target="_blank"><i><strong>Last modified: </strong>' . esc_html( $data['mu-plugins']['date'] ) .
-				'</i></a></p>';
+				'" aria-label="GitHub URL of the commit that the stack was deployed from."><i><strong><span class="screen-reader-text">Open in new tab </span>Last modified: </strong>' .
+				esc_html( $data['mu-plugins']['date'] ) . '</i></a></p>';
 			}
 			?>
 		</div>


### PR DESCRIPTION
## Description
Maybe me, but it's an annoyance if I open a link in a working window and it doesn't pop up in a new one.

## Changelog Description

### Plugin Updated: Query Monitor (VIP)

Open commit in new window.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create `.version` file with contents: `{ "tag": "staging", "stack_version": "20221115190626-cb35ffb7e-1234" }`
2) Go to Query Monitor > VIP and click on date displayed
3) Expect it to take you to a new window