### PR TITLE
Mitigate corrupted get_sites cache entry in multisite context

### DIFF
--- a/lib/sunrise/sunrise.php
+++ b/lib/sunrise/sunrise.php
@@ -66,6 +66,13 @@ function handle_not_found_error( $error_type ) {
 		exit;
 	}
 
+	// Empty get_sites() return would signify potential cache pollution
+	// We side-step by bumping the last changed which would result in the cache key change
+	// So the next request can recover
+	if ( 'site' == $error_type && ! get_sites() ) {
+		wp_cache_set_sites_last_changed();
+	}
+
 	$is_web_request = Context::is_web_request();
 	if ( $is_web_request ) {
 		$mu_plugin_dir       = defined( 'WPMU_PLUGIN_DIR' ) ? constant( 'WPMU_PLUGIN_DIR' ) : constant( 'WP_CONTENT_DIR' ) . '/mu-plugins';


### PR DESCRIPTION
## Description

WordPress doesn't handle get_sites population gracefully, and in case the query fails the corrupted value may get stored, essentially breaking sites in a hard-to-recover fashion. 

Luckily it's simple to detect - `get_sites()` return value should never be empty and if it is the things went south. 

The recovery is pretty simple too, we bump the sites_last_changed - this would invalidate the cache key, and the next request would try to run the query again. 

## Changelog Description

### Sunrise.php update

We've updated sunrise.php to recover from certain cache pollution edge case. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. The cache key is a bit salty, so the quickest way to test would be to hack `wp-includes/class-wp-site-query.php#361` to read as follows:

```php
		wp_cache_set( $cache_key, array(
			'site_ids' => [],
			'found_sites' => 0,
		), 'sites' );
		$cache_value = wp_cache_get( $cache_key, 'sites' );
```
2. Hit an existing subsite, verify you see the error
3. Comment out the hack
4. Hit the subsite again, verify that it recovered. 