### PR TITLE
Default setting Debug Bar to false and add deprecation + admin notice

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -47,3 +47,22 @@ add_action(
 		);
 	}
 );
+
+// Debug Bar deprecation notice
+add_action(
+	'vip_admin_notice_init',
+	function( $admin_notice_controller ) {
+		$message = 'Debug Bar will no longer be included in VIP MU Plugins as of January 31, 2023. Please use <a href="https://docs.wpvip.com/technical-references/query-monitor/" target="_blank">Query Monitor</a> instead for diagnostics. For more information, see <a href="https://lobby.vip.wordpress.com/2022/12/14/deprecation-notice-debug-bar-january-31-2023/" target="_blank">our Lobby post</a>.';
+
+		$admin_notice_controller->add(
+			new Admin_Notice(
+				$message,
+				[
+					new Expression_Condition( true === apply_filters( 'debug_bar_enable', false ) ),
+				],
+				'debug-bar-deprecation',
+				'error'
+			)
+		);
+	}
+);

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -9,19 +9,6 @@ Author URI: https://wordpress.org/
 Text Domain: debug-bar
 */
 
-// If the user is an Automattician (typically a vip_support user), then force-enable Debug Bar.
-add_filter( 'debug_bar_enable', function( $enable ) {
-	if ( is_automattician() ) {
-		return true;
-	}
-
-	if ( defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === WP_ENVIRONMENT_TYPE ) {
-		return true;
-	}
-
-	return $enable;
-}, PHP_INT_MAX );
-
 // We only need to load the files if it's enabled
 add_action( 'set_current_user', function() {
 	$enable = apply_filters( 'debug_bar_enable', false );
@@ -29,6 +16,8 @@ add_action( 'set_current_user', function() {
 	if ( ! $enable ) {
 		return;
 	}
+
+	trigger_error( 'Debug Bar will no longer be included in VIP MU Plugins as of January 31, 2023. Use Query Monitor instead, see https://lobby.vip.wordpress.com/2022/12/14/deprecation-notice-debug-bar-january-31-2023/.', E_USER_WARNING );
 
 	if ( ! class_exists( 'Debug_Bar' ) ) {
 		require_once __DIR__ . '/debug-bar/debug-bar.php';


### PR DESCRIPTION
## Description
As part of https://lobby.vip.wordpress.com/2022/12/14/deprecation-notice-debug-bar-january-31-2023/, @WPprodigy suggested that we disable it right now and add in deprecation notices.
<img width="1449" alt="Screenshot 2022-12-15 at 12 38 35 PM" src="https://user-images.githubusercontent.com/16962021/207951492-86fca241-73c3-4e6e-8634-0d21e744e2c2.png">

## Changelog Description

### Plugin Updated: Debug Bar

We added a deprecation notice to debug bar if it is set to be enabled.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) In `client-mu-plugins`, add the below:
```
remove_all_filters( 'debug_bar_enable' );
add_filter( 'debug_bar_enable', function( $enable ) {
    if ( ! is_admin() ) {
        $enable = false;
    }
    return $enable = true;
} );
```
2) Log in as admin and expect to see admin notice. Check logs and also see deprecation notice.
3) Log out and log in as user, and expect to not see admin notice