### PR TITLE
Add wp-cache-memcached to submodules for easier testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "search/elasticpress-next"]
 	path = search/elasticpress-next
 	url = https://github.com/Automattic/ElasticPress.git
+[submodule "drop-ins/wp-cache-memcached"]
+	path = drop-ins/wp-cache-memcached
+	url = https://github.com/Automattic/wp-cache-memcached.git


### PR DESCRIPTION
## Description

This brings in the prototype wp-cache-mecached into `drop-ins` for ease of testing.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
