### PR TITLE
Add 'local' to switch for WP_ENVIRONMENT_TYPE in 000-vip-init.php

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -249,6 +249,9 @@ if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && ! defined( 'WP_ENVIRONMENT_TYPE' ) )
 		case 'development':
 			$environment_type = 'development';
 			break;
+		case 'local':
+			$environment_type = 'local';
+			break;
 		default:
 			$environment_type = 'staging';
 			break;


### PR DESCRIPTION
## Description
It currently defaults to `staging` on local dev-env environments because we don't have `local` as a valid value in the switch statement in defining `WP_ENVIRONMENT_TYPE`

## Changelog Description

### Plugin Updated: 000-vip-init.php
Add 'local' as valid value in switch statement for defining WP_ENVIRONMENT_TYPE 
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Check out PR
2) Expect to see `WP_ENVIRONMENT_TYPE` as `local` instead of `staging`:
```
$ vip dev-env --slug es-site exec -- wp shell
wp> WP_ENVIRONMENT_TYPE;
=> string(5) "local"
```
