### PR TITLE
Make A8c-debug available in local environment

### DIFF
--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -40,7 +40,7 @@ function is_debug_mode_enabled() {
 	$is_nocache = isset( $_COOKIE['vip-go-cb'] ) && '1' === $_COOKIE['vip-go-cb'];  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	$is_debug   = isset( $_COOKIE['a8c-debug'] ) && '1' === $_COOKIE['a8c-debug'];  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	$is_proxied = \is_proxied_request();
-	$is_local   = defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === WP_ENVIRONMENT_TYPE;
+	$is_local   = \is_local_env();
 
 	if ( ( $is_nocache && $is_debug && $is_proxied ) || $is_local ) {
 		return true;
@@ -66,7 +66,7 @@ function redirect_back() {
 function enable_debug_mode() {
 	nocache_headers();
 
-	if ( ! \is_proxied_request() ) {
+	if ( ! \is_proxied_request() && ! \is_local_env() ) {
 		send_pixel( [ 'vip-go-a8c-debug' => 'fail-noproxy' ] );
 
 		wp_die( 'A8C: Please proxy to enable Debug Mode.', 'Proxy Required', [ 'response' => 403 ] );
@@ -95,9 +95,9 @@ function disable_debug_mode() {
 
 /**
  * Turns the debug mode on or off
- * 
+ *
  * @param bool $set     Whether to turn on (true) or off (false) the debug mode
- * @return void 
+ * @return void
  */
 function set_debug_mode( bool $set ) {
 	if ( $set ) {

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1477,6 +1477,15 @@ function is_proxied_request() {
 }
 
 /**
+ * Is the current environment a local one.
+ *
+ * @return bool True if the current environment is a local one
+ */
+function is_local_env() {
+	return defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === constant( 'WP_ENVIRONMENT_TYPE' );
+}
+
+/**
  * Is the current request being made from Jetpack servers?
  *
  * NOTE - This checks the REMOTE_ADDR against known JP IPs. The IP can still be spoofed,


### PR DESCRIPTION
## Description
We can't use the `?a8c-debug=true` query var on dev-env because it checks for a proxied request (which shouldn't matter in local context). This PR introduces the `is_local_env()` helper and uses that in the logic for enabling a8c debug mode.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) In dev-env, visit http://es-site.vipdev.lndo.site/?a8c-debug=true
2) You should see an error message indicating `A8C: Please proxy to enable Debug Mode.`
3) Check out PR
4) Hit step 1) and see that the error message no longer appears