### PR TITLE
Check plugin updates after every 6 hours

### DIFF
--- a/codebase-manager/plugins/plugins-manager.php
+++ b/codebase-manager/plugins/plugins-manager.php
@@ -67,7 +67,7 @@ class PluginsManager {
 
 		// Maybe refresh.
 		$last_refreshed = isset( $update_cache->last_checked ) ? ( time() - $update_cache->last_checked ) : null;
-		if ( ! $last_refreshed || 6 * HOUR_IN_SECONDS < $last_refreshed ) {
+		if ( ! $last_refreshed || $last_refreshed > ( 6 * HOUR_IN_SECONDS ) ) {
 			wp_update_plugins();
 			$update_cache = get_site_transient( 'update_plugins' );
 		}

--- a/codebase-manager/plugins/plugins-manager.php
+++ b/codebase-manager/plugins/plugins-manager.php
@@ -67,7 +67,7 @@ class PluginsManager {
 
 		// Maybe refresh.
 		$last_refreshed = isset( $update_cache->last_checked ) ? ( time() - $update_cache->last_checked ) : null;
-		if ( ! $last_refreshed || 6 * HOUR_IN_SECONDS > $last_refreshed ) {
+		if ( ! $last_refreshed || 6 * HOUR_IN_SECONDS < $last_refreshed ) {
 			wp_update_plugins();
 			$update_cache = get_site_transient( 'update_plugins' );
 		}


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

The Codebase Manager plugin keeps making POST requests to the WordPress' `update-check` (`ttps://api.wordpress.org/plugins/update-check/1.1/`) endpoint on every request.

In the code it was apparent that the developer intended to make such requests after every 6 hours, but instead of `<` they used `>` thereby ending up making those POST requests on every request instead.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->

This PR will ensure that sites using vip-go-mu-plugins will make requests to check for plugin updates after every 6 hours rather than on every request that they are doing currently.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
Before this PR:
1. Enable Query Monitor for your user
2. Open any `wp-admin` page (Dashboard page)
3. Check the `HTTP API Calls` section in the Query Monitor dashboard.
4. You will always see a POST request to `https://api.wordpress.org/plugins/update-check/1.1/` 
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/1535505/209506609-b1fede91-3868-410d-ac1e-d31fabee9a00.png">


After this PR:
1. Repeat the same steps as mentioned above, but you will only see the request after every 6 hours.