### PR TITLE
VIP Request Block: Add function to allow for blocking by partial User Agent string.

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -88,8 +88,8 @@ class VIP_Request_Block {
 	 * @return void|bool
 	 */
 	public static function ua_partial_match( string $user_agent_substring ) {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && str_contains( $_SERVER['HTTP_USER_AGENT'], $user_agent_substring ) ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && false !== strpos( $_SERVER['HTTP_USER_AGENT'], $user_agent_substring ) ) {
 			return self::block_and_log( $user_agent_substring, 'user-agent' );
 		}
 

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -50,7 +50,7 @@ class VIP_Request_Block {
 			$hdr = strtolower( $_SERVER['HTTP_TRUE_CLIENT_IP'] );
 			$bin = inet_pton( $hdr );
 			if ( $bin === $ip || $hdr === $value ) {
-				return self::block_and_log( $value, 'true-client-ip' );
+				return static::block_and_log( $value, 'true-client-ip' );
 			}
 		}
 
@@ -58,7 +58,7 @@ class VIP_Request_Block {
 			$ips = array_map( fn ( string $s ): string => strtolower( trim( $s ) ), explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
 			$bin = array_map( 'inet_pton', $ips );
 			if ( in_array( $value, $ips, true ) || in_array( $ip, $bin, true ) ) {
-				return self::block_and_log( $value, 'x-forwarded-for' );
+				return static::block_and_log( $value, 'x-forwarded-for' );
 			}
 		}
 
@@ -75,7 +75,7 @@ class VIP_Request_Block {
 	public static function ua( string $user_agent ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
 		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && $user_agent === $_SERVER['HTTP_USER_AGENT'] ) {
-			return self::block_and_log( $user_agent, 'user-agent' );
+			return static::block_and_log( $user_agent, 'user-agent' );
 		}
 
 		return false;
@@ -90,7 +90,7 @@ class VIP_Request_Block {
 	public static function ua_partial_match( string $user_agent_substring ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && false !== strpos( $_SERVER['HTTP_USER_AGENT'], $user_agent_substring ) ) {
-			return self::block_and_log( $user_agent_substring, 'user-agent' );
+			return static::block_and_log( $user_agent_substring, 'user-agent' );
 		}
 
 		return false;
@@ -110,7 +110,7 @@ class VIP_Request_Block {
 		$key = sprintf( 'HTTP_%s', str_ireplace( 'HTTP_', '', $key ) );
 
 		if ( isset( $_SERVER[ $key ] ) && $value === $_SERVER[ $key ] ) {
-			return self::block_and_log( $value, $header );
+			return static::block_and_log( $value, $header );
 		}
 
 		return false;

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -82,6 +82,21 @@ class VIP_Request_Block {
 	}
 
 	/**
+	 * Block by partial match of the user agent header
+	 *
+	 * @param string $user_agent_substring target user agent to be blocked.
+	 * @return void|bool
+	 */
+	public static function ua_partial_match( string $user_agent_substring ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && str_contains( $_SERVER['HTTP_USER_AGENT'], $user_agent_substring ) ) {
+			return self::block_and_log( $user_agent_substring, 'user-agent' );
+		}
+
+		return false;
+	}
+
+	/**
 	 * Block by exact match for an arbitrary header.
 	 *
 	 * @param string $header HTTP header.

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -11,7 +11,7 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 	 */
 
 	public function tearDown(): void {
-		unset( $_SERVER['HTTP_TRUE_CLIENT_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		unset( $_SERVER['HTTP_TRUE_CLIENT_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['HTTP_USER_AGENT']  );
 		parent::tearDown();
 	}
 
@@ -77,5 +77,17 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 			[ 'HTTP_X_FORWARDED_FOR', '2001:4860:4860::8844', '2001:4860:4860:0000:0000:0000:0000:8844' ],
 			[ 'HTTP_X_FORWARDED_FOR', '2001:4860:4860:0:0:0:0:8844', '2001:4860:4860:0000:0000:0000:0000:8844' ],
 		];
+	}
+
+	public function test_ua_partial_match() {
+		// Test that a partial match of the user agent string blocks bad site.
+		$_SERVER['HTTP_USER_AGENT'] = 'WordPress/6.1.1; https://www.BadSite.com';
+		$actual = VIP_Request_Block::ua_partial_match( 'https://www.BadSite.com' );
+		self::assertTrue( $actual, 'Expected request to be blocked based on partial User Agent string match.' );
+
+		// Test that allowed user agent string is not blocked.
+		$_SERVER['HTTP_USER_AGENT'] = 'WordPress/6.1.1; https://www.example.com';
+		$actual = VIP_Request_Block::ua_partial_match( 'https://www.BadSite.com' );
+		self::assertFalse( $actual, 'Expected request to be allowed.' );
 	}
 }

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -11,7 +11,8 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 	 */
 
 	public function tearDown(): void {
-		unset( $_SERVER['HTTP_TRUE_CLIENT_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['HTTP_USER_AGENT']  );
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		unset( $_SERVER['HTTP_TRUE_CLIENT_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['HTTP_USER_AGENT'] );
 		parent::tearDown();
 	}
 
@@ -81,13 +82,13 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 
 	public function test_ua_partial_match() {
 		// Test that a partial match of the user agent string blocks bad site.
-		$_SERVER['HTTP_USER_AGENT'] = 'WordPress/6.1.1; https://www.BadSite.com';
-		$actual = VIP_Request_Block::ua_partial_match( 'https://www.BadSite.com' );
+		$_SERVER['HTTP_USER_AGENT'] = 'WordPress/6.1.1; https://www.BadSite.com'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		$actual                     = VIP_Request_Block::ua_partial_match( 'https://www.BadSite.com' );
 		self::assertTrue( $actual, 'Expected request to be blocked based on partial User Agent string match.' );
 
 		// Test that allowed user agent string is not blocked.
-		$_SERVER['HTTP_USER_AGENT'] = 'WordPress/6.1.1; https://www.example.com';
-		$actual = VIP_Request_Block::ua_partial_match( 'https://www.BadSite.com' );
+		$_SERVER['HTTP_USER_AGENT'] = 'WordPress/6.1.1; https://www.example.com'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		$actual                     = VIP_Request_Block::ua_partial_match( 'https://www.BadSite.com' );
 		self::assertFalse( $actual, 'Expected request to be allowed.' );
 	}
 }


### PR DESCRIPTION
## Description
I would like to block requests by a partial match on the user agent string.  The use case is a User Agent header like 'WordPress/6.1.1; https://www.example.com' which is the default format of a User Agent string to WordPress.  If I block by exact match, as soon as WordPress is upgraded, this exact match will no longer work.  

## Changelog Description

Adds VIP_Request_Block::ua_partial_match

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Follow documentation in https://docs.wpvip.com/how-tos/block-requests/ to test, except use `VIP_Request_Block::ua_partial_match` with a substring instead of `VIP_Request_Block::ua`
