### PR TITLE
Fix issue with wpcom_vip_disable_new_relic_js being called incorrectly

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -69,7 +69,14 @@ add_action( 'parse_request', 'action_wpcom_vip_verify_string', 0 );
 /**
  * Disable New Relic browser monitoring on AMP pages, as the JS isn't AMP-compatible
  */
-add_action( 'pre_amp_render_post', 'wpcom_vip_disable_new_relic_js' );
+function wpcom_vip_disable_newrelic_on_amp() {
+	if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( function_exists( 'newrelic_disable_autorum' ) ) {
+			newrelic_disable_autorum();
+		}
+	}
+}
+add_action( 'template_redirect', 'wpcom_vip_disable_newrelic_on_amp' );
 
 /**
  * Fix a race condition in alloptions caching


### PR DESCRIPTION

## Description

This fixes this error:
PHP Notice:  wpcom_vip_disable_new_relic_js was called <strong>incorrectly</strong>. New Relic&#8217;s browser tracking can only be disabled at or before the `template_redirect` action. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 1.0.) in /var/www/nyp/wp-includes/functions.php on line 5777

The issue is that the action `pre_amp_render_post` is called after `template_redirect`.  This changes this code to run on `template_redirect` for AMP endpoints.

## Changelog Description

Fix PHP notice about wpcom_vip_disable_new_relic_js being called incorrectly.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Example:

1. Check out PR.
1. Visit an AMP endpoint.
1. Ensure that New Relic code has not been included.  Check the source code for the inclusion of new relic JS.
1. View PHP error log and check that there's no notice.
