### PR TITLE
GH-3754: Fix wpcom_vip_disable_new_relic_js being called incorrectly

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -70,10 +70,8 @@ add_action( 'parse_request', 'action_wpcom_vip_verify_string', 0 );
  * Disable New Relic browser monitoring on AMP pages, as the JS isn't AMP-compatible
  */
 function wpcom_vip_disable_newrelic_on_amp() {
-	if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
-		if ( function_exists( 'newrelic_disable_autorum' ) ) {
-			newrelic_disable_autorum();
-		}
+	if ( function_exists( 'is_amp_endpoint' ) && function_exists( 'newrelic_disable_autorum' ) && is_amp_endpoint() ) {
+		newrelic_disable_autorum();
 	}
 }
 add_action( 'template_redirect', 'wpcom_vip_disable_newrelic_on_amp' );

--- a/misc.php
+++ b/misc.php
@@ -69,7 +69,14 @@ add_action( 'parse_request', 'action_wpcom_vip_verify_string', 0 );
 /**
  * Disable New Relic browser monitoring on AMP pages, as the JS isn't AMP-compatible
  */
-add_action( 'pre_amp_render_post', 'wpcom_vip_disable_new_relic_js' );
+function wpcom_vip_disable_newrelic_on_amp() {
+	if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( function_exists( 'newrelic_disable_autorum' ) ) {
+			newrelic_disable_autorum();
+		}
+	}
+}
+add_action( 'template_redirect', 'wpcom_vip_disable_newrelic_on_amp' );
 
 /**
  * Fix a race condition in alloptions caching


### PR DESCRIPTION
## Description

Ref: #4002 
Closes: #3754 

## Changelog Description

### Plugin Updated: VIP Hosting Miscellaneous

Fix the issue with `wpcom_vip_disable_new_relic_js()` being called incorrectly.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
