### PR TITLE
CI: Only run search-e2e workflow when search path is modified and on PRs only

### DIFF
--- a/.github/workflows/search-e2e.yml
+++ b/.github/workflows/search-e2e.yml
@@ -3,16 +3,13 @@ env:
   NODE_VERSION: "16"
 
 on:
-  push:
-    branches:
-      - develop
-      - production
-      - staging
   pull_request:
     branches:
       - develop
       - production
       - staging
+    paths:
+    - 'search/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description
It's adding too much waiting time during deploys