### PR TITLE
ci: Set DO_NOT_TRACK=1 for E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   Run_e2e_tests:
     name: Run E2E Tests


### PR DESCRIPTION
This PR sets the `DO_NOT_TRACK` environment variable for E2E tests so that the CI does not affect the usage stats for VIP CLI.
