### PR TITLE
Composer: Remove Composer PHPCS plugin depedency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
         "phpunit/phpunit": "9.5.27",
         "automattic/vipwpcs": "2.3.3",
         "phpcompatibility/phpcompatibility-wp": "2.1.4",
-        "dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
         "erusev/parsedown": "1.7.4",
         "dms/phpunit-arraysubset-asserts": "0.4.0",
         "yoast/phpunit-polyfills": "1.0.4",


### PR DESCRIPTION
## Description
It's best to let the Composer PHPCS plugin be required by individual external standards, and VIPCS 2.3.3 and PHPCompatibility 2.1.4 both already require the Composer PHPCS plugin. There is no need for it to be required in the root of this project as well.

The `allow-plugins` config is still needed.

## Changelog Description

### Composer: Remove Composer PHPCS plugin.

We removed the Composer PHPCS plugin, as it is already included with the two external coding standards used as development dependencies.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Run `composer install`
2. Run `./vendor/bin/phpcs -i` to see the list of installed standards is the same.