### PR TITLE
CI: Add a repository_dispatch event for production branch

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - staging
-  workflow_dispatch:
+      - production
 
 permissions:
   contents: read
@@ -22,6 +22,6 @@ jobs:
             github.rest.repos.createDispatchEvent({
               owner: 'automattic',
               repo: 'vip-container-images',
-              event_type: 'build-mu-plugins',
+              event_type: 'build-mu-plugins-${{ github.ref }}',
               client_payload: {}
             })

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - staging
       - production
-    workflow_dispatch:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - staging
       - production
+    workflow_dispatch:
 
 permissions:
   contents: read
@@ -22,6 +23,8 @@ jobs:
             github.rest.repos.createDispatchEvent({
               owner: 'automattic',
               repo: 'vip-container-images',
-              event_type: 'build-mu-plugins-${{ github.ref }}',
-              client_payload: {}
+              event_type: 'build-mu-plugins',
+              client_payload: {
+                branch: '${{ github.ref_name }}'
+              }
             })


### PR DESCRIPTION
## Description
This adds the event `build-mu-plugins-production` and changes the current staging one to `build-mu-plugins-staging`. [We'll have to change the listen logic in vip-container-images](https://github.com/Automattic/vip-container-images/pull/394). Also removes the `workflow_dispatch` since we shouldn't ever need to trigger this manually.