### PR TITLE
Query Monitor: Add tab for DB Connections

### DIFF
--- a/qm-plugins/qm-db-connections/class-qm-db-connections-collector.php
+++ b/qm-plugins/qm-db-connections/class-qm-db-connections-collector.php
@@ -18,28 +18,23 @@ class QM_DB_Connections_Collector extends QM_Collector {
 	 * @return void
 	 */
 	public function process() {
-		foreach ( $GLOBALS as $global ) {
-			if ( ! is_object( $global ) || ! get_class( $global ) || ! is_a( $global, 'wpdb' ) ) {
-				continue;
-			}
+		if ( ! isset( $GLOBALS['wpdb'] ) || ! property_exists( $GLOBALS['wpdb'], 'db_connections' ) ) {
+			return;
+		}
 
-			if ( ! property_exists( $global, 'db_connections' ) ) {
-				break;
-			}
+		$db_connections = $GLOBALS['wpdb']->db_connections;
+		if ( ! is_array( $db_connections ) || empty( $db_connections ) ) {
+			return;
+		}
 
-			if ( is_array( $global->db_connections ) && ! empty( $global->db_connections ) ) {
-				$elapsed = 0;
+		$elapsed = 0;
+		foreach ( $db_connections as $conn ) {
+			$this->data['db_connections']['connections'][] = $conn;
 
-				foreach ( $global->db_connections as $conn ) {
-					$this->data['db_connections']['connections'][] = $conn;
-
-					if ( isset( $conn['elapsed'] ) ) {
-						$elapsed += $conn['elapsed'];
-					}
-				}
-
-				$this->data['db_connections']['total_connection_time'] = $elapsed;
+			if ( isset( $conn['elapsed'] ) ) {
+				$elapsed += $conn['elapsed'];
 			}
 		}
+		$this->data['db_connections']['total_connection_time'] = $elapsed;
 	}
 }

--- a/qm-plugins/qm-db-connections/class-qm-db-connections-collector.php
+++ b/qm-plugins/qm-db-connections/class-qm-db-connections-collector.php
@@ -1,0 +1,45 @@
+<?php
+
+class QM_DB_Connections_Collector extends QM_Collector {
+
+	/**
+	 * @var string
+	 */
+	public $id = 'qm-db-connections';
+
+	/**
+	 * @return string
+	 */
+	public function name() {
+		return esc_html__( 'DB Connections', 'query-monitor' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function process() {
+		foreach ( $GLOBALS as $global ) {
+			if ( ! is_object( $global ) || ! get_class( $global ) || ! is_a( $global, 'wpdb' ) ) {
+				continue;
+			}
+
+			if ( ! property_exists( $global, 'db_connections' ) ) {
+				break;
+			}
+
+			if ( is_array( $global->db_connections ) && ! empty( $global->db_connections ) ) {
+				$elapsed = 0;
+
+				foreach ( $global->db_connections as $conn ) {
+					$this->data['db_connections']['connections'][] = $conn;
+
+					if ( isset( $conn['elapsed'] ) ) {
+						$elapsed += $conn['elapsed'];
+					}
+				}
+
+				$this->data['db_connections']['total_connection_time'] = $elapsed;
+			}
+		}
+	}
+}

--- a/qm-plugins/qm-db-connections/class-qm-db-connections-output-html.php
+++ b/qm-plugins/qm-db-connections/class-qm-db-connections-output-html.php
@@ -20,8 +20,8 @@ class QM_DB_Connections_Output extends QM_Output_Html {
 
 	public function output() {
 		$data        = $this->collector->get_data();
-		$total_time  = $this->format_elapsed_time( $data['db_connections']['total_connection_time'] );
-		$connections = $data['db_connections']['connections'];
+		$total_time  = $this->format_elapsed_time( $data['db_connections']['total_connection_time'] ?? 0 );
+		$connections = $data['db_connections']['connections'] ?? [];
 		?>
 		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
 			<h3><strong>Total connection time:</strong> <?php echo esc_html( $total_time ); ?></h3>

--- a/qm-plugins/qm-db-connections/class-qm-db-connections-output-html.php
+++ b/qm-plugins/qm-db-connections/class-qm-db-connections-output-html.php
@@ -1,0 +1,79 @@
+<?php
+
+class QM_DB_Connections_Output extends QM_Output_Html {
+
+	public function __construct( \QM_Collector $collector ) {
+		parent::__construct( $collector );
+
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 99 );
+	}
+
+	public function admin_menu( array $menu ) {
+		$menu[] = $this->menu( array(
+			'id'    => 'qm-db-connections',
+			'href'  => '#qm-db-connections',
+			'title' => esc_html__( 'DB Connections', 'query-monitor' ),
+		));
+
+		return $menu;
+	}
+
+	public function output() {
+		$data = $this->collector->get_data();
+		$total_time = $this->format_elapsed_time( $data['db_connections']['total_connection_time'] );
+		$connections = $data['db_connections']['connections'];
+		?>
+		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
+			<h3><strong>Total connection time:</strong> <?php echo esc_html( $total_time ); ?></h3>
+			<h3><strong>Total connections:</strong> <?php echo count( $connections ); ?></h3>
+			<?php $this->display_connections( $connections ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Display a table of connections and their properties.
+	 *
+	 * @param array $connections Array of connections
+	 */
+	private function display_connections( $connections ) {
+		if ( empty( $connections ) ) {
+			return;
+		}
+
+		echo '<table class="qm-db-connections-table">
+				<thead>
+					<tr>
+						<th>', esc_html__( 'Database Name', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'Host', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'Port', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'User', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'Name', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'Server State', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'Elapsed', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'Success', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'Queries', 'query-monitor' ), '</th>
+						<th>', esc_html__( 'Lag', 'query-monitor' ), '</th>
+					</tr>
+				</thead>
+			<tbody>';
+
+		foreach( $connections as $connection ) {
+			echo '<tr><td>' . esc_html( $connection['dbhname'] ) . '</td>';
+			echo '<td>' . esc_html( $connection['host'] ) . '</td>';
+			echo '<td>' . esc_html( $connection['port'] ) . '</td>';
+			echo '<td>' . esc_html( $connection['user'] ) . '</td>';
+			echo '<td>' . esc_html( $connection['name'] ) . '</td>';
+			echo '<td>' . esc_html( $connection['server_state'] ) . '</td>';
+			echo '<td>' . esc_html( $this->format_elapsed_time( $connection['elapsed'] ) ) . '</td>';
+			echo '<td>' . esc_html( $connection['success'] ? 'true' : 'false' ) . '</td>';
+			echo '<td>' . esc_html( $connection['queries'] ) . '</td>';
+			echo '<td>' . esc_html( $connection['lag'] ) . '</td></tr>';
+		}
+		echo '</tbody></table>';
+	}
+
+	private function format_elapsed_time( $time ) {
+		return number_format( sprintf( '%0.1f', $time * 1000 ), 1 ) . 'ms';
+	}
+}

--- a/qm-plugins/qm-db-connections/class-qm-db-connections-output-html.php
+++ b/qm-plugins/qm-db-connections/class-qm-db-connections-output-html.php
@@ -19,8 +19,8 @@ class QM_DB_Connections_Output extends QM_Output_Html {
 	}
 
 	public function output() {
-		$data = $this->collector->get_data();
-		$total_time = $this->format_elapsed_time( $data['db_connections']['total_connection_time'] );
+		$data        = $this->collector->get_data();
+		$total_time  = $this->format_elapsed_time( $data['db_connections']['total_connection_time'] );
 		$connections = $data['db_connections']['connections'];
 		?>
 		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
@@ -58,7 +58,7 @@ class QM_DB_Connections_Output extends QM_Output_Html {
 				</thead>
 			<tbody>';
 
-		foreach( $connections as $connection ) {
+		foreach ( $connections as $connection ) {
 			echo '<tr><td>' . esc_html( $connection['dbhname'] ) . '</td>';
 			echo '<td>' . esc_html( $connection['host'] ) . '</td>';
 			echo '<td>' . esc_html( $connection['port'] ) . '</td>';

--- a/qm-plugins/qm-db-connections/qm-db-connections.php
+++ b/qm-plugins/qm-db-connections/qm-db-connections.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Plugin Name: Query Monitor DB Connections
+ * Description: Additional collector for Query Monitor for DB connection information.
+ * Version: 1.0
+ * Author: Automattic, Rebecca Hum
+ */
+
+if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+	return;
+}
+
+add_action( 'plugins_loaded', 'register_qm_db_connections' );
+function register_qm_db_connections() {
+	if ( ! class_exists( 'QM_Collectors' ) ) {
+		return;
+	}
+
+	require_once __DIR__ . '/class-qm-db-connections-collector.php';
+
+	QM_Collectors::add( new QM_DB_Connections_Collector() );
+	add_filter( 'qm/outputter/html', 'register_qm_db_connections_output', 120, 2 );
+}
+
+function register_qm_db_connections_output( array $output, \QM_Collectors $collectors ) {
+	$collector = \QM_Collectors::get( 'qm-db-connections' );
+	if ( $collector ) {
+		require_once __DIR__ . '/class-qm-db-connections-output-html.php';
+
+		$output['qm-db-connections'] = new QM_DB_Connections_Output( $collector );
+	}
+	return $output;
+}

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -166,3 +166,6 @@ if ( file_exists( __DIR__ . '/qm-plugins/qm-cron/qm-cron.php' ) ) {
 if ( file_exists( __DIR__ . '/qm-plugins/qm-vip/qm-vip.php' ) ) {
 	require_once __DIR__ . '/qm-plugins/qm-vip/qm-vip.php';
 }
+if ( file_exists( __DIR__ . '/qm-plugins/qm-db-connections/qm-db-connections.php' ) ) {
+	require_once __DIR__ . '/qm-plugins/qm-db-connections/qm-db-connections.php';
+}

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -114,6 +114,28 @@ function wpcom_vip_qm_require() {
 
 	// We know we haven't got the QM DB drop-in in place, so don't show the message
 	add_filter( 'qm/show_extended_query_prompt', '__return_false' );
+
+	/**
+	 * Load QM plugins
+	 */
+	if ( file_exists( __DIR__ . '/qm-plugins/qm-alloptions/qm-alloptions.php' ) ) {
+		require_once __DIR__ . '/qm-plugins/qm-alloptions/qm-alloptions.php';
+	}
+	if ( file_exists( __DIR__ . '/qm-plugins/qm-object-cache/qm-object-cache.php' ) ) {
+		require_once __DIR__ . '/qm-plugins/qm-object-cache/qm-object-cache.php';
+	}
+	if ( file_exists( __DIR__ . '/qm-plugins/qm-apcu-cache/qm-apcu-cache.php' ) ) {
+		require_once __DIR__ . '/qm-plugins/qm-apcu-cache/qm-apcu-cache.php';
+	}
+	if ( file_exists( __DIR__ . '/qm-plugins/qm-cron/qm-cron.php' ) ) {
+		require_once __DIR__ . '/qm-plugins/qm-cron/qm-cron.php';
+	}
+	if ( file_exists( __DIR__ . '/qm-plugins/qm-vip/qm-vip.php' ) ) {
+		require_once __DIR__ . '/qm-plugins/qm-vip/qm-vip.php';
+	}
+	if ( file_exists( __DIR__ . '/qm-plugins/qm-db-connections/qm-db-connections.php' ) ) {
+		require_once __DIR__ . '/qm-plugins/qm-db-connections/qm-db-connections.php';
+	}
 }
 add_action( 'plugins_loaded', 'wpcom_vip_qm_require', 1 );
 
@@ -153,19 +175,3 @@ function change_dispatchers_shutdown_priority( array $dispatchers ) {
 	return $dispatchers;
 }
 add_filter( 'qm/dispatchers', 'change_dispatchers_shutdown_priority', PHP_INT_MAX, 1 );
-
-/**
- * Load QM plugins
- */
-require_once __DIR__ . '/qm-plugins/qm-alloptions/qm-alloptions.php';
-require_once __DIR__ . '/qm-plugins/qm-object-cache/qm-object-cache.php';
-require_once __DIR__ . '/qm-plugins/qm-apcu-cache/qm-apcu-cache.php';
-if ( file_exists( __DIR__ . '/qm-plugins/qm-cron/qm-cron.php' ) ) {
-	require_once __DIR__ . '/qm-plugins/qm-cron/qm-cron.php';
-}
-if ( file_exists( __DIR__ . '/qm-plugins/qm-vip/qm-vip.php' ) ) {
-	require_once __DIR__ . '/qm-plugins/qm-vip/qm-vip.php';
-}
-if ( file_exists( __DIR__ . '/qm-plugins/qm-db-connections/qm-db-connections.php' ) ) {
-	require_once __DIR__ . '/qm-plugins/qm-db-connections/qm-db-connections.php';
-}


### PR DESCRIPTION
## Description
It's being removed in https://github.com/Automattic/vip-go-mu-plugins/pull/3979, so let's add it into QM.

<img width="1730" alt="Screenshot 2023-01-09 at 2 19 07 PM" src="https://user-images.githubusercontent.com/16962021/211410786-7d8d4997-095d-4d8e-8ea8-4fb1d378498c.png">


## Changelog Description

### Plugin Updated: Query Monitor

Added panel for DB Connections and only load qm-plugins if user has QM capability

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Enable Debug Bar
2) Go to Query Monitor > DB Connections and see if it matches the Debug Bar > DB Connections