### PR TITLE
Search: Add version of EP to footer text

### DIFF
--- a/search/includes/classes/class-dashboard.php
+++ b/search/includes/classes/class-dashboard.php
@@ -19,7 +19,7 @@ class Dashboard {
 	public static function admin_footer_text( $text ) {
 		$screen = get_current_screen();
 		if ( false !== strpos( $screen->base, 'elasticpress' ) || 'ep-pointer' === $screen->post_type ) {
-			$text = '<p>Enterprise Search is powered by <a href="https://10up.com/plugins/elasticpress/">10up\'s ElasticPress plugin</a>.</p>';
+			$text = '<p>Enterprise Search is powered by <a href="https://10up.com/plugins/elasticpress/">10up\'s ElasticPress plugin</a> (v' . esc_html( EP_VERSION ) . ').</p>';
 		}
 		return $text;
 	}

--- a/search/includes/classes/class-dashboard.php
+++ b/search/includes/classes/class-dashboard.php
@@ -19,7 +19,7 @@ class Dashboard {
 	public static function admin_footer_text( $text ) {
 		$screen = get_current_screen();
 		if ( false !== strpos( $screen->base, 'elasticpress' ) || 'ep-pointer' === $screen->post_type ) {
-			$text = '<p>Enterprise Search is powered by <a href="https://10up.com/plugins/elasticpress/">10up\'s ElasticPress plugin</a> (v' . esc_html( EP_VERSION ) . ').</p>';
+			$text = '<p>Enterprise Search is powered by <a href="https://10up.com/plugins/elasticpress/">10up\'s ElasticPress plugin</a> (v' . esc_html( constant( 'EP_VERSION' ) ) . ').</p>';
 		}
 		return $text;
 	}


### PR DESCRIPTION
## Description
Add the version that the fork of EP's version is based on in footer:
<img width="520" alt="Screenshot 2023-01-09 at 4 17 47 PM" src="https://user-images.githubusercontent.com/16962021/211427446-4b6a3565-5fbf-4e3e-858d-7ed3edf4201b.png">


## Changelog Description

### Plugin Updated: Enterprise Search

Add ElasticPress version to footer text

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Go to `wp-admin/admin.php?page=elasticpress` and scroll down to verify the version `v(x.x.x)` has been added