### PR TITLE
Unregister JP-related cron events when disabled

### DIFF
--- a/cron/cron.php
+++ b/cron/cron.php
@@ -11,3 +11,31 @@ if ( file_exists( __DIR__ . '/action-scheduler-dynamic-queue.php' ) ) {
 		( new Action_Scheduler_Dynamic_Queue() )->init();
 	}, 9 );
 }
+
+// Unregister Jetpack-related cron events when disabled.
+add_action( 'cli_init', function() {
+	$jetpack_is_disabled    = defined( 'VIP_JETPACK_SKIP_LOAD' ) && true === VIP_JETPACK_SKIP_LOAD;
+	$vaultpress_is_disabled = $jetpack_is_disabled || ( defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) && true === VIP_VAULTPRESS_SKIP_LOAD );
+
+	$events_to_unregister = [];
+	if ( $jetpack_is_disabled ) {
+		$events_to_unregister = array_merge( $events_to_unregister, [
+			'jetpack_sync_cron',
+			'jetpack_sync_full_cron',
+			'jetpack_clean_nonces',
+			'jetpack_waf_rules_update_cron',
+			'jetpack_v2_heartbeat',
+		] );
+	}
+
+	if ( $vaultpress_is_disabled ) {
+		$events_to_unregister = array_merge( $events_to_unregister, [ 'vp_scan_site', 'vp_scan_next_batch' ] );
+	}
+
+	// When/if the cron event hook runs, unschedule the event so it runs no more.
+	foreach ( $events_to_unregister as $event_hook ) {
+		add_action( $event_hook, function() use ( $event_hook ) {
+			wp_unschedule_hook( $event_hook );
+		} );
+	}
+} );

--- a/cron/cron.php
+++ b/cron/cron.php
@@ -34,8 +34,6 @@ add_action( 'cli_init', function() {
 
 	// When/if the cron event hook runs, unschedule the event so it runs no more.
 	foreach ( $events_to_unregister as $event_hook ) {
-		add_action( $event_hook, function() use ( $event_hook ) {
-			wp_unschedule_hook( $event_hook );
-		} );
+		add_action( $event_hook, fn() => wp_unschedule_hook( $event_hook ) );
 	}
 } );


### PR DESCRIPTION
## Description
Remove JP/VP cron events when they are disabled. Runs on just `cli_init` as we don't need these hooks except during cron execution.

## Changelog Description
### Cleanup Jetpack-related cron events when JP is disabled

When Jetpack is disabled, make sure all the cron events are also disabled/removed.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Run `wp cron-control events list`, and note the events.
2. With this code and JP disabled, the events will unregister themselves as they run.