### PR TITLE
Query Monitor (VIP): Fix link for commit

### DIFF
--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -26,7 +26,7 @@ class QM_VIP_Output extends QM_Output_Html {
 			<?php
 			if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
 				echo '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) .
-				' target="_blank"><i><strong><span class="screen-reader-text">Open in new tab </span>Last modified: </strong>' .
+				'" target="_blank"><i><strong><span class="screen-reader-text">Open in new tab </span>Last modified: </strong>' .
 				esc_html( $data['mu-plugins']['date'] ) . '</i></a></p>';
 			}
 			?>


### PR DESCRIPTION
## Description
The target attribute snuck in directly to the linked URL in the VIP panel. This PR fixes that.

## Changelog Description

### Plugin Updated: Query Monitor (VIP Panel)

Fix URL to not display target attribute
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create a `.version` file in the vip-go-mu-plugins root with content of ` { "tag": "staging", "stack_version": "20221115190626-cb35ffb7e-1234" }`
2) Go to Query Monitor > VIP and hover over "Last modified" link and expect to see no stray target attributes 