### PR TITLE
[BB8-9998] Search Dev Tools: Display current algorithm version

### DIFF
--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -273,6 +273,13 @@ function print_data() {
 					'collapsible' => true,
 				],
 			],
+			[
+				'label'   => 'Algorithm Version',
+				'value'   => apply_filters( 'ep_search_algorithm_version', get_option( 'ep_search_algorithm_version', '3.5' ) ),
+				'options' => [
+					'collapsible' => false,
+				],
+			],
 
 		],
 		'nonce'                   => wp_create_nonce( 'wp_rest' ),


### PR DESCRIPTION
## Description
Let's display the current search algorithm version in Search Dev Tools for easier debugging.
<img width="1149" alt="Screenshot 2023-01-12 at 2 08 59 PM" src="https://user-images.githubusercontent.com/16962021/212181635-d4d40092-bccc-4942-88cc-028d89cf24d3.png">

## Changelog Description

### Plugin Updated: Search Dev Tools

Display current search algorithm version

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Change algorithm version to 5.5:
```
 add_filter( 'ep_search_algorithm_version', function( $algo ) {
    return '5.5';
 });
```
2) Go to Search Dev Tools and see `5.5` listed under "Algorithm Version"
3) Remove snippet from step 1)
4) Go back to Search Dev Tools and see `4.0` or `3.5` listed under "Algorithm Version"