### PR TITLE
Debug Bar: Only trigger deprecation once every 10 minutes and on admin

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -17,7 +17,14 @@ add_action( 'set_current_user', function() {
 		return;
 	}
 
-	trigger_error( 'Debug Bar will no longer be included in VIP MU Plugins as of January 31, 2023. Use Query Monitor instead, see https://lobby.vip.wordpress.com/2022/12/14/deprecation-notice-debug-bar-january-31-2023/.', E_USER_WARNING );
+	if ( is_admin() ) {
+		$key = 'debug_bar_deprecation_warning';
+		$msg = 'Debug Bar will no longer be included in VIP MU Plugins as of January 31, 2023. Use Query Monitor instead, see https://lobby.vip.wordpress.com/2022/12/14/deprecation-notice-debug-bar-january-31-2023/.';
+		if ( false === wp_cache_get( $key, 'vip' ) ) {
+			trigger_error( esc_html( $msg ), E_USER_WARNING );
+			wp_cache_set( $key, true, 'vip', 10 * MINUTE_IN_SECONDS );
+		}
+	}
 
 	if ( ! class_exists( 'Debug_Bar' ) ) {
 		require_once __DIR__ . '/debug-bar/debug-bar.php';


### PR DESCRIPTION
## Description
For less noisy logs

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Force enable debug bar to be true `add_filter( 'debug_bar_enable', '__return_true' );`
2) Go to wp-admin and see warning in logs
3) Go to another wp-admin page and do not see warning appear again in log
4) `wp cache delete debug_bar_deprecation_warning vip`
5) Repeat step 2
