### PR TITLE
Search: Change frequency of cron jobs that run maybe_alert_for_field_count and maybe_alert_for_average_queue_time

### DIFF
--- a/search/includes/classes/class-fieldcountgaugejob.php
+++ b/search/includes/classes/class-fieldcountgaugejob.php
@@ -2,14 +2,12 @@
 
 namespace Automattic\VIP\Search;
 
-require_once __DIR__ . '/../../../config/class-sync.php';
+require_once __DIR__ . '/class-versioningcleanupjob.php';
 
 class FieldCountGaugeJob {
-	const CRON_EVENT_NAME = 'vip_config_sync_cron';
-
 	public function init() {
 		// We always add this action so that the job can unregister itself if it no longer should be running
-		add_action( \Automattic\VIP\Config\Sync::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_field_count' ] );
+		add_action( \Automattic\VIP\Search\VersioningCleanupJob::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_field_count' ] );
 	}
 
 	/**

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -15,11 +15,6 @@ class HealthJob {
 	const CRON_EVENT_VALIDATE_CONTENT_NAME = 'vip_search_health_validate_content';
 
 	/**
-	 * Custom cron interval value
-	 */
-	const CRON_INTERVAL = 1 * \HOUR_IN_SECONDS;
-
-	/**
 	 * @var int the number after which the alert should be sent for inconsistencies found.
 	 */
 	const INCONSISTENCIES_ALERT_THRESHOLD = 50;

--- a/search/includes/classes/class-queuewaittimejob.php
+++ b/search/includes/classes/class-queuewaittimejob.php
@@ -2,14 +2,12 @@
 
 namespace Automattic\VIP\Search;
 
+require_once __DIR__ . '/class-settingshealthjob.php';
+
 class QueueWaitTimeJob {
-	const CRON_EVENT_NAME = 'vip_config_sync_cron';
-
-	const FIELD_COUNT_GAUGE_DISABLED_SITES = array();
-
 	public function init() {
 		// We always add this action so that the job can unregister itself if it no longer should be running
-		add_action( self::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_average_queue_time' ] );
+		add_action( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_average_queue_time' ] );
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR changes the frequency for two cron jobs currently hooked onto `vip_config_sync_cron`, which runs every 5 minutes which is too frequent for these jobs.
- maybe_alert_for_field_count will run once a week
- maybe_alert_for_average_queue_time will run hourly

They are both hooked onto existing cron jobs since Caleb has been doing work around removing cron jobs and I don't want to add to that pile.

## Changelog Description

### Plugin Updated: Enterprise Search

Change frequency of cron jobs that run maybe_alert_for_field_count and maybe_alert_for_average_queue_time

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.