### PR TITLE
CI: Only run Search Dev Tools build on certain directory

### DIFF
--- a/.github/workflows/search-dev-tools.yml
+++ b/.github/workflows/search-dev-tools.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    paths:
+    - 'search/search-dev-tools/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/search-dev-tools.yml
+++ b/.github/workflows/search-dev-tools.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
     - 'search/search-dev-tools/**'
+    - '.github/workflows/search-dev-tools.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description
This should only run when `search/search-dev-tools` is modified