### PR TITLE
Bugfix: Patching Core bug #51058 in wpcom_vip_attachment_url_to_postid()

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -624,12 +624,7 @@ function wpcom_vip_attachment_url_to_postid( $url ) {
 
 			if ( isset( $path_parts['dirname'], $path_parts['filename'], $path_parts['extension'] ) ) {
 				$scaled_url = trailingslashit( $path_parts['dirname'] ) . $path_parts['filename'] . '-scaled.' . $path_parts['extension'];
-				$scaled_id  = attachment_url_to_postid( $scaled_url );
-
-				// Confirm that the url we had was in fact of a scaled image before returning its ID.
-				if ( wp_get_original_image_url( $scaled_id ) === $url ) {
-					$id = $scaled_id;
-				}
+				$id         = attachment_url_to_postid( $scaled_url );
 			}
 		}
 

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -619,7 +619,7 @@ function wpcom_vip_attachment_url_to_postid( $url ) {
 		 *
 		 * @see https://core.trac.wordpress.org/ticket/51058
 		 */
-		if ( empty( $id ) && str_contains( $url, '-scaled.' ) ) {
+		if ( empty( $id ) ) {
 			$path_parts = pathinfo( $url );
 
 			if ( isset( $path_parts['dirname'], $path_parts['filename'], $path_parts['extension'] ) ) {


### PR DESCRIPTION
Patching [Core bug #51058](https://core.trac.wordpress.org/ticket/51058) in `wpcom_vip_attachment_url_to_postid()`

<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description

This will allow `wpcom_vip_attachment_url_to_postid()` to work with "scaled" image URLs as well as full size image URLs.

This shouldn't normally happen on VIP due to our [`big_image_size_threshold` filter](https://github.com/Automattic/vip-go-mu-plugins/blob/217e6a8c5804fad11f363e89e3ca91e050ba6894/a8c-files.php#L695), but it could be possible that content was imported with the scaled media already in place.

Props to our friends at Yoast (@leonidasmi) for bringing this up and providing a fix.
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

## Changelog Description

### Plugin Updated: VIP Helpers

Added a patch for [core bug #51058](https://core.trac.wordpress.org/ticket/51058) in our `wpcom_vip_attachment_url_to_postid()` caching helper function. Thanks to our friends at Yoast for the information and the fix.

<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Check out PR.
1. Go to `wp-admin` and upload a large (more than 2048px) image and grab the URL. If this is not on a VIP site, use the `-scaled` URL.
1. In a `wp shell` run `attachment_url_to_postid( $url )` and verify it returns an ID.
1. Remove the `-scaled.` from the URL to get the full-sized version.
1. In a `wp shell` run `attachment_url_to_postid( $full_sized_url )` and verify it returns an ID (or `0` if not on VIP).
1. In a `wp shell` run `wpcom_vip_attachment_url_to_postid( $full_sized_url )` and verify it returns an ID.
