### PR TITLE
Search: Do maybe_self_heal() onto an hourly cron

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Search;
 
+require_once __DIR__ . '/class-settingshealthjob.php';
+
 use \ElasticPress\Indexable as Indexable;
 use \ElasticPress\Indexables as Indexables;
 
@@ -65,6 +67,8 @@ class Versioning {
 
 		add_action( 'init', [ $this, 'action__elasticpress_loaded' ], PHP_INT_MAX );
 
+		add_action( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_NAME, [ $this, 'maybe_self_heal' ] );
+
 		$this->elastic_search_instance   = \ElasticPress\Elasticsearch::factory();
 		$this->elastic_search_indexables = \ElasticPress\Indexables::factory();
 		$this->alerts                    = \Automattic\VIP\Utils\Alerts::instance();
@@ -77,10 +81,6 @@ class Versioning {
 
 		foreach ( $all_indexables as $indexable ) {
 			add_action( 'ep_delete_' . $indexable->slug, [ $this, 'action__ep_delete_indexable' ], 10, 2 );
-		}
-
-		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-			$this->maybe_self_heal();
 		}
 	}
 


### PR DESCRIPTION
## Description
Instead of on every `init`, which seems excessive, let's move `maybe_self_heal()` to an hourly cron job. Hooks onto the the index settings cron job.

## Changelog Description

### Plugin Updated: Enterprise Search

Only do maybe_self_heal on an hourly cron basis

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.