### PR TITLE
ci: Update E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,14 +43,15 @@ jobs:
             1.gravatar.com:80
             2.gravatar.com:80
             api.github.com:443
+            api.service.runforesight.com:443
             api.wordpress.org:443
             artifactcache.actions.githubusercontent.com:443
             auth.docker.io:443
-            codeload.github.com:443
             dl-cdn.alpinelinux.org:443
-            dl-cdn.alpinelinux.org:80
             downloads.wordpress.org:443
-            frsnacprodeus2file1.blob.core.windows.net:443
+            e2e-test-site.vipdev.lndo.site:443
+            foresight-cli-test-artifact-prod.s3-accelerate.amazonaws.com:443
+            geoip.elastic.co:443
             ghcr.io:443
             github.com:443
             nodejs.org:443
@@ -62,25 +63,10 @@ jobs:
             registry-1.docker.io:443
             registry.npmjs.org:443
             s.w.org:443
-            update.containous.cloud:443
-            update.traefik.io:443
+            storage.googleapis.com:443
+            upload.service.runforesight.com:443
             vaultpress.com:443
             wordpress.org:443
-            dns.google:53
-            e2e-test-site.vipdev.lndo.site:80
-            playwright-akamai.azureedge.net:443
-            playwright-verizon.azureedge.net:443
-            playwright.azureedge.net:443
-            ppa.launchpad.net:80
-            ppa.launchpad.net:443
-            azure.archive.ubuntu.com:80
-            azure.archive.ubuntu.com:443
-            packages.microsoft.com:443
-            foresight.service.thundra.io:443
-            foresight-cli-test-artifact-prod.s3-accelerate.amazonaws.com:443
-            upload.service.runforesight.com:443
-            api.service.runforesight.com:443
-            api.wpvip.com:443
 
       - name: Check out repository code
         uses: actions/checkout@v3.3.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,8 +76,6 @@ jobs:
             azure.archive.ubuntu.com:80
             azure.archive.ubuntu.com:443
             packages.microsoft.com:443
-            download.cypress.io:443
-            cdn.cypress.io:443
             foresight.service.thundra.io:443
             foresight-cli-test-artifact-prod.s3-accelerate.amazonaws.com:443
             upload.service.runforesight.com:443
@@ -114,7 +112,7 @@ jobs:
         working-directory: __tests__/e2e
 
       - name: Install VIP CLI
-        run: npm install -g @automattic/vip@2.24.2
+        run: npm install -g @automattic/vip
 
       - name: Determine WP version
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,7 @@ jobs:
             artifactcache.actions.githubusercontent.com:443
             auth.docker.io:443
             dl-cdn.alpinelinux.org:443
+            docker.io:443
             downloads.wordpress.org:443
             e2e-test-site.vipdev.lndo.site:443
             foresight-cli-test-artifact-prod.s3-accelerate.amazonaws.com:443


### PR DESCRIPTION
Update E2E workflow:
* install latest version of VIP CLI (so that we don't have to modify the workflow when new VIP CLI gets released);
* remove Cypress-related endpoints from the list of allowed outgoing connections;
* update the list of the allowed endpoints according to the [recommendations](https://app.stepsecurity.io/github/Automattic/vip-go-mu-plugins/actions/runs/3945923788).
