### PR TITLE
maybe_load_plugin: Remove nullable return type for $filtered_load_status

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -152,8 +152,8 @@ function maybe_load_plugin() {
 		return;
 	}
 
-	$option_load_status   = get_option( '_wpvip_parsely_mu', null );
-	$filtered_load_status = apply_filters( 'wpvip_parsely_load_mu', null );
+	$option_load_status   = get_option( '_wpvip_parsely_mu' );
+	$filtered_load_status = apply_filters( 'wpvip_parsely_load_mu', false );
 
 	$should_load            = true === $filtered_load_status || '1' === $option_load_status;
 	$should_prevent_loading = false === $filtered_load_status || '0' === $option_load_status;


### PR DESCRIPTION
## Description
Since we're checking if `$filtered_load_status` is a boolean @ https://github.com/Automattic/vip-go-mu-plugins/blob/731bd7db3abbd1237eebb7f3e781371f1d6f4352/wp-parsely.php#L158-L159

TODO: Update https://docs.wpvip.com/technical-references/plugins/parse-ly/#h-enable-only-on-selected-network-sites after

## Changelog Description

### Plugin Updated: VIP Parse.ly Integration

maybe_load_plugin: Remove nullable return for $filtered_load_status

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.