### PR TITLE
CI: [e2e workflow] update dev-env parameters to use trunk wordpress and explicitly disable mailhog

### DIFF
--- a/__tests__/e2e/bin/setup-env.sh
+++ b/__tests__/e2e/bin/setup-env.sh
@@ -26,7 +26,7 @@ fi
 vip dev-env destroy --slug=e2e-test-site || true
 
 # Create and run test site
-vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --wordpress="5.9" --multisite=false --app-code="${clientCodePath}" --php 8.0 --xdebug false --phpmyadmin false --elasticsearch true
+vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --mailhog false --wordpress=trunk --multisite=false --app-code="${clientCodePath}" --php 8.0 --xdebug false --phpmyadmin false --elasticsearch true
 vip dev-env start --slug e2e-test-site --skip-wp-versions-check
 
 # Install classic editor plugin


### PR DESCRIPTION
## Description
It makes sense to keep it at trunk rather than having us to manually update it each time a new WP version is released. Also accounts for the new `mailhog` parameter, since we're explicitly defining the parameters.