### PR TITLE
Add new drop-in files

### DIFF
--- a/drop-ins/db.php
+++ b/drop-ins/db.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Plugin Name: HyperDB
+ * Description: An advanced database class that supports replication, failover, load balancing, and partitioning.
+ * Version: 1.9
+ * Author: Automattic
+ * Plugin URI: https://wordpress.org/plugins/hyperdb/
+ * License: GPLv2 or later
+ *
+ * This file is require'd from wp-content/db.php
+ */
+
+require_once __DIR__ . '/hyperdb/db.php';

--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Plugin Name: Memcached
+ * Description: Memcached backend for the WP Object Cache.
+ * Version: 4.0.0
+ * Author: Automattic
+ * Plugin URI: https://wordpress.org/plugins/memcached/
+ * License: GPLv2 or later
+ *
+ * This file is require'd from wp-content/object-cache.php
+ */
+
+// Will use the "next" version on these specified environment types by default.
+if ( ! defined( 'VIP_USE_NEXT_OBJECT_CACHE_DROPIN' ) ) {
+	if ( in_array( VIP_GO_APP_ENVIRONMENT, [ 'develop', 'preprod', 'staging' ], true ) ) {
+		define( 'VIP_USE_NEXT_OBJECT_CACHE_DROPIN', true );
+	}
+}
+
+if ( defined( 'VIP_USE_ALPHA_OBJECT_CACHE_DROPIN' ) && true === VIP_USE_ALPHA_OBJECT_CACHE_DROPIN ) {
+	require_once __DIR__ . '/wp-cache-memcached/object-cache.php';
+} elseif ( defined( 'VIP_USE_NEXT_OBJECT_CACHE_DROPIN' ) && true === VIP_USE_NEXT_OBJECT_CACHE_DROPIN ) {
+	require_once __DIR__ . '/object-cache/object-cache-next.php';
+} else {
+	require_once __DIR__ . '/object-cache/object-cache-stable.php';
+}
+
+// Load in the apc user cache.
+if ( file_exists( dirname( __DIR__ ) . '/lib/class-apc-cache-interceptor.php' ) ) {
+	require_once dirname( __DIR__ ) . '/lib/class-apc-cache-interceptor.php';
+}


### PR DESCRIPTION
Creates new drop-in files for object-cache and db. Since WordPress requires these files to be specifically named in specific locations, it makes external management a bit tricky.

After these are deployed across all stacks, we can start to require them from the real drop-in locations such as `wp-content/object-cache.php` and `wp-content/db.php`. Those file will only need to point towards these new ones. And then moving forward we can more easily manage these (as well as ensure dev-envs stay up to date).