### PR TITLE
Fix failing test test__skip_vip_link_if_customer_link_set

### DIFF
--- a/tests/001-core/test-privacy.php
+++ b/tests/001-core/test-privacy.php
@@ -18,8 +18,10 @@ class Privacy_Policy_Link_Test extends WP_UnitTestCase {
 		$post = $this->factory->post->create_and_get();
 		update_option( 'wp_page_for_privacy_policy', $post->ID );
 
+		global $wp_version;
+		$rel = version_compare( $wp_version, '6.1.1', '>' ) ? ' rel="privacy-policy"' : '';
 		// Should show the custom one
-		$expected_link = sprintf( '<div><a class="privacy-policy-link" href="%s">%s</a></div>', get_permalink( $post->ID ), get_the_title( $post->ID ) );
+		$expected_link = sprintf( '<div><a class="privacy-policy-link" href="%s"%s>%s</a></div>', get_permalink( $post->ID ), $rel, get_the_title( $post->ID ) );
 
 		$actual_link = get_the_privacy_policy_link( '<div>', '</div>' );
 


### PR DESCRIPTION
## Description
`test__skip_vip_link_if_customer_link_set` is borked as of WP 6.2 beta because of changes to `get_the_privacy_policy_link()`
