### PR TITLE
Jetpack: Make default 11.8

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7
+ * Version: 11.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -29,7 +29,7 @@ if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
 	} elseif ( version_compare( $wp_version, '6.0', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.4' );
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.7' );
+		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.8' );
 	}
 }
 


### PR DESCRIPTION
## Changelog Description

### Plugin Updated: Jetpack 11.8

Jetpack 11.8 is now the default version for non-pinned applications.