### PR TITLE
Revert "Reverting wp-cli-db"

### DIFF
--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -17,7 +17,7 @@ $files = [
 ];
 
 $cli_files = [
-	// '/lib/helpers/wp-cli-db.php', - Reverting as it breaks dev-env import
+	'/lib/helpers/wp-cli-db.php',
 ];
 
 foreach ( $files as $file ) {

--- a/lib/helpers/wp-cli-db/class-config.php
+++ b/lib/helpers/wp-cli-db/class-config.php
@@ -9,9 +9,11 @@ class Config {
 	private bool $enabled      = false;
 	private bool $allow_writes = false;
 	private bool $is_sandbox   = false;
+	private bool $is_local     = false;
 
 	public function __construct() {
 		$this->is_sandbox   = class_exists( Environment::class ) && Environment::is_sandbox_container( gethostname(), [] );
+		$this->is_local     = defined( 'VIP_GO_APP_ENVIRONMENT' ) && constant( 'VIP_GO_APP_ENVIRONMENT' ) === 'local' || defined( 'WP_ENVIRONMENT_TYPE' ) && constant( 'WP_ENVIRONMENT_TYPE' ) === 'local';
 		$this->enabled      = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
 		$this->allow_writes = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
 	}
@@ -26,6 +28,10 @@ class Config {
 
 	public function is_sandbox(): bool {
 		return $this->is_sandbox;
+	}
+
+	public function is_local(): bool {
+		return $this->is_local;
 	}
 
 	/**

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -58,6 +58,10 @@ class Wp_Cli_Db {
 			return;
 		}
 
+		if ( $this->config->is_local() ) {
+			return;
+		}
+
 		// This will throw an exception if db commands are not enabled for this env:
 		$server = $this->config->get_database_server();
 


### PR DESCRIPTION
Reverts Automattic/vip-go-mu-plugins#3683

Previously, this broke the `import` command on dev-env:
```
Uncaught Exception: The db command is not currently supported in this environment. in /wp/wp-content/mu-plugins/lib/helpers/wp-cli-db/class-config.php:38
```

But it looks like that's not the case anymore:
```
╰─$ vip dev-env --slug es-site import sql ~/Downloads/test.sql
...
Success: Database imported.
```

## Changelog Description

### Plugin added: WP-DB-CLI
Previously reverted, this reverts that change and adds back `/lib/helpers/wp-cli-db.php`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. On Local dev-env, attempt to import `vip dev-env import sql ~/Downloads/test.sql` and expect no exception