### PR TITLE
chore: Update phpcs.xml.dist to reflect recent changes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,7 +33,7 @@
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/query-monitor/*</exclude-pattern>
 	<exclude-pattern>/search/elasticpress/*</exclude-pattern>
-	<exclude-pattern>/search/debug-bar-elasticpress/*</exclude-pattern>
+	<exclude-pattern>/search/elasticpress-next/*</exclude-pattern>
 	<exclude-pattern>/search/es-wp-query/*</exclude-pattern>
 	<exclude-pattern>/shared-plugins/*</exclude-pattern>
 	<exclude-pattern>/vaultpress/*</exclude-pattern>
@@ -65,7 +65,7 @@
 	<rule ref="WordPress-Extra"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.6"/>
+	<config name="minimum_supported_wp_version" value="5.8"/>
 
 	<!-- Rules: Check VIP Coding Standards - see
 		https://github.com/Automattic/VIP-Coding-Standards/ -->


### PR DESCRIPTION
This PR updates `phpcs.xml.dist`:
  * sets the minimum WP version to 5.8 (to match our CI pipeline);
  * removes `search/debug-bar-elasticpress` from the ignore list;
  * adds `search/elasticpress-next` to the ignore list.
