### PR TITLE
VIP_Request_Block: Do not log blocks in New Relic

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -26,6 +26,8 @@ class VIP_Request_Block {
 	 * @return bool|void
 	 */
 	public static function ip( string $value ) {
+		self::ignore_new_relic();
+
 		$value = strtolower( $value );
 		$ip    = inet_pton( $value );
 		// Don't try to block if the passed value is not a valid IP.
@@ -73,6 +75,8 @@ class VIP_Request_Block {
 	 * @return void|bool
 	 */
 	public static function ua( string $user_agent ) {
+		self::ignore_new_relic();
+
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
 		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && $user_agent === $_SERVER['HTTP_USER_AGENT'] ) {
 			return static::block_and_log( $user_agent, 'user-agent' );
@@ -88,6 +92,8 @@ class VIP_Request_Block {
 	 * @return void|bool
 	 */
 	public static function ua_partial_match( string $user_agent_substring ) {
+		self::ignore_new_relic();
+
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && false !== strpos( $_SERVER['HTTP_USER_AGENT'], $user_agent_substring ) ) {
 			return static::block_and_log( $user_agent_substring, 'user-agent' );
@@ -104,6 +110,8 @@ class VIP_Request_Block {
 	 * @return void|bool
 	 */
 	public static function header( string $header, string $value ) {
+		self::ignore_new_relic();
+
 		// Normalize the header to what PHP exposes in $_SERVER:
 		// will catch both x-my-header or HTTP_X_MY_HEADER passed as a $header arg.
 		$key = str_replace( '-', '_', strtoupper( $header ) );
@@ -136,5 +144,15 @@ class VIP_Request_Block {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Ignore New Relic transactions for blocked requests.
+	 * This is to prevent the blocked requests from being reported to New Relic.
+	 */
+	private static function ignore_new_relic() {
+		if ( extension_loaded( 'newrelic' ) && function_exists( 'newrelic_ignore_transaction' ) ) {
+			newrelic_ignore_transaction();
+		}
 	}
 }


### PR DESCRIPTION
## Description
Do not log any blocks in New Relic as a transaction

## Changelog Description

### Plugin Updated: VIP_Request_Block

Do not log blocks in New Relic

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) In vip-config, add:
```
VIP_Request_Block::ip( '13.37.13.37' );
VIP_Request_Block::ua( 'Fuzz Faster U Fool v1.337' );
VIP_Request_Block::header( 'x-my-header', 'my-header-value' );
```

