### PR TITLE
Environment: account for batch pods

### DIFF
--- a/lib/environment/class-environment.php
+++ b/lib/environment/class-environment.php
@@ -55,7 +55,7 @@ class Environment {
 	}
 
 	public static function is_batch_container( $hostname, $env = array() ) {
-		if ( false !== strpos( $hostname, '_wpcli_' ) || false !== strpos( $hostname, '_wp_cli_' ) ) {
+		if ( false !== strpos( $hostname, '_wpcli_' ) || false !== strpos( $hostname, '_wp_cli_' ) || false !== strpos( $hostname, '-batch-' ) ) {
 			return true;
 		}
 

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -202,6 +202,15 @@ class Environment_Test extends TestCase {
 				// Expected result
 				true,
 			),
+			// Batch hostname, no env var
+			array(
+				// Hostname
+				'foo-batch-123123',
+				// Env vars
+				array(),
+				// Expected result
+				true,
+			),
 		);
 	}
 


### PR DESCRIPTION
## Description
Currently in `is_batch_container()`, it doesn't account for batch pods where the constant `IS_VIP_BATCH_CONTAINER` is not set

## Changelog Description

### Plugin Updated: Environment

Fix `is_batch_container()` to account for batch pods without constant

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
