### PR TITLE
Take #3: WP_CLI_DB - Allow certain `wp db` subcommands

### DIFF
--- a/.github/actions/prepare-source/action.yml
+++ b/.github/actions/prepare-source/action.yml
@@ -13,6 +13,10 @@ runs:
       shell: bash
       run: 'rsync -r --delete --exclude-from="vip-go-mu-plugins-ext/.dockerignore" vip-go-mu-plugins-ext/* ./'
 
+    - name: Create .version file
+      shell: bash
+      run: touch .version
+
     - name: Clean up
       shell: bash
       run: rm -rf vip-go-mu-plugins-ext

--- a/.github/actions/prepare-source/action.yml
+++ b/.github/actions/prepare-source/action.yml
@@ -13,10 +13,6 @@ runs:
       shell: bash
       run: 'rsync -r --delete --exclude-from="vip-go-mu-plugins-ext/.dockerignore" vip-go-mu-plugins-ext/* ./'
 
-    - name: Create .version file
-      shell: bash
-      run: touch .version
-
     - name: Clean up
       shell: bash
       run: rm -rf vip-go-mu-plugins-ext

--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -17,7 +17,7 @@ $files = [
 ];
 
 $cli_files = [
-	// '/lib/helpers/wp-cli-db.php', - Reverting as it breaks dev-env import
+	'/lib/helpers/wp-cli-db.php',
 ];
 
 foreach ( $files as $file ) {

--- a/lib/helpers/wp-cli-db/class-config.php
+++ b/lib/helpers/wp-cli-db/class-config.php
@@ -19,7 +19,7 @@ class Config {
 		$this->is_batch   = class_exists( Environment::class ) && Environment::is_batch_container( gethostname(), getenv() );
 
 		$this->enabled      = $this->is_batch || $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
-		$this->allow_writes = $this->is_batch || $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
+		$this->allow_writes = defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
 	}
 
 	public function enabled(): bool {
@@ -40,6 +40,10 @@ class Config {
 
 	public function is_batch(): bool {
 		return $this->is_batch;
+	}
+
+	public function set_allow_writes( bool $allow ): void {
+		$this->allow_writes = $allow;
 	}
 
 	/**

--- a/lib/helpers/wp-cli-db/class-config.php
+++ b/lib/helpers/wp-cli-db/class-config.php
@@ -9,9 +9,11 @@ class Config {
 	private bool $enabled      = false;
 	private bool $allow_writes = false;
 	private bool $is_sandbox   = false;
+	private bool $is_local     = false;
 
 	public function __construct() {
 		$this->is_sandbox   = class_exists( Environment::class ) && Environment::is_sandbox_container( gethostname(), [] );
+		$this->is_local     = defined( 'VIP_GO_APP_ENVIRONMENT' ) && constant( 'VIP_GO_APP_ENVIRONMENT' ) === 'local' || defined( 'WP_ENVIRONMENT_TYPE' ) && constant( 'WP_ENVIRONMENT_TYPE' ) === 'local';
 		$this->enabled      = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
 		$this->allow_writes = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
 	}
@@ -26,6 +28,10 @@ class Config {
 
 	public function is_sandbox(): bool {
 		return $this->is_sandbox;
+	}
+
+	public function is_local(): bool {
+		return $this->is_local;
 	}
 
 	/**

--- a/lib/helpers/wp-cli-db/class-config.php
+++ b/lib/helpers/wp-cli-db/class-config.php
@@ -10,12 +10,16 @@ class Config {
 	private bool $allow_writes = false;
 	private bool $is_sandbox   = false;
 	private bool $is_local     = false;
+	private bool $is_batch     = false;
 
 	public function __construct() {
-		$this->is_sandbox   = class_exists( Environment::class ) && Environment::is_sandbox_container( gethostname(), [] );
-		$this->is_local     = defined( 'VIP_GO_APP_ENVIRONMENT' ) && constant( 'VIP_GO_APP_ENVIRONMENT' ) === 'local' || defined( 'WP_ENVIRONMENT_TYPE' ) && constant( 'WP_ENVIRONMENT_TYPE' ) === 'local';
-		$this->enabled      = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
-		$this->allow_writes = $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
+		$this->is_local = defined( 'VIP_GO_APP_ENVIRONMENT' ) && constant( 'VIP_GO_APP_ENVIRONMENT' ) === 'local' || defined( 'WP_ENVIRONMENT_TYPE' ) && constant( 'WP_ENVIRONMENT_TYPE' ) === 'local';
+		// We can't check via constants since they are not set yet
+		$this->is_sandbox = class_exists( Environment::class ) && Environment::is_sandbox_container( gethostname(), getenv() );
+		$this->is_batch   = class_exists( Environment::class ) && Environment::is_batch_container( gethostname(), getenv() );
+
+		$this->enabled      = $this->is_batch || $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB' );
+		$this->allow_writes = $this->is_batch || $this->is_sandbox || defined( 'WPVIP_ENABLE_WP_DB_WRITES' ) && 1 === constant( 'WPVIP_ENABLE_WP_DB_WRITES' );
 	}
 
 	public function enabled(): bool {
@@ -32,6 +36,10 @@ class Config {
 
 	public function is_local(): bool {
 		return $this->is_local;
+	}
+
+	public function is_batch(): bool {
+		return $this->is_batch;
 	}
 
 	/**

--- a/lib/helpers/wp-cli-db/class-vip-db-command.php
+++ b/lib/helpers/wp-cli-db/class-vip-db-command.php
@@ -1,0 +1,16 @@
+<?php
+class VIP_DB_Command extends DB_Command {
+	/**
+	 * Wrapper for WP-CLI's db query command to allow for --read-write flag to not get passed into the subcommand.
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
+	public function query( $args, $assoc_args ) {
+		if ( isset( $assoc_args['read-write'] ) ) {
+			unset( $assoc_args['read-write'] );
+		}
+
+		parent::query( $args, $assoc_args );
+	}
+}

--- a/lib/helpers/wp-cli-db/class-vip-db-command.php
+++ b/lib/helpers/wp-cli-db/class-vip-db-command.php
@@ -4,7 +4,7 @@ namespace Automattic\VIP\Helpers\WP_CLI_DB;
 
 class VIP_DB_Command extends \DB_Command {
 	/**
-	 * Wrapper for WP-CLI's db query command to allow for --read-write flag to not get passed into the subcommand.
+	 * Wrapper for WP-CLI's db query command to allow for certain flags to not get passed into the subcommand.
 	 *
 	 * @param array $args
 	 * @param array $assoc_args
@@ -12,6 +12,10 @@ class VIP_DB_Command extends \DB_Command {
 	public function query( $args, $assoc_args ) {
 		if ( isset( $assoc_args['read-write'] ) ) {
 			unset( $assoc_args['read-write'] );
+		}
+
+		if ( isset( $assoc_args['skip-confirm'] ) ) {
+			unset( $assoc_args['skip-confirm'] );
 		}
 
 		parent::query( $args, $assoc_args );

--- a/lib/helpers/wp-cli-db/class-vip-db-command.php
+++ b/lib/helpers/wp-cli-db/class-vip-db-command.php
@@ -1,5 +1,8 @@
 <?php
-class VIP_DB_Command extends DB_Command {
+
+namespace Automattic\VIP\Helpers\WP_CLI_DB;
+
+class VIP_DB_Command extends \DB_Command {
 	/**
 	 * Wrapper for WP-CLI's db query command to allow for --read-write flag to not get passed into the subcommand.
 	 *

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -72,9 +72,14 @@ class Wp_Cli_Db {
 	public function validate_query( string $query ): ?WP_Error {
 		$query = strtolower( $query );
 
-		if ( false !== strpos( $query, 'drop' ) ) {
-			return new \WP_Error( 'db-cli-disallowed-query', 'This query is disallowed.' );
+		$disallowed_syntax = [ 'drop', 'create' ];
+
+		foreach ( $disallowed_syntax as $syntax ) {
+			if ( false !== strpos( $query, $syntax ) ) {
+				return new \WP_Error( 'db-cli-disallowed-query', 'This query is disallowed.' );
+			}
 		}
+
 		return null;
 	}
 

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -94,7 +94,7 @@ class Wp_Cli_Db {
 			return;
 		}
 
-		if ( $this->config->is_local() && $this->config->is_batch() ) {
+		if ( $this->config->is_local() ) {
 			return;
 		}
 

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -108,7 +108,7 @@ class Wp_Cli_Db {
 		try {
 			$this->validate_subcommand( $command );
 		} catch ( Exception $e ) {
-			WP_CLI::Error( $e->getMessage() );
+			WP_CLI::error( $e->getMessage() );
 		}
 
 		$server->define_variables();

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -108,6 +108,7 @@ class Wp_Cli_Db {
 
 		if ( isset( $assoc_args['read-write'] ) ) {
 			if ( true === $assoc_args['read-write'] || 'true' === $assoc_args['read-write'] || '1' === $assoc_args['read-write'] ) {
+				WP_CLI::confirm( "You're running in read-write mode. Would you like to proceed?" );
 				$this->config->set_allow_writes( true );
 			}
 		}

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -58,8 +58,8 @@ class Wp_Cli_Db {
 
 			$query      = $command[2];
 			$validation = $this->validate_query( $query );
-			if ( is_wp_error( $validation ) ) {
-				WP_CLI::error( $validation->get_error_message() );
+			if ( ! $validation ) {
+				return new \WP_Error( 'db-cli-disallowed-query', 'This query is disallowed.' );
 			}
 		}
 	}
@@ -67,19 +67,20 @@ class Wp_Cli_Db {
 	/**
 	 * Ensure the query is allowed.
 	 *
-	 * @param string $query
-	 * @return void|WP_Error
+	 * @param string $query Query to execute.
+	 * @return bool Whether query is allowed or not.
 	 */
 	public function validate_query( string $query ) {
 		$query = strtolower( $query );
 
-		$disallowed_syntax = [ 'drop', 'create' ];
+		$disallowed_syntax = [ 'drop', 'create', 'truncate' ];
 
 		foreach ( $disallowed_syntax as $syntax ) {
 			if ( false !== strpos( $query, $syntax ) ) {
-				return new \WP_Error( 'db-cli-disallowed-query', 'This query is disallowed.' );
+				return false;
 			}
 		}
+		return true;
 	}
 
 	/**

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -39,11 +39,18 @@ class Wp_Cli_Db {
 	public function validate_subcommand( array $command ): ?WP_Error {
 		$subcommand = $command[1] ?? '';
 
-		if ( 'query' !== $subcommand ) {
-			return new \WP_Error( 'db-cli-disallowed-subcmd', 'Only the `wp db query` subcommand is permitted for this site.' );
+		$allowed_subcommands = [
+			'query',
+			'prefix',
+			'columns',
+			'size',
+		];
+
+		if ( ! in_array( $subcommand, $allowed_subcommands, true ) ) {
+			return new \WP_Error( 'db-cli-disallowed-subcmd', "The `wp db $subcommand` subcommand is not permitted for this site." );
 		}
 
-		if ( 2 === count( $command ) ) {
+		if ( 'query' === $subcommand && 2 === count( $command ) ) {
 			// Doing `wp db query` without a DB query is the equivalent of doing `wp db cli`
 			return new \WP_Error( 'db-cli-missing-query', 'Please provide the database query as a part of the command.' );
 		}

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -106,9 +106,13 @@ class Wp_Cli_Db {
 			return;
 		}
 
+		$skip_confirm = isset( $assoc_args['skip-confirm'] ) && ( true === $assoc_args['skip-confirm'] || 'true' === $assoc_args['skip-confirm'] || '1' === $assoc_args['skip-confirm'] );
+
 		if ( isset( $assoc_args['read-write'] ) ) {
 			if ( true === $assoc_args['read-write'] || 'true' === $assoc_args['read-write'] || '1' === $assoc_args['read-write'] ) {
-				WP_CLI::confirm( "You're running in read-write mode. Would you like to proceed?" );
+				if ( ! $skip_confirm ) {
+					WP_CLI::confirm( "You're running in read-write mode. Would you like to proceed?" );
+				}
 				$this->config->set_allow_writes( true );
 			}
 		}

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -34,9 +34,9 @@ class Wp_Cli_Db {
 	 * Ensure the command or query is allowed for the current Config.
 	 *
 	 * @param array $command
-	 * @return WP_Error|null
+	 * @return WP_Error|void
 	 */
-	public function validate_subcommand( array $command ): ?WP_Error {
+	public function validate_subcommand( array $command ) {
 		$subcommand = $command[1] ?? '';
 
 		$allowed_subcommands = [
@@ -60,16 +60,15 @@ class Wp_Cli_Db {
 		if ( is_wp_error( $validation ) ) {
 			WP_CLI::error( $validation->get_error_message() );
 		}
-		return null;
 	}
 
 	/**
 	 * Ensure the query is allowed.
 	 *
 	 * @param string $query
-	 * @return WP_Error|null
+	 * @return WP_Error|void
 	 */
-	public function validate_query( string $query ): ?WP_Error {
+	public function validate_query( string $query ) {
 		$query = strtolower( $query );
 
 		$disallowed_syntax = [ 'drop', 'create' ];
@@ -79,8 +78,6 @@ class Wp_Cli_Db {
 				return new \WP_Error( 'db-cli-disallowed-query', 'This query is disallowed.' );
 			}
 		}
-
-		return null;
 	}
 
 	/**

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -50,15 +50,17 @@ class Wp_Cli_Db {
 			return new \WP_Error( 'db-cli-disallowed-subcmd', "The `wp db $subcommand` subcommand is not permitted for this site." );
 		}
 
-		if ( 'query' === $subcommand && 2 === count( $command ) ) {
-			// Doing `wp db query` without a DB query is the equivalent of doing `wp db cli`
-			return new \WP_Error( 'db-cli-missing-query', 'Please provide the database query as a part of the command.' );
-		}
+		if ( 'query' === $subcommand ) {
+			if ( 2 === count( $command ) ) {
+				// Doing `wp db query` without a DB query is the equivalent of doing `wp db cli`
+				return new \WP_Error( 'db-cli-missing-query', 'Please provide the database query as a part of the command.' );
+			}
 
-		$query      = $command[2];
-		$validation = $this->validate_query( $query );
-		if ( is_wp_error( $validation ) ) {
-			WP_CLI::error( $validation->get_error_message() );
+			$query      = $command[2];
+			$validation = $this->validate_query( $query );
+			if ( is_wp_error( $validation ) ) {
+				WP_CLI::error( $validation->get_error_message() );
+			}
 		}
 	}
 
@@ -66,7 +68,7 @@ class Wp_Cli_Db {
 	 * Ensure the query is allowed.
 	 *
 	 * @param string $query
-	 * @return WP_Error|void
+	 * @return void|WP_Error
 	 */
 	public function validate_query( string $query ) {
 		$query = strtolower( $query );

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -58,6 +58,10 @@ class Wp_Cli_Db {
 			return;
 		}
 
+		if ( $this->config->is_local() ) {
+			return;
+		}
+
 		// This will throw an exception if db commands are not enabled for this env:
 		$server = $this->config->get_database_server();
 

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -33,7 +33,7 @@ class Wp_Cli_Db {
 			require_once $db_command_file;
 		}
 
-		WP_CLI::add_command( 'db', 'VIP_DB_Command' );
+		WP_CLI::add_command( 'db', __NAMESPACE__ . '\VIP_DB_Command' );
 	}
 
 	/**

--- a/tests/lib/helpers/test-wp-cli-db.php
+++ b/tests/lib/helpers/test-wp-cli-db.php
@@ -73,14 +73,14 @@ class WP_Cli_Db_Test extends TestCase {
 	}
 
 	public function test_validate_subcommand_db_blocked_command_no_write() {
-		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'drop', 'really_important_table' ] );
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'The `wp db drop` subcommand is not permitted for this site.' );
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'The `wp db drop` subcommand is not permitted for this site.' );
+		( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'drop', 'really_important_table' ] );
 	}
 
 	public function test_validate_subcommand_db_read_query() {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'query', 'SELECT * FROM crypto_wallet_keys' ] );
-		$this->assertEquals( $result, null );
+		$this->assertEquals( null, $result );
 	}
 
 	public function test_config_no_write() {
@@ -122,9 +122,9 @@ class WP_Cli_Db_Test extends TestCase {
 		];
 		Constant_Mocker::define( 'WPVIP_ENABLE_WP_DB', 1 );
 
-		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli' ] );
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( 'The `wp db cli` subcommand is not permitted for this site.', $result->get_error_message() );
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'The `wp db cli` subcommand is not permitted for this site.' );
+		( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli' ] );
 	}
 
 	public function test_validate_subcommand_no_console_query_and_no_querystring() {
@@ -133,9 +133,9 @@ class WP_Cli_Db_Test extends TestCase {
 		];
 		Constant_Mocker::define( 'WPVIP_ENABLE_WP_DB', 1 );
 
-		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'query' ] );
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( 'Please provide the database query as a part of the command.', $result->get_error_message() );
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Please provide the database query as a part of the command' );
+		( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'query' ] );
 	}
 
 	public function test_config_not_enabled_writes_disallowed_by_default() {
@@ -304,21 +304,21 @@ class WP_Cli_Db_Test extends TestCase {
 	}
 
 	public function test_console_is_blocked_for_cli_alone() {
-		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli' ] );
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'The `wp db cli` subcommand is not permitted for this site.' );
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'The `wp db cli` subcommand is not permitted for this site.' );
+		( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli' ] );
 	}
 
 	public function test_console_is_blocked_for_cli_with_extra_commands() {
-		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli', 'whatever' ] );
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'The `wp db cli` subcommand is not permitted for this site.' );
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'The `wp db cli` subcommand is not permitted for this site.' );
+		( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli', 'whatever' ] );
 	}
 
 	public function test_console_is_blocked_for_query_alone() {
-		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'query' ] );
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'Please provide the database query as a part of the command.' );
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Please provide the database query as a part of the command.' );
+		( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'query' ] );
 	}
 
 	public function test_console_is_allowed_for_query_with_extra_commands() {

--- a/tests/lib/helpers/test-wp-cli-db.php
+++ b/tests/lib/helpers/test-wp-cli-db.php
@@ -75,7 +75,7 @@ class WP_Cli_Db_Test extends TestCase {
 	public function test_validate_subcommand_db_blocked_command_no_write() {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'drop', 'really_important_table' ] );
 		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'Only the `wp db query` subcommand is permitted for this site.' );
+		$this->assertEquals( $result->get_error_message(), 'The `wp db drop` subcommand is not permitted for this site.' );
 	}
 
 	public function test_validate_subcommand_db_read_query() {
@@ -124,7 +124,7 @@ class WP_Cli_Db_Test extends TestCase {
 
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli' ] );
 		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( 'Only the `wp db query` subcommand is permitted for this site.', $result->get_error_message() );
+		$this->assertEquals( 'The `wp db cli` subcommand is not permitted for this site.', $result->get_error_message() );
 	}
 
 	public function test_validate_subcommand_no_console_query_and_no_querystring() {
@@ -306,13 +306,13 @@ class WP_Cli_Db_Test extends TestCase {
 	public function test_console_is_blocked_for_cli_alone() {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli' ] );
 		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'Only the `wp db query` subcommand is permitted for this site.' );
+		$this->assertEquals( $result->get_error_message(), 'The `wp db cli` subcommand is not permitted for this site.' );
 	}
 
 	public function test_console_is_blocked_for_cli_with_extra_commands() {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_subcommand( [ 'db', 'cli', 'whatever' ] );
 		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'Only the `wp db query` subcommand is permitted for this site.' );
+		$this->assertEquals( $result->get_error_message(), 'The `wp db cli` subcommand is not permitted for this site.' );
 	}
 
 	public function test_console_is_blocked_for_query_alone() {

--- a/tests/lib/helpers/test-wp-cli-db.php
+++ b/tests/lib/helpers/test-wp-cli-db.php
@@ -332,18 +332,16 @@ class WP_Cli_Db_Test extends TestCase {
 
 	public function test_validate_query_drop() {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_query( 'DROP TABLE table' );
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'This query is disallowed.' );
+		$this->assertFalse( $result );
 	}
 
 	public function test_validate_query_create() {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_query( 'CREATE TABLE wp_table' );
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( $result->get_error_message(), 'This query is disallowed.' );
+		$this->assertFalse( $result );
 	}
 
 	public function test_validate_query_select() {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_query( 'SELECT * FROM wp_options WHERE option_name="home"' );
-		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertTrue( $result );
 	}
 }

--- a/tests/lib/helpers/test-wp-cli-db.php
+++ b/tests/lib/helpers/test-wp-cli-db.php
@@ -344,4 +344,14 @@ class WP_Cli_Db_Test extends TestCase {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_query( 'SELECT * FROM wp_options WHERE option_name="home"' );
 		$this->assertTrue( $result );
 	}
+
+	public function test_allow_writes() {
+		$config = new Config();
+
+		$config->set_allow_writes( false );
+		$this->assertFalse( $config->allow_writes() );
+
+		$config->set_allow_writes( true );
+		$this->assertTrue( $config->allow_writes() );
+	}
 }

--- a/tests/lib/helpers/test-wp-cli-db.php
+++ b/tests/lib/helpers/test-wp-cli-db.php
@@ -336,6 +336,12 @@ class WP_Cli_Db_Test extends TestCase {
 		$this->assertEquals( $result->get_error_message(), 'This query is disallowed.' );
 	}
 
+	public function test_validate_query_create() {
+		$result = ( new Wp_Cli_Db( new Config() ) )->validate_query( 'CREATE TABLE wp_table' );
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEquals( $result->get_error_message(), 'This query is disallowed.' );
+	}
+
 	public function test_validate_query_select() {
 		$result = ( new Wp_Cli_Db( new Config() ) )->validate_query( 'SELECT * FROM wp_options WHERE option_name="home"' );
 		$this->assertFalse( is_wp_error( $result ) );


### PR DESCRIPTION
## Description
Previously, this was reverted in https://github.com/Automattic/vip-go-mu-plugins/pull/4125 due to database backup copies breaking due to the error `Uncaught Exception: The db command is not currently supported in this environment.`. This PR:
- adds the addition for a batch container property in `$is_batch`
- catches the Exception thrown from `get_database_server()` in `before_run_command()`
- changes `validate_subcommand()` to return a WP_Error instead of an exception
- adds `validate_query()` to check the query can be run
- adjusts + adds tests for all of the above 
- adds a few extra subcommands in addition to `query`: `columns`, `size`, `prefix`
- adds a `--read-write` flag for the `query` subcommand to enable writes on-demand basis

TODO: 
- Unblock subcommands at Parker level 

Previous reverts:
- https://github.com/Automattic/vip-go-mu-plugins/pull/3683
- https://github.com/Automattic/vip-go-mu-plugins/pull/4125

Attempted redos:
- https://github.com/Automattic/vip-go-mu-plugins/pull/4111
- https://github.com/Automattic/vip-go-mu-plugins/pull/3645

OG PR: https://github.com/Automattic/vip-go-mu-plugins/pull/3064

## Changelog Description

### Plugin Updated: WP_CLI_DB

Adds back WP_CLI_DB and accounts for both batch containers & dev-env environments

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.