### PR TITLE
Jetpack: Removed unneeded versions

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -21,13 +21,13 @@ function vip_default_jetpack_version() {
 	global $wp_version;
 
 	if ( version_compare( $wp_version, '5.9', '<' ) ) {
-		// Wordpress 5.8.x and older. Not including 5.9.
+		// WordPress 5.8.x and older. Not including 5.9.
 		return '10.9';
 	} elseif ( version_compare( $wp_version, '6.0', '<' ) ) {
-		// Wordpress 5.9.x and newer. Not including 6.0.
+		// WordPress 5.9.x and newer. Not including 6.0.
 		return '11.4';
 	} else {
-		// Wordpress 6.0 and newer
+		// WordPress 6.0 and newer
 		return '11.8';
 	}
 }

--- a/jetpack.php
+++ b/jetpack.php
@@ -17,16 +17,24 @@
 
 // Choose an appropriate default Jetpack version, ensuring that older WordPress versions
 // are not using a too modern Jetpack version that is not compatible with it
-if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
-	if ( version_compare( $wp_version, '5.8', '<' ) ) {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.4' );
-	} elseif ( version_compare( $wp_version, '5.9', '<' ) ) {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.9' );
+function vip_default_jetpack_version() {
+	global $wp_version;
+
+	if ( version_compare( $wp_version, '5.9', '<' ) ) {
+		// Wordpress 5.8.x and older. Not including 5.9.
+		return '10.9';
 	} elseif ( version_compare( $wp_version, '6.0', '<' ) ) {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.4' );
+		// Wordpress 5.9.x and newer. Not including 6.0.
+		return '11.4';
 	} else {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '11.8' );
+		// Wordpress 6.0 and newer
+		return '11.8';
 	}
+}
+
+// Set the default Jetpack version if it's not already defined
+if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
+	define( 'VIP_JETPACK_DEFAULT_VERSION', vip_default_jetpack_version() );
 }
 
 // Bump up the batch size to reduce the number of queries run to build a Jetpack sitemap.

--- a/jetpack.php
+++ b/jetpack.php
@@ -18,11 +18,7 @@
 // Choose an appropriate default Jetpack version, ensuring that older WordPress versions
 // are not using a too modern Jetpack version that is not compatible with it
 if ( ! defined( 'VIP_JETPACK_DEFAULT_VERSION' ) ) {
-	if ( version_compare( $wp_version, '5.6', '<' ) ) {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.4' );
-	} elseif ( version_compare( $wp_version, '5.7', '<' ) ) {
-		define( 'VIP_JETPACK_DEFAULT_VERSION', '9.8' );
-	} elseif ( version_compare( $wp_version, '5.8', '<' ) ) {
+	if ( version_compare( $wp_version, '5.8', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.4' );
 	} elseif ( version_compare( $wp_version, '5.9', '<' ) ) {
 		define( 'VIP_JETPACK_DEFAULT_VERSION', '10.9' );

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -1,0 +1,21 @@
+<?php
+
+// phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid
+
+class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
+	public function test__vip_default_jetpack_version() {
+		$versions_map = [
+			// WordPress version => Jetpack version
+			'5.8.6' => '10.9',
+			'5.9.0' => '11.4',
+			'6.0.0' => '11.8',
+		];
+
+		foreach ( $versions_map as $wordpress_version => $jetpack_version ) {
+			global $wp_version;
+			$wp_version = $wordpress_version;
+
+			$this->assertEquals( vip_default_jetpack_version(), $jetpack_version );
+		}
+	}
+}

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -4,6 +4,9 @@
 
 class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 	public function test__vip_default_jetpack_version() {
+		global $wp_version;
+		$saved_wp_version = $wp_version;
+
 		$versions_map = [
 			// WordPress version => Jetpack version
 			'5.8.6' => '10.9',
@@ -15,10 +18,11 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		];
 
 		foreach ( $versions_map as $wordpress_version => $jetpack_version ) {
-			global $wp_version;
 			$wp_version = $wordpress_version;
-
 			$this->assertEquals( vip_default_jetpack_version(), $jetpack_version );
 		}
+
+		// Reset back to original value.
+		$wp_version = $saved_wp_version;
 	}
 }

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,8 +7,11 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		$versions_map = [
 			// WordPress version => Jetpack version
 			'5.8.6' => '10.9',
-			'5.9.0' => '11.4',
-			'6.0.0' => '11.8',
+			'5.9'   => '11.4',
+			'5.9.5' => '11.4',
+			'6.0'   => '11.8',
+			'6.1'   => '11.8',
+			'6.1.1' => '11.8',
 		];
 
 		foreach ( $versions_map as $wordpress_version => $jetpack_version ) {


### PR DESCRIPTION
## Description

Removing Jetpack 9.4 and 9.8 fallback versions, because we don't have support with Wordpress 5.6 and 5.7

## Steps to Test

### With your local Wordpress version:

1. Check out PR.
2. On Local dev-env, run wp shell using `vip dev-env exec -- wp shell`
3. Type `VIP_JETPACK_DEFAULT_VERSION`. Then, you should receive the mapped Jetpack version for your Wordpress version. If you are using `6.1.1`, the shell should print `11.8`.

### With other Wordpress versions:

1. Set `$wp_version = '...'` with some Wordpress version.
2. type `vip_default_jetpack_version()` to reload the version.
3. type `VIP_JETPACK_DEFAULT_VERSION`
4. You should see the related Jetpack version

To help the debug, the versions map is listed below:

```php
$versions_map = [
	// WordPress version => Jetpack version
	'5.8.6' => '10.9',
	'5.9.0' => '11.4',
	'6.0.0' => '11.8',
];
```