### PR TITLE
Add vip_send_wplogin_header()

### DIFF
--- a/security.php
+++ b/security.php
@@ -237,7 +237,7 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 
 	/**
 	 * Login Limiting Username Threshold
-	 * 
+	 *
 	 * @param string $username Username of the login request
 	 */
 	$username_threshold = 5 * $ip_username_threshold; // Default to 5 times the IP + username threshold
@@ -264,7 +264,7 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 
 		/**
 		 * Password Reset Username Threshold
-		 * 
+		 *
 		 * @param string $username Username of the password reset request
 		 */
 		$username_threshold = 5 * $ip_username_threshold; // Default to 5 times the IP + username threshold
@@ -291,3 +291,14 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 	return false;
 }
 
+function vip_send_wplogin_header( $user ) {
+	if ( $user && isset( $_SERVER['HTTP_X_WPLOGIN'] ) && 'yes' === $_SERVER['HTTP_X_WPLOGIN'] && class_exists( 'WP_User' ) ) {
+		$_user = new WP_User( $user );
+		if ( $_user ) {
+			header( 'X-wplogin: ' . $_user->user_login );
+		}
+		unset( $_SERVER['HTTP_X_WPLOGIN'] );
+	}
+	return $user;
+}
+add_filter( 'determine_current_user', 'vip_send_wplogin_header', 10000 );

--- a/security.php
+++ b/security.php
@@ -291,6 +291,12 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 	return false;
 }
 
+/**
+ * Sends a header with the username of the current user for our logs.
+ *
+ * @param int|false $user User ID
+ * @return int|false $user User ID
+ */
 function vip_send_wplogin_header( $user ) {
 	if ( $user && isset( $_SERVER['HTTP_X_WPLOGIN'] ) && 'yes' === $_SERVER['HTTP_X_WPLOGIN'] && class_exists( 'WP_User' ) ) {
 		$_user = new WP_User( $user );

--- a/security.php
+++ b/security.php
@@ -300,7 +300,7 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 function vip_send_wplogin_header( $user ) {
 	if ( $user && isset( $_SERVER['HTTP_X_WPLOGIN'] ) && 'yes' === $_SERVER['HTTP_X_WPLOGIN'] && class_exists( 'WP_User' ) ) {
 		$_user = new WP_User( $user );
-		if ( $_user ) {
+		if ( isset( $_user->user_login ) ) {
 			header( 'X-wplogin: ' . $_user->user_login );
 		}
 		unset( $_SERVER['HTTP_X_WPLOGIN'] );


### PR DESCRIPTION
## Description
For our logging purposes, let's try to send an accurate `wplogin` when possible to prevent spoofing.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Deploy image
2) Log in and change `wordpress_logged_in_` cookie
3) Look at logs to ensure correct `wplogin` is displayed