### PR TITLE
Update the email address in overdue notice

### DIFF
--- a/security/class-lockout.php
+++ b/security/class-lockout.php
@@ -56,11 +56,11 @@ class Lockout {
 			switch ( $this->get_lockout_state() ) {
 				case self::ACCOUNT_STATUS_WARNING:
 					return 'Payment for this WordPress VIP account is overdue and access will be suspended soon.<br />
-Please contact <a href="mailto:accounts@wpvip.com">accounts@wpvip.com</a> to settle your bill.';
+Please contact <a href="mailto:accounting@automattic.com">accounting@automattic.com</a> to settle your bill.';
 				case self::ACCOUNT_STATUS_LOCK:
 				case self::ACCOUNT_STATUS_SHUTDOWN:
 					return 'Payment for this WordPress VIP account is overdue and access has been suspended.<br />
-Please contact <a href="mailto:accounts@wpvip.com">accounts@wpvip.com</a> to settle your bill and restore access.';
+Please contact <a href="mailto:accounting@automattic.com">accounting@automattic.com</a> to settle your bill and restore access.';
 			}
 		}
 		// Otherwise, read it from VIP_LOCKOUT_MESSAGE constant


### PR DESCRIPTION
## Description

Updates a contact email address for overdue sites. The team wishes to use a different account for these.

## Changelog Description

Updated overdue notice contact email address.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- N/A This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- N/A This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
2. In code somewhere, `define( 'VIP_ACCOUNT_STATUS', 'warned' );`
1. Go to `wp-admin` ... should see a warning with the new email
2. In code somewhere, `define( 'VIP_ACCOUNT_STATUS', 'locked' );`
1. Go to `wp-admin` ... should see a lockout warning with the new email
