### PR TITLE
Search: Add should_load_new_ep() for upcoming rollout of next ElasticPress version

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -24,6 +24,7 @@
         "wp-content/mu-plugins/unique-index-name.php": "./tests/search/e2e/wordpress-files/test-mu-plugins/unique-index-name.php",
         "wp-content/plugins/cpt-and-custom-tax.php": "./tests/search/e2e/wordpress-files/test-plugins/cpt-and-custom-tax.php",
         "wp-content/plugins/vip-enable-facet-taxonomies.php": "./tests/search/e2e/wordpress-files/test-plugins/vip-enable-facet-taxonomies.php",
+        "wp-content/plugins/vip-woocommerce-meta-allow-list.php": "./tests/search/e2e/wordpress-files/test-plugins/vip-woocommerce-meta-allow-list.php",
         "wp-content/plugins/fake-new-activation.php": "./tests/search/e2e/wordpress-files/test-plugins/fake-new-activation.php",
         "wp-content/plugins/unsupported-server-software.php": "./tests/search/e2e/wordpress-files/test-plugins/unsupported-server-software.php",
         "wp-content/plugins/unsupported-elasticsearch-version.php": "./tests/search/e2e/wordpress-files/test-plugins/unsupported-elasticsearch-version.php",

--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -58,9 +58,9 @@ add_action(
 			new Admin_Notice(
 				$message,
 				[
-					new Expression_Condition( defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === constant( 'VIP_ENABLE_VIP_SEARCH' ) && ! defined( 'VIP_SEARCH_USE_NEXT_EP' ) ),
+					new Expression_Condition( class_exists( '\Automattic\VIP\Search\Search' ) && ! \Automattic\VIP\Search\Search::should_load_new_ep() ),
 				],
-				'new-ep-version',
+				'new-ep-version-1',
 				'error'
 			)
 		);

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -17,7 +17,9 @@ class Feature {
 	 *
 	 * @var array
 	 */
-	public static $feature_percentages = [];
+	public static $feature_percentages = [
+		'vip-search-use-next-ep' => 0.0,
+	];
 
 	/**
 	 * Holds feature slug and then, key of ids with bool value to enable E.g.

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -995,7 +995,7 @@ class Health {
 		$diff = [];
 
 		if ( $indexable->index_exists() ) {
-			if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+			if ( \Automattic\VIP\Search\Search::should_load_new_ep() ) {
 				$index_name      = $indexable->get_index_name();
 				$settings        = $this->elasticsearch->get_index_settings( $index_name );
 				$actual_settings = $settings[ $index_name ]['settings'] ?? [];
@@ -1009,7 +1009,7 @@ class Health {
 				return $actual_settings;
 			}
 
-			if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+			if ( \Automattic\VIP\Search\Search::should_load_new_ep() ) {
 				$mapping          = $indexable->generate_mapping();
 				$desired_settings = $mapping['settings'];
 			} else {
@@ -1079,7 +1079,7 @@ class Health {
 			}
 		}
 
-		if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+		if ( \Automattic\VIP\Search\Search::should_load_new_ep() ) {
 			$mapping          = $indexable->generate_mapping();
 			$desired_settings = $mapping['settings'];
 		} else {
@@ -1102,7 +1102,7 @@ class Health {
 		// Limit to only the settings that we auto-heal
 		$desired_settings_to_heal = self::limit_index_settings_to_keys( $desired_settings, self::INDEX_SETTINGS_HEALTH_AUTO_HEAL_KEYS );
 		$index_name               = $indexable->get_index_name();
-		if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+		if ( \Automattic\VIP\Search\Search::should_load_new_ep() ) {
 			$result = $this->elasticsearch->update_index_settings( $index_name, $desired_settings_to_heal, true );
 		} else {
 			$result = $indexable->update_index_settings( $desired_settings_to_heal );

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -259,7 +259,7 @@ class Search {
 	 * @return bool Whether to load the latest version or not.
 	 */
 	public static function should_load_new_ep() {
-		if ( self::is_next_ep_constant_defined() ) {
+		if ( static::is_next_ep_constant_defined() ) {
 			return true;
 		}
 
@@ -280,7 +280,7 @@ class Search {
 
 	protected function load_dependencies() {
 		// Load ElasticPress
-		if ( self::should_load_new_ep() ) {
+		if ( static::should_load_new_ep() ) {
 			require_once __DIR__ . '/../../elasticpress-next/elasticpress.php';
 		} else {
 			require_once __DIR__ . '/../../elasticpress/elasticpress.php';

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -263,6 +263,10 @@ class Search {
 			return true;
 		}
 
+		if ( defined( 'VIP_SEARCH_USE_NEXT_EP' ) && true !== constant( 'VIP_SEARCH_USE_NEXT_EP' ) ) {
+			return false;
+		}
+
 		if ( defined( 'SKIP_VIP_SEARCH_USE_NEXT_EP_IDS' ) && defined( 'VIP_GO_APP_ID' ) && in_array( constant( 'VIP_GO_APP_ID' ), constant( 'SKIP_VIP_SEARCH_USE_NEXT_EP_IDS' ), true ) ) {
 			return false;
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -246,9 +246,41 @@ class Search {
 		return static::$instance;
 	}
 
+	/**
+	 * Whether to load the latest ElasticPress version.
+	 * Will return true for:
+	 * - If the constant VIP_SEARCH_USE_NEXT_EP is defined and set to true
+	 * - All non-prods
+	 * - If production and in the percentage
+	 *
+	 * Will return false for:
+	 * - If in the SKIP_LOAD_NEXT_EP_IDS array
+	 *
+	 * @return bool Whether to load the latest version or not.
+	 */
+	public static function should_load_new_ep() {
+		if ( self::is_next_ep_constant_defined() ) {
+			return true;
+		}
+
+		if ( defined( 'SKIP_VIP_SEARCH_USE_NEXT_EP_IDS' ) && defined( 'VIP_GO_APP_ID' ) && in_array( constant( 'VIP_GO_APP_ID' ), constant( 'SKIP_VIP_SEARCH_USE_NEXT_EP_IDS' ), true ) ) {
+			return false;
+		}
+
+		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			return true;
+		}
+
+		if ( \Automattic\VIP\Feature::is_enabled_by_percentage( 'vip-search-use-next-ep' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
 	protected function load_dependencies() {
 		// Load ElasticPress
-		if ( self::is_next_ep_constant_defined() ) {
+		if ( self::should_load_new_ep() ) {
 			require_once __DIR__ . '/../../elasticpress-next/elasticpress.php';
 		} else {
 			require_once __DIR__ . '/../../elasticpress/elasticpress.php';

--- a/search/includes/functions/ep-get-query-log.php
+++ b/search/includes/functions/ep-get-query-log.php
@@ -1,5 +1,5 @@
 <?php
-if ( \Automattic\VIP\Search\Search::is_next_ep_constant_defined() ) {
+if ( \Automattic\VIP\Search\Search::should_load_new_ep() ) {
 	require_once __DIR__ . '/../../elasticpress-next/elasticpress.php';
 } else {
 	require_once __DIR__ . '/../../elasticpress/elasticpress.php';

--- a/tests/search/e2e/integration/features/protected-content.spec.js
+++ b/tests/search/e2e/integration/features/protected-content.spec.js
@@ -1,17 +1,17 @@
 describe('Protected Content Feature', () => {
-	before(() => {
+	it('Can turn the feature on', () => {
+		cy.login();
+
 		cy.maybeEnableFeature('protected_content');
-		cy.wpCli('vip-search index --setup --skip-confirm');
-		
+
+		cy.wpCli('vip-search list-features').its('stdout').should('contain', 'protected_content');
 	});
 
-	beforeEach(() => {
-		cy.login();
-	})
-
 	it('Can use Elasticsearch in the Posts List Admin Screen', () => {
+		cy.login();
 
 		cy.maybeEnableFeature('protected_content');
+		cy.wpCli('vip-search index --setup --skip-confirm');
 
 		cy.visitAdminPage('edit.php');
 		cy.get('#vip-search-dev-tools-mount').click();
@@ -19,6 +19,7 @@ describe('Protected Content Feature', () => {
 	});
 
 	it('Can use Elasticsearch in the Draft Posts List Admin Screen', () => {
+		cy.login();
 
 		cy.maybeEnableFeature('protected_content');
 
@@ -41,6 +42,7 @@ describe('Protected Content Feature', () => {
 	});
 
 	it('Can sync autosaved drafts', () => {
+		cy.login();
 
 		cy.maybeEnableFeature('protected_content');
 

--- a/tests/search/e2e/integration/features/search/search.spec.js
+++ b/tests/search/e2e/integration/features/search/search.spec.js
@@ -1,30 +1,19 @@
-describe('Post Search Feature', () => {
+// eslint-disable-next-line jest/valid-describe-callback
+describe('Post Search Feature', { tags: '@slow' }, () => {
 	before(() => {
 		cy.wpCli('vip-search index --setup --skip-confirm');
-
 	});
 
-	beforeEach(() => {
-		cy.login();
-	})
-
 	it('Can use Elasticsearch for the default WP search', () => {
-
+		cy.login();
 
 		cy.visit('/?s=test');
-
-		// eslint-disable-next-line jest/valid-expect-in-promise
-		cy.get('#vip-search-dev-tools-mount')
-			.invoke('text')
-			.then((debugText) => {
-				expect(debugText).not.to.contain('0 queries');
-			});
 
 		cy.searchDevToolsResponseOK();
 	});
 
 	it('Can see exact matches showing higher', () => {
-
+		cy.login();
 
 		const postsData = [
 			{
@@ -47,7 +36,7 @@ describe('Post Search Feature', () => {
 	});
 
 	it('Can see newer matches showing higher', () => {
-
+		cy.login();
 
 		const attempt = Cypress._.get(cy.state('runnable'), '_currentRetry', 0);
 		const postTitle = `Duplicated post Attempt #${attempt}`;
@@ -110,7 +99,7 @@ describe('Post Search Feature', () => {
 	});
 
 	it('Can see highlighted text', () => {
-
+		cy.login();
 		cy.visitAdminPage('admin.php?page=elasticpress');
 		cy.get('.ep-feature-search .settings-button').click();
 		cy.get('.ep-feature-search [name="settings[highlight_excerpt]"][value="1"]').click();

--- a/tests/search/e2e/integration/features/search/search.spec.js
+++ b/tests/search/e2e/integration/features/search/search.spec.js
@@ -1,7 +1,7 @@
 describe('Post Search Feature', () => {
 	before(() => {
 		cy.wpCli('vip-search index --setup --skip-confirm');
-		
+
 	});
 
 	beforeEach(() => {
@@ -20,8 +20,7 @@ describe('Post Search Feature', () => {
 				expect(debugText).not.to.contain('0 queries');
 			});
 
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
+		cy.searchDevToolsResponseOK();
 	});
 
 	it('Can see exact matches showing higher', () => {

--- a/tests/search/e2e/integration/features/search/search.spec.js
+++ b/tests/search/e2e/integration/features/search/search.spec.js
@@ -114,7 +114,7 @@ describe('Post Search Feature', () => {
 
 		cy.visitAdminPage('admin.php?page=elasticpress');
 		cy.get('.ep-feature-search .settings-button').click();
-		cy.get('.ep-feature-search [name="highlight_excerpt"][value="1"]').click();
+		cy.get('.ep-feature-search [name="settings[highlight_excerpt]"][value="1"]').click();
 		cy.get('.ep-feature-search .button-primary').click();
 
 		cy.publishPost({

--- a/tests/search/e2e/integration/features/search/synonyms.spec.js
+++ b/tests/search/e2e/integration/features/search/synonyms.spec.js
@@ -41,7 +41,7 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 		cy.get('.synonym-sets-editor').within(() => {
 			cy.get('.synonym__remove').click();
 			cy.contains('.button', 'Add Set').click();
-			cy.get('.ep-synonyms__linked-multi-input').type(`${word1}{enter}${word2}{enter}`);
+			cy.get('.components-form-token-field__input').type(`${word1}{enter}${word2}{enter}`);
 		});
 		cy.get('#synonym-root .button-primary').click();
 
@@ -65,7 +65,7 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 			cy.get('.synonym__remove').click();
 			cy.contains('.button', 'Add Alternative').click();
 			cy.get('.ep-synonyms__input').type(word1);
-			cy.get('.ep-synonyms__linked-multi-input').type(`${word2}{enter}`);
+			cy.get('.components-form-token-field__input').type(`${word2}{enter}`);
 		});
 		cy.get('#synonym-root .button-primary').click();
 
@@ -122,7 +122,7 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 			'exist',
 		);
 		cy.get('.synonym-alternative-editor input[value="foo"]').should('exist');
-		cy.contains('.ep-synonyms__linked-multi-input div', 'bar').should(
+		cy.contains('.synonym-alternative-editor .components-form-token-field span', 'bar').should(
 			'exist',
 		);
 	});

--- a/tests/search/e2e/integration/features/search/weighting.spec.js
+++ b/tests/search/e2e/integration/features/search/weighting.spec.js
@@ -1,37 +1,31 @@
 describe('Post Search Feature - Weighting Functionality', () => {
-
-	before(() => {
-		cy.wpCli('vip-search index --setup --skip-confirm');
-		
-	});
-
-	beforeEach(() => {
-		cy.login();
-	})
-
 	it("Can't find a post by title if title is not marked as searchable", () => {
+		cy.login();
+
+		cy.updateWeighting();
 
 		cy.publishPost({
-			title: 'Test ElasticPress 1',
+			title: 'supercustomtitle',
 		});
 
-		cy.visit('/?s=Test+ElasticPress+1');
-		cy.get('.hentry').should('contain.text', 'Test ElasticPress 1');
+		cy.visit('/?s=supercustomtitle');
+		cy.get('.hentry').should('contain.text', 'supercustomtitle');
 
 		cy.visitAdminPage('admin.php?page=elasticpress-weighting');
-		cy.get('#post-post_title-enabled').click();
+		cy.get('#post-post_title-enabled').uncheck();
 		cy.get('#submit').click();
 
-		cy.visit('/?s=Test+ElasticPress+1');
+		cy.visit('/?s=supercustomtitle');
 		cy.get('.hentry').should('not.exist');
 
 		// Reset setting.
 		cy.visitAdminPage('admin.php?page=elasticpress-weighting');
-		cy.get('#post-post_title-enabled').click();
+		cy.get('#post-post_title-enabled').check();
 		cy.get('#submit').click();
 	});
 
 	it('Can increase post_title weighting and influence search results', () => {
+		cy.login();
 
 		const postsData = [
 			{

--- a/tests/search/e2e/integration/features/terms.spec.js
+++ b/tests/search/e2e/integration/features/terms.spec.js
@@ -41,13 +41,7 @@ describe('Terms Feature', { tags: '@slow' }, () => {
 			.should('contain.text', searchTerm);
 
 		// make sure elasticsearch result does contain the term.
-		// VIP: Use Search Dev Tools instead of Debug Bar
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().click();
-		cy.get('.line-numbers')
-			.first()
-			.should('contain.text', searchTerm);
-		cy.get('#vip-search-dev-tools-mount').click();
+		cy.searchDevToolsResponseOK( searchTerm ); // VIP: Use Search Dev Tools instead of Debug Bar
 
 		// Delete the term
 		cy.get('.wp-list-table tbody tr')
@@ -66,18 +60,13 @@ describe('Terms Feature', { tags: '@slow' }, () => {
 		cy.createTerm({ name: term });
 
 		// Search for the term
+		cy.reload();
 		cy.get('#tag-search-input').type(term);
 		cy.get('#search-submit').click();
 		cy.get('.wp-list-table tbody tr').should('have.length', 1).should('contain.text', term);
 
 		// make sure elasticsearch result does contain the term.
-		// VIP: Use Search Dev Tools instead of Debug Bar
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().click();
-		cy.get('.line-numbers')
-			.first()
-			.should('contain.text', term);
-		cy.get('#vip-search-dev-tools-mount').click();
+		cy.searchDevToolsResponseOK( term ); // VIP: Use Search Dev Tools instead of Debug Bar
 
 		// Delete the term
 		cy.get('.wp-list-table tbody tr')
@@ -97,9 +86,7 @@ describe('Terms Feature', { tags: '@slow' }, () => {
 		cy.get('#search-submit').click();
 		cy.get('.wp-list-table tbody').should('contain.text', 'No categories found');
 
-		// VIP: Use Search Dev Tools instead of Debug Bar
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
+		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
 	});
 
 	it('Can return a correct tag on searching a tag in admin dashboard', () => {
@@ -119,13 +106,7 @@ describe('Terms Feature', { tags: '@slow' }, () => {
 
 		cy.get('.wp-list-table tbody tr .row-title').should('contain.text', 'The Most Fun Thing');
 
-		// VIP: Use Search Dev Tools instead of Debug Bar
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().click();
-		cy.get('.line-numbers')
-			.first()
-			.should('contain.text', 'The Most Fun Thing');
-		cy.get('#vip-search-dev-tools-mount').click();
+		cy.searchDevToolsResponseOK( 'The Most Fun Thing' ); // VIP: Use Search Dev Tools instead of Debug Bar
 	});
 
 	it('Can update a child term when a parent term is deleted', () => {

--- a/tests/search/e2e/integration/features/terms.spec.js
+++ b/tests/search/e2e/integration/features/terms.spec.js
@@ -1,4 +1,5 @@
-describe('Terms Feature', () => {
+// eslint-disable-next-line jest/valid-describe-callback
+describe('Terms Feature', { tags: '@slow' }, () => {
 	const tags = ['Far From Home', 'No Way Home', 'The Most Fun Thing'];
 
 	before(() => {
@@ -13,14 +14,19 @@ describe('Terms Feature', () => {
 				true,
 			);
 		});
-		
 	});
 
-	beforeEach(() => {
+	it('Can turn the feature on', () => {
 		cy.login();
-	})
+		cy.maybeEnableFeature('terms');
+
+		// VIP: Only enable the feature via CLI
+		cy.wpCli('vip-search index --skip-confirm --setup');
+		cy.wpCli('wp vip-search list-features').its('stdout').should('contain', 'terms');
+	});
 
 	it('Can search a term in the admin dashboard using Elasticsearch', () => {
+		cy.login();
 		cy.maybeEnableFeature('terms');
 		cy.wpCli('vip-search index --skip-confirm --setup');
 
@@ -35,6 +41,7 @@ describe('Terms Feature', () => {
 			.should('contain.text', searchTerm);
 
 		// make sure elasticsearch result does contain the term.
+		// VIP: Use Search Dev Tools instead of Debug Bar
 		cy.get('#vip-search-dev-tools-mount').click();
 		cy.get('h3.vip-h3').first().click();
 		cy.get('.line-numbers')
@@ -50,6 +57,7 @@ describe('Terms Feature', () => {
 	});
 
 	it('Can a term be removed from the admin dashboard after deleting it', () => {
+		cy.login();
 		cy.maybeEnableFeature('terms');
 		cy.wpCli('vip-search index --skip-confirm --setup');
 
@@ -63,6 +71,7 @@ describe('Terms Feature', () => {
 		cy.get('.wp-list-table tbody tr').should('have.length', 1).should('contain.text', term);
 
 		// make sure elasticsearch result does contain the term.
+		// VIP: Use Search Dev Tools instead of Debug Bar
 		cy.get('#vip-search-dev-tools-mount').click();
 		cy.get('h3.vip-h3').first().click();
 		cy.get('.line-numbers')
@@ -75,16 +84,27 @@ describe('Terms Feature', () => {
 			.first()
 			.find('.row-actions .delete a')
 			.click({ force: true });
-		cy.reload();
+
+		/**
+		 * Give Elasticsearch some time. Apparently, if we search again it returns the outdated data.
+		 *
+		 * @see https://github.com/10up/ElasticPress/issues/2726
+		 */
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(2000);
 
 		// Re-search for the term and make sure it's not there.
 		cy.get('#search-submit').click();
 		cy.get('.wp-list-table tbody').should('contain.text', 'No categories found');
+
+		// VIP: Use Search Dev Tools instead of Debug Bar
+		cy.get('#vip-search-dev-tools-mount').click();
+		cy.get('h3.vip-h3').first().should('contain.text','(200)');
 	});
 
 	it('Can return a correct tag on searching a tag in admin dashboard', () => {
+		cy.login();
 		cy.maybeEnableFeature('terms');
-		cy.wpCli('vip-search index --skip-confirm --setup');
 
 		cy.visitAdminPage('edit-tags.php?taxonomy=post_tag');
 
@@ -99,7 +119,7 @@ describe('Terms Feature', () => {
 
 		cy.get('.wp-list-table tbody tr .row-title').should('contain.text', 'The Most Fun Thing');
 
-		// make sure elasticsearch result does contain the term.
+		// VIP: Use Search Dev Tools instead of Debug Bar
 		cy.get('#vip-search-dev-tools-mount').click();
 		cy.get('h3.vip-h3').first().click();
 		cy.get('.line-numbers')
@@ -109,8 +129,8 @@ describe('Terms Feature', () => {
 	});
 
 	it('Can update a child term when a parent term is deleted', () => {
+		cy.login();
 		cy.maybeEnableFeature('terms');
-		cy.wpCli('vip-search index --skip-confirm --setup');
 
 		const parentTerm = 'bar-parent';
 		const childTerm = 'baz-child';

--- a/tests/search/e2e/integration/features/woocommerce.spec.js
+++ b/tests/search/e2e/integration/features/woocommerce.spec.js
@@ -1,7 +1,7 @@
 describe('WooCommerce Feature', () => {
 	before(() => {
 		cy.deactivatePlugin('woocommerce', 'wpCli');
-		
+
 	});
 
 	beforeEach(() => {
@@ -26,8 +26,7 @@ describe('WooCommerce Feature', () => {
 		cy.maybeEnableFeature('woocommerce');
 
 		cy.visitAdminPage('edit.php?post_type=shop_order');
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
+		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
 	});
 
 	it('Can fetch products from Elasticsearch in WP Dashboard', () => {
@@ -36,8 +35,7 @@ describe('WooCommerce Feature', () => {
 		cy.maybeEnableFeature('woocommerce');
 
 		cy.visitAdminPage('edit.php?post_type=product');
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
+		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
 	});
 
 	it('Can fetch products from Elasticsearch in product category archives', () => {
@@ -45,8 +43,7 @@ describe('WooCommerce Feature', () => {
 		cy.maybeEnableFeature('woocommerce');
 
 		cy.visit('/product-category/uncategorized');
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
+		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
 	});
 
 	it('Can fetch products from Elasticsearch in product rivers', () => {
@@ -54,7 +51,6 @@ describe('WooCommerce Feature', () => {
 		cy.maybeEnableFeature('woocommerce');
 
 		cy.visit('/shop/?filter_size=small');
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
+		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
 	});
 });

--- a/tests/search/e2e/integration/features/woocommerce.spec.js
+++ b/tests/search/e2e/integration/features/woocommerce.spec.js
@@ -1,18 +1,26 @@
-describe('WooCommerce Feature', () => {
+// eslint-disable-next-line jest/valid-describe-callback
+describe('WooCommerce Feature', { tags: '@slow' }, () => {
+	const userData = {
+		username: 'testuser',
+		email: 'testuser@example.com',
+		firstName: 'John',
+		lastName: 'Doe',
+		address: '123 Main St',
+		city: 'Culver City',
+		postCode: '90230',
+		phoneNumber: '1234567890',
+	};
+
 	before(() => {
 		cy.deactivatePlugin('woocommerce', 'wpCli');
-
 	});
-
-	beforeEach(() => {
-		cy.login();
-	})
 
 	after(() => {
 		cy.deactivatePlugin('woocommerce', 'wpCli');
 	});
 
 	it('Can auto-activate the feature', () => {
+		cy.login();
 
 		cy.activatePlugin('woocommerce');
 
@@ -20,37 +28,142 @@ describe('WooCommerce Feature', () => {
 		cy.get('.ep-feature-woocommerce').should('have.class', 'feature-active');
 	});
 
-	it('Can fetch orders from Elasticsearch', () => {
-
-		cy.maybeEnableFeature('protected_content');
-		cy.maybeEnableFeature('woocommerce');
-
-		cy.visitAdminPage('edit.php?post_type=shop_order');
-		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
-	});
-
-	it('Can fetch products from Elasticsearch in WP Dashboard', () => {
-
-		cy.maybeEnableFeature('protected_content');
-		cy.maybeEnableFeature('woocommerce');
-
-		cy.visitAdminPage('edit.php?post_type=product');
-		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
-	});
-
-	it('Can fetch products from Elasticsearch in product category archives', () => {
-
-		cy.maybeEnableFeature('woocommerce');
-
-		cy.visit('/product-category/uncategorized');
-		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
-	});
-
-	it('Can fetch products from Elasticsearch in product rivers', () => {
+	it('Can fetch products from Elasticsearch in product rivers and category archives', () => {
+		cy.login();
 
 		cy.maybeEnableFeature('woocommerce');
 
 		cy.visit('/shop/?filter_size=small');
 		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
+
+		cy.visit('/product-category/uncategorized');
+		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
+	});
+
+	context('Dashboard', () => {
+		before(() => {
+			cy.login();
+			cy.activatePlugin('woocommerce', 'wpCli');
+			cy.maybeEnableFeature('protected_content');
+			cy.maybeEnableFeature('woocommerce');
+			cy.wpCli( 'plugin activate vip-woocommerce-meta-allow-list' ); // VIP: Since we index only on an explicit allow list, we need to add protected Woo keys.
+		});
+
+		it('Can fetch orders and products from Elasticsearch', () => {
+			/**
+			 * Orders
+			 */
+			// this is required to sync the orders to Elasticsearch.
+			cy.wpCli('vip-search index --setup --skip-confirm');
+
+			cy.visitAdminPage('edit.php?post_type=shop_order');
+			cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
+
+			/**
+			 * Products
+			 */
+			cy.visitAdminPage('edit.php?post_type=product');
+			cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
+		});
+
+		it('Can not display other users orders on the My Account Order page', () => {
+			// enable payment gateway.
+			cy.visitAdminPage('admin.php?page=wc-settings&tab=checkout&section=cod');
+			cy.get('#woocommerce_cod_enabled').check();
+			cy.get('.button-primary.woocommerce-save-button').click();
+
+			cy.logout();
+
+			// create new user.
+			cy.createUser({
+				username: userData.username,
+				email: userData.email,
+				login: true,
+			});
+
+			// add product to cart.
+			cy.visit('product/fantastic-silk-knife');
+			cy.get('.single_add_to_cart_button').click();
+
+			// checkout and place order.
+			cy.visit('checkout');
+			cy.get('#billing_first_name').type(userData.firstName);
+			cy.get('#billing_last_name').type(userData.lastName);
+			cy.get('#billing_address_1').type(userData.address);
+			cy.get('#billing_city').type(userData.city);
+			cy.get('#billing_postcode').type(userData.postCode);
+			cy.get('#billing_phone').type(userData.phoneNumber);
+			cy.get('#place_order').click();
+
+			// ensure order is placed.
+			cy.url().should('include', '/checkout/order-received');
+
+			/**
+			 * Give Elasticsearch some time to process the new posts.
+			 *
+			 */
+			// eslint-disable-next-line cypress/no-unnecessary-waiting
+			cy.wait(2000);
+
+			// ensure order is visible to user.
+			cy.visit('my-account/orders');
+			cy.get('.woocommerce-orders-table tbody tr').should('have.length', 1);
+
+			// VIP: Use Search Dev Tools instead of Debug Bar
+			cy.searchDevToolsResponseOK('shop_order');
+			cy.get('#vip-search-dev-tools-mount').click();
+			cy.get('h3.vip-h3').first().click();
+			cy.get('strong.vip-h4.wp_query').first().click();
+			cy.get('ol.wp_query.vip-collapse-ol').first().should('contain.text','orderby: "date"');
+			cy.get('#vip-search-dev-tools-mount').click();
+
+			cy.logout();
+
+			cy.createUser({
+				username: 'buyer',
+				email: 'buyer@example.com',
+				login: true,
+			});
+
+			// ensure no order is show.
+			cy.visit('my-account/orders');
+			cy.get('.woocommerce-orders-table tbody tr').should('have.length', 0);
+
+			cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
+		});
+
+		it('Can search orders from ElasticPress in WP Dashboard', () => {
+			cy.visitAdminPage('edit.php?post_type=shop_order');
+			cy.maybeRelogin(); // VIP: The login usually times out at this point
+
+			// search order by user's name.
+			cy.get('#post-search-input')
+				.clear()
+				.type(`${userData.firstName} ${userData.lastName}{enter}`);
+
+			cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
+
+			cy.get('.order_number .order-view').should(
+				'contain.text',
+				`${userData.firstName} ${userData.lastName}`,
+			);
+
+			// search order by user's address.
+			cy.get('#post-search-input').clear().type(`${userData.address}{enter}`);
+			cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
+			cy.get('.order_number .order-view').should(
+				'contain.text',
+				`${userData.firstName} ${userData.lastName}`,
+			);
+
+			// search order by product.
+			cy.get('#post-search-input').clear().type(`fantastic-silk-knife{enter}`);
+			cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools instead of Debug Bar
+
+			cy.get('.order_number .order-view').should(
+				'contain.text',
+				`${userData.firstName} ${userData.lastName}`,
+			);
+		});
 	});
 });

--- a/tests/search/e2e/integration/general.spec.js
+++ b/tests/search/e2e/integration/general.spec.js
@@ -1,14 +1,15 @@
-describe('WordPress can perform standard ElasticPress actions', () => {
-	beforeEach(() => {
+// eslint-disable-next-line jest/valid-describe-callback
+describe('WordPress can perform standard ElasticPress actions', { tags: '@slow' }, () => {
+	it('Can see the menu page link in wp-admin', () => {
 		cy.login();
-	});
 
-	it('Can see the settings page link in WordPress Dashboard', () => {
-		cy.visitAdminPage();
-		cy.get('.toplevel_page_elasticpress .wp-menu-name').should('contain.text', 'Enterprise Search');
+		cy.visitAdminPage('/');
+
+		cy.get('.toplevel_page_elasticpress').should('contain.text', 'Enterprise Search');
 	});
 
 	it('Can sync post data and meta details in Elasticsearch if user creates/updates a published post', () => {
+		cy.login();
 
 		cy.publishPost({
 			title: 'Test ElasticPress 1',
@@ -16,5 +17,16 @@ describe('WordPress can perform standard ElasticPress actions', () => {
 
 		cy.visit('/?s=Test+ElasticPress+1');
 		cy.contains('.site-content article h2', 'Test ElasticPress 1').should('exist');
+	});
+
+	it('Cannot save settings while a sync is in progress', () => {
+		cy.login();
+		cy.visitAdminPage('admin.php?page=elasticpress');
+		cy.wpCliEval(`update_option( 'ep_index_meta', [ 'indexing' => true ] );`).then(() => {
+			cy.get('.ep-feature-search .settings-button').click();
+			cy.get('.ep-feature-search .button-primary').click();
+			cy.get('.ep-feature-search .requirements-status-notice--syncing').should('be.visible');
+			cy.wpCliEval(`delete_option( 'ep_index_meta' );`);
+		});
 	});
 });

--- a/tests/search/e2e/integration/indexables/user.spec.js
+++ b/tests/search/e2e/integration/indexables/user.spec.js
@@ -47,7 +47,7 @@ describe('User Indexable', () => {
 		cy.searchDevToolsResponseOK('"user_email": "testuser@example.com"'); // VIP: Use Search Dev Tools over Debug Bar
 
 		// Test if the user is still found a reindex.
-		cy.wpCli('vip-search index --setup --skip-confirm').its('stdout').should('contain', 'Number of users indexed: 2');
+		cy.wpCli('vip-search index --setup --skip-confirm').its('stdout').should('contain', 'Number of users indexed: 3'); // VIP: There's 3 users from the WooCommerce test
 
 		searchUser();
 

--- a/tests/search/e2e/integration/indexables/user.spec.js
+++ b/tests/search/e2e/integration/indexables/user.spec.js
@@ -35,6 +35,7 @@ describe('User Indexable', () => {
 		cy.login();
 
 		cy.maybeEnableFeature('users');
+		cy.wpCli('vip-search index --setup --skip-confirm')
 
 		createUser();
 
@@ -42,10 +43,8 @@ describe('User Indexable', () => {
 
 		cy.get('.wp-list-table').should('contain.text', 'testuser@example.com');
 		cy.getTotal(1);
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
-		cy.get('.line-numbers').first().should('contain.text','"user_email": "testuser@example.com"');
-		cy.get('#vip-search-dev-tools-mount').click();
+
+		cy.searchDevToolsResponseOK('"user_email": "testuser@example.com"'); // VIP: Use Search Dev Tools over Debug Bar
 
 		// Test if the user is still found a reindex.
 		cy.wpCli('vip-search index --setup --skip-confirm').its('stdout').should('contain', 'Number of users indexed: 2');
@@ -54,9 +53,8 @@ describe('User Indexable', () => {
 
 		cy.get('.wp-list-table').should('contain.text', 'testuser@example.com');
 		cy.getTotal(1);
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
-		cy.get('.line-numbers').first().should('contain.text','"user_email": "testuser@example.com"');
+
+		cy.searchDevToolsResponseOK('"user_email": "testuser@example.com"'); // VIP: Use Search Dev Tools over Debug Bar
 	});
 
 	it('Can sync user meta data', () => {
@@ -77,14 +75,7 @@ describe('User Indexable', () => {
 
 		cy.get('.wp-list-table').should('contain.text', 'testuser@example.com');
 		cy.getTotal(1);
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
-		// eslint-disable-next-line jest/valid-expect-in-promise
-		cy.get('.line-numbers').first().invoke('text').then((text) => {
-			expect(text).to.contain('"user_email": "testuser@example.com"');
-			expect(text).to.contain('"value": "John"');
-			expect(text).to.contain('"value": "Doe"');
-		});
+		cy.searchDevToolsResponseOKArray( [ '"user_email": "testuser@example.com"', '"value": "John"', '"value": "Doe"' ] );
 	});
 
 	it('Only returns users from the current blog', () => {
@@ -115,8 +106,7 @@ describe('User Indexable', () => {
 		searchUser('nobloguser');
 		cy.get('.wp-list-table').should('contain.text', 'No users found.');
 		cy.getTotal(0);
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
+		cy.searchDevToolsResponseOK(); // VIP: Use Search Dev Tools over Debug Bar
 
 		// Add user to the blog.
 		cy.visitAdminPage('user-new.php');
@@ -129,8 +119,6 @@ describe('User Indexable', () => {
 		searchUser('nobloguser');
 		cy.get('.wp-list-table').should('contain.text', 'nobloguser');
 		cy.getTotal(1);
-		cy.get('#vip-search-dev-tools-mount').click();
-		cy.get('h3.vip-h3').first().should('contain.text','(200)');
-		cy.get('.line-numbers').first().should('contain.text','"user_email": "no-blog-user@example.com"');
+		cy.searchDevToolsResponseOK('"user_email": "no-blog-user@example.com"'); // VIP: Use Search Dev Tools over Debug Bar
 	});
 });

--- a/tests/search/e2e/integration/wp-cli.spec.js
+++ b/tests/search/e2e/integration/wp-cli.spec.js
@@ -26,8 +26,8 @@ describe('WP-CLI Commands', () => {
 			cy.wpCli('wp vip-search index --per-page=20')
 				.its('stdout')
 				.should('contain', 'Indexing posts')
-				.should('contain', '20/')
-				.should('contain', '40/')
+				.should('contain', '20 of')
+				.should('contain', '40 of ')
 				.should('contain', 'Number of posts indexed');
 		});
 
@@ -144,7 +144,7 @@ describe('WP-CLI Commands', () => {
 			cy.wpCli('wp vip-search index --network-wide')
 				.its('stdout')
 				.then((output) => {
-					expect((output.match(/Indexing posts.../g) || []).length).to.equal(2);
+					expect((output.match(/Indexing posts/g) || []).length).to.equal(2);
 					expect(
 						(output.match(/Number of posts indexed:/g) || []).length,
 					).to.equal(2);
@@ -156,7 +156,7 @@ describe('WP-CLI Commands', () => {
 			cy.wpCli(`wp vip-search index`)
 				.its('stdout')
 				.then((output) => {
-					expect((output.match(/Indexing posts.../g) || []).length).to.equal(1);
+					expect((output.match(/Indexing posts/g) || []).length).to.equal(1);
 					expect(
 						(output.match(/Number of posts indexed:/g) || []).length,
 					).to.equal(1);
@@ -168,7 +168,7 @@ describe('WP-CLI Commands', () => {
 			cy.wpCli(`wp vip-search index --url=${Cypress.config('baseUrl')}/second-site`)
 				.its('stdout')
 				.then((output) => {
-					expect((output.match(/Indexing posts.../g) || []).length).to.equal(1);
+					expect((output.match(/Indexing posts/g) || []).length).to.equal(1);
 					expect(
 						(output.match(/Number of posts indexed:/g) || []).length,
 					).to.equal(1);
@@ -218,7 +218,7 @@ describe('WP-CLI Commands', () => {
 
 		// mock the indexing process
 		cy.wpCliEval(
-			`set_transient('ep_wpcli_sync', true); set_transient('ep_sync_interrupted', true);`,
+			`update_option('ep_index_meta', [ 'method' => 'test' ]); set_transient('ep_sync_interrupted', true);`,
 		);
 
 		cy.wpCli('wp vip-search stop-indexing').its('stdout').should('contain', 'Done');

--- a/tests/search/e2e/support/commands.js
+++ b/tests/search/e2e/support/commands.js
@@ -423,3 +423,38 @@ Cypress.Commands.add('createAutosavePost', (postData) => {
 	cy.wait(5000);
 	cy.deactivatePlugin('shorten-autosave', 'wpCli');
 });
+
+Cypress.Commands.add('logout', () => {
+	cy.visit('/wp-admin');
+	cy.get('body').then(($body) => {
+		if ($body.find('#wpadminbar').length !== 0) {
+			cy.get('#wp-admin-bar-my-account').invoke('addClass', 'hover');
+			cy.get('#wp-admin-bar-logout > a').click();
+		}
+	});
+});
+
+Cypress.Commands.add('createUser', (userData) => {
+	const newUserDate = {
+		username: 'testuser',
+		password: 'password',
+		email: 'testuser@example.com',
+		role: 'subscriber',
+		login: false,
+		...userData,
+	};
+
+	// delete the user.
+	cy.wpCli(`wp user delete ${newUserDate.username} --yes --network`, true);
+
+	// create the user
+	cy.wpCli(
+		`wp user create ${newUserDate.username} ${newUserDate.email} --user_pass=${newUserDate.password} --role=${newUserDate.role}`,
+	);
+
+	if (newUserDate.login) {
+		cy.visit('wp-login.php');
+		cy.get('#user_login').clear().type(newUserDate.username);
+		cy.get('#user_pass').clear().type(`${newUserDate.password}{enter}`);
+	}
+});

--- a/tests/search/e2e/support/commands.js
+++ b/tests/search/e2e/support/commands.js
@@ -480,3 +480,20 @@ Cypress.Commands.add('searchDevToolsResponseOKArray', (array) => {
 	});
 	cy.get('#vip-search-dev-tools-mount').click();
 });
+
+// VIP: Since the login times out, we should re-login if redirected.
+Cypress.Commands.add('maybeRelogin', (username = 'test@test.com', password = 'password') => {
+	cy.url().then(url => {
+		const urlObject = new URL(url);
+		const pathname = urlObject.pathname;
+		if ( pathname.includes('wp-login.php') ) {
+			cy.get('body').then(($body) => {
+				if ($body.find('#wpwrap').length === 0) {
+					cy.get('input#user_login').clear();
+					cy.get('input#user_login').click().type(username);
+					cy.get('input#user_pass').type(`${password}{enter}`);
+				}
+			});
+		}
+	});
+});

--- a/tests/search/e2e/support/commands.js
+++ b/tests/search/e2e/support/commands.js
@@ -458,3 +458,25 @@ Cypress.Commands.add('createUser', (userData) => {
 		cy.get('#user_pass').clear().type(`${newUserDate.password}{enter}`);
 	}
 });
+
+// VIP: Check that Search Dev Tools returns a 200 status and a certain text in the response body
+Cypress.Commands.add('searchDevToolsResponseOK', (bodyText) => {
+	cy.get('#vip-search-dev-tools-mount').click();
+	cy.get('h3.vip-h3').first().should('contain.text','(200)');
+	if ( bodyText ) {
+		cy.get('.line-numbers').first().should('contain.text', bodyText);
+	}
+	cy.get('#vip-search-dev-tools-mount').click();
+});
+
+// VIP: Check that Search Dev Tools returns a 200 status and an array of certain text in the response body
+Cypress.Commands.add('searchDevToolsResponseOKArray', (array) => {
+	cy.get('#vip-search-dev-tools-mount').click();
+	cy.get('h3.vip-h3').first().should('contain.text','(200)');
+	cy.get('.line-numbers').first().invoke('text').then((text) => {
+		array.forEach((el) => {
+			expect(text).to.contain(el);
+		});
+	});
+	cy.get('#vip-search-dev-tools-mount').click();
+});

--- a/tests/search/e2e/support/global-hooks.js
+++ b/tests/search/e2e/support/global-hooks.js
@@ -15,8 +15,6 @@ before(() => {
 			$host            = str_replace( '172.17.0.1', 'localhost', $host );
 			$index_name      = \\ElasticPress\\Indexables::factory()->get( 'post' )->get_index_name();
 			$as_endpoint_url = $host . $index_name . '/_search';
-
-			$features['autosuggest']['endpoint_url'] = $as_endpoint_url;
 		}
 
 		update_option( 'ep_feature_settings', $features );

--- a/tests/search/e2e/support/index.js
+++ b/tests/search/e2e/support/index.js
@@ -39,9 +39,6 @@ cy.elasticPress = {
 		searchordering: {
 			active: 1,
 		},
-		autosuggest: {
-			active: 1,
-		},
 		woocommerce: {
 			active: 0,
 		},

--- a/tests/search/e2e/wordpress-files/test-plugins/vip-woocommerce-meta-allow-list.php
+++ b/tests/search/e2e/wordpress-files/test-plugins/vip-woocommerce-meta-allow-list.php
@@ -1,0 +1,31 @@
+<?php
+// phpcs:ignoreFile
+/**
+ * Plugin Name: Enable some protected meta keys for WooCommerce shop_orders
+ * Description: By default, no meta keys are configured. This plugin configures the meta keys for testing WooCommerce feature.
+ * Version:     1.0.0
+ * Author:      Automattic
+ * License:     GPLv2 or later
+ */
+
+/**
+ * Add some protected meta keys for WooCommerce shop_orders for tests
+ *
+ * @see https://github.com/10up/ElasticPress/blob/42da91b3a6daf687b539c4fd1283665d499b0af0/includes/classes/Feature/WooCommerce/WooCommerce.php#L54-L136
+ */
+add_filter( 'vip_search_post_meta_allow_list', 'vip_woo_meta_allow_list', 10, 2 );
+function vip_woo_meta_allow_list( $allow, $post = null  ) {
+	if ( is_object( $post ) && 'shop_order' === $post->post_type ) {
+		$allow['_customer_user'] = true;
+		$allow['_billing_first_name'] = true;
+		$allow['_billing_last_name'] = true;
+		$allow['_billing_address_1'] = true;
+		$allow['_billing_address_2'] = true;
+		$allow['_shipping_first_name'] = true;
+		$allow['_shipping_last_name'] = true;
+		$allow['_shipping_address_1'] = true;
+		$allow['_shipping_address_2'] = true;
+	}
+
+	return $allow;
+}


### PR DESCRIPTION
## Description
This PR:
- adds `should_load_new_ep()` to determine whether we are rolling out the next ElasticPress version
- rolls it out for non-production sites 
- adds a killswitch for sites in SKIP_VIP_SEARCH_USE_NEXT_EP_IDS constant
- only loads the admin notice if `should_load_new_ep()` is false
## Changelog Description

### Plugin Updated: Enterprise Search

Add should_load_new_ep() method and begin rollout of newest ElasticPress version for non-production sites

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) `define( 'VIP_SEARCH_USE_NEXT_EP', true );`
2) Go to wp-admin > Enterprise Search and look for 4.2.2 in footer text
3) Undo step 1 and add:
```
define( 'VIP_GO_APP_ID', 123 );
define( 'SKIP_VIP_SEARCH_USE_NEXT_EP_IDS', [ 123 ] );
```
4) Go to wp-admin > Enterprise Search and look for 3.6.5 in footer text
