### PR TITLE
Docs: Improve filter documentation for a security function

### DIFF
--- a/security.php
+++ b/security.php
@@ -221,54 +221,64 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 	$is_restricted_username = wpcom_vip_is_restricted_username( $username );
 
 	/**
-	 * Login Limiting IP Username Threshold
+	 * Filters the threshold for limiting logins by IP + username combination.
 	 *
-	 * @param string $ip IP address of the login request
-	 * @param string $username Username of the login request
+	 * Note that changing this value will also change the default value for the username login threshold as well,
+	 * which is set as 5 times this value.
+	 *
+	 * @param int    $threshold IP + Username combination login threshold. Default 5.
+	 * @param string $ip        IP address of the login request.
+	 * @param string $username  Username of the login request.
 	 */
 	$ip_username_threshold = apply_filters( 'wpcom_vip_ip_username_login_threshold', 5, $ip, $username );
 
 	/**
-	 * Login Limiting IP Threshold
+	 * Filters the threshold for limiting logins by IP.
 	 *
-	 * @param string $ip IP address of the login request
+	 * @param int    $threshold IP login threshold. Default 50.
+	 * @param string $ip        IP address of the login request.
 	 */
 	$ip_threshold = apply_filters( 'wpcom_vip_ip_login_threshold', 50, $ip );
 
 	/**
-	 * Login Limiting Username Threshold
+	 * Filters the threshold for limiting logins by username.
 	 *
-	 * @param string $username Username of the login request
+	 * @param int    $threshold Username login threshold. Default is 5 times the IP + username combination threshold.
+	 * @param string $username  Username of the login request.
 	 */
-	$username_threshold = 5 * $ip_username_threshold; // Default to 5 times the IP + username threshold
-	$username_threshold = apply_filters( 'wpcom_vip_username_login_threshold', $username_threshold, $username );
+	$username_threshold = apply_filters( 'wpcom_vip_username_login_threshold', 5 * $ip_username_threshold, $username );
 
 	/**
 	 * Change the thresholds for Password Resets
 	 */
 	if ( 'lost_password_limit' === $cache_group ) {
 		/**
-		 * Password Reset Limiting IP Username Threshold
+		 * Filters the threshold for limiting password resets by IP + username combination.
 		 *
-		 * @param string $ip IP address of the password reset request
-		 * @param string $username Username of the password reset request
+		 * Note that changing this value will also change the default value for the username password reset threshold as well,
+		 * which is set as 5 times this value.
+		 *
+		 * @param int    $threshold IP + Username combination password reset threshold. Default 3.
+		 * @param string $ip        IP address of the password reset request.
+		 * @param string $username  Username of the password reset request.
 		 */
 		$ip_username_threshold = apply_filters( 'wpcom_vip_ip_username_password_reset_threshold', 3, $ip, $username );
 
 		/**
-		 * Password Reset IP Threshold
+		 * Filters the threshold for limiting password resets by IP.
 		 *
-		 * @param string $ip IP address of the password reset request
+		 * @param int    $threshold IP password reset threshold. Default 3.
+		 * @param string $ip        IP address of the password reset request.
 		 */
 		$ip_threshold = apply_filters( 'wpcom_vip_ip_password_reset_threshold', 3, $ip );
 
 		/**
-		 * Password Reset Username Threshold
+		 * Filters the threshold for limiting password resets by username.
 		 *
-		 * @param string $username Username of the password reset request
+		 * @param int    $threshold Username password reset threshold. Default is 5 times the IP + username combination threshold.
+		 * @param string $username  Username of the password reset request
 		 */
-		$username_threshold = 5 * $ip_username_threshold; // Default to 5 times the IP + username threshold
-		$username_threshold = apply_filters( 'wpcom_vip_username_password_reset_threshold', $username_threshold, $username );
+		$username_threshold = apply_filters( 'wpcom_vip_username_password_reset_threshold', 5 * $ip_username_threshold, $username );
 	} elseif ( $is_restricted_username ) {
 		$ip_username_threshold = 2;
 	}


### PR DESCRIPTION
## Description

Improve documentation for threshold-related filter hooks in a security function.

- Params are needed for the filter's default value, not just the extra variables made available to filter hook callbacks.
- Summary for filters in WP core always start with `Filters...` as a best practice, so we do the same here too.
- [Inlines](https://refactoring.guru/inline-temp) a couple of temporary variables, since the highlighting of it being 5 times a different variable is now made in both the filter DocBlock applied to this variable, and the filter DocPlock applied to the original variable. The temporary variables were also placed such that the DocBlock for the filter was not associated with the filter call.

## Changelog Description

### Docs: Improve documentation for threshold-related filter hooks in a security function.

Add missing param tags and general tidy-up.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
Mostly a documentation change. Inlining of the temporary variable can be manually inspected.
