### PR TITLE
Add get_stats() to object cache drop-ins

### DIFF
--- a/drop-ins/object-cache/object-cache-next.php
+++ b/drop-ins/object-cache/object-cache-next.php
@@ -696,6 +696,58 @@ class WP_Object_Cache {
 		";
 	}
 
+	/**
+	 * Returns the collected raw stats.
+	 *
+	 * @return array $stats
+	 */
+	function get_stats() {
+		$stats = [];
+		$stats['totals'] = [
+			'query_time' => $this->time_total,
+			'size' => $this->size_total,
+		];
+		$stats['operation_counts'] = $this->stats;
+		$stats['operations'] = [];
+		$stats['groups'] = [];
+		$stats['slow-ops'] = [];
+		$stats['slow-ops-groups'] = [];
+		foreach ( $this->group_ops as $cache_group => $dataset ) {
+			if ( empty( $cache_group ) ) {
+				$cache_group = 'default';
+			}
+
+			foreach ( $dataset as $data ) {
+				$operation = $data[0];
+				$op = [
+					'key' => $data[1],
+					'size' => $data[2],
+					'time' => $data[3],
+					'group' => $cache_group,
+					'result' => $data[4],
+				];
+
+				if ( $cache_group === 'slow-ops' ) {
+					$key             = 'slow-ops';
+					$groups_key      = 'slow-ops-groups';
+					$op['group']     = $data[5];
+					$op['backtrace'] = $data[6];
+				} else {
+					$key        = 'operations';
+					$groups_key = 'groups';
+				}
+
+				$stats[ $key ][ $operation ][] = $op;
+
+				if ( ! in_array( $op['group'], $stats[ $groups_key ] ) ) {
+					$stats[ $groups_key ][] = $op['group'];
+				}
+			}
+		}
+
+		return $stats;
+	}
+
 	function stats() {
 		$this->js_toggle();
 

--- a/drop-ins/object-cache/object-cache-stable.php
+++ b/drop-ins/object-cache/object-cache-stable.php
@@ -696,6 +696,58 @@ class WP_Object_Cache {
 		";
 	}
 
+	/**
+	 * Returns the collected raw stats.
+	 *
+	 * @return array $stats
+	 */
+	function get_stats() {
+		$stats = [];
+		$stats['totals'] = [
+			'query_time' => $this->time_total,
+			'size' => $this->size_total,
+		];
+		$stats['operation_counts'] = $this->stats;
+		$stats['operations'] = [];
+		$stats['groups'] = [];
+		$stats['slow-ops'] = [];
+		$stats['slow-ops-groups'] = [];
+		foreach ( $this->group_ops as $cache_group => $dataset ) {
+			if ( empty( $cache_group ) ) {
+				$cache_group = 'default';
+			}
+
+			foreach ( $dataset as $data ) {
+				$operation = $data[0];
+				$op = [
+					'key' => $data[1],
+					'size' => $data[2],
+					'time' => $data[3],
+					'group' => $cache_group,
+					'result' => $data[4],
+				];
+
+				if ( $cache_group === 'slow-ops' ) {
+					$key             = 'slow-ops';
+					$groups_key      = 'slow-ops-groups';
+					$op['group']     = $data[5];
+					$op['backtrace'] = $data[6];
+				} else {
+					$key        = 'operations';
+					$groups_key = 'groups';
+				}
+
+				$stats[ $key ][ $operation ][] = $op;
+
+				if ( ! in_array( $op['group'], $stats[ $groups_key ] ) ) {
+					$stats[ $groups_key ][] = $op['group'];
+				}
+			}
+		}
+
+		return $stats;
+	}
+
 	function stats() {
 		$this->js_toggle();
 


### PR DESCRIPTION
## Description
Add `get_stats()` to the current object cache drop-ins so we can utilize the new QM @ https://github.com/Automattic/vip-go-mu-plugins/pull/4082

## Changelog Description

### Drop-in Updated: Object Cache

Added helper function `get_stats()`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Go to QM > Object Cache panel and expect to see new styling and formatting from https://github.com/Automattic/vip-go-mu-plugins/pull/4082