### PR TITLE
Query Monitor: Fix Object Cache size sorting in table

### DIFF
--- a/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-ops.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-ops.php
@@ -54,7 +54,7 @@ class QM_Output_Object_Cache_Ops extends QM_Output_Html {
 				} else {
 					$this->output_table_cell( $op['key'] );
 				}
-				$this->output_table_cell( $this->process_size( $op['size'] ) );
+				$this->output_table_cell( $this->process_size( $op['size'] ), $op['size'] );
 				$this->output_table_cell( $this->process_time( $op['time'] ) );
 				$this->output_table_cell( $op['group'] );
 				$this->output_table_cell( $this->process_result( $op['result'] ) );
@@ -205,8 +205,12 @@ class QM_Output_Object_Cache_Ops extends QM_Output_Html {
 	 * Outputs a table cell.
 	 *
 	 * @param string $value Value to be outputted in table cell
+	 * @param int|null $weight Weight by sorting priority
 	 */
-	public function output_table_cell( string $value ) {
-		echo '<td class="qm-nowrap qm-ltr">' . esc_html( $value ) . '</td>';
+	public function output_table_cell( string $value, int $weight = null ) {
+		if ( $weight ) {
+			$weight = ' data-qm-sort-weight="' . esc_attr( $weight ) . '"';
+		}
+		echo '<td class="qm-nowrap qm-ltr"' . $weight . '>' . esc_html( $value ) . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php
@@ -54,7 +54,7 @@ class QM_Output_Object_Cache_Slow_Ops extends QM_Output_Html {
 				} else {
 					$this->output_table_cell( $op['key'] );
 				}
-				$this->output_table_cell( $this->process_size( $op['size'] ) );
+				$this->output_sortable_weight_table_cell( $this->process_size( $op['size'] ), $op['size'] );
 				$this->output_table_cell( $this->process_time( $op['time'] ) );
 				$this->output_table_cell( $op['group'] );
 				$this->output_table_cell( $this->process_result( $op['result'] ) );
@@ -221,9 +221,12 @@ class QM_Output_Object_Cache_Slow_Ops extends QM_Output_Html {
 	 * Outputs a table cell.
 	 *
 	 * @param string $value Value to be outputted in table cell
+	 * @param int|null $weight Weight by sorting priority
 	 */
-	public function output_table_cell( string $value ) {
-		echo '<td class="qm-nowrap qm-ltr">' . esc_html( $value ) . '</td>';
+	public function output_table_cell( string $value, int $weight = null ) {
+		if ( $weight ) {
+			$weight = ' data-qm-sort-weight="' . esc_attr( $weight ) . '"';
+		}
+		echo '<td class="qm-nowrap qm-ltr"' . $weight . '>' . esc_html( $value ) . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
-
 }


### PR DESCRIPTION
## Description
Since the previous sorting by size was not taking into account the difference between B and KB and was sorting by string, this PR fixes that.

![image](https://user-images.githubusercontent.com/16962021/222790195-0c255a87-79ab-47bb-92af-f3c1692dada2.png)


## Changelog Description

### Plugin Updated: Query Monitor

Fix Object Cache sorting by size on table

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Go to QM > Object Cache > Operations panel
2) Attempt to sort by size and ensure that KB trumps B 