### PR TITLE
Query Monitor: Enable for non-production environments

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -66,6 +66,10 @@ function wpcom_vip_qm_enable( $enable ) {
 		return true;
 	}
 
+	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+		return true;
+	}
+
 	return $enable;
 }
 add_filter( 'wpcom_vip_qm_enable', 'wpcom_vip_qm_enable' );


### PR DESCRIPTION
## Description
Enables Query Monitor for non-production environments by default. You still need the view_query_monitor capability to see QM (which is by default, granted for users that have the manage_options cap). 

## Changelog Description

### Plugin Updated: Query Monitor

Enable QM for non-production environments by default. Only applies for users with `manage_options` cap and above. Filter `wpcom_vip_qm_enable` to opt out.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create administrator user
2) See no QM
3) Apply PR
4) See QM
