### PR TITLE
Add "Non-production" sticker

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -266,6 +266,10 @@ if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && ! defined( 'WP_ENVIRONMENT_TYPE' ) )
 	define( 'WP_ENVIRONMENT_TYPE', $environment_type );
 }
 
+if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+	require __DIR__ . '/vip-helpers/vip-non-production.php';
+}
+
 if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
 	// Load config related helpers
 	require_once __DIR__ . '/config/class-sync.php';

--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -266,7 +266,18 @@ if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && ! defined( 'WP_ENVIRONMENT_TYPE' ) )
 	define( 'WP_ENVIRONMENT_TYPE', $environment_type );
 }
 
-if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+$non_prod_envs = [
+	'local',
+	'develop',
+	'preprod',
+	'staging',
+	'testing',
+	'uat',
+	'development',
+	'dev',
+	'stage',
+];
+if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && in_array( constant( 'VIP_GO_APP_ENVIRONMENT' ), $non_prod_envs, true ) ) {
 	require __DIR__ . '/vip-helpers/vip-non-production.php';
 }
 

--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -25,8 +25,8 @@ function vip_do_non_prod_bar() {
 				this.classList.toggle('which-env');
 			} );
 
-			const sandboxedBar = document.querySelector('#wpcom-sandboxed-bar');
-			const debugBar = document.querySelector('#a8c-debug-flag');
+			const sandboxedBar = document.getElementById('wpcom-sandboxed-bar');
+			const debugBar = document.getElementById('a8c-debug-flag');
 			if ( ( sandboxedBar && debugBar ) || ( ! sandboxedBar && debugBar ) ) {
 				// Account for proper stacking of the debug bar
 				nonProdBar.style.bottom = '85px';

--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -20,7 +20,7 @@ function vip_do_non_prod_bar() {
 			</span>
 		</div>
 		<script>
-			const nonProdBar = document.querySelector('#vip-non-prod-bar');
+			const nonProdBar = document.getElementById('vip-non-prod-bar');
 			nonProdBar.addEventListener( 'click', function() {
 				this.classList.toggle('which-env');
 			} );

--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -25,7 +25,6 @@ function vip_do_non_prod_bar() {
 				this.classList.toggle('which-env');
 			} );
 
-			const sandboxedBar = document.getElementById('wpcom-sandboxed-bar');
 			const debugBar = document.getElementById('a8c-debug-flag');
 			if ( debugBar ) {
 				// Account for proper stacking of the debug bar

--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -8,7 +8,7 @@ add_action( 'wp_footer', 'vip_do_non_prod_bar', 10000 );
 add_action( 'admin_footer', 'vip_do_non_prod_bar', 10000 );
 
 function vip_do_non_prod_bar() {
-	if ( is_user_logged_in() && ! is_admin_bar_showing() ) {
+	if ( ! current_user_can( 'edit_posts' ) ) {
 		return;
 	}
 

--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -1,0 +1,81 @@
+<?php
+
+if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'production' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+	return;
+}
+
+add_action( 'wp_footer', 'vip_do_non_prod_bar', 10000 );
+add_action( 'admin_footer', 'vip_do_non_prod_bar', 10000 );
+
+function vip_do_non_prod_bar() {
+	if ( is_user_logged_in() && ! is_admin_bar_showing() ) {
+		return;
+	}
+
+	if ( apply_filters( 'vip_show_non_prod_bar', true ) ) :
+		?>
+		<div id="vip-non-prod-bar">
+			<span>
+				<strong><?php echo esc_html( constant( 'VIP_GO_APP_ENVIRONMENT' ) ); ?></strong>
+			</span>
+		</div>
+		<script>
+			const nonProdBar = document.querySelector('#vip-non-prod-bar');
+			nonProdBar.addEventListener( 'click', function() {
+				this.classList.toggle('which-env');
+			} );
+
+			const sandboxedBar = document.querySelector('#wpcom-sandboxed-bar');
+			const debugBar = document.querySelector('#a8c-debug-flag');
+			if ( ( sandboxedBar && debugBar ) || ( ! sandboxedBar && debugBar ) ) {
+				// Account for proper stacking of the debug bar
+				nonProdBar.style.bottom = '85px';
+			}
+		</script>
+		<style>
+		#vip-non-prod-bar {
+			z-index: 9991;
+			font-family: 'Helvetica Neue',Arial,Helvetica,sans-serif;
+			font-size:14px;
+			left: 0;
+			bottom: 55px;
+			position:fixed;
+			margin:0;
+			padding: 0 20px;
+			width: 100%;
+			height: 28px;
+			line-height: 28px;
+		}
+		#vip-non-prod-bar span {
+			display: none;
+			float: left;
+			padding: 0 10px;
+			background: #fff;
+			color: #333;
+		}
+
+		#vip-non-prod-bar:before {
+			content: 'Non-production';
+			text-transform: uppercase;
+			background: #4c2c92;
+			color: #fff;
+			letter-spacing: 0.2em;
+			text-shadow: none;
+			font-size: 9px;
+			font-weight: bold;
+			padding: 0 10px;
+			float: left;
+			cursor: pointer;
+		}
+		#vip-non-prod-bar.which-env span {
+			display: inline-block;
+		}
+		@media print {
+			div#vip-non-prod-bar {
+				display: none !important;
+			}
+		}
+		</style>
+		<?php
+	endif;
+}

--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -27,7 +27,7 @@ function vip_do_non_prod_bar() {
 
 			const sandboxedBar = document.getElementById('wpcom-sandboxed-bar');
 			const debugBar = document.getElementById('a8c-debug-flag');
-			if ( ( sandboxedBar && debugBar ) || ( ! sandboxedBar && debugBar ) ) {
+			if ( debugBar ) {
 				// Account for proper stacking of the debug bar
 				nonProdBar.style.bottom = '85px';
 			}


### PR DESCRIPTION
## Description
This adds a sticker (similar to what we have for A8C DEBUG and SANDBOXED) for non-production environments for users with `edit_posts` capabilities.

When you click on it, it will tell you which type of environment:
 
<img width="319" alt="Screenshot 2023-03-03 at 1 19 35 PM" src="https://user-images.githubusercontent.com/16962021/222820985-1c360c6e-66b5-4588-a935-2b501ab2caf9.png">


How it looks stacked on top of other stickers:

<img width="210" alt="Screenshot 2023-03-03 at 1 19 51 PM" src="https://user-images.githubusercontent.com/16962021/222821004-d875f481-7675-4985-a746-780600135286.png">
<img width="271" alt="Screenshot 2023-03-03 at 1 20 03 PM" src="https://user-images.githubusercontent.com/16962021/222821007-f006211c-b4b9-4547-8a27-ee7cf0aadf2c.png">
<img width="273" alt="Screenshot 2023-03-03 at 1 20 13 PM" src="https://user-images.githubusercontent.com/16962021/222821008-ea8abb4d-f22d-434d-9473-fa1081550569.png">



## Changelog Description

### Sticker Added: Non-production
Non-production sticker has been added to all non-production environments for users with `edit_posts` cap. Return false on `vip_show_non_prod_bar` filter to disable.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Click on sticker to ensure it shows the type of environment
2) Enable debug bar via `?a8c-debug=true` and see it stack properly
3) Enable sandboxed mode via `add_filter( 'wpcom_show_sandbox_bar', '__return_true' );` as well to see it stack properly
4) Take turns disabling 2 or 3