### PR TITLE
Add and set wp-parsely 3.8 as the default version

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -15,6 +15,7 @@ namespace Automattic\VIP\WP_Parsely_Integration;
 
 // The default version is the first entry in the SUPPORTED_VERSIONS list.
 const SUPPORTED_VERSIONS = [
+	'3.8',
 	'3.7',
 	'3.6',
 	'3.5',


### PR DESCRIPTION
## Description
This PR adds and sets wp-parsely 3.8 as the default version in vip-go-mu-plugins. Any users who are not pinned to a specific wp-parsely version will automatically be upgraded to 3.8.x when this PR takes effect.

## Changelog Description

### wp-parsely default version was upgraded to 3.8

Changed the default version of wp-parsely from 3.7 to 3.8.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Checkout the PR.
2. Enable wp-parsely:
```
add_filter( 'wpvip_parsely_load_mu', '__return_true' );
```
3. In wp-admin, go the plugin's settings (Settings -> Parse.ly). On the top of the page, you should be seeing the new default version number (3.8.x).