### PR TITLE
QM: Fix undefined error output_sortable_weight_table_cell

### DIFF
--- a/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php
@@ -54,7 +54,7 @@ class QM_Output_Object_Cache_Slow_Ops extends QM_Output_Html {
 				} else {
 					$this->output_table_cell( $op['key'] );
 				}
-				$this->output_sortable_weight_table_cell( $this->process_size( $op['size'] ), $op['size'] );
+				$this->output_table_cell( $this->process_size( $op['size'] ), $op['size'] );
 				$this->output_table_cell( $this->process_time( $op['time'] ) );
 				$this->output_table_cell( $op['group'] );
 				$this->output_table_cell( $this->process_result( $op['result'] ) );


### PR DESCRIPTION
## Description
Fix fatal:

```
PHP message: PHP Fatal error: Uncaught Error: Call to undefined method QM_Output_Object_Cache_Slow_Ops::output_sortable_weight_table_cell() in /var/www/wp-content/mu-plugins/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php:57 Stack trace: #0 /var/www/wp-content/mu-plugins/query-monitor/dispatchers/Html.php(323): QM_Output_Object_Cache_Slow_Ops->output() #1 /var/www/wp-includes/class-wp-hook.php(308): QM_Dispatcher_Html->dispatch('') #2 /var/www/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(false, Array) #3 /var/www/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #4 /var/www/wp-includes/load.php(1124): do_action('shutdown') #5 [internal function]: shutdown_action_hook() #6 {main} thrown in /var/www/wp-content/mu-plugins/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php on line 57
```