### PR TITLE
ci: Replace MariaDB with MySQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
           - { wp: nightly, ms: 'yes', jp: 'yes', php: '8.2', phpunit: '' }
     services:
       mysql:
-        image: ghcr.io/automattic/vip-container-images/mariadb-lite:10.3
+        image: mysql:8
         ports:
           - "3306:3306"
         env:
           MYSQL_ROOT_PASSWORD: wordpress
-          MARIADB_INITDB_SKIP_TZINFO: 1
+          MYSQL_INITDB_SKIP_TZINFO: 1
           MYSQL_USER: wordpress
           MYSQL_PASSWORD: wordpress
           MYSQL_DATABASE: wordpress_test

--- a/.github/workflows/coverage-develop.yml
+++ b/.github/workflows/coverage-develop.yml
@@ -25,12 +25,12 @@ jobs:
           - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.0' }
     services:
       mysql:
-        image: ghcr.io/automattic/vip-container-images/mariadb-lite:10.3
+        image: mysql:8
         ports:
           - "3306:3306"
         env:
           MYSQL_ROOT_PASSWORD: wordpress
-          MARIADB_INITDB_SKIP_TZINFO: 1
+          MYSQL_INITDB_SKIP_TZINFO: 1
           MYSQL_USER: wordpress
           MYSQL_PASSWORD: wordpress
           MYSQL_DATABASE: wordpress_test

--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -31,12 +31,12 @@ jobs:
           - { wp: latest, parsely: '3.3', mode: 'filter_and_option_enabled', php: '7.4' }
     services:
       mysql:
-        image: mariadb:10.3
+        image: mysql:8
         ports:
           - "3306:3306"
         env:
           MYSQL_ROOT_PASSWORD: wordpress
-          MARIADB_INITDB_SKIP_TZINFO: 1
+          MYSQL_INITDB_SKIP_TZINFO: 1
           MYSQL_USER: wordpress
           MYSQL_PASSWORD: wordpress
           MYSQL_DATABASE: wordpress_test

--- a/bin/pretest.sh
+++ b/bin/pretest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if php -r 'exit(PHP_VERSION_ID < 80100);'; then
+if php -r 'exit((int)(PHP_VERSION_ID < 80100));'; then
 	# This is executed if the PHP version is GREATER THAN OR EQUALS TO 8.1
 	# because `true` evaluates to `1` and `if` is executed if the exit code is `0`.
 	echo "Disabling WP_DEBUG in wp-test-config.php"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -70,8 +70,6 @@ echo "Will test with WP_VERSION=${WP_VERSION} and WP_MULTISITE=${WP_MULTISITE}"
 echo "--------------"
 echo
 
-MARIADB_VERSION="10.3"
-
 UUID=$(date +%s000)
 if [ -z "${NETWORK_NAME_OVERRIDE}" ]; then
     NETWORK_NAME="tests-${UUID}"
@@ -87,7 +85,7 @@ export MYSQL_DATABASE=wordpress_test
 db=""
 if [ -z "${MYSQL_HOST_OVERRIDE}" ]; then
     MYSQL_HOST="db-${UUID}"
-    db=$(docker run --rm --network "${NETWORK_NAME}" --name "${MYSQL_HOST}" -e MYSQL_ROOT_PASSWORD="wordpress" -e MARIADB_INITDB_SKIP_TZINFO=1 -e MYSQL_USER -e MYSQL_PASSWORD -e MYSQL_DATABASE -d "mariadb:${MARIADB_VERSION}")
+    db=$(docker run --rm --network "${NETWORK_NAME}" --name "${MYSQL_HOST}" -e MYSQL_ROOT_PASSWORD="wordpress" -e MYSQL_INITDB_SKIP_TZINFO=1 -e MYSQL_USER -e MYSQL_PASSWORD -e MYSQL_DATABASE -d "mysql:8")
 else
     MYSQL_HOST="${MYSQL_HOST_OVERRIDE}"
 fi

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -615,6 +615,7 @@ class Queue_Test extends WP_UnitTestCase {
 	}
 
 	public function test_free_deadlocked_jobs() {
+		$this->markTestSkipped( 'MySQL does not handle references to the same TEMPORARY table more than once in the same query, see https://dev.mysql.com/doc/refman/8.0/en/temporary-table-problems.html' );
 		$this->queue->queue_object( 1000, 'post' );
 		$this->queue->queue_object( 2000, 'post' );
 		$this->queue->queue_object( 3000, 'post' );

--- a/tests/test-schema.php
+++ b/tests/test-schema.php
@@ -5,7 +5,12 @@ require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 class VIP_Go_Schema_Test extends WP_UnitTestCase {
 	public function test__dbDelta__verify_blog_tables() {
 		$deltas = dbDelta( 'blog', false ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
-		
+
+		if ( count( $deltas ) !== 1 ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			print_r( $deltas );
+		}
+
 		$this->assertCount( 1, $deltas, 'More deltas than expected for blogs table' );
 		$this->assertEquals( $deltas[0], 'Added index wptests_postmeta KEY `vip_meta_key_value` (`meta_key`(191),`meta_value`(100))', 'Delta did not find vip_meta_key_value index or assertion needs updating.' );
 	}

--- a/tests/test-schema.php
+++ b/tests/test-schema.php
@@ -4,14 +4,24 @@ require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 
 class VIP_Go_Schema_Test extends WP_UnitTestCase {
 	public function test__dbDelta__verify_blog_tables() {
+		/** @var wpdb $wpdb */
+		global $wpdb;
+
 		$deltas = dbDelta( 'blog', false ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
 
+		$db_version     = $wpdb->db_version();
+		$db_server_info = $wpdb->db_server_info();
+
+		if ( version_compare( $db_version, '8.0.17', '>=' ) && false === strpos( $db_server_info, 'MariaDB' ) ) {
+			$deltas = array_filter( $deltas, fn ( $delta ) => ! preg_match( '!Changed type of [^ ]+ from ([^ ]+)( unsigned)? to \1\(\d+\)\2?!', $delta ) );
+		}
+	
 		if ( count( $deltas ) !== 1 ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			print_r( $deltas );
 		}
 
-		$this->assertCount( 1, $deltas, 'More deltas than expected for blogs table' );
+		$this->assertCount( 1, $deltas, 'More deltas than expected' );
 		$this->assertEquals( $deltas[0], 'Added index wptests_postmeta KEY `vip_meta_key_value` (`meta_key`(191),`meta_value`(100))', 'Delta did not find vip_meta_key_value index or assertion needs updating.' );
 	}
 }

--- a/tests/test-schema.php
+++ b/tests/test-schema.php
@@ -16,11 +16,6 @@ class VIP_Go_Schema_Test extends WP_UnitTestCase {
 			$deltas = array_filter( $deltas, fn ( $delta ) => ! preg_match( '!Changed type of [^ ]+ from ([^ ]+)( unsigned)? to \1\(\d+\)\2?!', $delta ) );
 		}
 	
-		if ( count( $deltas ) !== 1 ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-			print_r( $deltas );
-		}
-
 		$this->assertCount( 1, $deltas, 'More deltas than expected' );
 		$this->assertEquals( $deltas[0], 'Added index wptests_postmeta KEY `vip_meta_key_value` (`meta_key`(191),`meta_value`(100))', 'Delta did not find vip_meta_key_value index or assertion needs updating.' );
 	}


### PR DESCRIPTION
This PR replaces the `mariadb` image with `mysql` in GitHub workflows one to match our production environment.
