### PR TITLE
tests: Fix "Class 'WPCOM_VIP_CLI_Command' not found" error

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -231,7 +231,7 @@ if ( true === defined( 'WPCOM_VIP_CLEAN_TERM_CACHE' ) && true === constant( 'WPC
 }
 
 // Load WP_CLI helpers
-if ( Context::is_wp_cli() ) {
+if ( Context::is_wp_cli() || ( defined( 'WP_TESTS_DOMAIN' ) && ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) ) ) {
 	require_once __DIR__ . '/vip-helpers/vip-wp-cli.php';
 	require_once __DIR__ . '/vip-helpers/class-vip-backup-user-role-cli.php';
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -209,7 +209,7 @@ class Search {
 		$this->load_dependencies();
 		$this->setup_hooks();
 
-		if ( defined( 'WP_CLI' ) && \WP_CLI ) {
+		if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
 			$this->load_commands();
 			$this->setup_cron_jobs();
 			$this->setup_regular_stat_collection();
@@ -349,7 +349,7 @@ class Search {
 		/**
 		 * Load CLI commands
 		 */
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
 			require_once __DIR__ . '/commands/class-corecommand.php';
 			require_once __DIR__ . '/commands/class-healthcommand.php';
 			require_once __DIR__ . '/commands/class-queuecommand.php';
@@ -511,7 +511,7 @@ class Search {
 		}
 
 		// Disable DB and ES query logs for CLI commands to keep memory under control
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
 			if ( ! defined( 'SAVEQUERIES' ) ) {
 				define( 'SAVEQUERIES', false );
 			}
@@ -695,7 +695,7 @@ class Search {
 	}
 
 	protected function load_commands() {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
 			WP_CLI::add_command( 'vip-search health', __NAMESPACE__ . '\Commands\HealthCommand' );
 			WP_CLI::add_command( 'vip-search queue', __NAMESPACE__ . '\Commands\QueueCommand' );
 			WP_CLI::add_command( 'vip-search index-versions', __NAMESPACE__ . '\Commands\VersionCommand' );
@@ -917,7 +917,7 @@ class Search {
 		if ( null !== $type ) {
 			$x_opaque_id .= "_{$type}";
 		}
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
 			$x_opaque_id .= '_cli';
 		}
 
@@ -1150,7 +1150,7 @@ class Search {
 		// The error code for  the failed response.
 		$response_failure_code = '';
 
-		$is_cli = defined( 'WP_CLI' ) && WP_CLI;
+		$is_cli = defined( 'WP_CLI' ) && constant( 'WP_CLI' );
 
 		if ( is_wp_error( $request ) ) {
 			$encoded_request = $request->get_error_messages();
@@ -1241,7 +1241,7 @@ class Search {
 	}
 
 	public function get_http_timeout_for_query( $query, $args ) {
-		$is_cli  = defined( 'WP_CLI' ) && WP_CLI;
+		$is_cli  = defined( 'WP_CLI' ) && constant( 'WP_CLI' );
 		$timeout = $is_cli ? self::GLOBAL_QUERY_TIMEOUT_CLI_SEC : self::GLOBAL_QUERY_TIMEOUT_WEB_SEC;
 
 		$query_path      = wp_parse_url( $query['url'], PHP_URL_PATH );
@@ -1636,7 +1636,7 @@ class Search {
 		}
 
 		// Force the timeout for post search queries.
-		$global_timeout = defined( 'WP_CLI' ) && WP_CLI ? self::GLOBAL_QUERY_TIMEOUT_CLI_SEC : self::GLOBAL_QUERY_TIMEOUT_WEB_SEC;
+		$global_timeout = defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ? self::GLOBAL_QUERY_TIMEOUT_CLI_SEC : self::GLOBAL_QUERY_TIMEOUT_WEB_SEC;
 		if ( ! isset( $formatted_args['timeout'] ) && apply_filters( 'vip_search_force_global_timeout', true ) ) {
 			$formatted_args['timeout'] = sprintf( '%ds', $global_timeout );
 		}

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -6,8 +6,6 @@ use \WP_CLI;
 use \WP_CLI\Utils;
 use \ElasticPress\Elasticsearch;
 
-use function Automattic\VIP\Logstash\log2logstash;
-
 /**
  * Core commands for interacting with VIP Search
  *

--- a/search/includes/classes/commands/class-documentcommand.php
+++ b/search/includes/classes/commands/class-documentcommand.php
@@ -4,8 +4,6 @@ namespace Automattic\VIP\Search\Commands;
 
 use \WP_CLI;
 
-require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
-
 /**
  * Commands to view and manage individual documents
  *

--- a/search/includes/classes/commands/class-documentcommand.php
+++ b/search/includes/classes/commands/class-documentcommand.php
@@ -3,7 +3,8 @@
 namespace Automattic\VIP\Search\Commands;
 
 use \WP_CLI;
-use \WP_CLI\Utils;
+
+require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
 
 /**
  * Commands to view and manage individual documents
@@ -11,10 +12,6 @@ use \WP_CLI\Utils;
  * @package Automattic\VIP\Search
  */
 class DocumentCommand extends \WPCOM_VIP_CLI_Command {
-	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
-	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
-
-
 	/**
 	 * Get details about a document by type and an id
 	 *
@@ -22,13 +19,13 @@ class DocumentCommand extends \WPCOM_VIP_CLI_Command {
 	 *
 	 * <type>
 	 * : The index type (the slug of the Indexable, such as 'post', 'user', etc)
-	 * 
+	 *
 	 * <object_id>
 	 * : The ID of the object
-	 * 
+	 *
 	 * [--format=<string>]
 	 * : Optional one of: table json csv yaml ids count
-	 * 
+	 *
 	 * ## EXAMPLES
 	 *     wp vip-search documents get post 2
 	 *
@@ -37,7 +34,7 @@ class DocumentCommand extends \WPCOM_VIP_CLI_Command {
 	public function get( $args, $assoc_args ) {
 		$type      = $args[0];
 		$object_id = $args[1];
-	
+
 		$search = \Automattic\VIP\Search\Search::instance();
 
 		$indexable = \ElasticPress\Indexables::factory()->get( $type );
@@ -47,7 +44,7 @@ class DocumentCommand extends \WPCOM_VIP_CLI_Command {
 		}
 
 		$document = $indexable->get( $object_id );
-	
+
 		if ( ! $document ) {
 			return WP_CLI::error( sprintf( 'Document with ID %s of type %s was not found.', $object_id, $type ) );
 		}

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -3,9 +3,9 @@
 namespace Automattic\VIP\Search\Commands;
 
 use \WP_CLI;
-use \WP_CLI\Utils;
 use WP_Error;
 
+require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
 require_once __DIR__ . '/../class-health.php';
 
 /**

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -5,7 +5,6 @@ namespace Automattic\VIP\Search\Commands;
 use \WP_CLI;
 use WP_Error;
 
-require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
 require_once __DIR__ . '/../class-health.php';
 
 /**

--- a/search/includes/classes/commands/class-queuecommand.php
+++ b/search/includes/classes/commands/class-queuecommand.php
@@ -6,7 +6,6 @@ use \WP_CLI;
 
 use \Automattic\VIP\Search\Queue\Schema;
 
-require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
 require_once __DIR__ . '/../class-health.php';
 
 /**

--- a/search/includes/classes/commands/class-queuecommand.php
+++ b/search/includes/classes/commands/class-queuecommand.php
@@ -3,10 +3,10 @@
 namespace Automattic\VIP\Search\Commands;
 
 use \WP_CLI;
-use \WP_CLI\Utils;
 
 use \Automattic\VIP\Search\Queue\Schema;
 
+require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
 require_once __DIR__ . '/../class-health.php';
 
 /**

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -5,6 +5,8 @@ namespace Automattic\VIP\Search\Commands;
 use \WP_CLI;
 use \ElasticPress\Indexable as Indexable;
 
+require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
+
 /**
  * Commands to view and manage index versions
  *

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -5,8 +5,6 @@ namespace Automattic\VIP\Search\Commands;
 use \WP_CLI;
 use \ElasticPress\Indexable as Indexable;
 
-require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
-
 /**
  * Commands to view and manage index versions
  *


### PR DESCRIPTION
This PR fixes errors found in tests during CI.

Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/4358243887/jobs/7619353489#step:5:382
Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/4358243887/jobs/7619353489#step:5:369