### PR TITLE
tests: Fix database errors

### DIFF
--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -108,6 +108,13 @@ class Sync {
 	}
 
 	public function run_sync_checks() {
+		if ( defined( 'WP_TESTS_DOMAIN' ) ) {
+			// WordPress test library runs the `shutdown` hooks too late, which causes database errors
+			// (the required temporary tables no longer exist)
+			$this->blogs_to_sync = [];
+			return;
+		}
+
 		if ( 0 === count( $this->blogs_to_sync ) ) {
 			return;
 		}

--- a/tests/config/test-sync.php
+++ b/tests/config/test-sync.php
@@ -23,6 +23,11 @@ class Sync_Test extends WP_UnitTestCase {
 		Constant_Mocker::clear();
 	}
 
+	public function tearDown(): void {
+		Constant_Mocker::clear();
+		parent::tearDown();
+	}
+
 	/**
 	 * @runInSeparateProcess
 	 */

--- a/tests/lib/feature/test-class-feature-ms.php
+++ b/tests/lib/feature/test-class-feature-ms.php
@@ -2,27 +2,28 @@
 
 namespace Automattic\VIP;
 
-use PHPUnit\Framework\TestCase;
 use Automattic\Test\Constant_Mocker;
+use WP_UnitTestCase;
 
 require_once __DIR__ . '/../../../lib/feature/class-feature.php';
 
-class Feature_Multisite_Test extends TestCase {
+class Feature_Multisite_Test extends WP_UnitTestCase {
 
 	public static $site_id = 400; // Hashes to 13
 
 	public function setUp(): void {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped();
-		}
+		$this->skipWithoutMultisite();
 
 		parent::setUp();
 
 		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', self::$site_id );
+
+		remove_all_actions( 'switch_blog' );
 	}
 
 	public function tearDown(): void {
 		Constant_Mocker::clear();
+		parent::tearDown();
 	}
 
 	/**
@@ -36,119 +37,19 @@ class Feature_Multisite_Test extends TestCase {
 	 * The above will give you a list of blog ids that fall above or below your target threshold
 	 */
 	public function is_enabled_by_percentage_data() {
-		return array(
-			// Blog ID bucketed within the percentage threshold, enabled
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				0.25,
-				// blog id
-				6, // hashes to 4
-				// Expected enabled/disabled
-				true,
-			),
-			// blog id bucketed within the percentage threshold, enabled
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				0.25,
-				// blog id
-				37, // hashes to 3
-				// Expected enabled/disabled
-				true,
-			),
-			// blog id is bucketed to exact percentage, not enabled, b/c buckets are 0-based
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				0.25,
-				// blog id
-				20, // hashes to 25
-				// Expected enabled/disabled
-				false,
-			),
-			// blog id is bucketed to "percentage - 1", enabled, b/c buckets are 0-based
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				0.63,
-				// blog id
-				99, // hashes to 62
-				// Expected enabled/disabled
-				true,
-			),
-			// blog id bucketed outside the threshold, not enabled
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				0.25,
-				// blog id
-				7, // hashes to 26
-				// Expected enabled/disabled
-				false,
-			),
-
-			// 100% enabled
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				1,
-				// blog id
-				100,
-				// Expected enabled/disabled
-				true,
-			),
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				1,
-				// blog id
-				5,
-				// Expected enabled/disabled
-				true,
-			),
-
-			// 0% enabled
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				0,
-				// blog id
-				22,
-				// Expected enabled/disabled
-				false,
-			),
-			array(
-				// Feature name
-				'foo-feature',
-				// Enabled percentage
-				0,
-				// blog id
-				1,
-				// Expected enabled/disabled
-				false,
-			),
-
-			// Different feature name, should _not_ have the same bucket as the same id from earlier
-			array(
-				// Feature name
-				'bar-feature',
-				// Enabled percentage
-				0.25,
-				// blog id
-				37, // hashes to 90
-				// Expected enabled/disabled
-				false,
-			),
-		);
+		return [
+			// Feature name, percentage, blog ID, expected enabled/disabled
+			[ 'foo-feature', 0.25, 6, true ], // Blog ID bucketed within the percentage threshold, enabled; hashes to 4
+			[ 'foo-feature', 0.25, 37, true ], // Blog id bucketed within the percentage threshold, enabled; hashes to 3
+			[ 'foo-feature', 0.25, 20, false ], // blog id is bucketed to exact percentage, not enabled, b/c buckets are 0-based; hashes to 25
+			[ 'foo-feature', 0.63, 99, true ], // blog id is bucketed to "percentage - 1", enabled, b/c buckets are 0-based; hashes to 62
+			[ 'foo-feature', 0.25, 7, false ], // blog id bucketed outside the threshold, not enabled; hashes to 26
+			[ 'foo-feature', 1.00, 100, true ], // 100% enabled
+			[ 'foo-feature', 1.00, 5, true ],
+			[ 'foo-feature', 0.00, 22, false ], // 0% enabled
+			[ 'foo-feature', 0.00, 1, false ],
+			[ 'bar-feature', 0.25, 37, false ], // Different feature name, should _not_ have the same bucket as the same id from earlier; hashes to 90
+		];
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes database errors in our tests:
* [Table 'wordpress_test.wptests_XX_options' doesn't exist for query SELECT option_value FROM wptests_XX_options WHERE option_name = 'wptests_XX_user_roles' LIMIT 1](https://github.com/Automattic/vip-go-mu-plugins/actions/runs/4358243887/jobs/7619353489#step:5:351)
* [Table 'wordpress_test.wptests_XX_options' doesn't exist for query SELECT option_value FROM wptests_XX_options WHERE option_name = 'cron' LIMIT 1](https://github.com/Automattic/vip-go-mu-plugins/actions/runs/4358243887/jobs/7619353489#step:5:526)
* [Table 'wordpress_test.wptests_10_options' doesn't exist for query INSERT INTO `wptests_XX_options` (`option_name`, `option_value`, `autoload`) VALUES ('cron', '...', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)](https://github.com/Automattic/vip-go-mu-plugins/actions/runs/4358243887/jobs/7619353489#step:5:527)
