### PR TITLE
Feature: is_enabled() should also check if enabled by ID and adds is_enabled_by_env() & get_features() and `wp vip-feature` CLI commands

### DIFF
--- a/lib/feature/class-feature-cli.php
+++ b/lib/feature/class-feature-cli.php
@@ -6,7 +6,7 @@ use WP_CLI;
 use \Automattic\VIP\Feature as Feature;
 
 // phpcs:ignore WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli
-class FeatureCLI extends \WP_CLI_Command {
+class Feature_CLI_Command extends \WP_CLI_Command {
 	/**
 	 * List all available VIP features.
 	 *

--- a/lib/feature/class-feature-cli.php
+++ b/lib/feature/class-feature-cli.php
@@ -63,4 +63,4 @@ class FeatureCLI extends \WP_CLI_Command {
 	}
 }
 
-WP_CLI::add_command( 'vip feature', __NAMESPACE__ . '\FeatureCLI' );
+WP_CLI::add_command( 'vip feature', __NAMESPACE__ . '\Feature_CLI_Command' );

--- a/lib/feature/class-feature-cli.php
+++ b/lib/feature/class-feature-cli.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Automattic\VIP;
+
+use WP_CLI_Command;
+use WP_CLI;
+use \Automattic\VIP\Feature as Feature;
+
+class FeatureCLI extends WP_CLI_Command {
+	/**
+	 * List all available VIP features.
+	 *
+	 * @subcommand list
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp vip-feature list [--format=<table|json|csv|yaml>]
+	 */
+	public function list_features( $args, $assoc_args ) {
+		$format = $assoc_args['format'] ?? 'table';
+		if ( ! in_array( $format, [ 'table', 'json', 'csv', 'yaml' ], true ) ) {
+			WP_CLI::error( __( '--format only accepts the following values: table, json, csv, yaml' ) );
+		}
+
+		$features = Feature::get_features();
+		if ( empty( $features ) ) {
+			WP_CLI::error( __( 'No features found.' ) );
+		}
+
+		$listed_features = [];
+		foreach ( $features as $feature ) {
+			$listed_features[] = [
+				'Feature' => $feature,
+				'Status'  => Feature::is_enabled( $feature ) ? 'enabled' : 'disabled',
+			];
+		}
+
+		WP_CLI\Utils\format_items( $format, $listed_features, [ 'Feature', 'Status' ] );
+	}
+
+	/**
+	 * Get status of an available VIP feature.
+	 *
+	 * @subcommand get
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp vip-feature get <feature-slug>
+	 */
+	public function get_feature( $args ) {
+		$feature = $args[0];
+		if ( ! isset( $feature ) ) {
+			WP_CLI::error( 'Missing feature slug.' );
+		}
+
+		$features = Feature::get_features();
+		if ( ! in_array( $feature, $features, true ) ) {
+			WP_CLI::error( "Invalid feature slug '$feature'" );
+		}
+
+		WP_CLI::line( sprintf( '%1$s is %2$s.', $feature, Feature::is_enabled( $feature ) ? 'enabled' : 'disabled' ) );
+	}
+}
+
+WP_CLI::add_command( 'vip-feature', __NAMESPACE__ . '\FeatureCLI' );

--- a/lib/feature/class-feature-cli.php
+++ b/lib/feature/class-feature-cli.php
@@ -2,11 +2,11 @@
 
 namespace Automattic\VIP;
 
-use WP_CLI_Command;
 use WP_CLI;
 use \Automattic\VIP\Feature as Feature;
 
-class FeatureCLI extends WP_CLI_Command {
+// phpcs:ignore WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli
+class FeatureCLI extends \WP_CLI_Command {
 	/**
 	 * List all available VIP features.
 	 *
@@ -14,7 +14,7 @@ class FeatureCLI extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp vip-feature list [--format=<table|json|csv|yaml>]
+	 *     wp vip feature list [--format=<table|json|csv|yaml>]
 	 */
 	public function list_features( $args, $assoc_args ) {
 		$format = $assoc_args['format'] ?? 'table';
@@ -30,12 +30,12 @@ class FeatureCLI extends WP_CLI_Command {
 		$listed_features = [];
 		foreach ( $features as $feature ) {
 			$listed_features[] = [
-				'Feature' => $feature,
-				'Status'  => Feature::is_enabled( $feature ) ? 'enabled' : 'disabled',
+				'feature' => $feature,
+				'status'  => Feature::is_enabled( $feature ) ? 'enabled' : 'disabled',
 			];
 		}
 
-		WP_CLI\Utils\format_items( $format, $listed_features, [ 'Feature', 'Status' ] );
+		WP_CLI\Utils\format_items( $format, $listed_features, [ 'feature', 'status' ] );
 	}
 
 	/**
@@ -45,13 +45,14 @@ class FeatureCLI extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp vip-feature get <feature-slug>
+	 *     wp vip feature get <feature-slug>
 	 */
 	public function get_feature( $args ) {
-		$feature = $args[0];
-		if ( ! isset( $feature ) ) {
-			WP_CLI::error( 'Missing feature slug.' );
+		if ( ! isset( $args[0] ) ) {
+			WP_CLI::error( 'Missing feature slug. Usage as follows: `wp vip feature get <slug>`' );
 		}
+
+		$feature = $args[0];
 
 		$features = Feature::get_features();
 		if ( ! in_array( $feature, $features, true ) ) {
@@ -62,4 +63,4 @@ class FeatureCLI extends WP_CLI_Command {
 	}
 }
 
-WP_CLI::add_command( 'vip-feature', __NAMESPACE__ . '\FeatureCLI' );
+WP_CLI::add_command( 'vip feature', __NAMESPACE__ . '\FeatureCLI' );

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -30,8 +30,14 @@ class Feature {
 	 */
 	public static $feature_ids = [];
 
+	/**
+	 * Checks if a feature is enabled.
+	 *
+	 * @param string $feature The feature we are targeting.
+	 * @return bool Whether it is enabled or not.
+	 */
 	public static function is_enabled( $feature ) {
-		return static::is_enabled_by_percentage( $feature );
+		return static::is_enabled_by_percentage( $feature ) || static::is_enabled_by_ids( $feature );
 	}
 
 	/**

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -51,6 +51,21 @@ class Feature {
 	}
 
 	/**
+	 * Returns all features that exist.
+	 *
+	 * @return array $features Array of features.
+	 */
+	public static function get_features() {
+		$features = array_merge(
+			array_keys( static::$feature_percentages ),
+			array_keys( static::$feature_ids ),
+			array_keys( static::$feature_envs )
+		);
+
+		return array_unique( $features );
+	}
+
+	/**
 	 * Selectively enable by certain environments.
 	 *
 	 * @param string $feature The feature we are targeting.

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\VIP;
 
-if ( defined( 'WP_CLI' ) && \WP_CLI ) {
+if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
 	$cli_file = __DIR__ . '/class-feature-cli.php';
 	if ( file_exists( $cli_file ) ) {
 		require_once $cli_file;

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -35,7 +35,7 @@ class Feature {
 	 * // Enable feature for non-production sites
 	 * // 'feature-flag' => [ 'non-production' => true ],
 	 *
-	 * @var array
+	 * @var array Accepts values of specific environment names (i.e. staging, production) or 'non-production' for all non-production environments.
 	 */
 	public static $feature_envs = [];
 
@@ -57,9 +57,9 @@ class Feature {
 	 */
 	public static function get_features() {
 		$features = array_merge(
-			array_keys( static::$feature_percentages ),
-			array_keys( static::$feature_ids ),
-			array_keys( static::$feature_envs )
+			is_array( static::$feature_percentages ) ? array_keys( static::$feature_percentages ) : [],
+			is_array( static::$feature_ids ) ? array_keys( static::$feature_ids ) : [],
+			is_array( static::$feature_envs ) ? array_keys( static::$feature_envs ) : [],
 		);
 
 		return array_unique( $features );

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -2,6 +2,13 @@
 
 namespace Automattic\VIP;
 
+if ( defined( 'WP_CLI' ) && \WP_CLI ) {
+	$cli_file = __DIR__ . '/class-feature-cli.php';
+	if ( file_exists( $cli_file ) ) {
+		require_once $cli_file;
+	}
+}
+
 /**
  * Feature provides a simple interface to gate the functionality by the Go Site Id
  *
@@ -35,7 +42,8 @@ class Feature {
 	 * // Enable feature for non-production sites
 	 * // 'feature-flag' => [ 'non-production' => true ],
 	 *
-	 * @var array Accepts values of specific environment names (i.e. staging, production) or 'non-production' for all non-production environments.
+	 *
+	 * @var array Array of values of specific environment names (i.e. staging, production). Also accepts 'non-production' as environment name for all non-production environments.
 	 */
 	public static $feature_envs = [];
 
@@ -64,6 +72,7 @@ class Feature {
 
 		return array_unique( $features );
 	}
+
 
 	/**
 	 * Selectively enable by certain environments.

--- a/tests/lib/feature/test-class-feature.php
+++ b/tests/lib/feature/test-class-feature.php
@@ -333,4 +333,23 @@ class Feature_Test extends TestCase {
 
 		$this->assertFalse( $result );
 	}
+
+	public function test_get_features() {
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 123 );
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'local' );
+
+		Feature::$feature_percentages = array(
+			'foo-bar-aaa' => 1,
+		);
+
+		Feature::$feature_ids  = array(
+			'foo-bar-zzz' => [ 123 => true ],
+		);
+		Feature::$feature_envs = array(
+			'foo-bar-zzz' => [ 'local' => true ],
+		);
+
+		$result = Feature::get_features();
+		$this->assertEquals( $result, [ 'foo-bar-aaa', 'foo-bar-zzz' ] );
+	}
 }

--- a/tests/lib/feature/test-class-feature.php
+++ b/tests/lib/feature/test-class-feature.php
@@ -231,6 +231,64 @@ class Feature_Test extends TestCase {
 		$this->assertEquals( false, $result );
 	}
 
+	public function test_is_enabled_by_env__non_prod() {
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'local' );
+
+		Feature::$feature_envs = array(
+			'non-prod-feature-only' => [ 'non-production' => true ],
+		);
+
+		$result = Feature::is_enabled_by_env( 'non-prod-feature-only' );
+		$this->assertTrue( $result );
+	}
+
+	public function test_is_enabled_by_env__staging() {
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'staging' );
+
+		Feature::$feature_envs = array(
+			'staging-feature-only' => [ 'staging' => true ],
+		);
+
+		$result = Feature::is_enabled_by_env( 'staging-feature-only' );
+		$this->assertTrue( $result );
+
+		Constant_Mocker::clear();
+
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'production' );
+		$result = Feature::is_enabled_by_env( 'staging-feature-only' );
+		$this->assertFalse( $result );
+	}
+
+	public function test_is_enabled_by_env__other() {
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'local' );
+
+		Feature::$feature_envs = array(
+			'other-feature-only' => [ 'other' => true ],
+		);
+
+		$result = Feature::is_enabled_by_env( 'other-feature-only' );
+		$this->assertFalse( $result );
+	}
+
+	public function test_is_enabled_by_env__no_prod() {
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'production' );
+
+		Feature::$feature_envs = array(
+			'no-prod' => [
+				'production' => false,
+				'local'      => true,
+			],
+		);
+
+		$result = Feature::is_enabled_by_env( 'no-prod' );
+		$this->assertFalse( $result );
+
+		Constant_Mocker::clear();
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'local' );
+		$result = Feature::is_enabled_by_env( 'no-prod' );
+		$this->assertTrue( $result );
+	}
+
 	public function test_is_enabled__percentage_only() {
 		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 456 );
 
@@ -251,6 +309,19 @@ class Feature_Test extends TestCase {
 		);
 
 		$result = Feature::is_enabled( 'foo-bar' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_is_enabled__env_only() {
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 123 );
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'local' );
+
+		Feature::$feature_envs = array(
+			'foo-bar-feature' => [ 'local' => true ],
+		);
+
+		$result = Feature::is_enabled( 'foo-bar-feature' );
 
 		$this->assertTrue( $result );
 	}

--- a/tests/lib/feature/test-class-feature.php
+++ b/tests/lib/feature/test-class-feature.php
@@ -230,4 +230,36 @@ class Feature_Test extends TestCase {
 
 		$this->assertEquals( false, $result );
 	}
+
+	public function test_is_enabled__percentage_only() {
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 456 );
+
+		Feature::$feature_percentages = array(
+			'foobar' => 1,
+		);
+
+		$result = Feature::is_enabled( 'foobar' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_is_enabled__id_only() {
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 123 );
+
+		Feature::$feature_ids = array(
+			'foo-bar' => [ 123 => true ],
+		);
+
+		$result = Feature::is_enabled( 'foo-bar' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_is_enabled__none() {
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 123 );
+
+		$result = Feature::is_enabled( 'foo-bar-test' );
+
+		$this->assertFalse( $result );
+	}
 }


### PR DESCRIPTION
## Description
This PR includes the below:
1. When we use `is_enabled()` to check if a feature is enabled, we should also take into account if it's enabled on an ID-basis rather than just percentage
2. Adds `is_enabled_by_env()` to control enabling by environment.
3. Adds `get_features()` to see a list of existing features in place
4. Adds `wp vip feature` CLI commands.

## Changelog Description

### Plugin Updated: Feature

- Adds two new functions `is_enabled_by_env()` and `get_features()`
- `is_enabled()` will take into account if the feature is also enabled on an ID-basis or env-basis
- Adds `wp vip-feature` CLI commands to check the status of a feature

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to test
1) Add to `testing` feature to `$feature_envs` for local only:
```
	public static $feature_envs = [
		'testing' => [
			'local' => true,
		],
	];
```
2) Do `\Automattic\VIP\Feature::is_enabled_by_env( 'testing' );` and expect it to return `true`
3) Do `\Automattic\VIP\Feature::get_features();` and expect it to return `[ 'testing' ]`
4) Do `wp vip-feature list` and expect to see `testing` returned:
```
+------------------------+----------+
| Feature                | Status   |
+------------------------+----------+
| testing                | enabled  |
+------------------------+----------+
```