### PR TITLE
Search: Include ALL users in count when running `wp vip-search health validate-users-count`

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -164,7 +164,11 @@ class Health {
 				add_filter( 'ep_exclude_password_protected_from_search', '__return_false' );
 			}
 
-			$query          = self::query_objects( $query_args, $indexable->slug );
+			$query = self::query_objects( $query_args, $indexable->slug );
+			if ( 'user' === $indexable->slug && isset( $query->query_vars['blog_id'] ) ) {
+				// Since the user indexable is global, we want to include ALL in count.
+				unset( $query->query_vars['blog_id'] );
+			}
 			$formatted_args = $indexable->format_args( $query->query_vars, $query );
 
 			// Get exact total count since Elasticsearch default stops at 10,000.


### PR DESCRIPTION
## Description

This is a bugfix for when when on a multi-site, we run `wp vip-search health validate-counts --url=<subsite2>` or `wp vip-search health validate-users-count --url=<subsite2>` and it doesn't show ALL users but only the users added to the site. Since the Users Indexable is a global index, we should be querying for ALL existing users, not just the ones added onto the targeted subsite.

## Changelog Description

### Plugin Updated: Enterprise Search

Fix accuracy of `wp vip-search health validate-counts` for the users feature on multi-sites.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Create a multi-site, with primarysite.com being blog ID 1
2) Create a new user called `testUser` 
3) Create a new subsite called `secondsite.com` being blog ID 2
4) Do not add user in step 2 to blog ID 2
5) Run `wp vip-search health validate-users-count` and you will see an inaccurate count on the ES site, as it's only counting users added to step 2, but it should be ALL, as users is a global indexable. 