### PR TITLE
tests: Fix "assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10"

### DIFF
--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -240,7 +240,7 @@ class Queue_Test extends WP_UnitTestCase {
 
 		$job = $jobs[0];
 		self::assertIsObject( $job );
-		self::assertObjectHasAttribute( 'priority', $job );
+		self::assertTrue( property_exists( $job, 'priority' ) );
 		self::assertSame( 2 * Queue::INDEX_DEFAULT_PRIORITY, (int) $job->priority );
 	}
 


### PR DESCRIPTION
Related: #4193

```
16) Automattic\VIP\Search\Queue_Test::test_requeue_with_different_priority
assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10.
```