### PR TITLE
Jetpack: Upgrade default non-pinned to 11.9

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.8
+ * Version: 11.9
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -28,7 +28,7 @@ function vip_default_jetpack_version() {
 		return '11.4';
 	} else {
 		// WordPress 6.0 and newer
-		return '11.8';
+		return '11.9';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -12,9 +12,9 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 			'5.8.6' => '10.9',
 			'5.9'   => '11.4',
 			'5.9.5' => '11.4',
-			'6.0'   => '11.8',
-			'6.1'   => '11.8',
-			'6.1.1' => '11.8',
+			'6.0'   => '11.9',
+			'6.1'   => '11.9',
+			'6.1.1' => '11.9',
 		];
 
 		foreach ( $versions_map as $wordpress_version => $jetpack_version ) {


### PR DESCRIPTION
## Description
11.9 for errrrrone

## Changelog Description

### Plugin Updated: Jetpack

Jetpack 11.9 is now the default version for non-pinned applications.
