### PR TITLE
Add Feature::get_bucket method which returns the bucket the site is in based on ID and feature

### DIFF
--- a/lib/feature/README.md
+++ b/lib/feature/README.md
@@ -1,0 +1,81 @@
+# Library: Feature
+
+## Description
+
+The purpose of this library is to allow for gradual rollouts of features that may be too risky/complex to be deployed at once.
+
+## Usage
+
+There are currently three ways to target the feature: By percentage, by environment ID and by environment type.
+
+Global helper to check whether a particular feature is enabled by any means:
+
+```php
+\Automattic\VIP\Feature::is_enabled( 'my-awesome-complex-feature' );
+```
+
+### Define and checking features by percentage
+
+This is defined via `$feature_percentages` class property. It's an associative array where the key is the feature slug and the value is % as a decimal.
+
+For multisites this also applies for network sites. E.g. to avoid the situation where a large multisite environment falls into enabled bucket and has the feature enabled for ALL of the network sites.
+
+E.g. to roll out `my-awesome-complex-feature` to 10% of environments (and 10% of network sites in multisites)
+
+```php
+public static $feature_percentages = [
+	'my-awesome-complex-feature' => 0.1,
+];
+```
+
+To check specifically for percentage:
+
+```php
+\Automattic\VIP\Feature::is_enabled_by_percentage( 'my-awesome-complex-feature' );
+```
+
+### Defining and checking features by Env IDs
+
+This is defined via `$feature_ids` class property. It's an associative array where the key is the feature slug and the value is an array of Env IDS:
+
+```php
+public static $feature_ids = [
+	'my-awesome-complex-feature' => [
+		// enable for Env ID 123
+		123 => true,
+		// disable for Env ID 234
+		234 => false,
+	],
+];
+```
+
+To check:
+
+```php
+\Automattic\VIP\Feature::is_enabled_by_ids( 'my-awesome-complex-feature' );
+```
+
+### Defining and checking features by environment type
+
+This is defined via `$feature_envs` class property. It's an associative array where the key is the feature slug and the value is an array of environments names as keys and booleans for values. Also supports `non-production`
+
+```php
+public static $feature_envs = [
+	'my-awesome-complex-feature' => [
+		// enable for all staging envs
+		'staging' => true,
+		// disable for prod envs
+		'production' => false,
+		// Enable for ALL non-production environments
+		'non-production' => true
+	],
+];
+```
+
+To check:
+
+```php
+\Automattic\VIP\Feature::is_enabled_by_env( 'my-awesome-complex-feature', $default = false );
+```
+
+`$default` is default return value if environment is not on list.

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -159,9 +159,12 @@ class Feature {
 	}
 
 	/**
-	 * Given a site ID and a feature, return the bucket the site is in
+	 * Given a site ID and a feature, return the bucket the site is in.
 	 *
-	 * @param integer $site_id
+	 * Note: this is a lower-level API, it doesn't care if the feature is defined or whether it's a multisite or not.
+	 * Please use is_enabled()/is_enabled_by_ids()/is_enabled_by_percentage() instead.
+	 *
+	 * @param mixed $site_id
 	 * @param string $feature
 	 * @return integer
 	 */

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -145,16 +145,31 @@ class Feature {
 
 		// Which bucket is the site in - 100 possibilites, one for each percentage. We run this through crc32 with
 		// the feature name so that the same sites aren't always the canaries
-		$bucket = crc32( $feature . '-' . constant( 'FILES_CLIENT_SITE_ID' ) ) % 100;
+		$bucket = static::get_bucket( constant( 'FILES_CLIENT_SITE_ID' ), $feature );
 
 		// Is the bucket enabled?
 		$threshold = $percentage * 100; // $percentage is decimal
 
 		if ( is_multisite() && $bucket < $threshold ) {
 			// For multisites, we don't want to roll out for all subsites
-			$bucket = crc32( $feature . '-' . get_current_blog_id() ) % 100;
+			$bucket = static::get_bucket( get_current_blog_id(), $feature );
 		}
 
 		return $bucket < $threshold; // If our 0-based bucket is inside our threshold, it's enabled
+	}
+
+	/**
+	 * Given a site ID and a feature, return the bucket the site is in
+	 *
+	 * @param integer $site_id
+	 * @param string $feature
+	 * @return integer
+	 */
+	public static function get_bucket( $site_id = 0, string $feature = '' ) {
+		// Which bucket is the site in - 100 possibilites, one for each percentage. We run this through crc32 with
+		// the feature name so that the same sites aren't always the canaries
+		$bucket = crc32( $feature . '-' . $site_id ) % 100;
+
+		return $bucket;
 	}
 }


### PR DESCRIPTION
## Description

This is just a tiny abstraction of existing logic that will unlock us to easier answer a question like "is site X and network site Y is included in certain bucket in %-based rollout?".

## Changelog Description

### Library Updated: Feature

We've introduced an API to get the bucket the current site is in for %-based feature rollouts.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. `wp shell`
2. `\Automattic\VIP\Feature::get_bucket( 31337, 'cool-feature' );` should return an integer in the range of 0-99

