### PR TITLE
tests: WP_UnitTestCase_Base::$factory is deprecated since 6.1.0

### DIFF
--- a/tests/001-core/test-privacy.php
+++ b/tests/001-core/test-privacy.php
@@ -15,7 +15,7 @@ class Privacy_Policy_Link_Test extends WP_UnitTestCase {
 	}
 
 	public function test__skip_vip_link_if_customer_link_set() {
-		$post = $this->factory->post->create_and_get();
+		$post = $this->factory()->post->create_and_get();
 		update_option( 'wp_page_for_privacy_policy', $post->ID );
 
 		global $wp_version;

--- a/tests/files/acl/test-acl.php
+++ b/tests/files/acl/test-acl.php
@@ -268,7 +268,7 @@ class VIP_Files_Acl_Test extends WP_UnitTestCase {
 		$expected_is_allowed = false;
 
 		// Get file path for a subsite
-		$subsite_id = $this->factory->blog->create();
+		$subsite_id = $this->factory()->blog->create();
 		$file_path  = sprintf( 'sites/%d/2021/01/dogs.gif', $subsite_id );
 
 		// Stay in main site context
@@ -286,7 +286,7 @@ class VIP_Files_Acl_Test extends WP_UnitTestCase {
 		$expected_is_allowed = true;
 
 		// Get file path for a subsite
-		$subsite_id = $this->factory->blog->create();
+		$subsite_id = $this->factory()->blog->create();
 		$file_path  = sprintf( 'sites/%d/2021/01/hamster.gif', $subsite_id );
 
 		// Run test in subsite context
@@ -308,7 +308,7 @@ class VIP_Files_Acl_Test extends WP_UnitTestCase {
 		$file_path = '2021/01/parakeets.gif';
 
 		// Run test in a subsite context
-		$subsite_id = $this->factory->blog->create();
+		$subsite_id = $this->factory()->blog->create();
 		switch_to_blog( $subsite_id );
 
 		$actual_is_allowed = is_valid_path_for_site( $file_path );
@@ -324,8 +324,8 @@ class VIP_Files_Acl_Test extends WP_UnitTestCase {
 		$expected_is_allowed = false;
 
 		// Create two subsites
-		$first_subsite_id  = $this->factory->blog->create();
-		$second_subsite_id = $this->factory->blog->create();
+		$first_subsite_id  = $this->factory()->blog->create();
+		$second_subsite_id = $this->factory()->blog->create();
 
 		// Get file path from second
 		$file_path = sprintf( 'sites/%d/2021/01/parakeets.gif', $second_subsite_id );

--- a/tests/files/acl/test-restrict-all-files.php
+++ b/tests/files/acl/test-restrict-all-files.php
@@ -37,7 +37,7 @@ class VIP_Files_Acl_Restrict_All_Files_Test extends WP_UnitTestCase {
 		$file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PUBLIC;
 		$file_path       = '2021/01/kittens.jpg';
 
-		$test_user_id = $this->factory->user->create();
+		$test_user_id = $this->factory()->user->create();
 		$user         = new \WP_User( $test_user_id );
 		$user->remove_role( 'subscriber' );
 		wp_set_current_user( $test_user_id );
@@ -53,7 +53,7 @@ class VIP_Files_Acl_Restrict_All_Files_Test extends WP_UnitTestCase {
 		$file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PUBLIC;
 		$file_path       = '2021/01/kittens.jpg';
 
-		$test_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$test_user_id = $this->factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $test_user_id );
 
 		$actual_file_visibility = check_file_visibility( $file_visibility, $file_path );

--- a/tests/files/acl/test-restrict-unpublished-files.php
+++ b/tests/files/acl/test-restrict-unpublished-files.php
@@ -50,8 +50,8 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 	public function test__check_file_visibility__attachment_not_inherit() {
 		$expected_file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PUBLIC;
 
-		$post_id       = $this->factory->post->create();
-		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
+		$post_id       = $this->factory()->post->create();
+		$attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
 
 		wp_update_post( [
 			'ID'          => $attachment_id,
@@ -74,11 +74,11 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 		$expected_file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PUBLIC;
 
 		// Switch to a subsite
-		$subsite_id = $this->factory->blog->create();
+		$subsite_id = $this->factory()->blog->create();
 		switch_to_blog( $subsite_id );
 
 		// Create attachment
-		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+		$attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH );
 
 		$file_visibility = false;
 		$file_path       = sprintf( 'sites/%d/%s', $subsite_id, get_post_meta( $attachment_id, '_wp_attached_file', true ) );
@@ -91,8 +91,8 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 	public function test__check_file_visibility__attachment_with_publish_parent() {
 		$expected_file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PUBLIC;
 
-		$post_id       = $this->factory->post->create( [ 'post_status' => 'publish' ] );
-		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
+		$post_id       = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		$attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
 
 		$file_visibility = false;
 		$file_path       = get_post_meta( $attachment_id, '_wp_attached_file', true );
@@ -105,8 +105,8 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 	public function test__check_file_visibility__attachment_with_draft_parent_and_without_user() {
 		$expected_file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PRIVATE_AND_DENIED;
 
-		$post_id       = $this->factory->post->create( [ 'post_status' => 'draft' ] );
-		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
+		$post_id       = $this->factory()->post->create( [ 'post_status' => 'draft' ] );
+		$attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
 
 		$file_visibility = false;
 		$file_path       = get_post_meta( $attachment_id, '_wp_attached_file', true );
@@ -119,10 +119,10 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 	public function test__check_file_visibility__attachment_with_draft_parent_and_without_user_permissions() {
 		$expected_file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PRIVATE_AND_DENIED;
 
-		$post_id       = $this->factory->post->create( [ 'post_status' => 'draft' ] );
-		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
+		$post_id       = $this->factory()->post->create( [ 'post_status' => 'draft' ] );
+		$attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
 
-		$test_user_id = $this->factory->user->create( array( 'role' => 'contributor' ) ); // will not have access to post
+		$test_user_id = $this->factory()->user->create( array( 'role' => 'contributor' ) ); // will not have access to post
 		wp_set_current_user( $test_user_id );
 
 		$file_visibility = false;
@@ -136,10 +136,10 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 	public function test__check_file_visibility__attachment_with_draft_parent_and_with_user_permissions() {
 		$expected_file_visibility = \Automattic\VIP\Files\Acl\FILE_IS_PRIVATE_AND_ALLOWED;
 
-		$post_id       = $this->factory->post->create( [ 'post_status' => 'draft' ] );
-		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
+		$post_id       = $this->factory()->post->create( [ 'post_status' => 'draft' ] );
+		$attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH, $post_id );
 
-		$test_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$test_user_id = $this->factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $test_user_id );
 
 		$file_visibility = false;
@@ -162,7 +162,7 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 
 	public function test__get_attachment_id_from_file_path__attachment_only_one_result() {
 		// Set up a test attachment.
-		$expected_attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+		$expected_attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH );
 		list( $attachment_src ) = wp_get_attachment_image_src( $expected_attachment_id, 'full' );
 		$attachment_path        = wp_parse_url( $attachment_src, PHP_URL_PATH );
 		$attachment_path        = $this->strip_wpcontent_uploads( $attachment_path );
@@ -175,10 +175,10 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 
 	public function test__get_attachment_id_from_file_path__attachment_multiple_results_first_in_list() {
 		// Set up the first attachment.
-		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+		$attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH );
 
 		// Create a second attachment with the same file path.
-		$duplicate_attachment_id   = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+		$duplicate_attachment_id   = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH );
 		$duplicate_attachment_file = get_post_meta( $duplicate_attachment_id, '_wp_attached_file', true );
 		update_post_meta( $duplicate_attachment_id, '_wp_attached_file', $duplicate_attachment_file );
 
@@ -196,10 +196,10 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 
 	public function test__get_attachment_id_from_file_path__attachment_multiple_results_exact_match_first() {
 		// Set up the first attachment.
-		$this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+		$this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH );
 
 		// Create a second attachment with the same file path.
-		$duplicate_attachment_id   = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+		$duplicate_attachment_id   = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH );
 		$duplicate_attachment_file = get_post_meta( $duplicate_attachment_id, '_wp_attached_file', true );
 		update_post_meta( $duplicate_attachment_id, '_wp_attached_file', strtoupper( $duplicate_attachment_file ) );
 
@@ -246,7 +246,7 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 		];
 
 		// No attachments for post
-		$test_post_id = $this->factory->post->create();
+		$test_post_id = $this->factory()->post->create();
 
 		$actual_urls = purge_attachments_for_post( $input_urls, $test_post_id );
 
@@ -258,10 +258,10 @@ class VIP_Files_Acl_Restrict_Unpublished_Files_Test extends WP_UnitTestCase {
 			'https://example.com',
 		];
 
-		$test_post_id    = $this->factory->post->create();
-		$attachment_id_1 = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
-		$attachment_id_2 = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
-		$attachment_id_3 = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
+		$test_post_id    = $this->factory()->post->create();
+		$attachment_id_1 = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
+		$attachment_id_2 = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
+		$attachment_id_3 = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH, $test_post_id );
 
 		// Output should include new attachment URLs
 		$expected_urls = [

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -225,7 +225,7 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		$remove_filters = self::get_method( 'remove_filters' );
 		$remove_filters->invoke( $this->vip_filesystem );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( self::TEST_IMAGE_PATH );
+		$attachment_id = $this->factory()->attachment->create_upload_object( self::TEST_IMAGE_PATH );
 
 		$actual_metadata = $this->vip_filesystem->filter_wp_generate_attachment_metadata( $initial_metadata, $attachment_id );
 

--- a/tests/performance/test-do-pings.php
+++ b/tests/performance/test-do-pings.php
@@ -47,7 +47,7 @@ class Do_Pings_Test extends WP_UnitTestCase {
 	}
 
 	public function test__add_post_meta_integration() {
-		$post = $this->factory->post->create_and_get();
+		$post = $this->factory()->post->create_and_get();
 		
 		$object_id  = $post->ID;
 		$meta_key   = 'test';

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -327,7 +327,7 @@ class Health_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_last_post_id() {
-		$post = $this->factory->post->create_and_get( [ 'post_status' => 'publish' ] );
+		$post = $this->factory()->post->create_and_get( [ 'post_status' => 'publish' ] );
 
 		$last_db_post_id = $post->ID;
 		$last_es_post_id = 0;
@@ -338,7 +338,7 @@ class Health_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_last_db_post_id() {
-		$post = $this->factory->post->create_and_get( [ 'post_status' => 'draft' ] );
+		$post = $this->factory()->post->create_and_get( [ 'post_status' => 'draft' ] );
 
 		$last_post_id = \Automattic\VIP\Search\Health::get_last_db_post_id();
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -1163,7 +1163,7 @@ class Search_Test extends WP_UnitTestCase {
 	}
 
 	public function test__truncate_search_string_length__user_with_cap() {
-		$admin_user = $this->factory->user->create( [
+		$admin_user = $this->factory()->user->create( [
 			'user_email' => 'admin@automattic.com',
 			'user_login' => 'vip_admin',
 			'role'       => 'administrator',
@@ -1834,7 +1834,7 @@ class Search_Test extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__filter__ep_skip_post_meta_sync_should_return_true_if_meta_not_in_allow_list() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test Post' ) );
 
 		$post = \get_post( $post_id );
 
@@ -1848,7 +1848,7 @@ class Search_Test extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__filter__ep_skip_post_meta_sync_should_return_false_if_meta_is_in_allow_list() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test Post' ) );
 
 		$post = \get_post( $post_id );
 
@@ -1871,7 +1871,7 @@ class Search_Test extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__filter__ep_skip_post_meta_sync_should_return_true_if_a_previous_filter_is_true() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test Post' ) );
 
 		$post = \get_post( $post_id );
 
@@ -1894,7 +1894,7 @@ class Search_Test extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__ep_skip_post_meta_sync_filter_should_return_true_if_meta_not_in_allow_list() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test Post' ) );
 
 		$post = \get_post( $post_id );
 
@@ -1908,7 +1908,7 @@ class Search_Test extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__ep_skip_post_meta_sync_filter_should_return_false_if_meta_is_in_allow_list() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test Post' ) );
 
 		$post = \get_post( $post_id );
 
@@ -1931,7 +1931,7 @@ class Search_Test extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test__ep_skip_post_meta_sync_filter_should_return_true_if_a_previous_filter_is_true() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test Post' ) );
 
 		$post = \get_post( $post_id );
 

--- a/tests/security/test-lockout.php
+++ b/tests/security/test-lockout.php
@@ -44,7 +44,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	public function test__user_seen_notice__warning() {
 		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'warning' );
 
-		$user = $this->factory->user->create_and_get();
+		$user = $this->factory()->user->create_and_get();
 
 		$user_seen_notice = self::get_method( 'user_seen_notice' );
 		$user_seen_notice->invokeArgs( $this->lockout, [ $user ] );
@@ -61,7 +61,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	public function test__user_seen_notice__locked() {
 		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
 
-		$user = $this->factory->user->create_and_get();
+		$user = $this->factory()->user->create_and_get();
 
 		$user_seen_notice = self::get_method( 'user_seen_notice' );
 		$user_seen_notice->invokeArgs( $this->lockout, [ $user ] );
@@ -78,7 +78,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	public function test__user_seen_notice__already_seen() {
 		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
 
-		$user = $this->factory->user->create_and_get();
+		$user = $this->factory()->user->create_and_get();
 
 		$date_str = gmdate( 'Y-m-d H:i:s' );
 		add_user_meta( $user->ID, Lockout::USER_SEEN_WARNING_KEY, 'warning', true );
@@ -100,7 +100,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	public function test__filter_user_has_cap__locked() {
 		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
 
-		$user = $this->factory->user->create_and_get( [
+		$user = $this->factory()->user->create_and_get( [
 			'role' => 'editor',
 		]);
 
@@ -115,7 +115,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	public function test__filter_user_has_cap__warning() {
 		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'warning' );
 
-		$user = $this->factory->user->create_and_get( [
+		$user = $this->factory()->user->create_and_get( [
 			'role' => 'editor',
 		]);
 
@@ -127,7 +127,7 @@ class Lockout_Test extends WP_UnitTestCase {
 	}
 
 	public function test__filter_user_has_cap__no_state() {
-		$user = $this->factory->user->create_and_get( [
+		$user = $this->factory()->user->create_and_get( [
 			'role' => 'editor',
 		]);
 
@@ -187,7 +187,7 @@ class Lockout_Test extends WP_UnitTestCase {
 		global $wpdb;
 
 		// Arrange: Have an existing user that's a super admin
-		$user = $this->factory->user->create_and_get();
+		$user = $this->factory()->user->create_and_get();
 		grant_super_admin( $user->ID );
 
 		Constant_Mocker::define( 'VIP_LOCKOUT_STATE', 'locked' );
@@ -201,7 +201,7 @@ class Lockout_Test extends WP_UnitTestCase {
 		);
 
 		// Act: Try granting another user super admin
-		$user2 = $this->factory->user->create_and_get();
+		$user2 = $this->factory()->user->create_and_get();
 		grant_super_admin( $user2->ID );
 
 		// Assert: Check the raw value to avoid conflicts with the filter
@@ -223,7 +223,7 @@ class Lockout_Test extends WP_UnitTestCase {
 		global $wpdb;
 
 		// Arrange: Have an existing user that's a super admin
-		$user = $this->factory->user->create_and_get();
+		$user = $this->factory()->user->create_and_get();
 		grant_super_admin( $user->ID );
 
 		// No lockout enabled
@@ -236,7 +236,7 @@ class Lockout_Test extends WP_UnitTestCase {
 		);
 
 		// Act: Try granting another user super admin
-		$user2 = $this->factory->user->create_and_get();
+		$user2 = $this->factory()->user->create_and_get();
 		grant_super_admin( $user2->ID );
 
 		// Assert: Check the raw value to avoid conflicts with the filter

--- a/tests/security/test-machine-user.php
+++ b/tests/security/test-machine-user.php
@@ -11,7 +11,7 @@ class Machine_User_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->machine_user = $this->factory->user->create_and_get( [
+		$this->machine_user = $this->factory()->user->create_and_get( [
 			'user_login' => WPCOM_VIP_MACHINE_USER_LOGIN,
 			'user_email' => WPCOM_VIP_MACHINE_USER_EMAIL,
 			'role'       => WPCOM_VIP_MACHINE_USER_ROLE,
@@ -49,7 +49,7 @@ class Machine_User_Test extends WP_UnitTestCase {
 	 * @dataProvider get_test_data__user_modification_caps
 	 */
 	public function test__non_admin_users_cannot_modify_machine_user( $test_cap ) {
-		$test_user = $this->factory->user->create_and_get( [ 'role' => 'editor' ] );
+		$test_user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		$actual_has_cap = $test_user->has_cap( $test_cap, $this->machine_user->ID );
 
@@ -60,7 +60,7 @@ class Machine_User_Test extends WP_UnitTestCase {
 	 * @dataProvider get_test_data__user_modification_caps
 	 */
 	public function test__admin_users_cannot_modify_machine_user( $test_cap ) {
-		$test_user = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		$test_user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 
 		$actual_has_cap = $test_user->has_cap( $test_cap, $this->machine_user->ID );
 
@@ -75,7 +75,7 @@ class Machine_User_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'No superadmins on single site installs.' );
 		}
 
-		$test_user = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		$test_user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 		grant_super_admin( $test_user->ID );
 
 		$actual_has_cap = $test_user->has_cap( $test_cap, $this->machine_user->ID );
@@ -84,7 +84,7 @@ class Machine_User_Test extends WP_UnitTestCase {
 	}
 
 	public function test__non_admin_users_can_still_modify_self() {
-		$test_user = $this->factory->user->create_and_get( [ 'role' => 'editor' ] );
+		$test_user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		$actual_has_cap = $test_user->has_cap( 'edit_user', $test_user->ID );
 
@@ -92,7 +92,7 @@ class Machine_User_Test extends WP_UnitTestCase {
 	}
 
 	public function test__admin_users_can_still_modify_self() {
-		$test_user = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		$test_user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 
 		$actual_has_cap = $test_user->has_cap( 'edit_user', $test_user->ID );
 
@@ -104,7 +104,7 @@ class Machine_User_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'No superadmins on single site installs.' );
 		}
 
-		$test_user = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		$test_user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 		grant_super_admin( $test_user->ID );
 
 		$actual_has_cap = $test_user->has_cap( 'edit_user', $test_user->ID );
@@ -116,8 +116,8 @@ class Machine_User_Test extends WP_UnitTestCase {
 	 * @dataProvider get_test_data__user_modification_caps
 	 */
 	public function test__non_admin_users_cannot_modify_others( $test_cap ) {
-		$test_user    = $this->factory->user->create_and_get( [ 'role' => 'editor' ] );
-		$user_to_edit = $this->factory->user->create_and_get( [ 'role' => 'editor' ] );
+		$test_user    = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
+		$user_to_edit = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		$actual_has_cap = $test_user->has_cap( $test_cap, $user_to_edit->ID );
 
@@ -132,8 +132,8 @@ class Machine_User_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Single site test for administrator user; multisite tested separately.' );
 		}
 
-		$test_user    = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
-		$user_to_edit = $this->factory->user->create_and_get( [ 'role' => 'editor' ] );
+		$test_user    = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$user_to_edit = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		$actual_has_cap = $test_user->has_cap( $test_cap, $user_to_edit->ID );
 
@@ -150,8 +150,8 @@ class Machine_User_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Multisite test for administrator user; single site tested separately.' );
 		}
 
-		$test_user    = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
-		$user_to_edit = $this->factory->user->create_and_get( [ 'role' => 'editor' ] );
+		$test_user    = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$user_to_edit = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		$actual_has_cap = $test_user->has_cap( $test_cap, $user_to_edit->ID );
 
@@ -166,9 +166,9 @@ class Machine_User_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'No superadmins on single site installs.' );
 		}
 
-		$test_user = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		$test_user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 		grant_super_admin( $test_user->ID );
-		$user_to_edit = $this->factory->user->create_and_get( [ 'role' => 'editor' ] );
+		$user_to_edit = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		$actual_has_cap = $test_user->has_cap( $test_cap, $user_to_edit->ID );
 

--- a/tests/security/test-password.php
+++ b/tests/security/test-password.php
@@ -11,7 +11,7 @@ class Current_Password_Change_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->factory->user->create( [
+		$this->factory()->user->create( [
 			'user_login' => 'john',
 			'user_email' => 'john@example.com',
 			'user_pass'  => 'secret1',

--- a/tests/test-cache-ttl-manager-rest.php
+++ b/tests/test-cache-ttl-manager-rest.php
@@ -79,7 +79,7 @@ class TTL_Manager__REST_API__Test extends WP_Test_REST_TestCase {
 	 * @dataProvider get_rest_write_methods
 	 */
 	public function test__skip_ttl_for_authenticated_requests( $method ) {
-		$user_id = $this->factory->user->create();
+		$user_id = $this->factory()->user->create();
 		wp_set_current_user( $user_id );
 
 		$response = $this->dispatch_request( $method );

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -9,7 +9,7 @@ class VIP_Go__Core__Disable_Update_Caps_Test extends WP_UnitTestCase {
 	}
 
 	public function test__super_admin_should_not_have_update_core_cap() {
-		$super_admin = $this->factory->user->create_and_get( array( 'role' => 'administrator' ) );
+		$super_admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
 		grant_super_admin( $super_admin->ID );
 
 		$this->assertFalse( user_can( $super_admin, 'update_core' ), 'Superadmin user should not have `update_core` cap' );
@@ -18,14 +18,14 @@ class VIP_Go__Core__Disable_Update_Caps_Test extends WP_UnitTestCase {
 	}
 
 	public function test__administrator_should_not_have_update_core_cap() {
-		$admin = $this->factory->user->create_and_get( array( 'role' => 'administrator' ) );
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
 
 		$this->assertFalse( user_can( $admin, 'update_core' ), 'Admin user should not have `update_core` cap' );
 		$this->assertTrue( user_can( $admin, 'manage_options' ), 'Admin user missing `manage_options` cap' );
 	}
 
 	public function test__contributor_should_not_have_update_core_cap() {
-		$contributor = $this->factory->user->create_and_get( array( 'role' => 'contributor' ) );
+		$contributor = $this->factory()->user->create_and_get( array( 'role' => 'contributor' ) );
 
 		$this->assertFalse( user_can( $contributor, 'update_core' ), 'Contributor user should not have `update_core` cap' );
 		$this->assertTrue( user_can( $contributor, 'edit_posts' ), 'Contributor user missing `edit_posts` cap' );

--- a/tests/test-performance-lastpostmodified.php
+++ b/tests/test-performance-lastpostmodified.php
@@ -16,7 +16,7 @@ class lastpostmodified_Test extends WP_UnitTestCase {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", Last_Post_Modified::OPTION_PREFIX . '%' ) );
 
-		$this->post = $this->factory->post->create_and_get( [ 'post_status' => 'draft' ] );
+		$this->post = $this->factory()->post->create_and_get( [ 'post_status' => 'draft' ] );
 	}
 
 	public function test__transition_post_status__save_on_publish() {

--- a/tests/test-security.php
+++ b/tests/test-security.php
@@ -4,7 +4,7 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 	private $original_post;
 
 	public function test__admin_username_restricted() {
-		$this->factory->user->create( [
+		$this->factory()->user->create( [
 			'user_login' => 'admin',
 			'user_email' => 'admin@example.com',
 			'user_pass'  => 'secret1',
@@ -17,7 +17,7 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 	}
 
 	public function test__vip_machine_user_username_restricted() {
-		$this->factory->user->create( [
+		$this->factory()->user->create( [
 			'user_login' => WPCOM_VIP_MACHINE_USER_LOGIN,
 			'user_email' => WPCOM_VIP_MACHINE_USER_EMAIL,
 			'user_pass'  => 'secret2',
@@ -30,7 +30,7 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 	}
 
 	public function test__vip_machine_user_email_restricted() {
-		$this->factory->user->create( [
+		$this->factory()->user->create( [
 			'user_login' => WPCOM_VIP_MACHINE_USER_LOGIN,
 			'user_email' => WPCOM_VIP_MACHINE_USER_EMAIL,
 			'user_pass'  => 'secret3',
@@ -43,7 +43,7 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 	}
 
 	public function test__other_username_not_restricted() {
-		$user_id = $this->factory->user->create( [
+		$user_id = $this->factory()->user->create( [
 			'user_login' => 'taylorswift',
 			'user_email' => 'taylor@example.com',
 			'user_pass'  => 'secret4',
@@ -56,7 +56,7 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 	}
 
 	public function test__other_email_not_restricted() {
-		$user_id = $this->factory->user->create( [
+		$user_id = $this->factory()->user->create( [
 			'user_login' => 'taylorswift',
 			'user_email' => 'taylor@example.com',
 			'user_pass'  => 'secret5',

--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -79,7 +79,7 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 	}
 
 	public function test__page_for_posts_post_purge_url() {
-		$page_for_posts = $this->factory->post->create_and_get(
+		$page_for_posts = $this->factory()->post->create_and_get(
 			[
 				'post_type'  => 'page',
 				'post_title' => 'blog-archive',
@@ -88,7 +88,7 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 		update_option( 'page_for_posts', $page_for_posts->ID );
 		$permalink = get_permalink( $page_for_posts );
 
-		$post = (array) $this->factory->post->create_and_get( [ 'post_title' => 'test post' ] );
+		$post = (array) $this->factory()->post->create_and_get( [ 'post_title' => 'test post' ] );
 
 		$post['post_title'] = 'updated';
 

--- a/tests/test-wp-cli-ssl.php
+++ b/tests/test-wp-cli-ssl.php
@@ -81,14 +81,14 @@ class VIP_WP_CLI__SSL__Test extends WP_UnitTestCase {
 			return;
 		}
 
-		$blog_1_id = $this->factory->blog->create_object( [
+		$blog_1_id = $this->factory()->blog->create_object( [
 			'domain'  => 'not-ssl.com',
 			'path'    => '/',
 			'title'   => 'Not SSL',
 			'site_id' => 1,
 		] );
 
-		$blog_2_id = $this->factory->blog->create_object( [
+		$blog_2_id = $this->factory()->blog->create_object( [
 			'domain'  => 'is-ssl.com',
 			'path'    => '/',
 			'title'   => 'Is SSL',

--- a/tests/vip-helpers/test-class-user-cleanup.php
+++ b/tests/vip-helpers/test-class-user-cleanup.php
@@ -90,7 +90,7 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 	public function test__fetch_user_ids_for_emails__exact_match() {
 		$user_1_email = 'user@example.com';
-		$user_1_id    = $this->factory->user->create( array( 'user_email' => $user_1_email ) );
+		$user_1_id    = $this->factory()->user->create( array( 'user_email' => $user_1_email ) );
 
 		$expected_ids = [ $user_1_id ];
 
@@ -101,9 +101,9 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 	public function test__fetch_user_ids_for_emails__exact_match_multiples() {
 		$user_1_email = 'user@example.com';
-		$user_1_id    = $this->factory->user->create( array( 'user_email' => $user_1_email ) );
+		$user_1_id    = $this->factory()->user->create( array( 'user_email' => $user_1_email ) );
 		$user_2_email = 'user2@other.com';
-		$user_2_id    = $this->factory->user->create( array( 'user_email' => $user_2_email ) );
+		$user_2_id    = $this->factory()->user->create( array( 'user_email' => $user_2_email ) );
 
 		$expected_ids = [ $user_1_id, $user_2_id ];
 
@@ -114,7 +114,7 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 	public function test__fetch_user_ids_for_emails__exact_match_with_plus() {
 		$user_1_email = 'user+extra@example.com';
-		$user_1_id    = $this->factory->user->create( array( 'user_email' => $user_1_email ) );
+		$user_1_id    = $this->factory()->user->create( array( 'user_email' => $user_1_email ) );
 
 		$expected_ids = [ $user_1_id ];
 
@@ -125,7 +125,7 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 	public function test__fetch_user_ids_for_emails__email_with_plus() {
 		$user_1_email = 'user+extra@example.com';
-		$user_1_id    = $this->factory->user->create( array( 'user_email' => $user_1_email ) );
+		$user_1_id    = $this->factory()->user->create( array( 'user_email' => $user_1_email ) );
 
 		$expected_ids = [ $user_1_id ];
 
@@ -136,7 +136,7 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 	public function test__fetch_user_ids_for_emails__username_match_different_host() {
 		$user_1_email = 'user+extra@different.com';
-		$this->factory->user->create( array( 'user_email' => $user_1_email ) );
+		$this->factory()->user->create( array( 'user_email' => $user_1_email ) );
 
 		$expected_ids = []; // emails will not match
 
@@ -147,7 +147,7 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 	public function test__fetch_user_ids_for_emails__host_match_different_username() {
 		$user_1_email = 'different+extra@example.com';
-		$this->factory->user->create( array( 'user_email' => $user_1_email ) );
+		$this->factory()->user->create( array( 'user_email' => $user_1_email ) );
 
 		$expected_ids = []; // emails will not match
 
@@ -158,7 +158,7 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 	public function test__fetch_user_ids_for_emails__no_caps() {
 		$user_1_email = 'user@example.com';
-		$user_1_id    = $this->factory->user->create( array( 'user_email' => $user_1_email ) );
+		$user_1_id    = $this->factory()->user->create( array( 'user_email' => $user_1_email ) );
 
 		get_userdata( $user_1_id )->remove_all_caps();
 
@@ -177,8 +177,8 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 		$this->backup_super_admins();
 
-		$user_id_1 = $this->factory->user->create();
-		$user_id_2 = $this->factory->user->create();
+		$user_id_1 = $this->factory()->user->create();
+		$user_id_2 = $this->factory()->user->create();
 		grant_super_admin( $user_id_1 );
 		grant_super_admin( $user_id_2 );
 
@@ -202,7 +202,7 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 		$this->backup_super_admins();
 
-		$user_id_1 = $this->factory->user->create();
+		$user_id_1 = $this->factory()->user->create();
 		grant_super_admin( $user_id_1 );
 
 		$expected_results = [
@@ -226,8 +226,8 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 		$this->backup_super_admins();
 
-		$user_id_1 = $this->factory->user->create();
-		$user_id_2 = $this->factory->user->create();
+		$user_id_1 = $this->factory()->user->create();
+		$user_id_2 = $this->factory()->user->create();
 		grant_super_admin( $user_id_1 );
 		grant_super_admin( $user_id_2 );
 
@@ -253,8 +253,8 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 
 		$this->backup_super_admins();
 
-		$user_id_1 = $this->factory->user->create();
-		$user_id_2 = $this->factory->user->create();
+		$user_id_1 = $this->factory()->user->create();
+		$user_id_2 = $this->factory()->user->create();
 		// user_id_1 is not a super admin
 		grant_super_admin( $user_id_2 );
 
@@ -281,9 +281,9 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 		$this->backup_super_admins();
 
 		// 3 super admins, and we only revoke two of them
-		$user_id_1 = $this->factory->user->create();
-		$user_id_2 = $this->factory->user->create();
-		$user_id_3 = $this->factory->user->create();
+		$user_id_1 = $this->factory()->user->create();
+		$user_id_2 = $this->factory()->user->create();
+		$user_id_3 = $this->factory()->user->create();
 		grant_super_admin( $user_id_1 );
 		grant_super_admin( $user_id_2 );
 		grant_super_admin( $user_id_3 );
@@ -304,7 +304,7 @@ class User_Cleanup_Test extends WP_UnitTestCase {
 	}
 
 	public function test__revoke_roles_for_users() {
-		$user_1_id = $this->factory->user->create();
+		$user_1_id = $this->factory()->user->create();
 
 		$expected_results = [
 			$user_1_id => true,

--- a/tests/vip-helpers/vip-utils/test-vip-utils-resized-attachments.php
+++ b/tests/vip-helpers/vip-utils/test-vip-utils-resized-attachments.php
@@ -12,7 +12,7 @@ class WPCOM_VIP_Get_Resized_Attachment_Url_Test extends WP_UnitTestCase {
 	public function test__valid_attachment() {
 		$expected_end_of_url = '/image.jpg?w=100&h=101';
 
-		$attachment_id = $this->factory->attachment->create_object( [
+		$attachment_id = $this->factory()->attachment->create_object( [
 			'file' => 'image.jpg',
 		] );
 

--- a/tests/vip-support/test-role.php
+++ b/tests/vip-support/test-role.php
@@ -25,7 +25,7 @@ class VIPSupportRoleTest extends WP_UnitTestCase {
 			'user_pass'  => 'password',
 		) );
 
-		$this->admin_user = $this->factory->user->create( [
+		$this->admin_user = $this->factory()->user->create( [
 			'user_email' => 'admin@automattic.com',
 			'user_login' => 'vip_admin',
 			'role'       => 'administrator',

--- a/tests/vip-support/test-user.php
+++ b/tests/vip-support/test-user.php
@@ -109,7 +109,7 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	}
 
 	public function test_is_verified_automattician(): void {
-		$user_id = $this->factory->user->create( [
+		$user_id = $this->factory()->user->create( [
 			'user_email' => 'admin@automattic.com',
 			'user_login' => 'vip_admin',
 		] );
@@ -128,7 +128,7 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	public function test_is_verified_automattician_for_disallowed_user(): void {
 		define( 'VIP_SUPPORT_USER_ALLOWED_EMAILS', array( 'admin@automattic.com' ) );
 
-		$user_id = $this->factory->user->create( [
+		$user_id = $this->factory()->user->create( [
 			'user_email' => 'foo@automattic.com',
 			'user_login' => 'vip_foo',
 		] );
@@ -153,14 +153,14 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	}
 
 	public function test__has_vip_support_meta__nope(): void {
-		$user = $this->factory->user->create( array( 'user_login' => 'not-vip-support' ) );
+		$user = $this->factory()->user->create( array( 'user_login' => 'not-vip-support' ) );
 
 		$is_vip_support_user = User::has_vip_support_meta( $user );
 		$this->assertFalse( $is_vip_support_user );
 	}
 
 	public function test__add__update_email_for_existing_user_with_different_login(): void {
-		$existing_user_id = $this->factory->user->create( [
+		$existing_user_id = $this->factory()->user->create( [
 			'user_email' => 'existing123@automattic.com',
 			'user_login' => 'existing-user-123',
 		] );
@@ -183,7 +183,7 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	}
 
 	public function test__add__update_account_for_existing_user_with_same_login(): void {
-		$existing_user_id = $this->factory->user->create( [
+		$existing_user_id = $this->factory()->user->create( [
 			'user_email'   => 'existing456@automattic.com',
 			'user_login'   => 'vip-support-user-456',
 			'display_name' => 'Existing User',


### PR DESCRIPTION
Automatically replace `WP_UnitTestCase_Base::$factory` (deprecated as of WPTL 6.1) with `WP_UnitTestCase_Base::factory()`.
