### PR TITLE
vipd: Fix fatal "Too few arguments to function Automattic\VIP\Helpers…

### DIFF
--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -96,7 +96,7 @@ class Wp_Cli_Db {
 	 * @param array $command
 	 * @param array $assoc_args
 	 */
-	public function before_run_command( array $command, array $assoc_args = [] ): void {
+	public function before_run_command( array $command = [], array $assoc_args = [] ): void {
 		if ( ! ( isset( $command[0] ) && 'db' === $command[0] ) ) {
 			// Don't do anything for any command other than `db`
 			return;


### PR DESCRIPTION
## Description
On vipd, we are running WP-CLI 2.4.0, and on k8s, we are running 2.6.0. Unfortunately, WP-CLI 2.4.0 does not support additional arguments to be passed into the `before_run_command()` hook: https://github.com/wp-cli/wp-cli/blob/74c949c74708e3a88ad0add70f3236c8675dfd85/php/WP_CLI/Runner.php#L348-L349

Whereas in 2.6.0, it supports those: https://github.com/wp-cli/wp-cli/blob/dee13c2baf6bf972484a63f8b8dab48f7220f095/php/WP_CLI/Runner.php#L394-L395

Let's make those arguments optional to avoid the fatal:

```
PHP Fatal error: Uncaught ArgumentCountError: Too few arguments to function Automattic\VIP\Helpers\WP_CLI_DB\Wp_Cli_Db::before_run_command(), 0 passed in phar:///root/roles/docker-container-vip-web-cli/usr/local/bin/wp/vendor/wp-cli/wp-cli/php/class-wp-cli.php on line 304 and at least 1 expected in /chroot/var/www/wp-content/mu-plugins/lib/helpers/wp-cli-db/class-wp-cli-db.php:99
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.