### PR TITLE
Search: Add CLI command `wp vip-search queue info`

### DIFF
--- a/search/includes/classes/commands/class-queuecommand.php
+++ b/search/includes/classes/commands/class-queuecommand.php
@@ -16,6 +16,38 @@ require_once __DIR__ . '/../class-health.php';
  */
 class QueueCommand extends \WPCOM_VIP_CLI_Command {
 	/**
+	 * Get info on the queue
+	 *
+	 * ## OPTIONS
+	 *
+	 *[--format=<format>]
+	 * : Accepts 'table', 'json', 'csv', or 'yaml'. Default: table
+	 *
+	 * ## EXAMPLES
+	 *     wp vip-search queue info
+	 *     wp vip-search queue info --format=json
+	 *
+	 * @subcommand info
+	 */
+	public function info( $args, $assoc_args ) {
+		$format = $assoc_args['format'] ?? 'table';
+		if ( ! in_array( $format, [ 'table', 'json', 'csv', 'yaml' ], true ) ) {
+			WP_CLI::error( __( '--format only accepts the following values: table, json, csv, yaml' ) );
+		}
+
+		$search = \Automattic\VIP\Search\Search::instance();
+		$stats  = $search->queue->get_queue_stats();
+		$info   = [];
+		$info[] = [
+			'queue_count'       => $stats->queue_count,
+			'average_wait_time' => $stats->average_wait_time,
+			'longest_wait_time' => $stats->longest_wait_time,
+		];
+
+		WP_CLI\Utils\format_items( $format, $info, [ 'queue_count', 'average_wait_time', 'longest_wait_time' ] );
+	}
+
+	/**
 	 * Purge the queue
 	 *
 	 * ## OPTIONS
@@ -29,7 +61,6 @@ class QueueCommand extends \WPCOM_VIP_CLI_Command {
 	 *
 	 * @subcommand purge
 	 */
-
 	public function purge( $args, $assoc_args ) {
 		if ( ! isset( $assoc_args['skip-confirm'] ) ) {
 			WP_CLI::confirm( 'Are you sure you want to truncate the existing indexing queue? Any items currently queued will be dropped' );

--- a/search/includes/classes/commands/class-queuecommand.php
+++ b/search/includes/classes/commands/class-queuecommand.php
@@ -37,11 +37,12 @@ class QueueCommand extends \WPCOM_VIP_CLI_Command {
 
 		$search = \Automattic\VIP\Search\Search::instance();
 		$stats  = $search->queue->get_queue_stats();
-		$info   = [];
-		$info[] = [
-			'queue_count'       => $stats->queue_count,
-			'average_wait_time' => $stats->average_wait_time,
-			'longest_wait_time' => $stats->longest_wait_time,
+		$info   = [
+			[
+				'queue_count'       => number_format_i18n( $stats->queue_count ),
+				'average_wait_time' => $stats->average_wait_time > 0 ? human_readable_duration( gmdate( 'H:i:s', $stats->average_wait_time ) ) : $stats->average_wait_time,
+				'longest_wait_time' => $stats->longest_wait_time > 0 ? human_readable_duration( gmdate( 'H:i:s', $stats->longest_wait_time ) ) : $stats->longest_wait_time,
+			],
 		];
 
 		WP_CLI\Utils\format_items( $format, $info, [ 'queue_count', 'average_wait_time', 'longest_wait_time' ] );


### PR DESCRIPTION
## Description
Would be nice to have a CLI command to give a quick overview on the current queue.

```
+-------------+-------------------------------+--------------------------------+
| queue_count | average_wait_time             | longest_wait_time              |
+-------------+-------------------------------+--------------------------------+
| 170,961     | 1 hour, 8 minutes, 53 seconds | 1 hour, 53 minutes, 29 seconds |
+-------------+-------------------------------+--------------------------------+
```

## Changelog Description

### Plugin Updated: Enterprise Search

Add CLI command `wp vip-search queue info`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) `wp vip-search queue info`
2) see:
```
+-------------+-------------------+-------------------+
| queue_count | average_wait_time | longest_wait_time |
+-------------+-------------------+-------------------+
| 0           | 0                 | 0                 |
+-------------+-------------------+-------------------+
```