### PR TITLE
Search: Add CLI command `wp vip-search health stop-validate-contents`

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -128,7 +128,7 @@ class Health {
 
 			$db_total = (int) $db_result['total_objects'];
 		} catch ( \Exception $e ) {
-			return new WP_Error( 'db_query_error', sprintf( 'failure querying the DB: %s #vip-search', $e->getMessage() ) );
+			return new WP_Error( 'es_db_query_error', sprintf( 'failure querying the DB: %s #vip-search', $e->getMessage() ) );
 		}
 
 		$diff = 0;
@@ -440,11 +440,11 @@ class Health {
 		$track_process = ( ! $start_post_id || 1 === $start_post_id ) && ! $force_parallel_execution;
 
 		if ( $process_parallel_execution_lock && $this->is_validate_content_ongoing() ) {
-			return new WP_Error( 'content_validation_already_ongoing', 'Content validation is already ongoing' );
+			return new WP_Error( 'es_content_validation_already_ongoing', 'Content validation is already ongoing' );
 		}
 
 		if ( $this->is_validate_content_ongoing() && false !== wp_cache_get( self::STOP_VALIDATE_CONTENTS_KEY, self::CACHE_GROUP, true ) ) {
-			return new WP_Error( 'request_to_stop_content_validation', 'Content validation is in the process of being stopped. Please wait a bit before re-attempting!' );
+			return new WP_Error( 'es_request_to_stop_content_validation', 'Content validation is in the process of being stopped. Please wait a bit before re-attempting!' );
 		}
 
 		$interrupted_start_post_id = $this->get_validate_content_abandoned_process();
@@ -527,7 +527,7 @@ class Health {
 			if ( count( $results ) > $max_diff_size && ( $is_cli && ! $silent ) ) {
 				echo sprintf( "...%s\n", \WP_CLI::colorize( '🛑' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-				$error = new WP_Error( 'diff-size-limit-reached', sprintf( 'Reached diff size limit of %d elements, aborting', $max_diff_size ) );
+				$error = new WP_Error( 'es_diff_size_limit_reached', sprintf( 'Reached diff size limit of %d elements, aborting', $max_diff_size ) );
 
 				$error->add_data( $results, 'diff' );
 

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -566,6 +566,7 @@ class Health {
 			$this->remove_validate_content_lock();
 			if ( $should_stop ) {
 				delete_transient( self::STOP_VALIDATE_CONTENTS_TRANSIENT );
+				$results = new WP_Error( 'es_validate_content_aborted', 'Validation aborted by CLI command stop-validate-contents!' );
 			}
 		}
 		if ( $track_process ) {

--- a/search/includes/classes/class-healthjob.php
+++ b/search/includes/classes/class-healthjob.php
@@ -138,7 +138,7 @@ class HealthJob {
 			)
 		);
 
-		if ( is_wp_error( $results ) && 'content_validation_already_ongoing' !== $results->get_error_code() ) {
+		if ( is_wp_error( $results ) && 'es_content_validation_already_ongoing' !== $results->get_error_code() ) {
 			$message = sprintf( 'Cron validate-contents error for site %d (%s): %s', FILES_CLIENT_SITE_ID, home_url(), $results->get_error_message() );
 			Alerts::chat( '#vip-go-es-alerts', $message, 2 );
 		}

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -36,15 +36,11 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 			WP_CLI::error( 'There is no validate-contents run ongoing' );
 		}
 
-		if ( false !== get_transient( $health::STOP_VALIDATE_CONTENTS_TRANSIENT ) ) {
-			WP_CLI::error( 'There is already a request to stop validate-contents!' );
-		}
-
-		$stop = set_transient( $health::STOP_VALIDATE_CONTENTS_TRANSIENT, true, 3 * MINUTE_IN_SECONDS );
+		$stop = wp_cache_add( $health::STOP_VALIDATE_CONTENTS_KEY, true, $health::CACHE_GROUP );
 		if ( $stop ) {
-			WP_CLI::success( 'Stopping validate-contents run...' );
+			WP_CLI::success( 'Attempting to abort validate-contents run...' );
 		} else {
-			WP_CLI::error( 'Failed to stop validate-contents run!' );
+			WP_CLI::error( 'Failed to abort validate-contents run! There is already a request to stop it.' );
 		}
 	}
 

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -25,6 +25,30 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 	}
 
 	/**
+	 * Stop an ongoing validate-contents from continuing to be run.
+	 *
+	 * @subcommand stop-validate-contents
+	 */
+	public function stop_validate_contents( $args, $assoc_args ) {
+		$health = new \Automattic\VIP\Search\Health( \Automattic\VIP\Search\Search::instance() );
+
+		if ( ! $health->is_validate_content_ongoing() ) {
+			WP_CLI::error( 'There is no validate-contents run ongoing' );
+		}
+
+		if ( false !== get_transient( $health::STOP_VALIDATE_CONTENTS_TRANSIENT ) ) {
+			WP_CLI::error( 'There is already a request to stop validate-contents!' );
+		}
+
+		$stop = set_transient( $health::STOP_VALIDATE_CONTENTS_TRANSIENT, true, 3 * MINUTE_IN_SECONDS );
+		if ( $stop ) {
+			WP_CLI::success( 'Stopping validate-contents run...' );
+		} else {
+			WP_CLI::error( 'Failed to stop validate-contents run!' );
+		}
+	}
+
+	/**
 	 * Validate DB and ES index counts for all objects for active indexables
 	 *
 	 * ## OPTIONS

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -372,6 +372,10 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		$results = $health->validate_index_posts_content( $assoc_args );
 
 		if ( is_wp_error( $results ) ) {
+			if ( $results->get_error_code() === 'es_validate_content_aborted' ) {
+				WP_CLI::error( $results->get_error_message() );
+			}
+
 			$diff = $results->get_error_data( 'diff' );
 
 			if ( ! empty( $diff ) ) {

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -431,7 +431,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 			}
 
 			$message = $results->get_error_message();
-			if ( 'content_validation_already_ongoing' === $results->get_error_code() ) {
+			if ( 'es_content_validation_already_ongoing' === $results->get_error_code() ) {
 				$message .= "\n\nYou can use --force_parallel_execution to run the command even with the lock in place";
 			}
 			WP_CLI::error( $message );


### PR DESCRIPTION
## Description
Would be nice to have a killswitch for the validate-contents CLI command since it can eat up a lot of resources.

## Changelog Description

### Plugin Updated: Enterprise Search

Added CLI command `stop-validate-contents` to stop any validate_contents processing.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Kick off a validate contents `wp vip-search health validate-contents --max_diff_size=1000000`
2) While 1) is still running, run `wp vip-search health stop-validate-contents` and see process stop in 1)
3) Ensure that lock and transient is cleaned up via `wp option get vip_search_content_validation_process_post_id` and `wp cache get search_interrupt_validate_contents vip_search` 