### PR TITLE
VaultPress: Stop loading VaultPress plugin by default for all VIP environments

### DIFF
--- a/vaultpress.php
+++ b/vaultpress.php
@@ -13,12 +13,10 @@
  * @package automattic/vaultpress
  */
 
-// On non-production environments, do not load VaultPress unless explicitly enabled via the VIP_VAULTPRESS_SKIP_LOAD constant
+// Do not load VaultPress unless explicitly enabled via the VIP_VAULTPRESS_SKIP_LOAD constant
 // Please see this post for more information: https://lobby.vip.wordpress.com/2023/02/28/upcoming-vaultpress-deprecation/
 if ( ! defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) ) {
-	if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'production' !== VIP_GO_APP_ENVIRONMENT ) {
-		define( 'VIP_VAULTPRESS_SKIP_LOAD', true );
-	}
+	define( 'VIP_VAULTPRESS_SKIP_LOAD', true );
 }
 
 // Avoid loading VaultPress altogether if VIP_JETPACK_SKIP_LOAD is set to true (Jetpack is required for VP to work in VIP)


### PR DESCRIPTION
## Description

_Follow up to https://github.com/Automattic/vip-go-mu-plugins/pull/4183 which did the same for VIP non-production environments_

With the change proposed in this PR, will stop loading VaultPress for production environments by default from the 28th of March 2023. **Do not deploy to production before this date.**

Adding the following line to a site's `vip-config.php` file should override this for now:

```
define( 'VIP_VAULTPRESS_SKIP_LOAD', false );
```

Find more information here: https://lobby.vip.wordpress.com/2023/02/28/upcoming-vaultpress-deprecation/

## Changelog Description

### Plugin Updated: VaultPress

Stop loading VaultPress plugin by default for all VIP environments


