### PR TITLE
fix: Do not load client MU plugins when WP is being installed

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1292,8 +1292,10 @@ function wpcom_vip_should_load_plugins() {
 
 	$should_load_plugins = true;
 
-	// WP-CLI loaded with --skip-plugins flag
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
+		$should_load_plugins = false;
+	} elseif ( defined( 'WP_CLI' ) && WP_CLI ) {
+		// WP-CLI loaded with --skip-plugins flag
 		$skipped_plugins = \WP_CLI::get_runner()->config['skip-plugins'];
 		if ( $skipped_plugins ) {
 			$should_load_plugins = false;


### PR DESCRIPTION
## Description

This PR disables loading of client MU plguins while WordPress is being installed. This mainly affects dev environments where an unaware plugin could fail the installation process.

## Changelog Description

### Plugin Updated: VIP Client mu-plugins

Do not load client mu-plugins while WordPress is being installed.

## Checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Create a MU plugin that dies when `WP_INSTALLING === true`
2. Make sure it does not interfere with the installation process.
