### PR TITLE
Search: Update wording on confirmation prompt when --using-versions on index command

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -51,7 +51,7 @@ class CoreCommand extends \ElasticPress\Command {
 			}
 
 			if ( ! $skip_confirm ) {
-				WP_CLI::confirm( '⚠️  You are about to remove a previously used index version. It is advised to verify that the new version is being used before continuing. Continue?' );
+				WP_CLI::confirm( '⚠️ The previous version of the index is now inactive and should be deleted. Delete previous index version?' );
 			}
 
 			WP_CLI::line( sprintf( 'Removing inactive version for "%s"', $indexable->slug ) );


### PR DESCRIPTION
## Description
Props @yolih for the suggestion.

This changes the confirmation prompt on `index --using-versions` at the last step from:

```
You are about to remove a previously used index version. It is advised to verify that the new version is being used before continuing. Continue? [y/n]
```
to:
```
The previous version of the index is now inactive and should be deleted. Delete previous index version? [y/n] 
```
