### PR TITLE
QM: For $value, add nullable to type in output_table_cell()

### DIFF
--- a/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-ops.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-ops.php
@@ -207,7 +207,7 @@ class QM_Output_Object_Cache_Ops extends QM_Output_Html {
 	 * @param string $value Value to be outputted in table cell
 	 * @param int|null $weight Weight by sorting priority
 	 */
-	public function output_table_cell( string $value, int $weight = null ) {
+	public function output_table_cell( ?string $value, int $weight = null ) {
 		if ( $weight ) {
 			$weight = ' data-qm-sort-weight="' . esc_attr( $weight ) . '"';
 		}

--- a/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php
@@ -223,7 +223,7 @@ class QM_Output_Object_Cache_Slow_Ops extends QM_Output_Html {
 	 * @param string $value Value to be outputted in table cell
 	 * @param int|null $weight Weight by sorting priority
 	 */
-	public function output_table_cell( string $value, int $weight = null ) {
+	public function output_table_cell( ?string $value, int $weight = null ) {
 		if ( $weight ) {
 			$weight = ' data-qm-sort-weight="' . esc_attr( $weight ) . '"';
 		}


### PR DESCRIPTION
## Description
Fixes fatal:
```
[23-Mar-2023 17:10:59 UTC] PHP Fatal error:  Uncaught TypeError: QM_Output_Object_Cache_Slow_Ops::output_table_cell(): Argument #1 ($value) must be of type string, null given, called in /wp/wp-content/mu-plugins/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php on line 59 and defined in /wp/wp-content/mu-plugins/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php:226
Stack trace:
#0 /wp/wp-content/mu-plugins/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php(59): QM_Output_Object_Cache_Slow_Ops->output_table_cell(NULL)
#1 /wp/wp-content/mu-plugins/query-monitor/dispatchers/Html.php(323): QM_Output_Object_Cache_Slow_Ops->output()
#2 /wp/wp-includes/class-wp-hook.php(308): QM_Dispatcher_Html->dispatch('')
#3 /wp/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array)
#4 /wp/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#5 /wp/wp-includes/load.php(1124): do_action('shutdown')
#6 [internal function]: shutdown_action_hook()
#7 {main}
  thrown in /wp/wp-content/mu-plugins/qm-plugins/qm-object-cache/html/class-qm-output-object-cache-slow-ops.php on line 226
```
