### PR TITLE
Feature: Add is_disabled_by_ids() into is_enabled()

### DIFF
--- a/lib/feature/README.md
+++ b/lib/feature/README.md
@@ -49,11 +49,17 @@ public static $feature_ids = [
 ];
 ```
 
-To check:
+To check if enabled:
 
 ```php
 \Automattic\VIP\Feature::is_enabled_by_ids( 'my-awesome-complex-feature' );
 ```
+
+To check if disabled:
+```php
+\Automattic\VIP\Feature::is_disabled_by_ids( 'my-awesome-complex-feature' );
+```
+
 
 ### Defining and checking features by environment type
 

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -129,7 +129,7 @@ class Feature {
 	}
 
 	/**
-	 * Selectively enable or disable feature by certain IDs.
+	 * Selectively enable feature by certain IDs.
 	 *
 	 * @param string $feature The feature we are targeting.
 	 *

--- a/lib/feature/class-feature.php
+++ b/lib/feature/class-feature.php
@@ -55,6 +55,10 @@ class Feature {
 	 * @return bool Whether it is enabled or not.
 	 */
 	public static function is_enabled( string $feature ) {
+		if ( true === static::is_disabled_by_ids( $feature ) ) {
+			return false;
+		}
+
 		return static::is_enabled_by_percentage( $feature ) || static::is_enabled_by_ids( $feature ) || static::is_enabled_by_env( $feature );
 	}
 
@@ -106,23 +110,41 @@ class Feature {
 	}
 
 	/**
-	 * Selectively enable or disable feature by certain IDs.
+	 * Selectively disable feature by certain IDs.
 	 *
 	 * @param string $feature The feature we are targeting.
-	 * @param mixed $default Default return value if ID is not on list.
 	 *
-	 * @return mixed Returns bool if on list and if not, $default value.
+	 * @return mixed Returns true if on list.
 	 */
-	public static function is_enabled_by_ids( string $feature, $default = false ) {
+	public static function is_disabled_by_ids( string $feature ) {
 		if ( ! isset( static::$feature_ids[ $feature ] ) ) {
 			return false;
 		}
 
 		if ( array_key_exists( constant( 'FILES_CLIENT_SITE_ID' ), static::$feature_ids[ $feature ] ) ) {
-			return static::$feature_ids[ $feature ][ constant( 'FILES_CLIENT_SITE_ID' ) ];
+			return false === static::$feature_ids[ $feature ][ constant( 'FILES_CLIENT_SITE_ID' ) ];
 		}
 
-		return $default;
+		return false;
+	}
+
+	/**
+	 * Selectively enable or disable feature by certain IDs.
+	 *
+	 * @param string $feature The feature we are targeting.
+	 *
+	 * @return bool Returns true if on list.
+	 */
+	public static function is_enabled_by_ids( string $feature ) {
+		if ( ! isset( static::$feature_ids[ $feature ] ) ) {
+			return false;
+		}
+
+		if ( array_key_exists( constant( 'FILES_CLIENT_SITE_ID' ), static::$feature_ids[ $feature ] ) ) {
+			return true === static::$feature_ids[ $feature ][ constant( 'FILES_CLIENT_SITE_ID' ) ];
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/lib/feature/test-class-feature.php
+++ b/tests/lib/feature/test-class-feature.php
@@ -231,6 +231,28 @@ class Feature_Test extends TestCase {
 		$this->assertEquals( false, $result );
 	}
 
+	public function test_is_disabled_by_ids() {
+		Feature::$feature_ids = [
+			'foo'  => [
+				123 => true,
+				789 => false,
+			],
+			'bar'  => [ 456 => true ],
+			'test' => [ 456 => false ],
+		];
+
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 456 );
+
+		$result = Feature::is_disabled_by_ids( 'foo' );
+		$this->assertFalse( $result );
+
+		$result = Feature::is_disabled_by_ids( 'bar' );
+		$this->assertFalse( $result );
+
+		$result = Feature::is_disabled_by_ids( 'test' );
+		$this->assertTrue( $result );
+	}
+
 	public function test_is_enabled_by_env__non_prod() {
 		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'local' );
 
@@ -330,6 +352,21 @@ class Feature_Test extends TestCase {
 		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 123 );
 
 		$result = Feature::is_enabled( 'foo-bar-test' );
+
+		$this->assertFalse( $result );
+	}
+
+
+	public function test_is_enabled__disabled_ids() {
+		Feature::$feature_ids = [
+			'foo' => [
+				123 => false,
+			],
+		];
+
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 123 );
+
+		$result = Feature::is_enabled( 'foo' );
 
 		$this->assertFalse( $result );
 	}


### PR DESCRIPTION
## Description
If we want to explicitly disable a site ID, `is_enabled()` should take that into account. This PR adds `is_disabled_by_ids()`.

## Changelog Description

### Plugin Updated: Feature

Add `is_disabled_by_ids()`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Edit `$feature_ids` locally on dev-env to:
```
	public static $feature_ids = [
		'test-feature' => [ 200508 => false ],
	];
```
(200508 is the default site ID for dev-env)
2) shell in and do the below, expecting `false`:
```
wp> \Automattic\VIP\Feature::is_enabled( 'test-feature' );
=> bool(false)
```