### PR TITLE
Search: Improve get-last-indexed-post-id to include timestamp for debugging

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -675,9 +675,8 @@ class Search {
 
 		add_filter( 'ep_sync_indexable_kill', [ $this, 'do_not_sync_if_no_index' ], PHP_INT_MAX, 2 );
 
-		// Store last processed id into option and clean up before & after indexing command
+		// Store last processed id into option and clean up before indexing command
 		add_action( 'ep_cli_post_bulk_index', [ $this, 'update_last_processed_post_id_option' ], 10, 2 );
-		add_action( 'ep_wp_cli_after_index', [ $this, 'delete_last_processed_post_id_option' ] );
 		add_action( 'ep_wp_cli_pre_index', [ $this, 'delete_last_processed_post_id_option' ] );
 
 		// Use default ES version as fallback

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2268,7 +2268,11 @@ class Search {
 	 * @return void
 	 */
 	public function update_last_processed_post_id_option( $objects, $response ) {
-		update_option( self::LAST_INDEXED_POST_ID_OPTION, array_key_last( $objects ) );
+		$info = [
+			'post_id' => array_key_last( $objects ),
+			'time'    => gmdate( 'Y-m-d H:i:s', time() ),
+		];
+		update_option( self::LAST_INDEXED_POST_ID_OPTION, $info );
 	}
 
 	/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -675,8 +675,9 @@ class Search {
 
 		add_filter( 'ep_sync_indexable_kill', [ $this, 'do_not_sync_if_no_index' ], PHP_INT_MAX, 2 );
 
-		// Store last processed id into option and clean up before indexing command
+		// Store last processed id into option and clean up before & after indexing command
 		add_action( 'ep_cli_post_bulk_index', [ $this, 'update_last_processed_post_id_option' ], 10, 2 );
+		add_action( 'ep_wp_cli_after_index', [ $this, 'delete_last_processed_post_id_option' ] );
 		add_action( 'ep_wp_cli_pre_index', [ $this, 'delete_last_processed_post_id_option' ] );
 
 		// Use default ES version as fallback

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -516,7 +516,7 @@ class CoreCommand extends \ElasticPress\Command {
 		if ( false === $last_id ) {
 			WP_CLI::line( 'No last indexed object ID found!' );
 		} else {
-			WP_CLI::line( sprintf( 'Last indexed object ID: %d', $last_id ) );
+			WP_CLI::line( wp_json_encode( $last_id ) );
 		}
 	}
 


### PR DESCRIPTION
## Description
If an index gets interrupted, we usually use `wp vip-search get-last-indexed-post-id` to check the last post ID. This change adds the timestamp and changes it to a JSON format:
```
wp vip-search get-last-indexed-post-id                                                                                             
{"post_id":979,"time":"2023-03-24 18:15:37"}
```
## Changelog Description

### Plugin Updated: Enterprise Search

Add timestamp to `wp vip-search get-last-indexed-post-id`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Kick off an index with `wp vip-search index`
2) While the index is happening, in another window, do `wp vip-search get-last-indexed-post-id` and you should see a format similar to Description