### PR TITLE
Shift placement of stickers

### DIFF
--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -139,14 +139,13 @@ function show_debug_flag() {
 	<style>
 	#a8c-debug-flag {
 		z-index: 9991;
-		font-family: 'Helvetica Neue',Arial,Helvetica,sans-serif;
+		font: 14px/28px 'Helvetica Neue',Arial,Helvetica,sans-serif;
 		background: rgb(194,156,105);
-		bottom: 50px;
+		bottom: 145px;
 		left: 20px;
 		position: fixed;
 		width: 93px;
 		height: 28px;
-		line-height: 28px;
 	}
 
 	#a8c-debug-flag a {
@@ -158,9 +157,6 @@ function show_debug_flag() {
 		text-align: center;
 		width: 100%;
 		display: block;
-	}
-
-	#a8c-debug-flag a:hover {
 		text-decoration: none;
 	}
 	</style>

--- a/vip-helpers/sandbox.php
+++ b/vip-helpers/sandbox.php
@@ -43,16 +43,14 @@ function wpcom_do_sandbox_bar() {
 		#wpcom-sandboxed-bar {
 			z-index: 9991;
 			color:<?php echo esc_html( apply_filters( 'wpcom_sandbox_bar_debug_info_color', '#ddd' ) ); ?>;
-			font-family: 'Helvetica Neue',Arial,Helvetica,sans-serif;
-			font-size:14px;
-			bottom: 15px;
+			font: 14px/28px 'Helvetica Neue',Arial,Helvetica,sans-serif;
+			bottom: 110px;
 			left: 0;
 			position:fixed;
 			margin:0;
 			padding: 0 20px;
 			width: 100%;
 			height: 28px;
-			line-height: 28px;
 		}
 		#wpcom-sandboxed-bar span {
 			display: none;

--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -28,22 +28,20 @@ function vip_do_non_prod_bar() {
 			const debugBar = document.getElementById('a8c-debug-flag');
 			if ( debugBar ) {
 				// Account for proper stacking of the debug bar
-				nonProdBar.style.bottom = '85px';
+				nonProdBar.style.bottom = '180px';
 			}
 		</script>
 		<style>
 		#vip-non-prod-bar {
 			z-index: 9991;
-			font-family: 'Helvetica Neue',Arial,Helvetica,sans-serif;
-			font-size:14px;
+			font: 14px/28px 'Helvetica Neue',Arial,Helvetica,sans-serif;
 			left: 0;
-			bottom: 55px;
+			bottom: 145px;
 			position:fixed;
 			margin:0;
 			padding: 0 20px;
 			width: 100%;
 			height: 28px;
-			line-height: 28px;
 		}
 		#vip-non-prod-bar span {
 			display: none;


### PR DESCRIPTION
## Description
Let's shift the placement of stickers since it's been overlapping over the modal after a post is published.
Also removes underline on A8c-debug sticker so styling is consistent with the other stickers.

When a post is published:
<img width="477" alt="Screenshot 2023-03-24 at 2 22 34 PM" src="https://user-images.githubusercontent.com/16962021/227631675-42b5e10b-66f8-4776-bfc8-7e20635312f3.png">

Non-prod + a8c-debug sticker:
<img width="392" alt="Screenshot 2023-03-24 at 2 42 12 PM" src="https://user-images.githubusercontent.com/16962021/227634837-289aaf2b-5a0a-4fb9-8b2d-db60cb79e7db.png">


a8c-debug + sandboxed sticker:
<img width="1173" alt="Screenshot 2023-03-24 at 2 19 17 PM" src="https://user-images.githubusercontent.com/16962021/227631804-7758fff1-6e6c-4a95-b83e-1271895ec23a.png">

All 3 stickers:
<img width="299" alt="Screenshot 2023-03-24 at 2 42 41 PM" src="https://user-images.githubusercontent.com/16962021/227635040-bba0b5c5-6372-42a1-885c-be962cdd05d9.png">


## Changelog Description

### Non-production sticker placement updated

Shift sticker "non-production" so it doesn't block modal after post is updated

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) To see sandboxed sticker, comment out if statement in `000-vip-init.php` (leaving require statement intact):
```
if ( WPCOM_SANDBOXED ) {
	require __DIR__ . '/vip-helpers/sandbox.php';
}
```
also comment out in `vip-helpers/sandbox.php`:
```
if ( ! defined( 'WPCOM_SANDBOXED' ) || ! WPCOM_SANDBOXED ) {
	return;
}
```
2) To see a8c-debug sticker, just pass in query var `?a8c-debug=true` locally
3) Non-production sticker should be default locally
4) Do combinations of 1, 2, 3 to match screenshots in Description
5) Publish post and ensure stickers don't block modal