### PR TITLE
fix: Fix 'Undefined array key "format"' warning

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -372,7 +372,7 @@ class CoreCommand extends \ElasticPress\Command {
 		$settings = Elasticsearch::factory()->get_mapping( $index_name );
 
 		$keys = array_keys( $settings );
-		\WP_CLI\Utils\format_items( $assoc_args['format'], array( $settings ), $keys );
+		\WP_CLI\Utils\format_items( $assoc_args['format'] ?? 'table', array( $settings ), $keys );
 	}
 
 	/**


### PR DESCRIPTION
## Description

`vip -- wp vip-search get-index-settings post` generates a warning:

```
[28-Mar-2023 09:54:05 UTC] Warning: Undefined array key "format" in /chroot/var/www/wp-content/mu-plugins/search/includes/classes/commands/class-corecommand.php on line 375 [$ /usr/local/bin/wp --path=/var/www vip-search get-index-settings post] [Automattic\VIP\Search\Commands\CoreCommand->get_index_settings(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:417 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:440 WP_CLI\Runner->run_command(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1237 WP_CLI\Runner->run_command_and_exit(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28 WP_CLI\Runner->start(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php:78 WP_CLI\Bootstrap\LaunchRunner->process(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/bin/wp/php/boot-phar.php:11 include('phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/bin/wp/php/boot-phar.php')]
```

This PR‌ fixes it.

## Changelog Description

### Plugin Updated: Enterprise Search

Fix PHP warning for "wp vip-search get-index-settings"

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

`vip -- wp vip-search get-index-settings post` should work.
