### PR TITLE
Search: Do not automatically swap index versions

### DIFF
--- a/tests/search/includes/classes/test-class-settingshealthjob.php
+++ b/tests/search/includes/classes/test-class-settingshealthjob.php
@@ -289,7 +289,7 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 
 		$stub = $this->getMockBuilder( \Automattic\VIP\Search\SettingsHealthJob::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'check_process_build', 'swap_index_versions' ] )
+			->setMethods( [ 'check_process_build', 'alert_to_swap_index_versions' ] )
 			->getMock();
 
 		$stub->search = self::$search;
@@ -298,7 +298,7 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 		->willReturn( 'swap' );
 
 		$stub->expects( $this->once() )
-			->method( 'swap_index_versions' );
+			->method( 'alert_to_swap_index_versions' );
 
 		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
 		$status    = $stub->maybe_process_build( $indexable );


### PR DESCRIPTION
## Description
In a case where manual commands are being run at the same time as the cron job to rebuild a new index version with an incorrect number of shards, there's a chance of the index being swapped accidentally in a scenario where the indexing has already completed on the cron job, but the cron job to swap it has not run yet. This allows a small window for a user to delete the already-completed index and create a new one in the background. While the new one is being built in the background, at any given chance when the cron job runs, it can be swapped since it was marked as "completed".

Since most indexes have the correct shards now, we should disable the automatic swap functionality.

## Changelog Description
### Plugin Updated: Enterprise Search

Remove automatic swapping in cron job to rebuild index with incorrect number of shards.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
0) Create a new index version `wp vip-search index-versions add post` and note results from `wp vip-search index-versions list post`
1)
```
$es = new \Automattic\VIP\Search\Search();
$es->init();
$hj = new \Automattic\VIP\Search\SettingsHealthJob( $es );
$indexable = \ElasticPress\Indexables::factory()->get('post');
$hj->alert_to_swap_index_versions( \ElasticPress\Indexables::factory()->get($indexable->slug);
```
2) Check alert channel and check that `wp vip-search index-versions list post` remains the same