### PR TITLE
Don't auto-update active version when --using-versions

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -45,6 +45,10 @@ class CoreCommand extends \ElasticPress\Command {
 
 		foreach ( $indexables as $indexable ) {
 			WP_CLI::line( sprintf( 'Updating active version for "%s"', $indexable->slug ) );
+			if ( ! $skip_confirm ) {
+				WP_CLI::confirm( 'Please confirm' );
+			}
+
 			$result = $search->versioning->activate_version( $indexable, 'next' );
 			if ( is_wp_error( $result ) ) {
 				WP_CLI::error( sprintf( 'Error activating next version: %s', $result->get_error_message() ) );

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -46,7 +46,7 @@ class CoreCommand extends \ElasticPress\Command {
 		foreach ( $indexables as $indexable ) {
 			WP_CLI::line( sprintf( 'Updating active version for "%s"', $indexable->slug ) );
 			if ( ! $skip_confirm ) {
-				WP_CLI::confirm( 'Please confirm' );
+				WP_CLI::confirm( sprintf( 'Update the active index version for "%s"?' ), $indexable->slug );
 			}
 
 			$result = $search->versioning->activate_version( $indexable, 'next' );


### PR DESCRIPTION
## Description

Currently `--using-versions` automatically switches the active versions, this may lead to undesirable consequences (unattended switch). 

This PR addresses that by making switching logic ask for confirmation before the switch, unless `--skip-confirm` is passed.

## Changelog Description

### Plugin Updated: Enterprise Search

`wp vip-search index --using-versions` will ask to confirm the index version switch unless `--skip-confirm` is passed.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Run a `wp vip-search index --using-versions --indexables=post`

The output should resemble:

```
Success: Indexing posts…
Processed posts 0 - 279 of 279. Last Object ID: 1
Success: Number of posts indexed: 279
Success: Sync complete
Total time elapsed: 00:00:01.685000
Success: Done!
Updating active version for "post"
Please confirm [y/n] y
⚠️ The previous version of the index is now inactive and should be deleted. Delete previous index version? [y/n] n
```

