### PR TITLE
Remove SyncManager hooks if an indexable doesn't have an active index

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2257,6 +2257,12 @@ class Search {
 
 	public function action__init() {
 		remove_action( 'wp_initialize_site', [ \ElasticPress\Indexables::factory()->get( 'post' )->sync_manager, 'action_create_blog_index' ] );
+		// Force disable sync hooks for indexables that don't have an index, this prevents the sync manager from creating the index with broken mappings
+		foreach ( \ElasticPress\Indexables::factory()->get_all() as $indexable ) {
+			if ( ! $indexable->index_exists() && is_callable( [ $indexable->sync_manager, 'disable_sync_hooks' ] ) ) {
+				$indexable->sync_manager->disable_sync_hooks();
+			}
+		}
 	}
 
 	/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2259,8 +2259,8 @@ class Search {
 		remove_action( 'wp_initialize_site', [ \ElasticPress\Indexables::factory()->get( 'post' )->sync_manager, 'action_create_blog_index' ] );
 		// Force disable sync hooks for indexables that don't have an index, this prevents the sync manager from creating the index with broken mappings
 		foreach ( \ElasticPress\Indexables::factory()->get_all() as $indexable ) {
-			if ( ! $indexable->index_exists() && is_callable( [ $indexable->sync_manager, 'disable_sync_hooks' ] ) ) {
-				$indexable->sync_manager->disable_sync_hooks();
+			if ( ! $indexable->index_exists() && is_callable( [ $indexable->sync_manager, 'tear_down' ] ) ) {
+				$indexable->sync_manager->tear_down();
 			}
 		}
 	}


### PR DESCRIPTION
## Description

To prevent Sync Manager from ever firing on non-existing indexes (thus forcing their creation with default mappings) this PR introduces a check that goes over each indexable and disables the sync hooks by calling `disable_sync_hooks`. That method has to be implemented in each Indexable's SyncManager.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
