### PR TITLE
Search e2e: Wait for DOM elements to be loaded in openWidgetsPage()

### DIFF
--- a/tests/search/e2e/integration/features/facets.spec.js
+++ b/tests/search/e2e/integration/features/facets.spec.js
@@ -79,7 +79,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 		cy.get('.wp-block-legacy-widget')
 			.should('contain.text', 'Enterprise Search - Facet')
 			.first()
-			.click({ force: true });
+			.click();
 
 		/**
 		 * Transform the legacy widget into the block.

--- a/tests/search/e2e/integration/features/related-posts.spec.js
+++ b/tests/search/e2e/integration/features/related-posts.spec.js
@@ -157,7 +157,7 @@ describe('Related Posts Feature', () => {
 		/**
 		 * Transform the legacywidget into the block.
 		 */
-		cy.get('@widget').click({ force:true });
+		cy.get('@widget').click();
 		cy.get('.block-editor-block-switcher button').click();
 	});
 });

--- a/tests/search/e2e/support/commands.js
+++ b/tests/search/e2e/support/commands.js
@@ -52,6 +52,7 @@ Cypress.Commands.add('visitAdminPage', (page = 'index.php') => {
 Cypress.Commands.add('openWidgetsPage', () => {
 	cy.login();
 	cy.visitAdminPage('widgets.php');
+	cy.wait(3000); // Wait for all DOM elements to be loaded
 	cy.get('body').then(($body) => {
 		const $button = $body.find('.edit-widgets-welcome-guide .components-modal__header button');
 		if ($button.is(':visible')) {


### PR DESCRIPTION
## Description
I prefer this approach over #4296, where we are forcing a click, but in reality, all the DOM elements haven't loaded yet. 🙂 It does slow the test down by a tad, but better for accuracy-wise. 
