### PR TITLE
chore(dev-deps): Update eslint-plugin-cypress, @wordpress/api-fetch, @wordpress/env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5116,9 +5116,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.14.0.tgz",
-      "integrity": "sha512-kLB3alkOMgQ4EE8inQCMRN1hmUJ3iaPc+xGKDaHgbY8TqNSiA0FXttMinBPz5wzOytj8gyeCP3ff5GQrVezAnw==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.15.0.tgz",
+      "integrity": "sha512-2e4S9+RRaptujTE5v5xWKL4jv25KRNI4qu57VsBKqnn0nfoHqNe0UAgjkcKiygcrd4rRjfGY+4pLa7SU/Qczdg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5074,13 +5074,13 @@
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.26.0.tgz",
-      "integrity": "sha512-gAishZDwMkcAakgIO4qgKzUR9VTMWOTNuRlP4Y0KozoI42EXvBomjlnH0nvlPXRf1K4vfmS2Bx03bpma5OPrBQ==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.27.0.tgz",
+      "integrity": "sha512-5DAOOhvA4rmAGIoQX8gbut73Ls0nD5vKo4ImhaeMt+5o7JO7Mn+FU1t7GFy2MwzdBEu/toh/XuCHqF6F3HaooQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.29.0",
-        "@wordpress/url": "^3.30.0"
+        "@wordpress/i18n": "^4.30.0",
+        "@wordpress/url": "^3.31.0"
       },
       "engines": {
         "node": ">=12"
@@ -5209,9 +5209,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.29.0.tgz",
-      "integrity": "sha512-zegXz35LCUntVgCMLfTNuzC42TEMetGp2mcdNEZdQRDOrjxoqdXZrIRRupJBdJduKvUjwjG/aL+61svq8WpBXw==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.30.0.tgz",
+      "integrity": "sha512-cvM5OWMQx0D2+wxvsTCI68LXy4cHz1Db97LliiQ+KprSBmYRG5Uy2PqtPv1sMlK8IOypKOlzmG5H5V1CwBN44A==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5220,12 +5220,12 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.29.0.tgz",
-      "integrity": "sha512-7azBKWunyHhGHAvRTR7dytURV5UcJnMSbnMB+TfAhxJu7wMBUR/wHHaMWEbshCYN79KKabNSMhqHTcUnETKdCQ==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.30.0.tgz",
+      "integrity": "sha512-vIntwrTBSU2MXOBlpyFntPgimHP+RW+k7/Y00BMPL+xoxPr7J7sXX/GNoYlH1BNsAo7XOi5AY5FrUnQ7ZIYdtQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.29.0",
+        "@wordpress/hooks": "^3.30.0",
         "gettext-parser": "^1.3.1",
         "memize": "^1.1.0",
         "sprintf-js": "^1.1.1",
@@ -5272,9 +5272,9 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.30.0.tgz",
-      "integrity": "sha512-RtvReNo2TRuorS4JdgVeV53mgDJeMrWokCiE4LV2oTdguGuBrlQ3YcywEApfZMkoAY7MSwxexy1WAfyBdee/qg==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.31.0.tgz",
+      "integrity": "sha512-3sxbDKU8OQTeGat3Roef9dN/NR0Rb6ld9KN0618Ec+FHU05dI+7nolA0jfOAJka+Vvf7gfP0WQ7cJAZdlwfNuw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "remove-accents": "^0.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9869,9 +9869,9 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
-      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.2.tgz",
+      "integrity": "sha512-LlwjnBTzuKuC0A4H0RxVjs0YeAWK+CD1iM9Dp8un3lzT713ePQxfpPstCD+9HSAss8emuE3b2hCNUST+NrUwKw==",
       "dev": true,
       "dependencies": {
         "globals": "^11.12.0"


### PR DESCRIPTION
A combined PR for #4284, #4287, and #4289.

* [chore(deps-dev): bump eslint-plugin-cypress from 2.12.1 to 2.13.2](https://github.com/Automattic/vip-go-mu-plugins/commit/4dfd9aff1848e7bb35d7286cfce190df8f0d31f6)
* [chore(deps): bump @wordpress/api-fetch from 6.26.0 to 6.27.0](https://github.com/Automattic/vip-go-mu-plugins/commit/f3ae14be72dd3eb6cd0c397394c978e1df5d36a3)
* [chore(deps-dev): bump @wordpress/env from 5.14.0 to 5.15.0](https://github.com/Automattic/vip-go-mu-plugins/commit/9163686b8073c015a15c43daa55496b9d1ec308a)
