### PR TITLE
Fix fatal error in "widget updated" event

### DIFF
--- a/vip-parsely/Telemetry/Events/track-widget-updated.php
+++ b/vip-parsely/Telemetry/Events/track-widget-updated.php
@@ -14,14 +14,18 @@ use WP_Widget;
 /**
  * Records an event using the given Telemetry System whenever a `parsely_recommended_widget` instance is updated.
  *
- * @param array $instance The current widget instance's settings.
+ * @param array|false $instance The current widget instance's settings.
  * @param array|null $new_instance Array of new widget settings.
  * @param array|null $old_instance Array of old widget settings.
  * @param WP_Widget $widget_obj The current widget instance.
  * @param Telemetry_System $telemetry_system
  * @return array Updated widget settings
  */
-function track_widget_updated( array $instance, ?array $new_instance, ?array $old_instance, WP_Widget $widget_obj, Telemetry_System $telemetry_system ): array {
+function track_widget_updated( $instance, ?array $new_instance, ?array $old_instance, WP_Widget $widget_obj, Telemetry_System $telemetry_system ): array {
+	if ( ! is_array( $instance ) ) {
+		return $instance;
+	}
+
 	$id_base = $widget_obj->id_base;
 	if ( WP_PARSELY_RECOMMENDED_WIDGET_BASE_ID !== $id_base ) {
 		return $instance;


### PR DESCRIPTION
## Description
@bratvanov recently reported a fatal error that was occurring in our code in the `widget updated` event:

> We are getting a fatal error in a preproduction environment when attempting to save a custom widget. The stack trace shows `false` is passed to the `track_widget_updated` function but it expects an `array`.
> 
> This looks to be an issue with our code in mu plugins. The code didn’t account for the case where we could pass `false` to short-circuit the update. It just assumes the `$instance` is always an `array`.
> 
> https://developer.wordpress.org/reference/hooks/widget_update_callback/

Reading the docs above, although the `$instance` variable is typed as an array, the docs [explicitly state](https://developer.wordpress.org/reference/hooks/widget_update_callback/#description):
> Returning `false` will effectively short-circuit the widget’s ability to update settings.

Since our docs mention the `false` value as a way to short-circuit the update, we should be supporting it. This PR makes the function more flexible to receiving a `false` value, and returning if the `$instance` variable is not an array.

## Changelog Description

### Fixed error in the "widget updated" event

We fixed a fatal error that could occur in the "widget updated" event when attempting to save a custom widget.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.