### PR TITLE
Don't add objects to queue if index doesn't exist

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -385,6 +385,12 @@ class Queue {
 			return;
 		}
 
+		$indexable = Indexables::factory()->get( $indexable_slug );
+
+		if ( ! $indexable || ! \ElasticPress\Elasticsearch::factory()->index_exists( $indexable->get_index_name() ) ) {
+			return;
+		}
+
 		foreach ( $object_ids as $object_id ) {
 			$this->queue_object( $object_id, $indexable_slug, $options );
 		}

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -313,6 +313,10 @@ class Queue {
 			return new WP_Error( 'invalid-indexable', sprintf( 'Indexable not found for type %s', $indexable_slug ) );
 		}
 
+		if ( ! \ElasticPress\Elasticsearch::factory()->index_exists( $indexable->get_index_name() ) ) {
+			return new WP_Error( 'index-not-exists', sprintf( 'Index not found for type %s', $indexable_slug ) );
+		}
+
 		global $wpdb;
 
 		$next_index_time = $this->get_next_index_time( $object_id, $indexable_slug );

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -387,7 +387,7 @@ class Queue {
 
 		$indexable = Indexables::factory()->get( $indexable_slug );
 
-		if ( ! $indexable || ! \ElasticPress\Elasticsearch::factory()->index_exists( $indexable->get_index_name() ) ) {
+		if ( ! $indexable || ! $indexable->index_exists() ) {
 			return;
 		}
 

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -313,7 +313,7 @@ class Queue {
 			return new WP_Error( 'invalid-indexable', sprintf( 'Indexable not found for type %s', $indexable_slug ) );
 		}
 
-		if ( ! \ElasticPress\Elasticsearch::factory()->index_exists( $indexable->get_index_name() ) ) {
+		if ( ! $indexable->index_exists() ) {
 			return new WP_Error( 'index-not-exists', sprintf( 'Index not found for type %s', $indexable_slug ) );
 		}
 

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -56,6 +56,14 @@ class Queue_Test extends WP_UnitTestCase {
 		$this->queue->schema->prepare_table();
 
 		$this->queue->empty_queue();
+
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_ok' ], PHP_INT_MAX, 5 );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_ok' ], PHP_INT_MAX );
+
+		parent::tearDown();
 	}
 
 	public function get_index_version_number_from_options_data() {
@@ -1274,6 +1282,51 @@ class Queue_Test extends WP_UnitTestCase {
 				);
 
 		$this->queue->log_index_ratelimiting_start();
+	}
+
+	public function test__no_index_queueing() {
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_ok' ], PHP_INT_MAX );
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_bad' ], PHP_INT_MAX, 5 );
+
+		$result = $this->queue->queue_object( 1000, 'post' );
+		$this->assertWPError( $result );
+
+		$object_ids = array(
+			'12',
+			'45',
+			'89',
+			'246',
+		);
+		$result     = $this->queue->queue_objects( $object_ids );
+		$this->assertNull( $result );
+
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_bad' ], PHP_INT_MAX );
+	}
+
+	/**
+	 * We need to fake the OK response from the ES server to avoid the actual request.
+	 */
+	public function filter_index_exists_request_ok( $request, $query, $args, $failures, $type ) {
+		if ( 'index_exists' === $type ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => [],
+			];
+		}
+		return $request;
+	}
+
+	/**
+	 * We need to fake the bad response from the ES server to avoid the actual request.
+	 */
+	public function filter_index_exists_request_bad( $request, $query, $args, $failures, $type ) {
+		if ( 'index_exists' === $type ) {
+			return [
+				'response' => [ 'code' => 404 ],
+				'body'     => [],
+			];
+		}
+		return $request;
 	}
 
 	/**

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -73,8 +73,22 @@ class Versioning_Test extends WP_UnitTestCase {
 		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 200508 );
 	}
 
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_ok' ], PHP_INT_MAX, 5 );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_ok' ], PHP_INT_MAX );
+
+		parent::tearDown();
+	}
+
 	public static function tearDownAfterClass(): void {
 		Constant_Mocker::clear();
+
+		parent::tearDownAfterClass();
 	}
 
 	public function get_next_version_number_data() {


### PR DESCRIPTION
## Description

There's no particularly good reason to add anything to queue if an index doesn't exist. It means that the initial set up was not performed yet. It also has negative implications (a default mapping might be used which leaves the index in a broken state).

This PR addresses that by adding checks both to `queue_object` and `queue_objects` method to prevent pushing anything into queue if an index doesn't exist.

## Changelog Description

### Plugin Updated: Enteprise Search

Improved handling of async queue in scenarios where an index doesn't exist yet.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Have Search active but don't do the set up steps
2. Use `wp post generate` to generate a few hundred of posts
3. Edit the `Uncategorized` term
4. Verify the queue is at `0` 
5. Run `wp vip-search index --setup` 
6. Repeat the steps and verify that the queue is not empty anymore.
