### PR TITLE
Search: Add constant to disable search

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1171,20 +1171,23 @@ class Health {
 
 		return $result;
 	}
-	/**
-	 * Verify if the post mapping is incorrect from running `wp vip-search index` without the --setup flag on initial indexing.
-	 *
-	 * @param mixed $indexable Instance of an ElasticPress post Indexable
-	 * @return bool Whether mapping is correct
-	 */
-	public function validate_post_index_mapping( $indexable ) {
-		$index_name = $indexable->get_index_name();
-		$mapping    = $this->elasticsearch->get_mapping( $index_name );
 
-		if ( ! isset( $mapping[ $index_name ]['mappings']['_meta']['mapping_version'] ) ) {
-			return false;
+	/**
+	 * Validate post index has correct mapping.
+	 *
+	 * @param string $index_name Name of index
+	 * @param array $mapping Mapping array
+	 * @return bool Whether index has correct mapping
+	 */
+	public static function validate_post_index_mapping( $index_name, $mapping = [] ) {
+		if ( empty( $mapping ) ) {
+			$mapping = \ElasticPress\Elasticsearch::factory()->get_mapping( $index_name );
 		}
 
-		return true;
+		if ( isset( $mapping[ $index_name ]['mappings']['_meta']['mapping_version'] ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -89,6 +89,7 @@ class Versioning {
 	 * that index active
 	 *
 	 * @param \ElasticPress\Indexable $indexable The Indexable type for which to temporarily set the current index version
+	 * @param int $version_number Index version number to set
 	 * @return bool|WP_Error True on success, or WP_Error on failure
 	 */
 	public function set_current_version_number( Indexable $indexable, $version_number ) {
@@ -136,7 +137,6 @@ class Versioning {
 	 * (Function ReflectionType::__toString() is deprecated), because we mock this function, which causes __toString() to be called for params
 	 *
 	 * @param \ElasticPress\Indexable $indexable The Indexable type for which to get the current version number
-	 *
 	 * @return int The current version number
 	 */
 	public function get_current_version_number( $indexable ) {
@@ -287,7 +287,9 @@ class Versioning {
 	/**
 	 * Given a version number, normalize it by translating any aliases into actual version numbers
 	 *
+	 * @param Indexable $indexable Indexable
 	 * @param int|string $version_number The version number to normalize, can be an id or alias like "next" or "previous"
+	 * @return int|WP_Error $version_number Normalized version number
 	 */
 	public function normalize_version_number( Indexable $indexable, $version_number ) {
 		if ( is_int( $version_number ) ) {
@@ -412,10 +414,10 @@ class Versioning {
 	}
 
 	/**
-	 * Retrieve details about available index versions
+	 * Add new index version
 	 *
 	 * @param \ElasticPress\Indexable $indexable The Indexable for which to create a new version
-	 * @return bool Boolean indicating if the new version was successfully added or not
+	 * @return array|WP_Error Array of new version if successfully added, WP_Error if not.
 	 */
 	public function add_version( Indexable $indexable ) {
 		$versions = $this->get_versions( $indexable );
@@ -451,13 +453,53 @@ class Versioning {
 		$result = $this->update_versions( $indexable, $versions );
 
 		if ( true !== $result ) {
-			return $result;
+			return new WP_Error( 'es-update-versions-failed', 'Failed updating versions with new version' );
 		}
 
 		// Setup the index + mapping so that it's available for immediate use (as changes will start getting replicated here)
-		$this->create_versioned_index_with_mapping( $indexable, $new_version_number );
+		$new_index = $this->create_versioned_index_with_mapping( $indexable, $new_version_number );
+		if ( ! $new_index ) {
+			return new WP_Error( 'es-create-new-index-failed', 'Unable to properly create new index with mapping' );
+		} elseif ( is_wp_error( $new_index ) ) {
+			return $new_index;
+		}
+
+		$new_index_name = $this->get_index_name( $indexable, $new_version_number );
+		if ( ! \ElasticPress\Elasticsearch::factory()->index_exists( $new_index_name ) ) {
+			return new WP_Error( 'es-new-index-non-existence', sprintf( 'New index "%s" does not exist', $new_index_name ) );
+		}
+		if ( 'post' === $indexable->slug ) {
+			$is_mapping_ok = Health::validate_post_index_mapping( $new_index_name );
+
+			if ( ! $is_mapping_ok ) {
+				return new WP_Error( 'es-bad-mapping-new-index', sprintf( 'Validation for new index "%s" with correct mapping failed', $new_index_name ) );
+			}
+		}
 
 		return $new_version;
+	}
+
+	/**
+	 * Generates index name based off of Indexable and version number.
+	 *
+	 * @param Indexable $indexable Indexable type
+	 * @param int $version Index version
+	 * @return string $index_name Index name
+	 */
+	public function get_index_name( $indexable, $version ) {
+		$index_name = sprintf( 'vip-%s-%s', constant( 'FILES_CLIENT_SITE_ID' ), $indexable->slug );
+
+		// $blog_id won't be appended onto global indexes (such as users)
+		if ( ! $indexable->global ) {
+			$blog_id     = get_current_blog_id();
+			$index_name .= sprintf( '-%s', $blog_id );
+		}
+
+		if ( $version > 1 ) {
+			$index_name .= sprintf( '-v%d', $version );
+		}
+
+		return $index_name;
 	}
 
 	/**
@@ -465,6 +507,7 @@ class Versioning {
 	 *
 	 * @param \ElasticPress\Indexable $indexable The Indexable type for which to create the new versioned index
 	 * @param int|string $version_number The index version number to create
+	 * @return bool Whether index was created successfully or not
 	 */
 	public function create_versioned_index_with_mapping( $indexable, $version_number ) {
 		$version_number = $this->normalize_version_number( $indexable, $version_number );

--- a/search/includes/classes/commands/class-versioncommand.php
+++ b/search/includes/classes/commands/class-versioncommand.php
@@ -73,10 +73,6 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			return WP_CLI::error( $new_version->get_error_message() );
 		}
 
-		if ( false === $new_version ) {
-			return WP_CLI::error( 'Failed to register the new index version' );
-		}
-
 		return $new_version;
 	}
 

--- a/search/search.php
+++ b/search/search.php
@@ -18,6 +18,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+// If VIP_ELASTICSEARCH_DISABLED is explicitly set to `true`, then don't load the plugin
+if ( defined( 'VIP_ELASTICSEARCH_DISABLED' ) && true === constant( 'VIP_ELASTICSEARCH_DISABLED' ) ) {
+	return;
+}
+
 require_once __DIR__ . '/includes/functions/utils.php';
 require_once __DIR__ . '/includes/classes/class-search.php';
 

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -1604,6 +1604,17 @@ class Health_Test extends WP_UnitTestCase {
 				// Expected result
 				false,
 			],
+			// Bad mapping
+			[
+				// Index name
+				'bar-post-1',
+				// Mapping
+				[
+					'bar-post-1' => [],
+				],
+				// Expected result
+				false,
+			],
 			// Good mapping
 			[
 				// Index name
@@ -1627,22 +1638,8 @@ class Health_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider validate_post_index_mapping_data
 	 */
-	public function test_validate_post_index_mapping( $idx_name, $mapping, $expected_result ) {
-		/** @var \ElasticPress\Indexable&MockObject */
-		$mocked_indexable       = $this->getMockBuilder( \ElasticPress\Indexable::class )
-									->setMethods( self::$indexable_methods )
-									->getMock();
-		$mocked_indexable->slug = 'post';
-		$mocked_indexable->method( 'get_index_name' )->willReturn( $idx_name );
-
-		$health                = new Health( self::$search_instance );
-		$health->elasticsearch = $this->getMockBuilder( \ElasticPress\Elasticsearch::class )
-									->setMethods( [ 'get_mapping' ] )
-									->getMock();
-
-		$health->elasticsearch->method( 'get_mapping' )->willReturn( $mapping )->with( $idx_name );
-
-		$correct_mapping = $health->validate_post_index_mapping( $mocked_indexable );
-		$this->assertEquals( $correct_mapping, $expected_result );
+	public function test__validate_post_index_mapping( $index_name, $mapping, $expected_result ) {
+		$correct_mapping = \Automattic\VIP\Search\Health::validate_post_index_mapping( $index_name, $mapping );
+		$this->assertEquals( $expected_result, $correct_mapping );
 	}
 }

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -5,6 +5,7 @@ namespace Automattic\VIP\Search;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_Error;
 use WP_UnitTestCase;
+use Automattic\Test\Constant_Mocker;
 
 // phpcs:disable Squiz.PHP.CommentedOutCode.Found -- false positives
 
@@ -15,6 +16,27 @@ use WP_UnitTestCase;
 class Versioning_Test extends WP_UnitTestCase {
 	public static $version_instance;
 	public static $search;
+
+	/** @var array */
+	private static $indexable_methods = [
+		'query_es',
+		'query_db',
+		'format_args',
+		'get_mapping',
+		'prepare_document',
+		'put_mapping',
+		'build_mapping',
+		'index_exists',
+		'get_index_name',
+		'get_index_settings',
+		'update_index_settings',
+	];
+
+	public function mock_http_response( $mocked_response ) {
+		add_filter( 'pre_http_request', function( $response, $args, $url ) use ( $mocked_response ) {
+			return $mocked_response;
+		}, 10, 3 );
+	}
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
@@ -39,6 +61,20 @@ class Versioning_Test extends WP_UnitTestCase {
 		do_action( 'init' );
 
 		self::$version_instance = self::$search->versioning;
+
+		add_filter( 'ep_intercept_remote_request', '__return_true' );
+
+		if ( method_exists( \ElasticPress\Indexable::class, 'build_settings' ) ) {
+			self::$indexable_methods[] = 'build_settings';
+		} else {
+			self::$indexable_methods[] = 'generate_mapping';
+		}
+
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 200508 );
+	}
+
+	public static function tearDownAfterClass(): void {
+		Constant_Mocker::clear();
 	}
 
 	public function get_next_version_number_data() {
@@ -553,8 +589,8 @@ class Versioning_Test extends WP_UnitTestCase {
 			array(
 				// Input array of versions
 				array(
-					2 => array(
-						'number' => 2,
+					1 => array(
+						'number' => 1,
 						'active' => false,
 					),
 				),
@@ -562,12 +598,12 @@ class Versioning_Test extends WP_UnitTestCase {
 				'post',
 				// Expected new versions
 				array(
-					2 => array(
-						'number' => 2,
+					1 => array(
+						'number' => 1,
 						'active' => false,
 					),
-					3 => array(
-						'number' => 3,
+					2 => array(
+						'number' => 2,
 						'active' => false,
 					),
 				),
@@ -575,12 +611,12 @@ class Versioning_Test extends WP_UnitTestCase {
 			array(
 				// Input array of versions
 				array(
-					2 => array(
-						'number' => 2,
+					1 => array(
+						'number' => 1,
 						'active' => true,
 					),
-					3 => array(
-						'number' => 3,
+					2 => array(
+						'number' => 2,
 						'active' => false,
 					),
 				),
@@ -619,8 +655,12 @@ class Versioning_Test extends WP_UnitTestCase {
 
 		self::$version_instance->update_versions( $indexable, $versions );
 
+		$this->setup_ok_es_requests();
+
 		// Add the new version
 		$new_version = self::$version_instance->add_version( $indexable );
+
+		$this->clean_up_ok_es_requests();
 
 		if ( is_wp_error( $new_version ) ) {
 			$this->assertEquals( $expected_new_versions, $new_version, 'The WP_Error thrown should match the expected WP_Error' );
@@ -975,7 +1015,11 @@ class Versioning_Test extends WP_UnitTestCase {
 
 		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
 
+		$this->setup_ok_es_requests();
+
 		$result = self::$version_instance->add_version( $indexable );
+
+		$this->clean_up_ok_es_requests();
 
 		$this->assertNotFalse( $result, 'Failed to add new version of index' );
 		$this->assertNotInstanceOf( \WP_Error::class, $result, 'Got WP_Error when adding new index version' );
@@ -1332,7 +1376,11 @@ class Versioning_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 1, $one['number'], 'Wrong version number for returned version (expected 1)' );
 
+		$this->setup_ok_es_requests();
+
 		$new = self::$version_instance->add_version( $indexable );
+
+		$this->clean_up_ok_es_requests();
 
 		$new_retrieved = self::$version_instance->get_version( $indexable, $new['number'] );
 
@@ -1822,6 +1870,29 @@ class Versioning_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $result );
 	}
 
+	public function test__create_versioned_index_with_mapping__ok_mapping() {
+		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
+
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter_put_mapping_request_ok' ], PHP_INT_MAX, 5 );
+
+		$result = self::$version_instance->create_versioned_index_with_mapping( $indexable, 2 );
+
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_put_mapping_request_ok' ], PHP_INT_MAX );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test__create_versioned_index_with_mapping__bad_mapping() {
+		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
+
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter_put_mapping_request_bad' ], PHP_INT_MAX, 5 );
+
+		$result = self::$version_instance->create_versioned_index_with_mapping( $indexable, 2 );
+
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_put_mapping_request_bad' ], PHP_INT_MAX );
+
+		$this->assertFalse( $result );
+	}
 
 	/**
 	 * Helper function for accessing protected properties.
@@ -1833,5 +1904,139 @@ class Versioning_Test extends WP_UnitTestCase {
 		$property->setAccessible( true );
 
 		return $property;
+	}
+
+	public function get_index_name_data__post() {
+		return [
+			[
+				// Version
+				1,
+				// Blog ID
+				1,
+				// App ID
+				200508,
+				// Expected result
+				'vip-200508-post-1',
+				// Indexable
+				'post',
+			],
+			[
+				// Version
+				3,
+				// Blog ID
+				1,
+				// App ID
+				123,
+				// Expected result
+				'vip-123-post-1-v3',
+				// Indexable
+				'post',
+			],
+			[
+				// Version
+				null,
+				// Blog ID
+				1,
+				// App ID
+				665,
+				// Expected result
+				'vip-665-user',
+				// Indexable
+				'user',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_index_name_data__post
+	 */
+	public function test__get_index_name__post( $version, $blog_id, $app_id, $expected, $indexable ) {
+		Constant_Mocker::clear();
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', $app_id );
+
+		/** @var \ElasticPress\Indexable&MockObject */
+		$mocked_indexable = $this->getMockBuilder( \ElasticPress\Indexable::class )
+			->setMethods( self::$indexable_methods )
+			->getMock();
+		if ( 'post' === $indexable ) {
+			$mocked_indexable->slug   = 'post';
+			$mocked_indexable->global = false;
+		} elseif ( 'user' === $indexable ) {
+			$mocked_indexable->slug   = 'user';
+			$mocked_indexable->global = true;
+		}
+
+		$index_name = self::$version_instance->get_index_name( $mocked_indexable, $version );
+		$this->assertEquals( $expected, $index_name );
+	}
+
+	/**
+	 * This fakes the needed ES requests for add_version() to work correctly
+	 */
+	private function setup_ok_es_requests() {
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter_put_mapping_request_ok' ], PHP_INT_MAX, 5 );
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_ok' ], PHP_INT_MAX, 5 );
+		add_filter( 'ep_do_intercept_request', [ $this, 'filter_get_mapping_request_ok' ], PHP_INT_MAX, 5 );
+	}
+
+	/**
+	 * Removes the filter from clean_up_ok_es_requests()
+	 */
+	private function clean_up_ok_es_requests() {
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_put_mapping_request_ok' ], PHP_INT_MAX );
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_index_exists_request_ok' ], PHP_INT_MAX );
+		remove_filter( 'ep_do_intercept_request', [ $this, 'filter_get_mapping_request_ok' ], PHP_INT_MAX );
+	}
+
+	/**
+	 * We need to fake the OK response from the ES server to avoid the actual request.
+	 */
+	public function filter_index_exists_request_ok( $request, $query, $args, $failures, $type ) {
+		if ( 'index_exists' === $type ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => [],
+			];
+		}
+		return $request;
+	}
+
+	/**
+	 * We need to fake the OK response from the ES server to avoid the actual failing put_mapping request.
+	 */
+	public function filter_put_mapping_request_ok( $request, $query, $args, $failures, $type ) {
+		if ( 'put_mapping' === $type ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => '',
+			];
+		}
+		return $request;
+	}
+
+	/**
+	 * We need to fake the failed mapping response from the ES server.
+	 */
+	public function filter_put_mapping_request_bad( $request, $query, $args, $failures, $type ) {
+		if ( 'put_mapping' === $type ) {
+			return [
+				'response' => [ 'code' => 400 ],
+				'body'     => '',
+			];
+		}
+		return $request;
+	}
+
+	/**
+	 * We need to fake the OK response from the ES server to avoid the actual get_mapping request.
+	 */
+	public function filter_get_mapping_request_ok( $request, $query, $args, $failures, $type ) {
+		if ( 'get_mapping' === $type ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => '{"vip-200508-post-1-v2":{"aliases":{},"mappings":{"_meta":{"mapping_version":"7-0.php"}}}}', // phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation
+			];
+		}
+		return $request;
 	}
 }


### PR DESCRIPTION
## Description
The constant `VIP_ELASTICSEARCH_DISABLED` explicitly disables the loading of search as a killswitch

## Changelog Description

### Plugin Updated: Enterprise Search

Add `VIP_ELASTICSEARCH_DISABLED` killswitch constant

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Add to vip-config to enable ES:
```
define( 'VIP_ENABLE_VIP_SEARCH', true ); // Enables Enterprise Search
define( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION', true ); // Integrates search queries with Enterprise Search
```
2) Check search is enabled
3) Add to vip-config to disable ES (leaving the code in step 1):
```
define( 'VIP_ELASTICSEARCH_DISABLED', true );
```
4) Check search is disabled