### PR TITLE
Disables Parse.ly if VIP_PARSELY_SKIP_LOAD or VIP_IS_FEDRAMP constant is set

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -128,9 +128,16 @@ if ( ! defined( 'WPCOM_VIP_MAIL_TRACKING_KEY' ) ) {
 // Define constants for custom VIP Go paths
 define( 'WPCOM_VIP_CLIENT_MU_PLUGIN_DIR', WP_CONTENT_DIR . '/client-mu-plugins' );
 
-// FedRAMP sites do not load Jetpack by default
-if ( method_exists( Context::class, 'is_fedramp' ) && Context::is_fedramp() && ! defined( 'VIP_JETPACK_SKIP_LOAD' ) ) {
-	define( 'VIP_JETPACK_SKIP_LOAD', true );
+if ( method_exists( Context::class, 'is_fedramp' ) && Context::is_fedramp() ) {
+	// FedRAMP sites do not load Jetpack by default
+	if ( ! defined( 'VIP_JETPACK_SKIP_LOAD' ) ) {
+		define( 'VIP_JETPACK_SKIP_LOAD', true );
+	}
+
+	// FedRAMP sites do not load Parse.ly by default
+	if ( ! defined( 'VIP_PARSELY_SKIP_LOAD' ) ) {
+		define( 'VIP_PARSELY_SKIP_LOAD', true );
+	}
 }
 
 $private_dir_path = WP_CONTENT_DIR . '/private'; // Local fallback

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -208,7 +208,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertFalse( Parsely_Loader_Info::is_active() );
-		$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+		$this->assertEquals( Parsely_Integration_Type::BLOCKED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 	}
 
 	public function test_parsely_ui_hooks() {

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -170,6 +170,67 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_bootstrap_modes_for_parsely_skip_load_constant() {
+		define( 'VIP_PARSELY_SKIP_LOAD', true );
+		$this->verify_disabled_constant_integration_type();
+	}
+
+	public function test_bootstrap_modes_for_fedramp() {
+		define( 'VIP_IS_FEDRAMP', true );
+		$this->verify_disabled_constant_integration_type();
+	}
+
+	public function verify_disabled_constant_integration_type() {
+		maybe_load_plugin();
+
+		switch ( self::$test_mode ) {
+			case 'disabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'filter_enabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'filter_disabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'option_enabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'option_disabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'filter_and_option_enabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+				break;
+			case 'filter_and_option_disabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
+				$this->assertFalse( Parsely_Loader_Info::is_active() );
+				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+				break;
+			default:
+				$this->fail( 'Invalid test mode specified: ' . self::$test_mode );
+		}
+	}
+
 	public function test_parsely_ui_hooks() {
 		maybe_load_plugin();
 

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -172,63 +172,43 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 
 	public function test_bootstrap_modes_for_parsely_skip_load_constant() {
 		define( 'VIP_PARSELY_SKIP_LOAD', true );
-		$this->verify_disabled_constant_integration_type();
-	}
-
-	public function test_bootstrap_modes_for_fedramp() {
-		define( 'VIP_IS_FEDRAMP', true );
-		$this->verify_disabled_constant_integration_type();
-	}
-
-	public function verify_disabled_constant_integration_type() {
 		maybe_load_plugin();
 
 		switch ( self::$test_mode ) {
 			case 'disabled':
 				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'filter_enabled':
 				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'filter_disabled':
 				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'option_enabled':
 				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'option_disabled':
 				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'filter_and_option_enabled':
 				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 				break;
 			case 'filter_and_option_disabled':
 				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse( Parsely_Loader_Info::is_active() );
-				$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 				break;
 			default:
 				$this->fail( 'Invalid test mode specified: ' . self::$test_mode );
 		}
+
+		$this->assertFalse( Parsely_Loader_Info::is_active() );
+		$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 	}
 
 	public function test_parsely_ui_hooks() {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -186,11 +186,8 @@ function maybe_load_plugin() {
 		return;
 	}
 
-	$is_disabled_via_constant = defined( 'VIP_PARSELY_SKIP_LOAD' ) && true === constant( 'VIP_PARSELY_SKIP_LOAD' );
-	$is_fedramp               = defined( 'VIP_IS_FEDRAMP' ) && true === constant( 'VIP_IS_FEDRAMP' );
-
-	// Allow opting out via the VIP_PARSELY_SKIP_LOAD or VIP_IS_FEDRAMP constants.
-	if ( $is_disabled_via_constant || $is_fedramp ) {
+	// Allow opting out via the VIP_PARSELY_SKIP_LOAD constant
+	if ( defined( 'VIP_PARSELY_SKIP_LOAD' ) && true === constant( 'VIP_PARSELY_SKIP_LOAD' ) ) {
 		Parsely_Loader_Info::set_active( false );
 		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_CONSTANT );
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -13,8 +13,6 @@
 
 namespace Automattic\VIP\WP_Parsely_Integration;
 
-use stdClass;
-
 // The default version is the first entry in the SUPPORTED_VERSIONS list.
 const SUPPORTED_VERSIONS = [
 	'3.8',
@@ -188,6 +186,17 @@ function maybe_load_plugin() {
 		return;
 	}
 
+	$is_disabled_via_constant = defined( 'VIP_PARSELY_SKIP_LOAD' ) && true === constant( 'VIP_PARSELY_SKIP_LOAD' );
+	$is_fedramp               = defined( 'VIP_IS_FEDRAMP' ) && true === constant( 'VIP_IS_FEDRAMP' );
+
+	// Allow opting out via the VIP_PARSELY_SKIP_LOAD or VIP_IS_FEDRAMP constants.
+	if ( $is_disabled_via_constant || $is_fedramp ) {
+		Parsely_Loader_Info::set_active( false );
+		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_CONSTANT );
+
+		return;
+	}
+
 	// Self-managed integration: The plugin exists on the site and is being loaded already.
 	$plugin_class_exists = class_exists( 'Parsely' ) || class_exists( 'Parsely\Parsely' );
 	if ( $plugin_class_exists ) {
@@ -321,6 +330,7 @@ abstract class Parsely_Integration_Type {
 
 	const DISABLED_MUPLUGINS_FILTER        = 'DISABLED_MUPLUGINS_FILTER';
 	const DISABLED_MUPLUGINS_SILENT_OPTION = 'DISABLED_MUPLUGINS_SILENT_OPTION';
+	const DISABLED_CONSTANT                = 'DISABLED_CONSTANT';
 
 	const SELF_MANAGED = 'SELF_MANAGED';
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -189,7 +189,7 @@ function maybe_load_plugin() {
 	// Allow opting out via the VIP_PARSELY_SKIP_LOAD constant
 	if ( defined( 'VIP_PARSELY_SKIP_LOAD' ) && true === constant( 'VIP_PARSELY_SKIP_LOAD' ) ) {
 		Parsely_Loader_Info::set_active( false );
-		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_CONSTANT );
+		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::BLOCKED_CONSTANT );
 
 		return;
 	}
@@ -327,11 +327,11 @@ abstract class Parsely_Integration_Type {
 
 	const DISABLED_MUPLUGINS_FILTER        = 'DISABLED_MUPLUGINS_FILTER';
 	const DISABLED_MUPLUGINS_SILENT_OPTION = 'DISABLED_MUPLUGINS_SILENT_OPTION';
-	const DISABLED_CONSTANT                = 'DISABLED_CONSTANT';
-
+	
 	const SELF_MANAGED = 'SELF_MANAGED';
 
 	// When parsely is not active
-	const NONE = 'NONE';
-	const NULL = 'NULL';
+	const BLOCKED_CONSTANT = 'BLOCKED_CONSTANT'; // Prevent loading of plugin based on `parsely_blocked` meta attribute.
+	const NONE             = 'NONE';
+	const NULL             = 'NULL';
 }


### PR DESCRIPTION
## Description
- We should disable the plugin based on `VIP_IS_FEDRAMP` constant which indicates that the current site is fedramp
- We should disable the plugin based on `VIP_PARSELY_SKIP_LOAD` constant which is a new opt-out mechanism
  - We will set this constant based on the meta attributes of client or site
  - After this PR we will have three ways of enabling/disabling Parse.ly ( via filter, option and this constant ) but in future we will only use this constant and migrate the users from other two approaches to make enabling/disabling simpler.

## Changelog Description

Disables Parse.ly if `VIP_PARSELY_SKIP_LOAD` or `VIP_IS_FEDRAMP` constant is set

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Pull branch

2. Run `vip dev-env start` (if dev env already exists else create it via help from readme)

3. Enable `wp-parsely` by following [VIP Docs](https://docs.wpvip.com/how-tos/enabling-and-disabling-parsely/)

4. Verify these cases separately

    - Open `vip-config.php` file, adds `define( 'VIP_PARSELY_SKIP_LOAD', true );` and verify that plugin is not loading.

    - Open `vip-config.php` file, adds `define( 'VIP_IS_FEDRAMP', true );` and verify that plugin is not loading.