### PR TITLE
Vaultpress: Remove from mandatory JP modules

### DIFF
--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -18,7 +18,6 @@ class WPCOM_VIP_Jetpack_Mandatory {
 	 */
 	protected $mandatory_modules = array(
 		'stats',
-		'vaultpress',
 	);
 
 	/**


### PR DESCRIPTION
## Description
Remove `vaultpress` as mandatory JP module
