### PR TITLE
Add VIP_PARSELY_ENABLED constant to enable / disable wp-parsely plugin

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -135,8 +135,8 @@ if ( method_exists( Context::class, 'is_fedramp' ) && Context::is_fedramp() ) {
 	}
 
 	// FedRAMP sites do not load Parse.ly by default
-	if ( ! defined( 'VIP_PARSELY_SKIP_LOAD' ) ) {
-		define( 'VIP_PARSELY_SKIP_LOAD', true );
+	if ( ! defined( 'VIP_PARSELY_ENABLED' ) ) {
+		define( 'VIP_PARSELY_ENABLED', false );
 	}
 }
 

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\VIP\WP_Parsely_Integration;
 
+use Automattic\Test\Constant_Mocker;
 use Parsely\UI\Row_Actions;
 use WP_UnitTestCase;
 
@@ -99,7 +100,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		$this->assertEquals( self::$major_version, $matches[1] );
 	}
 
-	public function test_bootstrap_modes() {
+	public function test_bootstrap_modes_enabled_without_constant() {
 		maybe_load_plugin();
 		switch ( self::$test_mode ) {
 			case 'disabled':
@@ -170,8 +171,49 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_bootstrap_modes_for_parsely_skip_load_constant() {
-		define( 'VIP_PARSELY_SKIP_LOAD', true );
+	public function test_bootstrap_modes_enabled_via_constant() {
+		define( 'VIP_PARSELY_ENABLED', true );
+		maybe_load_plugin();
+
+		switch ( self::$test_mode ) {
+			case 'disabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'filter_enabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'filter_disabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'option_enabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'option_disabled':
+				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'filter_and_option_enabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
+				break;
+			case 'filter_and_option_disabled':
+				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
+				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
+				break;
+			default:
+				$this->fail( 'Invalid test mode specified: ' . self::$test_mode );
+		}
+
+		$this->assertTrue( Parsely_Loader_Info::is_active() );
+		$this->assertEquals( Parsely_Integration_Type::ENABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+	}
+
+	public function test_bootstrap_modes_disabled_via_constant() {
+		define( 'VIP_PARSELY_ENABLED', false );
 		maybe_load_plugin();
 
 		switch ( self::$test_mode ) {
@@ -208,7 +250,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertFalse( Parsely_Loader_Info::is_active() );
-		$this->assertEquals( Parsely_Integration_Type::BLOCKED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
+		$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
 	}
 
 	public function test_parsely_ui_hooks() {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -237,11 +237,11 @@ function maybe_load_plugin() {
 
 			return;
 		}
-	}
 
-	// Enqueuing the disabling of Parse.ly features when the plugin is loaded (after the `plugins_loaded` hook)
-	// We need priority 0, so it's executed before `widgets_init`
-	add_action( 'init', __NAMESPACE__ . '\maybe_disable_some_features', 0 );
+		// Enqueuing the disabling of Parse.ly features when the plugin is loaded (after the `plugins_loaded` hook)
+		// We need priority 0, so it's executed before `widgets_init`
+		add_action( 'init', __NAMESPACE__ . '\maybe_disable_some_features', 0 );
+	}
 
 	$versions_to_try = SUPPORTED_VERSIONS;
 
@@ -349,7 +349,7 @@ abstract class Parsely_Integration_Type {
 	// When parsely is not active
 	const DISABLED_MUPLUGINS_FILTER        = 'DISABLED_MUPLUGINS_FILTER';
 	const DISABLED_MUPLUGINS_SILENT_OPTION = 'DISABLED_MUPLUGINS_SILENT_OPTION';
-	const DISABLED_CONSTANT                = 'DISABLED_CONSTANT'; // Prevent loading of plugin based on `parsely_blocked` meta attribute.
+	const DISABLED_CONSTANT                = 'DISABLED_CONSTANT'; // Prevent loading of plugin based on `parsely_blocked` meta attribute or customers can also define it.
 
 	const NONE = 'NONE';
 	const NULL = 'NULL';


### PR DESCRIPTION
## Description

- Added `ENABLED_CONSTANT` integration_type (also renamed `BLOCKED_CONSTANT` to `DISABLED_CONSTANT` because it matches with `ENABLED_*` and `DISABLED_*` naming convention)

- Using `VIP_PARSELY_ENABLED` constant and possible scenarios of this constant are:

    - If not defined then it means parsely is neither enabled nor blocked (look enablement via filter or option)
    - If `true` then means parsely is enabled and integration_type should be `ENABLED_CONSTANT`
    - If not `true` (false or anything else) then means parsely is disabled and integration_type should be `DISABLED_CONSTANT`

## Changelog Description

Add VIP_PARSELY_ENABLED constant and remove VIP_PARSELY_SKIP_LOAD constant

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Pull branch

2. Run `vip dev-env start` (if dev env already exists else create it via help from readme)

3. Enable `wp-parsely` by following [VIP Docs](https://docs.wpvip.com/how-tos/enabling-and-disabling-parsely/)

4. Verify these cases separately

    - Open `vip-config.php` file, adds `define( 'VIP_PARSELY_ENABLED', false );` and verify that plugin is not loading.

    - Open `vip-config.php` file, adds `define( 'VIP_IS_FEDRAMP', true );` and verify that plugin is not loading.
    
    - Revert changes of point 3, open `vip-config.php` file, adds `define( 'VIP_PARSELY_ENABLED', true );` and verify that plugin is loading.