### PR TITLE
chore(dev-deps): Update dependencies for ES E2E tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5016,13 +5016,13 @@
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.27.0.tgz",
-      "integrity": "sha512-5DAOOhvA4rmAGIoQX8gbut73Ls0nD5vKo4ImhaeMt+5o7JO7Mn+FU1t7GFy2MwzdBEu/toh/XuCHqF6F3HaooQ==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.28.0.tgz",
+      "integrity": "sha512-kEe8zqjEs1paZAS0ZSaUkiLTIrNFBy11ZkdBDYOYgl707zZCQt50HYs/J+zATWegWpp5scd4Tt18cJy1O9dosg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.30.0",
-        "@wordpress/url": "^3.31.0"
+        "@wordpress/i18n": "^4.31.0",
+        "@wordpress/url": "^3.32.0"
       },
       "engines": {
         "node": ">=12"
@@ -5214,9 +5214,9 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.31.0.tgz",
-      "integrity": "sha512-3sxbDKU8OQTeGat3Roef9dN/NR0Rb6ld9KN0618Ec+FHU05dI+7nolA0jfOAJka+Vvf7gfP0WQ7cJAZdlwfNuw==",
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.32.0.tgz",
+      "integrity": "sha512-dbz4KjcwYxkd2GsJwNVXD6Do39W13jlGmsLgWkSe/4dEw4SnaJQVYJv3yBpykmYqbfwilPrSM/KmpybKeghPFA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "remove-accents": "^0.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5058,9 +5058,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.15.0.tgz",
-      "integrity": "sha512-2e4S9+RRaptujTE5v5xWKL4jv25KRNI4qu57VsBKqnn0nfoHqNe0UAgjkcKiygcrd4rRjfGY+4pLa7SU/Qczdg==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.16.0.tgz",
+      "integrity": "sha512-zx6UO8PuJBrQ34cfeedK1HlGHLFaj7oWzTo9tTt+noB79Ttqc4+a0lYwDqBLLJhlHU+cWgcyOP2lB6TboXH0xA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5151,9 +5151,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.30.0.tgz",
-      "integrity": "sha512-cvM5OWMQx0D2+wxvsTCI68LXy4cHz1Db97LliiQ+KprSBmYRG5Uy2PqtPv1sMlK8IOypKOlzmG5H5V1CwBN44A==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.31.0.tgz",
+      "integrity": "sha512-dtXTk6miFaqAQmtjuO1Ox11sdkJNMl/Wv402VlPI8Z3QBUyEAH+FMGoHbAwpy3AGHJJb5pFYSRQBNAgZMGZLIw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5162,12 +5162,12 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.30.0.tgz",
-      "integrity": "sha512-vIntwrTBSU2MXOBlpyFntPgimHP+RW+k7/Y00BMPL+xoxPr7J7sXX/GNoYlH1BNsAo7XOi5AY5FrUnQ7ZIYdtQ==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.31.0.tgz",
+      "integrity": "sha512-MRPnym60ZUqZv4AZkXK3HPdZBRUEUD+zU11sB+5ydBPYMQXLSSxOGmt3NlEiPxynYPNkjBtW/52DCQz99rsDzw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.30.0",
+        "@wordpress/hooks": "^3.31.0",
         "gettext-parser": "^1.3.1",
         "memize": "^1.1.0",
         "sprintf-js": "^1.1.1",


### PR DESCRIPTION
* Bump `@wordpress/env` from 5.15.0 to 5.16.0 (#4354);
* Bump `@wordpress/i18n` from 4.30.0 to 4.31.0 (#4353);
* Bump `@wordpress/api-fetch` from 6.27.0 to 6.28.0 (#4351).
