### PR TITLE
Jetpack: Upgrade default non-pinned to 12.0

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.9
+ * Version: 12.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -28,7 +28,7 @@ function vip_default_jetpack_version() {
 		return '11.4';
 	} else {
 		// WordPress 6.0 and newer
-		return '11.9';
+		return '12.0';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,14 +7,16 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
+		$latest = '12.0';
+
 		$versions_map = [
 			// WordPress version => Jetpack version
 			'5.8.6' => '10.9',
 			'5.9'   => '11.4',
 			'5.9.5' => '11.4',
-			'6.0'   => '11.9',
-			'6.1'   => '11.9',
-			'6.1.1' => '11.9',
+			'6.0'   => $latest,
+			'6.1'   => $latest,
+			'6.1.1' => $latest,
 		];
 
 		foreach ( $versions_map as $wordpress_version => $jetpack_version ) {


### PR DESCRIPTION
## Description
12.0 for all

## Changelog Description
### Plugin Updated: Jetpack

Jetpack 12.0 is now the default version for non-pinned applications.