### PR TITLE
Fix wp-parsely track info in self managed mode

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -186,6 +186,20 @@ function maybe_load_plugin() {
 		return;
 	}
 
+	// Self-managed integration: The plugin exists on the site and is being loaded already.
+	$plugin_class_exists = class_exists( 'Parsely' ) || class_exists( 'Parsely\Parsely' );
+	if ( $plugin_class_exists ) {
+		Parsely_Loader_Info::set_active( true );
+		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::SELF_MANAGED );
+
+		$parsely_options = Parsely_Loader_Info::get_parsely_options();
+		if ( array_key_exists( 'plugin_version', $parsely_options ) ) {
+			Parsely_Loader_Info::set_version( $parsely_options['plugin_version'] );
+		}
+
+		return;
+	}
+
 	$parsely_enabled_constant = null; // Represents that the site doesn't have parsely enabled / blocked.
 
 	if ( defined( 'VIP_PARSELY_ENABLED' ) ) {
@@ -201,20 +215,6 @@ function maybe_load_plugin() {
 
 		Parsely_Loader_Info::set_active( true );
 		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::ENABLED_CONSTANT );
-	}
-
-	// Self-managed integration: The plugin exists on the site and is being loaded already.
-	$plugin_class_exists = class_exists( 'Parsely' ) || class_exists( 'Parsely\Parsely' );
-	if ( $plugin_class_exists ) {
-		Parsely_Loader_Info::set_active( true );
-		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::SELF_MANAGED );
-
-		$parsely_options = Parsely_Loader_Info::get_parsely_options();
-		if ( array_key_exists( 'plugin_version', $parsely_options ) ) {
-			Parsely_Loader_Info::set_version( $parsely_options['plugin_version'] );
-		}
-
-		return;
 	}
 
 	$option_load_status   = get_option( '_wpvip_parsely_mu', null );


### PR DESCRIPTION
## Description
If customer is self managing Parsely and we set `VIP_PARSELY_ENABLED` constant as `false` on our side then in this case we should track the plugin as active and in self managed mode which was not happening.

## Changelog Description
Fixed wp-parsely track info in self managed mode

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.