### PR TITLE
Query Monitor: Add more information to VIP panel and structure better

### DIFF
--- a/qm-plugins/qm-vip/class-qm-vip-collector.php
+++ b/qm-plugins/qm-vip/class-qm-vip-collector.php
@@ -52,12 +52,12 @@ class QM_VIP_Collector extends QM_Collector {
 	private function process_app() {
 		global $wp_version;
 
-		$env = constant( 'VIP_GO_APP_ENVIRONMENT' );
+		$env               = constant( 'VIP_GO_APP_ENVIRONMENT' );
 		$this->data['app'] = [
-			'env'    => $env,
+			'env' => $env,
 		];
 
-		if ( $env !== 'local' ) {
+		if ( 'local' !== $env ) {
 			$this->data['app']['commit'] = getenv( 'VIP_GO_APP_CURRENT_COMMIT_HASH' );
 			$this->data['app']['branch'] = constant( 'VIP_GO_APP_BRANCH' );
 
@@ -68,7 +68,11 @@ class QM_VIP_Collector extends QM_Collector {
 			}
 		}
 		$this->data['app']['php'] = phpversion();
-		$this->data['app']['wp'] = $wp_version;
+		$this->data['app']['wp']  = $wp_version;
+
+		if ( defined( 'JETPACK__VERSION' ) ) {
+			$this->data['app']['jetpack'] = constant( 'JETPACK__VERSION' );
+		}
 
 		if ( defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === constant( 'VIP_ENABLE_VIP_SEARCH' ) && class_exists( '\ElasticPress\Elasticsearch' ) ) {
 			$this->data['app']['es_version'] = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();

--- a/qm-plugins/qm-vip/class-qm-vip-collector.php
+++ b/qm-plugins/qm-vip/class-qm-vip-collector.php
@@ -5,7 +5,7 @@ class QM_VIP_Collector extends QM_Collector {
 	/**
 	 * @var string
 	 */
-	public $id = 'qm-vip';
+	public $id = 'vip';
 
 	/**
 	 * @return string
@@ -19,6 +19,8 @@ class QM_VIP_Collector extends QM_Collector {
 	 */
 	public function process() {
 		$this->process_version_file();
+
+		$this->process_app();
 	}
 
 	private function process_version_file() {
@@ -45,6 +47,32 @@ class QM_VIP_Collector extends QM_Collector {
 			'commit' => $commit,
 			'date'   => $date,
 		];
+	}
+
+	private function process_app() {
+		global $wp_version;
+
+		$env = constant( 'VIP_GO_APP_ENVIRONMENT' );
+		$this->data['app'] = [
+			'env'    => $env,
+		];
+
+		if ( $env !== 'local' ) {
+			$this->data['app']['commit'] = getenv( 'VIP_GO_APP_CURRENT_COMMIT_HASH' );
+			$this->data['app']['branch'] = constant( 'VIP_GO_APP_BRANCH' );
+
+			if ( is_automattician() ) {
+				$this->data['app']['id']   = constant( 'VIP_GO_APP_ID' );
+				$this->data['app']['name'] = constant( 'VIP_GO_APP_NAME' );
+				$this->data['app']['pod']  = gethostname();
+			}
+		}
+		$this->data['app']['php'] = phpversion();
+		$this->data['app']['wp'] = $wp_version;
+
+		if ( defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === constant( 'VIP_ENABLE_VIP_SEARCH' ) && class_exists( '\ElasticPress\Elasticsearch' ) ) {
+			$this->data['app']['es_version'] = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();
+		}
 	}
 
 	/**

--- a/qm-plugins/qm-vip/class-qm-vip-collector.php
+++ b/qm-plugins/qm-vip/class-qm-vip-collector.php
@@ -53,7 +53,7 @@ class QM_VIP_Collector extends QM_Collector {
 		$env = constant( 'VIP_GO_APP_ENVIRONMENT' );
 
 		if ( 'local' !== $env ) {
-			if ( defined( 'VIP_GO_APP_ID') ) {
+			if ( defined( 'VIP_GO_APP_ID' ) ) {
 				$this->data['app']['id'] = constant( 'VIP_GO_APP_ID' );
 			}
 			if ( defined( 'VIP_GO_APP_NAME' ) ) {

--- a/qm-plugins/qm-vip/class-qm-vip-collector.php
+++ b/qm-plugins/qm-vip/class-qm-vip-collector.php
@@ -53,12 +53,21 @@ class QM_VIP_Collector extends QM_Collector {
 		$env = constant( 'VIP_GO_APP_ENVIRONMENT' );
 
 		if ( 'local' !== $env ) {
-			$this->data['app']['commit'] = getenv( 'VIP_GO_APP_CURRENT_COMMIT_HASH' );
-			$this->data['app']['branch'] = constant( 'VIP_GO_APP_BRANCH' );
+			if ( defined( 'VIP_GO_APP_ID') ) {
+				$this->data['app']['id'] = constant( 'VIP_GO_APP_ID' );
+			}
+			if ( defined( 'VIP_GO_APP_NAME' ) ) {
+				$this->data['app']['name'] = constant( 'VIP_GO_APP_NAME' );
+			}
+			$commit = getenv( 'VIP_GO_APP_CURRENT_COMMIT_HASH' );
+			if ( $commit ) {
+				$this->data['app']['commit'] = $commit;
+			}
+			if ( defined( 'VIP_GO_APP_BRANCH' ) ) {
+				$this->data['app']['branch'] = constant( 'VIP_GO_APP_BRANCH' );
+			}
 
-			if ( is_automattician() ) {
-				$this->data['app']['id']      = constant( 'VIP_GO_APP_ID' );
-				$this->data['app']['name']    = constant( 'VIP_GO_APP_NAME' );
+			if ( is_automattician() && defined( 'VIP_IS_FEDRAMP' ) ) {
 				$this->data['app']['fedramp'] = constant( 'VIP_IS_FEDRAMP' );
 			}
 		}
@@ -67,7 +76,7 @@ class QM_VIP_Collector extends QM_Collector {
 			$this->data['app']['jetpack'] = constant( 'JETPACK__VERSION' );
 		}
 
-		if ( defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === constant( 'VIP_ENABLE_VIP_SEARCH' ) && class_exists( '\ElasticPress\Elasticsearch' ) ) {
+		if ( defined( 'VIP_ENABLE_VIP_SEARCH' ) && true === constant( 'VIP_ENABLE_VIP_SEARCH' ) && method_exists( '\ElasticPress\Elasticsearch', 'get_elasticsearch_version' ) ) {
 			$this->data['app']['es_version'] = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();
 		}
 	}

--- a/qm-plugins/qm-vip/class-qm-vip-collector.php
+++ b/qm-plugins/qm-vip/class-qm-vip-collector.php
@@ -50,25 +50,18 @@ class QM_VIP_Collector extends QM_Collector {
 	}
 
 	private function process_app() {
-		global $wp_version;
-
-		$env               = constant( 'VIP_GO_APP_ENVIRONMENT' );
-		$this->data['app'] = [
-			'env' => $env,
-		];
+		$env = constant( 'VIP_GO_APP_ENVIRONMENT' );
 
 		if ( 'local' !== $env ) {
 			$this->data['app']['commit'] = getenv( 'VIP_GO_APP_CURRENT_COMMIT_HASH' );
 			$this->data['app']['branch'] = constant( 'VIP_GO_APP_BRANCH' );
 
 			if ( is_automattician() ) {
-				$this->data['app']['id']   = constant( 'VIP_GO_APP_ID' );
-				$this->data['app']['name'] = constant( 'VIP_GO_APP_NAME' );
-				$this->data['app']['pod']  = gethostname();
+				$this->data['app']['id']      = constant( 'VIP_GO_APP_ID' );
+				$this->data['app']['name']    = constant( 'VIP_GO_APP_NAME' );
+				$this->data['app']['fedramp'] = constant( 'VIP_IS_FEDRAMP' );
 			}
 		}
-		$this->data['app']['php'] = phpversion();
-		$this->data['app']['wp']  = $wp_version;
 
 		if ( defined( 'JETPACK__VERSION' ) ) {
 			$this->data['app']['jetpack'] = constant( 'JETPACK__VERSION' );

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -25,7 +25,7 @@ class QM_VIP_Output extends QM_Output_Html {
 
 		// MU-Plugins section
 		$this->output_before_section( 'MU-Plugins' );
-		$this->output_table_row( 'Branch', $data['mu-plugins']['branch'] === 'prod' ? 'production' : $data['mu-plugins']['branch'] );
+		$this->output_table_row( 'Branch', 'prod' === $data['mu-plugins']['branch'] ? 'production' : $data['mu-plugins']['branch'] );
 		if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
 			$this->output_table_row( 'Last modified', $data['mu-plugins']['date'] );
 			$this->output_table_row( 'Commit', $data['mu-plugins']['commit'], 'https://github.com/automattic/vip-go-mu-plugins/commit/' . $data['mu-plugins']['commit'] );
@@ -52,6 +52,9 @@ class QM_VIP_Output extends QM_Output_Html {
 		$this->output_table_row( 'Environment', $data['app']['env'] );
 		$this->output_table_row( 'PHP', $data['app']['php'] );
 		$this->output_table_row( 'WordPress', $data['app']['wp'] );
+		if ( isset( $data['app']['jetpack'] ) ) {
+			$this->output_table_row( 'Jetpack', $data['app']['jetpack'] );
+		}
 		if ( isset( $data['app']['es_version'] ) ) {
 			$this->output_table_row( 'Elasticsearch', $data['app']['es_version'] );
 		}

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -20,17 +20,93 @@ class QM_VIP_Output extends QM_Output_Html {
 
 	public function output() {
 		$data = $this->collector->get_data();
-		?>
-		<div class="qm qm-non-tabular" id="<?php echo esc_attr( $this->collector->id ); ?>">
-			<h3><strong>MU-Plugins Branch: </strong><?php echo esc_html( $data['mu-plugins']['branch'] ); ?></h3>
-			<?php
-			if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
-				echo '<p><a href="https://github.com/automattic/vip-go-mu-plugins/commit/' . rawurlencode( $data['mu-plugins']['commit'] ) .
-				'" target="_blank"><i><strong><span class="screen-reader-text">Open in new tab </span>Last modified: </strong>' .
-				esc_html( $data['mu-plugins']['date'] ) . '</i></a></p>';
-			}
-			?>
-		</div>
-		<?php
+
+		$this->before_non_tabular_output();
+
+		// MU-Plugins section
+		$this->output_before_section( 'MU-Plugins' );
+		$this->output_table_row( 'Branch', $data['mu-plugins']['branch'] === 'prod' ? 'production' : $data['mu-plugins']['branch'] );
+		if ( isset( $data['mu-plugins']['commit'] ) && isset( $data['mu-plugins']['date'] ) ) {
+			$this->output_table_row( 'Last modified', $data['mu-plugins']['date'] );
+			$this->output_table_row( 'Commit', $data['mu-plugins']['commit'], 'https://github.com/automattic/vip-go-mu-plugins/commit/' . $data['mu-plugins']['commit'] );
+		}
+		$this->output_after_section();
+
+		// App section
+		$this->output_before_section( 'Application' );
+		if ( isset( $data['app']['id'] ) ) {
+			$this->output_table_row( 'ID', $data['app']['id'] );
+		}
+		if ( isset( $data['app']['id'] ) ) {
+			$this->output_table_row( 'Name', $data['app']['name'] );
+		}
+		if ( isset( $data['app']['commit'] ) ) {
+			$this->output_table_row( 'Branch', $data['app']['branch'] );
+		}
+		if ( isset( $data['app']['commit'] ) ) {
+			$this->output_table_row( 'Commit', $data['app']['commit'] );
+		}
+		if ( isset( $data['app']['pod'] ) ) {
+			$this->output_table_row( 'Pod', $data['app']['pod'] );
+		}
+		$this->output_table_row( 'Environment', $data['app']['env'] );
+		$this->output_table_row( 'PHP', $data['app']['php'] );
+		$this->output_table_row( 'WordPress', $data['app']['wp'] );
+		if ( isset( $data['app']['es_version'] ) ) {
+			$this->output_table_row( 'Elasticsearch', $data['app']['es_version'] );
+		}
+		$this->output_after_section();
+
+		$this->after_non_tabular_output();
+	}
+	/**
+	 * Outputs a table row with a key-value pairing.
+	 *
+	 * @param string $title Title of table row
+	 * @param string $value Value of table row
+	 * @param string $link Inline link of table row value
+	 */
+	public function output_table_row( string $title, string $value, string $link = '' ) {
+		echo '<tr>';
+		echo '<th scope="row">' . esc_html( $title ) . '</th>';
+		echo '<td>';
+		if ( ! empty( $link ) ) {
+			echo '<a href="' . esc_url( $link ) . '">';
+		}
+		echo esc_html( $value );
+		if ( ! empty( $link ) ) {
+			echo '</a>';
+		}
+		echo '</td>';
+		echo '</tr>';
+	}
+
+	/**
+	 * Outputs the beginning of a table section.
+	 *
+	 * @param string $heading Heading of table
+	 */
+	public function output_before_section( string $heading ) {
+		echo '<section>';
+		if ( $heading ) {
+			echo '<h3><strong>' . esc_html( $heading ) . '</strong></h3>';
+		}
+		echo '<table>';
+		echo '<thead class="qm-screen-reader-text">';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Property', 'qm-vip' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Value', 'qm-vip' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+		echo '<tbody>';
+	}
+
+	/**
+	 * Outputs the end of a table section.
+	 */
+	public function output_after_section() {
+		echo '</tbody>';
+		echo '</table>';
+		echo '</section>';
 	}
 }

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -46,17 +46,14 @@ class QM_VIP_Output extends QM_Output_Html {
 		if ( isset( $data['app']['commit'] ) ) {
 			$this->output_table_row( 'Commit', $data['app']['commit'] );
 		}
-		if ( isset( $data['app']['pod'] ) ) {
-			$this->output_table_row( 'Pod', $data['app']['pod'] );
-		}
-		$this->output_table_row( 'Environment', $data['app']['env'] );
-		$this->output_table_row( 'PHP', $data['app']['php'] );
-		$this->output_table_row( 'WordPress', $data['app']['wp'] );
 		if ( isset( $data['app']['jetpack'] ) ) {
 			$this->output_table_row( 'Jetpack', $data['app']['jetpack'] );
 		}
 		if ( isset( $data['app']['es_version'] ) ) {
 			$this->output_table_row( 'Elasticsearch', $data['app']['es_version'] );
+		}
+		if ( isset( $data['app']['fedramp'] ) ) {
+			$this->output_table_row( 'FedRAMP', $data['app']['fedramp'] ? 'Yes' : 'No' );
 		}
 		$this->output_after_section();
 

--- a/qm-plugins/qm-vip/class-qm-vip-output-html.php
+++ b/qm-plugins/qm-vip/class-qm-vip-output-html.php
@@ -37,10 +37,10 @@ class QM_VIP_Output extends QM_Output_Html {
 		if ( isset( $data['app']['id'] ) ) {
 			$this->output_table_row( 'ID', $data['app']['id'] );
 		}
-		if ( isset( $data['app']['id'] ) ) {
+		if ( isset( $data['app']['name'] ) ) {
 			$this->output_table_row( 'Name', $data['app']['name'] );
 		}
-		if ( isset( $data['app']['commit'] ) ) {
+		if ( isset( $data['app']['branch'] ) ) {
 			$this->output_table_row( 'Branch', $data['app']['branch'] );
 		}
 		if ( isset( $data['app']['commit'] ) ) {

--- a/qm-plugins/qm-vip/qm-vip.php
+++ b/qm-plugins/qm-vip/qm-vip.php
@@ -24,11 +24,11 @@ function register_qm_vip() {
 }
 
 function register_qm_vip_output( array $output, \QM_Collectors $collectors ) {
-	$collector = \QM_Collectors::get( 'qm-vip' );
+	$collector = \QM_Collectors::get( 'vip' );
 	if ( $collector ) {
 		require_once __DIR__ . '/class-qm-vip-output-html.php';
 
-		$output['qm-vip'] = new QM_VIP_Output( $collector );
+		$output['vip'] = new QM_VIP_Output( $collector );
 	}
 	return $output;
 }


### PR DESCRIPTION
## Description
Re-works the VIP panel to add an application section which includes:
- app ID
- app name
- app branch
- app commit
- app pod (only visible to a12n)
- jetpack version
- elasticsearch version (only if search is enabled)
- fedramp (only visible to a12n)

As an a12n  on a development env:
<img width="855" alt="Screenshot 2023-04-19 at 12 08 37 PM" src="https://user-images.githubusercontent.com/16962021/233162862-2970a995-0f47-40f8-924c-852819e34ac5.png">


Locally on dev-env:
<img width="531" alt="Screenshot 2023-04-18 at 1 51 24 PM" src="https://user-images.githubusercontent.com/16962021/232889904-26e4b041-e57d-4520-a858-249c58c9eabb.png">


## Changelog Description

### Plugin Updated: Query Monitor

Added "Application" section to Query Monitor "VIP" panel
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
