### PR TITLE
Allow environment information to be shown in Query Monitor

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -113,9 +113,6 @@ function wpcom_vip_qm_require() {
 		update_option( 'wpcom_vip_qm_activated', 1, true );
 	}
 
-	// We don't want to share our environment information via Query Monitor
-	remove_filter( 'qm/collectors', 'register_qm_collector_environment', 20, 2 );
-
 	// We know we haven't got the QM DB drop-in in place, so don't show the message
 	add_filter( 'qm/show_extended_query_prompt', '__return_false' );
 


### PR DESCRIPTION
## Description

I'd like to propose that the "Environment" panel in Query Monitor is reinstated on VIP. It provides useful information relating to PHP, the database, WordPress, and the server. None of the information in this panel is sensitive and the value of exposing the information is greater than any perceived caution gained by hiding it.

I couldn't find any concrete discussion around the reason for removing this panel. [Here's the original PR](https://github.com/Automattic/vip-go-mu-plugins/pull/120). Query Monitor is bundled on several other hosted WordPress platforms and VIP appears to be the only one that removes this panel.

## Screenshot

This screenshot is from my personal production website, demonstrating there is no sensitive information present:

<img width="1505" alt="" src="https://user-images.githubusercontent.com/208434/233097389-62b11f80-1ac4-4447-a061-2886cf3f682a.png">

## Changelog Description

### Plugin Updated: Query Monitor

Add back "Environment" panel to Query Monitor

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Log in to a site on VIP using a super-admin account
2. Open the Query Monitor -> Environment panel
3. Confirm the panel appears as expected
