### PR TITLE
Assign `dbname` property in `define_db_constants()` in CLI context

### DIFF
--- a/001-core/constants.php
+++ b/001-core/constants.php
@@ -40,5 +40,10 @@ function define_db_constants( $hyperdb ): void {
 		define( 'DB_USER', $db[0]['user'] );
 		define( 'DB_PASSWORD', $db[0]['password'] );
 		define( 'DB_NAME', $db[0]['name'] );
+
+		if ( ! isset( $GLOBALS['wpdb']->dbname ) && \Automattic\VIP\Utils\Context::is_wp_cli() ) {
+			// Only assign the property for the database name if we're in WP-CLI (for now).
+			$GLOBALS['wpdb']->dbname = constant( 'DB_NAME' );
+		}
 	}
 }


### PR DESCRIPTION
## Description
Fixes the issue described in https://github.com/wp-cli/search-replace-command/issues/207:
```
WordPress database error Unknown column 'Tables_in_' in 'where clause' for query SHOW TABLES WHERE `Tables_in_` IN ('wp_users', 'wp_usermeta', 'wp_posts', 'wp_comments', 'wp_links', 'wp_options', 'wp_postmeta', 'wp_terms', 'wp_term_taxonomy', 'wp_term_relationships', 'wp_termmeta', 'wp_commentmeta', 'wp_blogs', 'wp_blogmeta', 'wp_signups', 'wp_site', 'wp_sitemeta', 'wp_registration_log') made by WP_CLI\Utils\wp_get_table_names
```

## Changelog Description

### Plugin Updated: VIP Constants

Assign `dbname` property in `define_db_constants()`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Do `wp search-replace  --dry-run hello hello1 wp_posts` and expect no error