### PR TITLE
Search: Add ability to deactivate versions

### DIFF
--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -174,13 +174,13 @@ class Versioning {
 	 * Grab just the version number for the active version
 	 *
 	 * @param \ElasticPress\Indexable $indexable The Indexable to get the active version number for
-	 * @return int The currently active version number
+	 * @return int|WP_Error The currently active version number
 	 */
 	public function get_active_version_number( Indexable $indexable ) {
 		$active_version = $this->get_active_version( $indexable );
 
 		if ( ! $active_version ) {
-			return 1;
+			return new WP_Error( 'no-active-version', 'No active version found' );
 		}
 
 		return $active_version['number'];
@@ -204,10 +204,14 @@ class Versioning {
 	}
 
 	public function get_inactive_versions( Indexable $indexable ) {
-		$versions              = $this->get_versions( $indexable );
-		$active_version_number = $this->get_active_version_number( $indexable );
+		$versions = $this->get_versions( $indexable );
+		if ( ! empty( $versions ) ) {
+			$active_version_number = $this->get_active_version_number( $indexable );
 
-		unset( $versions[ $active_version_number ] );
+			if ( ! is_wp_error( $active_version_number ) ) {
+				unset( $versions[ $active_version_number ] );
+			}
+		}
 
 		return $versions;
 	}
@@ -325,7 +329,7 @@ class Versioning {
 		$active_version_number = $this->get_active_version_number( $indexable );
 
 		// If there is no active version, we can't determine what next is
-		if ( ! $active_version_number ) {
+		if ( is_wp_error( $active_version_number ) ) {
 			return new WP_Error( 'no-active-index-found', 'There is no active index version so the "next" version cannot be determined' );
 		}
 
@@ -360,7 +364,7 @@ class Versioning {
 		$active_version_number = $this->get_active_version_number( $indexable );
 
 		// If there is no active version, we can't determine what previous is
-		if ( ! $active_version_number ) {
+		if ( is_wp_error( $active_version_number ) ) {
 			return new WP_Error( 'no-active-index-found', 'There is no active index version so the "next" version cannot be determined' );
 		}
 
@@ -618,6 +622,42 @@ class Versioning {
 	}
 
 	/**
+	 * Deactivate a version of an index
+	 *
+	 * Verifies that the target index does in-fact exist, then marks it as inactive
+	 *
+	 * @param \ElasticPress\Indexable $indexable The Indexable type for which index to deactivate
+	 * @param int|string $version_number The index version to deactivate
+	 * @return bool|WP_Error Boolean indicating success, or WP_Error on error
+	 */
+	public function deactivate_version( Indexable $indexable, $version_number ) {
+		$version_number = $this->normalize_version_number( $indexable, $version_number );
+
+		if ( is_wp_error( $version_number ) ) {
+			return $version_number;
+		}
+
+		$versions = $this->get_versions( $indexable );
+
+		// If this wasn't a valid version, abort with error
+		if ( ! isset( $versions[ $version_number ] ) ) {
+			return new WP_Error( 'invalid-index-version', sprintf( 'The index version %d was not found', $version_number ) );
+		}
+		// Version is already inactive
+		if ( false === $versions[ $version_number ]['active'] ) {
+			return new WP_Error( 'inactive-index-version-already', sprintf( 'The index version %d already inactive', $version_number ) );
+		}
+
+		$versions[ $version_number ]['active'] = false;
+
+		if ( ! $this->update_versions( $indexable, $versions ) ) {
+			return new WP_Error( 'failed-deactivating-version', sprintf( 'The index version %d failed to deactivate', $version_number ) );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Delete the version of an index and remove the index from Elasticsearch
 	 *
 	 * @param \ElasticPress\Indexable $indexable The Indexable type for which to delete index
@@ -755,8 +795,8 @@ class Versioning {
 
 			$active_version_number = $this->get_active_version_number( $indexable );
 
-			// Were there any changes to the active version? If not, we skip - we don't keep replicate non-active indexes to others
-			if ( ! isset( $objects_by_version[ $active_version_number ] ) || empty( $objects_by_version[ $active_version_number ] ) ) {
+			// Is there an active version and no changes to the active version? If so, we skip - we don't keep replicate non-active indexes to others
+			if ( ! is_wp_error( $active_version_number ) && ( ! isset( $objects_by_version[ $active_version_number ] ) || empty( $objects_by_version[ $active_version_number ] ) ) ) {
 				continue;
 			}
 

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -365,7 +365,7 @@ class Versioning {
 
 		// If there is no active version, we can't determine what previous is
 		if ( is_wp_error( $active_version_number ) ) {
-			return new WP_Error( 'no-active-index-found', 'There is no active index version so the "next" version cannot be determined' );
+			return new WP_Error( 'no-active-index-found', 'There is no active index version so the "previous" version cannot be determined' );
 		}
 
 		$versions = $this->get_versions( $indexable );

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -200,7 +200,7 @@ class Versioning_Test extends WP_UnitTestCase {
 				// Indexable slug
 				'post',
 				// Expected active version
-				1,
+				new \WP_Error( 'no-active-version', 'No active version found' ),
 			),
 
 			// No versions tracked
@@ -501,7 +501,7 @@ class Versioning_Test extends WP_UnitTestCase {
 				// Version string to be normalized
 				'active',
 				// Expected active version
-				1, // NOTE - expect 1 because get_active_version_number() returns 1 by default. This behavior is likely to change
+				new \WP_Error( 'no-active-version' ),
 			),
 
 			// No active, trying to get next
@@ -522,7 +522,7 @@ class Versioning_Test extends WP_UnitTestCase {
 				// Version string to be normalized
 				'next',
 				// Expected active version
-				new \WP_Error( 'active-index-not-found-in-versions-list' ), // NOTE - like above, this is because the default active version is 1, even if it doesn't exist in the list. Likely to change
+				new \WP_Error( 'no-active-index-found' ),
 			),
 			// Regular, 'inactive'
 			array(
@@ -561,7 +561,7 @@ class Versioning_Test extends WP_UnitTestCase {
 				'post',
 				// Version string to be normalized
 				'inactive',
-				// Expected inactive version
+				// Expected first inactive version found
 				4,
 			),
 			// No versions
@@ -910,6 +910,97 @@ class Versioning_Test extends WP_UnitTestCase {
 		// Can only compare the deterministic parts of the version info (not activated_time, for example), but should be unchanged
 		$this->assertEquals( wp_list_pluck( $versions, 'number' ), wp_list_pluck( $new_versions, 'number' ), 'New version numbers do not match expected values' );
 		$this->assertEquals( wp_list_pluck( $versions, 'active' ), wp_list_pluck( $new_versions, 'active' ), 'New versions "active" statuses do not match expected values' );
+	}
+
+	public function deactivate_version_data() {
+		return array(
+			array(
+				// Input array of versions
+				array(
+					2 => array(
+						'number' => 2,
+						'active' => false,
+					),
+					3 => array(
+						'number' => 3,
+						'active' => true,
+					),
+				),
+				// Indexable slug
+				'post',
+				// Version to deactivate
+				3,
+				// Expected new versions
+				array(
+					2 => array(
+						'number' => 2,
+						'active' => false,
+					),
+					3 => array(
+						'number' => 3,
+						'active' => false,
+					),
+				),
+			),
+			// With an index already marked inactive
+			array(
+				// Input array of versions
+				array(
+					2 => array(
+						'number' => 2,
+						'active' => false,
+					),
+					3 => array(
+						'number' => 3,
+						'active' => false,
+					),
+				),
+				// Indexable slug
+				'post',
+				// Version to deactivate
+				2,
+				// Expected
+				new \WP_Error( 'inactive-index-version-already', 'The index version 2 already inactive' ),
+			),
+			// With no indexes
+			array(
+				// Input array of versions
+				array(),
+				// Indexable slug
+				'post',
+				// Version to deactivate
+				2,
+				// Expected
+				new \WP_Error( 'invalid-index-version', 'The index version 2 was not found' ),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider deactivate_version_data
+	 */
+	public function test_deactivate_version( $versions, $indexable_slug, $version_to_deactivate, $expected_new_versions ) {
+		$indexable = \ElasticPress\Indexables::factory()->get( $indexable_slug );
+
+		self::$version_instance->update_versions( $indexable, $versions );
+
+		$succeeded = self::$version_instance->deactivate_version( $indexable, $version_to_deactivate );
+
+		if ( ! is_wp_error( $succeeded ) ) {
+			$this->assertTrue( $succeeded, 'Deactivating version failed, but it should have succeeded' );
+
+			$new_versions = self::$version_instance->get_versions( $indexable );
+
+			// Can only compare the deterministic parts of the version info (not activated_time, for example)
+			$this->assertEquals( wp_list_pluck( $expected_new_versions, 'number' ), wp_list_pluck( $new_versions, 'number' ), 'New version numbers do not match expected values' );
+			$this->assertEquals( wp_list_pluck( $expected_new_versions, 'active' ), wp_list_pluck( $new_versions, 'active' ), 'New versions "active" statuses do not match expected values' );
+
+			// And make sure the now active version recorded when it was activated
+			$inactive_versions = self::$version_instance->get_inactive_versions( $indexable );
+			$this->assertEquals( $version_to_deactivate, $inactive_versions[ $version_to_deactivate ]['number'], 'Currently active version does not match expected active version' );
+		} else {
+			$this->assertEquals( $succeeded, $expected_new_versions );
+		}
 	}
 
 	public function delete_version_data() {


### PR DESCRIPTION
## Description
As part of breaking https://github.com/Automattic/vip-go-mu-plugins/pull/3963 into smaller commits, this adds the ability to deactivate versions.

Previously, we added https://github.com/Automattic/vip-go-mu-plugins/pull/4327

## Changelog Description

### Plugin Updated: Enterprise Search

Add ability to deactivate in index version management

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) `wp vip-search index-versions deactivate post 1`
2) `wp vip-search index-versions list post` and see index 1 marked as inactive:
```
+--------+--------+--------------+----------------+----------------+
| number | active | created_time | activated_time | document_count |
+--------+--------+--------------+----------------+----------------+
| 1      |        |              |                | 2              |
+--------+--------+--------------+----------------+----------------+
```