### PR TITLE
WP 6.2 deprecation: Change `wpcom_vip_get_page_by_title` to use `WP_Query` if possible

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -176,15 +176,15 @@ function wpcom_vip_get_page_by_title( $title, $output = OBJECT, $post_type = 'pa
 			$page_id = $page ? $page->ID : 0;
 		} else {
 			// WP 6.2 deprecates `get_page_by_title` in favor of `WP_Query`
-			$query = new WP_Query(
+			$query   = new WP_Query(
 				array(
-					's' => $title,
-					'post_type' => $post_type,
+					's'              => $title,
+					'post_type'      => $post_type,
 					'posts_per_page' => 1,
-					'orderby' => 'ID',
-					'order' => 'ASC',
-					'no_found_rows' => true,
-					'fields' => 'ids',
+					'orderby'        => 'ID',
+					'order'          => 'ASC',
+					'no_found_rows'  => true,
+					'fields'         => 'ids',
 				),
 			);
 			$page_id = ! empty( $query->posts ) ? $query->posts[0] : 0;

--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -170,8 +170,25 @@ function wpcom_vip_get_page_by_title( $title, $output = OBJECT, $post_type = 'pa
 	$page_id   = wp_cache_get( $cache_key, 'get_page_by_title' );
 
 	if ( false === $page_id ) {
-		$page    = get_page_by_title( $title, OBJECT, $post_type );
-		$page_id = $page ? $page->ID : 0;
+		if ( ! function_exists( 'is_user_logged_in' ) ) {
+			// If too early to call `WP_Query`, fallback to deprecated `get_page_by_title`
+			$page    = get_page_by_title( $title, OBJECT, $post_type );
+			$page_id = $page ? $page->ID : 0;
+		} else {
+			// WP 6.2 deprecates `get_page_by_title` in favor of `WP_Query`
+			$query = new WP_Query(
+				array(
+					's' => $title,
+					'post_type' => $post_type,
+					'posts_per_page' => 1,
+					'orderby' => 'ID',
+					'order' => 'ASC',
+					'no_found_rows' => true,
+					'fields' => 'ids',
+				),
+			);
+			$page_id = ! empty( $query->posts ) ? $query->posts[0] : 0;
+		}
 		wp_cache_set( $cache_key, $page_id, 'get_page_by_title', 3 * HOUR_IN_SECONDS ); // We only store the ID to keep our footprint small
 	}
 


### PR DESCRIPTION
## Description
Fixes #4381. 

It will still call `get_page_by_title()` if `wpcom_vip_get_page_by_title()` is used too early. Otherwise, it uses `WP_Query` instead.

## Changelog Description

### Plugin Updated: VIP Caching

Change `wpcom_vip_get_page_by_title` to use `WP_Query` if possible

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Comment out the caching in `wpcom_vip_get_page_by_title`
2) Call `wpcom_vip_get_page_by_title()` in client-mu-plugins to ensure that it still works early
3) Call `wpcom_vip_get_page_by_title()` in `functions.php`
4) Comment out the `function_exists()` block and compare results