### PR TITLE
Tests: PHPUnit 10 Compatibility Fixes

### DIFF
--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -28,8 +28,8 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-        	throw new \Exception( $errstr, $errno );
-        }, E_USER_WARNING );
+			throw new \Exception( $errstr, $errno );
+		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -26,8 +26,9 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 		Constant_Mocker::clear();
 
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-            throw new \Exception( $errstr, $errno );
+        	throw new \Exception( $errstr, $errno );
         }, E_USER_WARNING );
 	}
 

--- a/tests/files/acl/test-acl.php
+++ b/tests/files/acl/test-acl.php
@@ -22,8 +22,8 @@ class VIP_Files_Acl_Test extends WP_UnitTestCase {
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-        	throw new \Exception( $errstr, $errno );
-        }, E_USER_WARNING );
+			throw new \Exception( $errstr, $errno );
+		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {

--- a/tests/files/acl/test-acl.php
+++ b/tests/files/acl/test-acl.php
@@ -20,8 +20,9 @@ class VIP_Files_Acl_Test extends WP_UnitTestCase {
 		Constant_Mocker::clear();
 
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-            throw new \Exception( $errstr, $errno );
+        	throw new \Exception( $errstr, $errno );
         }, E_USER_WARNING );
 	}
 

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -9,9 +9,10 @@ require_once __DIR__ . '/../../../files/acl/pre-wp-utils.php';
 class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-			throw new \Exception( $errstr, $errno );
-		}, E_USER_WARNING );
+        	throw new \Exception( $errstr, $errno );
+        }, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -3,16 +3,25 @@
 namespace Automattic\VIP\Files\Acl\Pre_WP_Utils;
 
 use WP_UnitTestCase;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 require_once __DIR__ . '/../../../files/acl/pre-wp-utils.php';
 
 class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
-	use ExpectPHPException;
+	public function setUp(): void {
+		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		set_error_handler( static function ( int $errno, string $errstr ): never {
+			throw new \Exception( $errstr, $errno );
+		}, E_USER_WARNING );
+	}
 
+	public function tearDown(): void {
+		restore_error_handler();
+
+		parent::tearDown();
+	}
 	public function test__prepare_request__empty_request_uri() {
-		$this->expectWarning();
-		$this->expectWarningMessage( 'VIP Files ACL failed due to empty URI' );
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'VIP Files ACL failed due to empty URI' );
 
 		$request_uri = '';
 
@@ -22,7 +31,7 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 	}
 
 	public function test__prepare_request__invalid_request_uri() {
-		$this->expectWarning();
+		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'VIP Files ACL failed due to relative path (for invalid/path.jpg)' );
 
 		$request_uri = 'invalid/path.jpg';
@@ -50,30 +59,30 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 				null,
 				'VIP Files ACL failed due to empty path',
 			],
-	
+
 			'empty-uri'                    => [
 				'',
 				'VIP Files ACL failed due to empty path',
 			],
-	
+
 			'path-no-wp-content'           => [
 				'/a/path/to/a/file.jpg',
 				'VIP Files ACL failed due to invalid path (for /a/path/to/a/file.jpg)',
 			],
-	
+
 			'relative-url-with-wp-content' => [
 				'en/wp-content/uploads/file.png',
 				'VIP Files ACL failed due to relative path (for en/wp-content/uploads/file.png)',
 			],
 		];
 	}
-	
+
 	public function get_data__validate_path__valid() {
 		return [
 			'valid-path'                     => [
 				'/wp-content/uploads/kittens.gif',
 			],
-	
+
 			'valid-path-nested'              => [
 				'/wp-content/uploads/subfolder/2099/12/cats.jpg',
 			],
@@ -89,7 +98,7 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 			'multi-wp-content-directories'   => [
 				'/wp-content/uploads/path/to/wp-content/uploads/otters.png',
 			],
-	
+
 			/* TODO: not supported yet
 			'resized-image' => [
 				'/wp-content/uploads/2021/01/dinos-100x100.jpg',
@@ -102,11 +111,11 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 	 * @dataProvider get_data__validate_path__invalid
 	 */
 	public function test__validate_path__invalid( $file_path, $expected_warning ) {
-		$this->expectWarning();
-		$this->expectWarningMessage( $expected_warning );
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( $expected_warning );
 
 		$actual_is_valid = validate_path( $file_path );
-	
+
 		$this->assertFalse( $actual_is_valid );
 	}
 
@@ -115,7 +124,7 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 	 */
 	public function test__validate_path__valid( $file_path ) {
 		$actual_is_valid = validate_path( $file_path );
-	
+
 		$this->assertTrue( $actual_is_valid );
 	}
 

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -11,8 +11,8 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-        	throw new \Exception( $errstr, $errno );
-        }, E_USER_WARNING );
+			throw new \Exception( $errstr, $errno );
+		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -25,8 +25,9 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 		] );
 
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-            throw new \Exception( $errstr, $errno );
+        	throw new \Exception( $errstr, $errno );
         }, E_USER_WARNING );
 	}
 

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -27,8 +27,8 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-        	throw new \Exception( $errstr, $errno );
-        }, E_USER_WARNING );
+			throw new \Exception( $errstr, $errno );
+		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -23,9 +23,16 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 			$this->fs_uploads_mock,
 			$this->fs_direct_mock,
 		] );
+
+		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		set_error_handler( static function ( int $errno, string $errstr ): never {
+            throw new \Exception( $errstr, $errno );
+        }, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {
+		restore_error_handler();
+
 		$this->filesystem = null;
 
 		Constant_Mocker::clear();
@@ -282,7 +289,7 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 	public function test__get_transport_for_path__disallowed_write() {
 		$get_transport_for_path = self::get_method( 'get_transport_for_path' );
 
-		$this->expectError();
+		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'The `/test/random/directory/file.file` file cannot be managed by the `Automattic\VIP\Files\WP_Filesystem_VIP` class. Writes are only allowed for the `/tmp/` and `/tmp/wordpress/wp-content/uploads` directories and reads can be performed everywhere.' );
 
 		$result = $get_transport_for_path->invokeArgs( $this->filesystem, [ '/test/random/directory/file.file', 'write' ] );

--- a/tests/lib/environment/test-class-environment.php
+++ b/tests/lib/environment/test-class-environment.php
@@ -4,15 +4,12 @@ namespace Automattic\VIP;
 
 use Automattic\Test\Constant_Mocker;
 use PHPUnit\Framework\TestCase;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 require_once __DIR__ . '/../../../lib/environment/class-environment.php';
 
 // phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
 
 class Environment_Test extends TestCase {
-	use ExpectPHPException;
-
 	private $error_reporting;
 
 	protected function setUp(): void {

--- a/tests/lib/helpers/test-environment.php
+++ b/tests/lib/helpers/test-environment.php
@@ -6,11 +6,8 @@ require_once __DIR__ . '/../../../lib/helpers/environment.php';
 
 use Automattic\Test\Constant_Mocker;
 use PHPUnit\Framework\TestCase;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 class Environment_Test extends TestCase {
-	use ExpectPHPException;
-
 	public function setUp(): void {
 		parent::setUp();
 		Constant_Mocker::clear();

--- a/tests/prometheus/test-prometheus.php
+++ b/tests/prometheus/test-prometheus.php
@@ -21,8 +21,8 @@ class Test_Prometheus extends WP_UnitTestCase {
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-        	throw new \Exception( $errstr, $errno );
-        }, E_USER_WARNING );
+			throw new \Exception( $errstr, $errno );
+		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {

--- a/tests/prometheus/test-prometheus.php
+++ b/tests/prometheus/test-prometheus.php
@@ -19,8 +19,9 @@ class Test_Prometheus extends WP_UnitTestCase {
 		Plugin_Helper::clear_instance();
 
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-            throw new \Exception( $errstr, $errno );
+        	throw new \Exception( $errstr, $errno );
         }, E_USER_WARNING );
 	}
 

--- a/tests/prometheus/test-prometheus.php
+++ b/tests/prometheus/test-prometheus.php
@@ -4,13 +4,10 @@ namespace Automattic\VIP\Prometheus;
 
 use Prometheus\RegistryInterface;
 use WP_UnitTestCase;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 require_once __DIR__ . '/class-plugin-helper.php';
 
 class Test_Prometheus extends WP_UnitTestCase {
-	use ExpectPHPException;
-
 	public function setUp(): void {
 		parent::setUp();
 
@@ -20,9 +17,16 @@ class Test_Prometheus extends WP_UnitTestCase {
 		remove_all_actions( 'init' );
 
 		Plugin_Helper::clear_instance();
+
+		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		set_error_handler( static function ( int $errno, string $errstr ): never {
+            throw new \Exception( $errstr, $errno );
+        }, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {
+		restore_error_handler();
+
 		Plugin::get_instance();
 		parent::tearDown();
 	}
@@ -97,7 +101,7 @@ class Test_Prometheus extends WP_UnitTestCase {
 			return new \stdClass();
 		} );
 
-		$this->expectWarning();
+		$this->expectException( \Exception::class );
 		do_action( 'vip_mu_plugins_loaded' );
 	}
 

--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -5,7 +5,6 @@ namespace Automattic\VIP\Search;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 use wpdb;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 // phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
@@ -14,7 +13,6 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
  * @preserveGlobalState disabled
  */
 class Queue_Test extends WP_UnitTestCase {
-	use ExpectPHPException;
 
 	/** @var \Automattic\VIP\Search\Search */
 	private $es;

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -40,8 +40,8 @@ class Search_Test extends WP_UnitTestCase {
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-        	throw new \Exception( $errstr, $errno );
-        }, E_USER_WARNING );
+			throw new \Exception( $errstr, $errno );
+		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -38,8 +38,9 @@ class Search_Test extends WP_UnitTestCase {
 		header_remove();
 
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( static function ( int $errno, string $errstr ): never {
-            throw new \Exception( $errstr, $errno );
+        	throw new \Exception( $errstr, $errno );
         }, E_USER_WARNING );
 	}
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -5,7 +5,6 @@ namespace Automattic\VIP\Search;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 use Automattic\Test\Constant_Mocker;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 require_once __DIR__ . '/mock-header.php';
 require_once __DIR__ . '/../../../../search/search.php';
@@ -18,8 +17,6 @@ require_once __DIR__ . '/../../../../prometheus.php';
  * @preserveGlobalState disabled
  */
 class Search_Test extends WP_UnitTestCase {
-	use ExpectPHPException;
-
 	public static $mock_global_functions;
 	public $test_index_name = 'vip-1234-post-0-v3';
 
@@ -39,9 +36,16 @@ class Search_Test extends WP_UnitTestCase {
 			->getMock();
 
 		header_remove();
+
+		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
+		set_error_handler( static function ( int $errno, string $errstr ): never {
+            throw new \Exception( $errstr, $errno );
+        }, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {
+		restore_error_handler();
+
 		Constant_Mocker::clear();
 		parent::tearDown();
 	}
@@ -2118,8 +2122,8 @@ class Search_Test extends WP_UnitTestCase {
 
 		// trigger_error is only called if an alert should happen
 		if ( $should_alert ) {
-			$this->expectWarning();
-			$this->expectWarningMessage(
+			$this->expectException( \Exception::class );
+			$this->expectExceptionMessage(
 				sprintf(
 					'Application 123 - http://example.org has had its Elasticsearch queries rate-limited for %d seconds. Half of traffic is diverted to the database when queries are rate-limited.',
 					$difference

--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -1,10 +1,6 @@
 <?php
 
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
-
 class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
-	use ExpectPHPException;
-
 	public $cache_manager;
 
 	public function setUp(): void {


### PR DESCRIPTION
## Description
Fixes #4193.

Also removes `ExpectPHPException` use from Polyfills because it's being deprecated in favour of `expectException()` per https://github.com/Yoast/PHPUnit-Polyfills/issues/95
