### PR TITLE
Update the mu-plugin header for Query Monitor

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -1,32 +1,6 @@
 <?php
 /**
- * Query Monitor plugin for WordPress
- *
- * @package   query-monitor
- * @link      https://github.com/johnbillion/query-monitor
- * @author    John Blackbourn <john@johnblackbourn.com>
- * @copyright 2009-2022 John Blackbourn
- * @license   GPL v2 or later
- *
- * Plugin Name:  Query Monitor
- * Description:  The developer tools panel for WordPress.
- * Version:      3.10.1
- * Plugin URI:   https://querymonitor.com/
- * Author:       John Blackbourn
- * Author URI:   https://querymonitor.com/
- * Text Domain:  query-monitor
- * Domain Path:  /languages/
- * Requires PHP: 5.6.20
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * Integration of the Query Monitor plugin for WordPress
  */
 
 /**


### PR DESCRIPTION
## Description

In #4383 the header of the VIP-specific query-monitor.php mu-plugin file didn't get updated. This has happened before and is easy to forget.

As this file doesn't originate from Query Monitor, the header (including its copyright notice) is misleading, so I propose removing it altogether.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR
1. Go to wp-admin
1. Ensure Query Monitor is still available and functional from the admin toolbar
