### PR TITLE
QM Cron: Add safeguarding for dev-env where data is not fully available

### DIFF
--- a/qm-plugins/qm-cron/class-qm-cron-output-html.php
+++ b/qm-plugins/qm-cron/class-qm-cron-output-html.php
@@ -45,11 +45,15 @@ class QM_Cron_Output extends QM_Output_Html {
 					<td><?php true === $this->doing_cron ? esc_html_e( 'Yes', 'query-monitor' ) : esc_html_e( 'No', 'query-monitor' ); ?></td>
 					<td>
 						<?php
-						echo esc_html( $data['next_event_time']['human_time'] );
-						echo '<br />';
-						echo absint( $data['next_event_time']['unix'] );
-						echo '<br />';
-						echo '<i>' . esc_html( $this->display_past_time( human_time_diff( $data['next_event_time']['unix'] ), $data['next_event_time']['unix'] ) ) . '</i>';
+						if ( isset( $data['next_event_time']['human_time'] ) ) {
+							echo esc_html( $data['next_event_time']['human_time'] );
+							echo '<br />';
+						}
+						if ( isset( $data['next_event_time']['unix'] ) ) {
+							echo absint( $data['next_event_time']['unix'] );
+							echo '<br />';
+							echo '<i>' . esc_html( $this->display_past_time( human_time_diff( $data['next_event_time']['unix'] ), $data['next_event_time']['unix'] ) ) . '</i>';
+						}
 						?>
 					</td>
 					<td><?php echo esc_html( gmdate( 'H:i:s' ) ); ?></td>
@@ -71,14 +75,16 @@ class QM_Cron_Output extends QM_Output_Html {
 			</thead>
 			<tbody>
 				<?php
-				foreach ( $data['schedules'] as $schedule => $value ) {
-					echo '<tr>';
-					echo '<th>' . esc_html( $schedule ) . '</th>';
-					echo '<th>' . esc_html( $value['interval'] ) . '</th>';
-					echo '<th>' . esc_html( $this->get_minutes( $value['interval'] ) ) . '</th>';
-					echo '<th>' . esc_html( $this->get_hours( $value['interval'] ) ) . '</th>';
-					echo '<th>' . esc_html( $value['display'] ) . '</th>';
-					echo '</tr>';
+				if ( is_array( $data['schedules'] ) ) {
+					foreach ( $data['schedules'] as $schedule => $value ) {
+						echo '<tr>';
+						echo '<th>' . esc_html( $schedule ) . '</th>';
+						echo '<th>' . esc_html( $value['interval'] ) . '</th>';
+						echo '<th>' . esc_html( $this->get_minutes( $value['interval'] ) ) . '</th>';
+						echo '<th>' . esc_html( $this->get_hours( $value['interval'] ) ) . '</th>';
+						echo '<th>' . esc_html( $value['display'] ) . '</th>';
+						echo '</tr>';
+					}
 				}
 				?>
 			</tbody>


### PR DESCRIPTION
## Description
Fixes the errors below that usually only happen on dev-env since cron isn't 100% working:

```
[26-Apr-2023 17:20:28 UTC] Warning: Trying to access array offset on value of type null in /wp/wp-content/mu-plugins/qm-plugins/qm-cron/class-qm-cron-output-html.php on line 48 [es-site.vipdev.lndo.site/] [wp-content/mu-plugins/query-monitor/dispatchers/Html.php:326 QM_Cron_Output->output(), wp-includes/class-wp-hook.php:308 QM_Dispatcher_Html->dispatch(), wp-includes/class-wp-hook.php:332 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-includes/load.php:1144 do_action('shutdown'), shutdown_action_hook()]
[26-Apr-2023 17:20:28 UTC] Warning: Trying to access array offset on value of type null in /wp/wp-content/mu-plugins/qm-plugins/qm-cron/class-qm-cron-output-html.php on line 50 [es-site.vipdev.lndo.site/] [wp-content/mu-plugins/query-monitor/dispatchers/Html.php:326 QM_Cron_Output->output(), wp-includes/class-wp-hook.php:308 QM_Dispatcher_Html->dispatch(), wp-includes/class-wp-hook.php:332 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-includes/load.php:1144 do_action('shutdown'), shutdown_action_hook()]
[26-Apr-2023 17:20:28 UTC] Warning: Trying to access array offset on value of type null in /wp/wp-content/mu-plugins/qm-plugins/qm-cron/class-qm-cron-output-html.php on line 52 [es-site.vipdev.lndo.site/] [wp-content/mu-plugins/query-monitor/dispatchers/Html.php:326 QM_Cron_Output->output(), wp-includes/class-wp-hook.php:308 QM_Dispatcher_Html->dispatch(), wp-includes/class-wp-hook.php:332 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-includes/load.php:1144 do_action('shutdown'), shutdown_action_hook()]
[26-Apr-2023 17:20:28 UTC] Warning: Trying to access array offset on value of type null in /wp/wp-content/mu-plugins/qm-plugins/qm-cron/class-qm-cron-output-html.php on line 52 [es-site.vipdev.lndo.site/] [wp-content/mu-plugins/query-monitor/dispatchers/Html.php:326 QM_Cron_Output->output(), wp-includes/class-wp-hook.php:308 QM_Dispatcher_Html->dispatch(), wp-includes/class-wp-hook.php:332 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-includes/load.php:1144 do_action('shutdown'), shutdown_action_hook()]
[26-Apr-2023 17:20:28 UTC] Warning: foreach() argument must be of type array|object, null given in /wp/wp-content/mu-plugins/qm-plugins/qm-cron/class-qm-cron-output-html.php on line 74 [es-site.vipdev.lndo.site/] [wp-content/mu-plugins/query-monitor/dispatchers/Html.php:326 QM_Cron_Output->output(), wp-includes/class-wp-hook.php:308 QM_Dispatcher_Html->dispatch(), wp-includes/class-wp-hook.php:332 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-includes/load.php:1144 do_action('shutdown'), shutdown_action_hook()]
```


## Changelog Description

### Plugin Updated: Query Monitor (cron)

Fix PHP warnings generated by cron data unavailable on dev-env

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1) Apply PR
2) Check logs on dev-env and ensure they are no longer being generated