### PR TITLE
Fixing bug where Super Admins cannot setup Time Based One-Time Password as first option Two Factor 

### DIFF
--- a/shared-plugins/two-factor/providers/class-two-factor-totp.php
+++ b/shared-plugins/two-factor/providers/class-two-factor-totp.php
@@ -83,7 +83,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 					'args'                => array(
 						'user_id' => array(
 							'required' => true,
-							'type'     => 'number',
+							'type'     => 'integer',
 						),
 					),
 				),
@@ -96,7 +96,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 					'args'                => array(
 						'user_id' => array(
 							'required' => true,
-							'type'     => 'number',
+							'type'     => 'integer',
 						),
 						'key'     => array(
 							'type'              => 'string',


### PR DESCRIPTION
## Changelog Description
I am setting the controller parameter configuration to have user_id as an integer instead of a number because strict comparison requires matching types. Please have a look at #4409 for more information.

Fixes #4409

## Checklist

Please make sure the items below have been covered before requesting a review:

- [Y] This change works and has been tested locally (or has an appropriate fallback).
- [Y] This change works and has been tested on a Go sandbox.
  - I used filters to apply this change in our WP VIP production.
- [Y] This change has relevant unit tests.
  - No tests were found
- [Y] This change uses a rollout method to ease with deployment
  - Not applicable
- [Y] This change has relevant documentation additions/updates.
  - I do not believe applicable
- [Y] I've created a changelog description that aligns with the provided examples.
  - See #4409 

## Hotfix Code
```php
function hooks_filter_two_factor_endpoint_configuration(array $endpoints): array {
    if ( isset($endpoints['/two-factor/1.0/totp']) ) {
        $endpoints['/two-factor/1.0/totp'][0]['args']['user_id']['type'] = 'integer';
        $endpoints['/two-factor/1.0/totp'][1]['args']['user_id']['type'] = 'integer';
    }

    if ( isset($endpoints['/two-factor/1.0/generate-backup-codes']) ) {
        $endpoints['/two-factor/1.0/totp'][0]['args']['user_id']['type'] = 'integer';
    }

    return $endpoints;
}
add_filter( 'rest_endpoints', 'hooks_filter_two_factor_endpoint_configuration' );
```

## Steps to Test

1. Setup a multisite
2. Create a new user that is a super_admin
3. Log in as the new super_admin
4. Go to `wp-admin` > `Edit Profile`
5. submit an authentication code

