### PR TITLE
vip_strict_sanitize_username(): return empty string if not string

### DIFF
--- a/security.php
+++ b/security.php
@@ -33,6 +33,10 @@ if ( \Automattic\VIP\Security\Private_Sites::has_privacy_restrictions() ) {
  * @return string
  */
 function vip_strict_sanitize_username( $username ) {
+	if ( ! is_string( $username ) ) {
+		return '';
+	}
+
 	if ( is_email( $username ) ) {
 		// We don't want to do this strict filter on email addresses. Sanitize the email and return.
 		$username = sanitize_email( $username );

--- a/security.php
+++ b/security.php
@@ -33,7 +33,7 @@ if ( \Automattic\VIP\Security\Private_Sites::has_privacy_restrictions() ) {
  * @return string
  */
 function vip_strict_sanitize_username( $username ) {
-	if ( ! is_string( $username ) ) {
+	if ( is_object( $username ) || is_array( $username ) ) {
 		return '';
 	}
 

--- a/security.php
+++ b/security.php
@@ -33,7 +33,7 @@ if ( \Automattic\VIP\Security\Private_Sites::has_privacy_restrictions() ) {
  * @return string
  */
 function vip_strict_sanitize_username( $username ) {
-	if ( is_object( $username ) || is_array( $username ) ) {
+	if ( ! is_scalar( $username ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
## Description
Uses a similar approach to `sanitize_text_field()` which calls `_sanitize_text_fields()`: https://github.com/WordPress/WordPress/blob/fe8c41f574bf10400af550e59d289dde45a1470a/wp-includes/formatting.php#L5531-L5534

## Changelog Description

### Function Updated: vip_strict_sanitize_username()

Return empty string if string not passed in

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
