### PR TITLE
Jetpack: Make 12.1 default

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.0
+ * Version: 12.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -24,11 +24,14 @@ function vip_default_jetpack_version() {
 		// WordPress 5.8.x and older. Not including 5.9.
 		return '10.9';
 	} elseif ( version_compare( $wp_version, '6.0', '<' ) ) {
-		// WordPress 5.9.x and newer. Not including 6.0.
+		// WordPress 5.9.x
 		return '11.4';
-	} else {
-		// WordPress 6.0 and newer
+	} elseif ( version_compare( $wp_version, '6.1', '<' ) ) {
+		// WordPress 6.0.x
 		return '12.0';
+	} else {
+		// WordPress 6.1 and newer.
+		return '12.1';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,14 +7,14 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '12.0';
+		$latest = '12.1';
 
 		$versions_map = [
 			// WordPress version => Jetpack version
 			'5.8.6' => '10.9',
 			'5.9'   => '11.4',
 			'5.9.5' => '11.4',
-			'6.0'   => $latest,
+			'6.0'   => '12.0',
 			'6.1'   => $latest,
 			'6.1.1' => $latest,
 		];


### PR DESCRIPTION
## Description
12.1 for everyone

## Changelog Description

### Plugin Updated: Jetpack 

Jetpack 12.1 is now the default version for all non-pinned applications.
