### PR TITLE
Search: Fix fatal `Warning: Undefined property: Automattic\VIP\Search\Queue::$alerts`

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -1137,7 +1137,7 @@ class Queue {
 			$index_limiting_time
 		);
 
-		$this->alerts->send_to_chat( self::INDEX_RATE_LIMITING_ALERT_SLACK_CHAT, $message, self::INDEX_RATE_LIMITING_ALERT_LEVEL );
+		\Automattic\VIP\Utils\Alerts::instance()->send_to_chat( self::INDEX_RATE_LIMITING_ALERT_SLACK_CHAT, $message, self::INDEX_RATE_LIMITING_ALERT_LEVEL );
 
 		trigger_error( $message, \E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 


### PR DESCRIPTION
## Description
Fixes the fatal `PHP message: Warning: Undefined property: Automattic\VIP\Search\Queue::$alerts in /var/www/wp-content/mu-plugins/search/includes/classes/class-queue.php on line 1140`

## Changelog Description

### Plugin Updated: Enterprise Search
Fix fatal `PHP message: Warning: Undefined property: Automattic\VIP\Search\Queue::$alerts in /var/www/wp-content/mu-plugins/search/includes/classes/class-queue.php on line 1140`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
