### PR TITLE
Revert "chore(deps-dev): bump @wordpress/env from 6.0.0 to 7.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@babel/plugin-syntax-decorators": "^7.19.0",
-        "@wordpress/env": "^7.0.0",
+        "@wordpress/env": "^6.0.0",
         "10up-toolkit": "^5.0.0",
         "classnames": "^2.3.1",
         "cypress": "^9.5.0",
@@ -5064,9 +5064,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-7.0.0.tgz",
-      "integrity": "sha512-C0Z/smvyEeMFPjoDo149dv/w83W9hVOIkBQSGpRzeWSwDEJVYPKeZ1sUSC4y01zdXVyIxeyWIRLSm611pYIlAQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-6.0.0.tgz",
+      "integrity": "sha512-hlJHol3QlbTE0KHbuS7AePUQXGWNB2ycb+Fv2YMW05AMZYUmcO3BNaj/lQ4Yuw/KVUfMCB74rJMTXtk/I39Z4A==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Automattic",
   "devDependencies": {
     "@babel/plugin-syntax-decorators": "^7.19.0",
-    "@wordpress/env": "^7.0.0",
+    "@wordpress/env": "^6.0.0",
     "10up-toolkit": "^5.0.0",
     "classnames": "^2.3.1",
     "cypress": "^9.5.0",


### PR DESCRIPTION
Reverts Automattic/vip-go-mu-plugins#4456