### PR TITLE
tests: Fix `expectException()` usage

### DIFF
--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -3,6 +3,8 @@
 namespace Automattic\VIP\Cache;
 
 use Automattic\Test\Constant_Mocker;
+use Exception;
+use Throwable;
 use WP_UnitTestCase;
 
 require_once __DIR__ . '/mock-header.php';
@@ -264,15 +266,17 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 	public function test__register_groups__did_send_headers() {
 		do_action( 'send_headers' );
 
-		$this->expectException( \Exception::class );
-
-		$actual_result = Vary_Cache::register_groups( [
-			'dev-group',
-			'design-group',
-		] );
-
-		$this->assertFalse( $actual_result, 'register_groups after send_headers did not return false' );
-		$this->assertEquals( [], Vary_Cache::get_groups(), 'Registered groups are not empty.' );
+		try {
+			Vary_Cache::register_groups( [
+				'dev-group',
+				'design-group',
+			] );
+			self::assertTrue( false );
+		} catch ( Throwable $e ) {
+			self::assertInstanceOf( Exception::class, $e );
+			self::assertEquals( E_USER_WARNING, $e->getCode() );
+			self::assertEmpty( Vary_Cache::get_groups(), 'Registered groups are not empty.' );
+		}
 	}
 
 	public function get_test_data__register_groups_invalid() {
@@ -292,11 +296,9 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 	 * @dataProvider get_test_data__register_groups_invalid
 	 */
 	public function test__register_groups__invalid( $invalid_groups ) {
-		$this->expectException( \Exception::class );
-		$actual_result = Vary_Cache::register_groups( $invalid_groups );
-
-		$this->assertFalse( $actual_result, 'Invalid register_groups call did not return false' );
-		$this->assertEquals( [], Vary_Cache::get_groups(), 'Registered groups was not empty.' );
+		$this->expectException( Exception::class );
+		$this->expectExceptionCode( E_USER_WARNING );
+		Vary_Cache::register_groups( $invalid_groups );
 	}
 
 	public function get_test_data__set_group_for_user_invalid() {

--- a/tests/cache/test-vary-cache.php
+++ b/tests/cache/test-vary-cache.php
@@ -3,18 +3,19 @@
 namespace Automattic\VIP\Cache;
 
 use Automattic\Test\Constant_Mocker;
-use Exception;
-use Throwable;
+use ErrorException;
 use WP_UnitTestCase;
 
 require_once __DIR__ . '/mock-header.php';
 require_once __DIR__ . '/../../cache/class-vary-cache.php';
 
 // phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
 
 class Vary_Cache_Test extends WP_UnitTestCase {
 	private $original_cookie;
 	private $original_server;
+	private $original_error_reporting;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -27,10 +28,16 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 		Vary_Cache::load();
 		Constant_Mocker::clear();
 
+		$this->original_error_reporting = error_reporting();
+
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
-		set_error_handler( static function ( int $errno, string $errstr ): never {
-			throw new \Exception( $errstr, $errno );
+		set_error_handler( static function ( int $errno, string $errstr ) {
+			if ( $errno & error_reporting() ) {
+				throw new ErrorException( $errstr, $errno );
+			}
+
+			return false;
 		}, E_USER_WARNING );
 	}
 
@@ -42,6 +49,8 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 
 		$_COOKIE = $this->original_cookie;
 		$_SERVER = $this->original_server;
+
+		error_reporting( $this->original_error_reporting );
 
 		parent::tearDown();
 	}
@@ -263,20 +272,28 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_groups, Vary_Cache::get_groups(), 'Multiple register_groups did not result in expected groups' );
 	}
 
+	public function test__register_groups__did_send_headers__warning() {
+		do_action( 'send_headers' );
+		$this->expectException( ErrorException::class );
+		$this->expectExceptionCode( E_USER_WARNING );
+
+		Vary_Cache::register_groups( [
+			'dev-group',
+			'design-group',
+		] );
+	}
+
 	public function test__register_groups__did_send_headers() {
 		do_action( 'send_headers' );
 
-		try {
-			Vary_Cache::register_groups( [
-				'dev-group',
-				'design-group',
-			] );
-			self::assertTrue( false );
-		} catch ( Throwable $e ) {
-			self::assertInstanceOf( Exception::class, $e );
-			self::assertEquals( E_USER_WARNING, $e->getCode() );
-			self::assertEmpty( Vary_Cache::get_groups(), 'Registered groups are not empty.' );
-		}
+		error_reporting( $this->original_error_reporting & ~E_USER_WARNING );
+		$result = Vary_Cache::register_groups( [
+			'dev-group',
+			'design-group',
+		] );
+
+		self::assertFalse( $result );
+		self::assertEmpty( Vary_Cache::get_groups(), 'Registered groups are not empty.' );
 	}
 
 	public function get_test_data__register_groups_invalid() {
@@ -295,10 +312,19 @@ class Vary_Cache_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider get_test_data__register_groups_invalid
 	 */
-	public function test__register_groups__invalid( $invalid_groups ) {
-		$this->expectException( Exception::class );
+	public function test__register_groups__invalid__warning( $invalid_groups ) {
+		$this->expectException( ErrorException::class );
 		$this->expectExceptionCode( E_USER_WARNING );
 		Vary_Cache::register_groups( $invalid_groups );
+	}
+
+	/**
+	 * @dataProvider get_test_data__register_groups_invalid
+	 */
+	public function test__register_groups__invalid( $invalid_groups ) {
+		error_reporting( $this->original_error_reporting & ~E_USER_WARNING );
+		$result = Vary_Cache::register_groups( $invalid_groups );
+		self::assertTrue( $result );
 	}
 
 	public function get_test_data__set_group_for_user_invalid() {

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -1,40 +1,71 @@
 <?php
 
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+
 namespace Automattic\VIP\Files\Acl\Pre_WP_Utils;
 
+use ErrorException;
 use WP_UnitTestCase;
 
 require_once __DIR__ . '/../../../files/acl/pre-wp-utils.php';
 
 class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
+	private $original_error_reporting;
+
 	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_error_reporting = error_reporting();
+
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
-		set_error_handler( static function ( int $errno, string $errstr ): never {
-			throw new \Exception( $errstr, $errno );
+		set_error_handler( static function ( int $errno, string $errstr ) {
+			if ( error_reporting() & $errno ) {
+				throw new ErrorException( $errstr, $errno );
+			}
+
+			return false;
 		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {
 		restore_error_handler();
+		error_reporting( $this->original_error_reporting );
 
 		parent::tearDown();
 	}
 
-	public function test__prepare_request__empty_request_uri() {
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'VIP Files ACL failed due to empty URI' );
+	public function data__prepare_request(): iterable {
+		return [
+			'Empty request URI'   => [
+				'',
+				'VIP Files ACL failed due to empty URI',
+			],
+			'Invalid request URI' => [
+				'invalid/path.jpg',
+				'VIP Files ACL failed due to relative path (for invalid/path.jpg)',
+			],
+		];
+	}
 
-		$request_uri = '';
+	/**
+	 * @dataProvider data__prepare_request
+	 */
+	public function test__prepare_request__warning( string $request_uri, string $expected_message ): void {
+		$this->expectException( ErrorException::class );
+		$this->expectExceptionCode( E_USER_WARNING );
+		$this->expectExceptionMessage( $expected_message );
+
 		prepare_request( $request_uri );
 	}
 
-	public function test__prepare_request__invalid_request_uri() {
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'VIP Files ACL failed due to relative path (for invalid/path.jpg)' );
-
-		$request_uri = 'invalid/path.jpg';
-		prepare_request( $request_uri );
+	/**
+	 * @dataProvider data__prepare_request
+	 */
+	public function test__prepare_request( string $request_uri, string $expected_message ): void {
+		error_reporting( $this->original_error_reporting & ~E_USER_WARNING );
+		$result = prepare_request( $request_uri );
+		self::assertFalse( $result );
 	}
 
 	public function test__prepare_request__valid() {
@@ -106,11 +137,21 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider get_data__validate_path__invalid
 	 */
-	public function test__validate_path__invalid( $file_path, $expected_warning ) {
-		$this->expectException( \Exception::class );
+	public function test__validate_path__invalid__warning( $file_path, $expected_warning ) {
+		$this->expectException( ErrorException::class );
+		$this->expectExceptionCode( E_USER_WARNING );
 		$this->expectExceptionMessage( $expected_warning );
 
 		validate_path( $file_path );
+	}
+
+	/**
+	 * @dataProvider get_data__validate_path__invalid
+	 */
+	public function test__validate_path__invalid( $file_path, $expected_warning ) {
+		error_reporting( $this->original_error_reporting & ~E_USER_WARNING );
+		$result = validate_path( $file_path );
+		self::assertFalse( $result );
 	}
 
 	/**

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -20,15 +20,13 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 
 		parent::tearDown();
 	}
+
 	public function test__prepare_request__empty_request_uri() {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'VIP Files ACL failed due to empty URI' );
 
 		$request_uri = '';
-
-		$actual_result = prepare_request( $request_uri );
-
-		$this->assertFalse( $actual_result );
+		prepare_request( $request_uri );
 	}
 
 	public function test__prepare_request__invalid_request_uri() {
@@ -36,10 +34,7 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 		$this->expectExceptionMessage( 'VIP Files ACL failed due to relative path (for invalid/path.jpg)' );
 
 		$request_uri = 'invalid/path.jpg';
-
-		$actual_result = prepare_request( $request_uri );
-
-		$this->assertFalse( $actual_result );
+		prepare_request( $request_uri );
 	}
 
 	public function test__prepare_request__valid() {
@@ -115,9 +110,7 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( $expected_warning );
 
-		$actual_is_valid = validate_path( $file_path );
-
-		$this->assertFalse( $actual_is_valid );
+		validate_path( $file_path );
 	}
 
 	/**

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -1,9 +1,13 @@
 <?php
 
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+
 namespace Automattic\VIP\Files;
 
-use WP_UnitTestCase;
 use Automattic\Test\Constant_Mocker;
+use ErrorException;
+use WP_Filesystem_Direct;
+use WP_UnitTestCase;
 
 require_once __DIR__ . '/../../files/class-wp-filesystem-vip.php';
 
@@ -11,28 +15,36 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 	private $filesystem;
 	private $fs_uploads_mock;
 	private $fs_direct_mock;
+	private $original_error_reporting;
 
 	public function setUp(): void {
 		parent::setUp();
 		Constant_Mocker::clear();
 
 		$this->fs_uploads_mock = $this->createMock( WP_Filesystem_VIP_Uploads::class );
-		$this->fs_direct_mock  = $this->createMock( \WP_Filesystem_Direct::class );
+		$this->fs_direct_mock  = $this->createMock( WP_Filesystem_Direct::class );
 
 		$this->filesystem = new WP_Filesystem_VIP( [
 			$this->fs_uploads_mock,
 			$this->fs_direct_mock,
 		] );
 
+		$this->original_error_reporting = error_reporting();
+
 		// As of PHPUnit 10.x, expectWarning() is removed. We'll use a custom error handler to test for warnings.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
-		set_error_handler( static function ( int $errno, string $errstr ): never {
-			throw new \Exception( $errstr, $errno );
+		set_error_handler( static function ( int $errno, string $errstr ) {
+			if ( error_reporting() & $errno ) {
+				throw new ErrorException( $errstr, $errno );
+			}
+
+			return false;
 		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {
 		restore_error_handler();
+		error_reporting( $this->original_error_reporting );
 
 		$this->filesystem = null;
 
@@ -287,13 +299,22 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 		$this->assertEquals( $result, $this->fs_direct_mock );
 	}
 
-	public function test__get_transport_for_path__disallowed_write() {
+	public function test__get_transport_for_path__disallowed_write__warning() {
 		$get_transport_for_path = self::get_method( 'get_transport_for_path' );
 
-		$this->expectException( \Exception::class );
+		$this->expectException( ErrorException::class );
+		$this->expectExceptionCode( E_USER_WARNING );
 		$this->expectExceptionMessage( 'The `/test/random/directory/file.file` file cannot be managed by the `Automattic\VIP\Files\WP_Filesystem_VIP` class. Writes are only allowed for the `/tmp/` and `/tmp/wordpress/wp-content/uploads` directories and reads can be performed everywhere.' );
 
 		$get_transport_for_path->invokeArgs( $this->filesystem, [ '/test/random/directory/file.file', 'write' ] );
+	}
+
+	public function test__get_transport_for_path__disallowed_write() {
+		error_reporting( $this->original_error_reporting & ~E_USER_WARNING );
+		$get_transport_for_path = self::get_method( 'get_transport_for_path' );
+
+		$result = $get_transport_for_path->invokeArgs( $this->filesystem, [ '/test/random/directory/file.file', 'write' ] );
+		self::assertFalse( $result );
 	}
 
 	public function test__get_transport_for_path__non_vip_go_env() {

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -293,9 +293,7 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'The `/test/random/directory/file.file` file cannot be managed by the `Automattic\VIP\Files\WP_Filesystem_VIP` class. Writes are only allowed for the `/tmp/` and `/tmp/wordpress/wp-content/uploads` directories and reads can be performed everywhere.' );
 
-		$result = $get_transport_for_path->invokeArgs( $this->filesystem, [ '/test/random/directory/file.file', 'write' ] );
-
-		$this->assertFalse( $result );
+		$get_transport_for_path->invokeArgs( $this->filesystem, [ '/test/random/directory/file.file', 'write' ] );
 	}
 
 	public function test__get_transport_for_path__non_vip_go_env() {

--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -1,8 +1,13 @@
 <?php
 
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+
 class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 	/** @var WPCOM_VIP_Cache_Manager */
 	public $cache_manager;
+
+	private $original_error_reporting;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -11,14 +16,19 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 		$this->cache_manager->init();
 		$this->cache_manager->clear_queued_purge_urls();
 
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
-		set_error_handler( static function ( int $errno, string $errstr ): never {
-			throw new ErrorException( $errstr, $errno );
+		$this->original_error_reporting = error_reporting();
+		set_error_handler( static function ( int $errno, string $errstr ) {
+			if ( error_reporting() & $errno ) {
+				throw new ErrorException( $errstr, $errno );
+			}
+
+			return false;
 		}, E_USER_WARNING );
 	}
 
 	public function tearDown(): void {
 		restore_error_handler();
+		error_reporting( $this->original_error_reporting );
 		parent::tearDown();
 	}
 
@@ -76,15 +86,21 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_data_for_invalid_queue_purge_url_test
 	 */
+	public function test__invalid__queue_purge_url__warning( $queue_url ) {
+		$this->expectException( ErrorException::class );
+		$this->expectExceptionCode( E_USER_WARNING );
+		$this->cache_manager->queue_purge_url( $queue_url );
+	}
+
+	/**
+	 * @dataProvider get_data_for_invalid_queue_purge_url_test
+	 */
 	public function test__invalid__queue_purge_url( $queue_url ) {
-		try {
-			$this->cache_manager->queue_purge_url( $queue_url );
-			self::assertTrue( false );
-		} catch ( Throwable $e ) {
-			self::assertInstanceOf( ErrorException::class, $e );
-			self::assertEquals( E_USER_WARNING, $e->getCode() );
-			self::assertEmpty( $this->cache_manager->get_queued_purge_urls(), 'List of queued purge urls should be empty' );
-		}
+		error_reporting( $this->original_error_reporting & ~E_USER_WARNING );
+
+		$result = $this->cache_manager->queue_purge_url( $queue_url );
+		self::assertFalse( $result );
+		self::assertEmpty( $this->cache_manager->get_queued_purge_urls(), 'List of queued purge urls should be empty' );
 	}
 
 	public function test__page_for_posts_post_purge_url() {


### PR DESCRIPTION
When we `expectException()`, the code that follows the statement that throws an exception, does not run.

For example,

```php
$this->expectException( \Exception::class );

$actual_result = Vary_Cache::register_groups( [
	'dev-group',
	'design-group',
] );

$this->assertFalse( $actual_result, 'register_groups after send_headers did not return false' );
$this->assertEquals( [], Vary_Cache::get_groups(), 'Registered groups are not empty.' );
```

`Vary_Cache::register_groups()` spits a warning that gets converted into an `Exception` (we do this with our custom error handler; PHPUnit employs a similar technique). Assertions that follow `Vary_Cache::register_groups()`, are not run.

The same thing happens here:

```php
function send_visibility_headers( $file_visibility, $file_path ) {
	// ...
	switch ( $file_visibility ) {
		// ...
		default:
			trigger_error( sprintf( 'Invalid file visibility (%s) ACL set for %s', $file_visibility, $file_path ), E_USER_WARNING );
			break;
	}

	http_response_code( $status_code );

	if ( null !== $is_private ) {
		$private_header_value = $is_private ? 'true' : 'false';
		header( sprintf( 'X-Private: %s', $private_header_value ) );
	}
}
```

```php
	public function test__send_visibility_headers__invalid_visibility() {
		$this->expectException( \Exception::class );
		$this->expectExceptionMessage( 'Invalid file visibility (NOT_A_VISIBILITY) ACL set for /wp-content/uploads/invalid.jpg' );

		send_visibility_headers( 'NOT_A_VISIBILITY', '/wp-content/uploads/invalid.jpg' );

// The checks below will not run:
		$this->assertEquals( 500, http_response_code(), 'Status code does not match expected' );

		$headers = headers_list();
		$this->assertNotContains( 'X-Private: true', $headers, 'Sent headers include X-Private: true header but should not.', true );
		$this->assertNotContains( 'X-Private: false', $headers, 'Sent headers include X-Private:false header but should not.', true );
	}
```

When the code spits a warning that we convert to an exception, no code that follows the guilty statement is run; in this case, we leave the function right after `trigger_error()`; no headers are sent.
