### PR TITLE
tests: Do not contact external sites in Site_Details_Index_Test

### DIFF
--- a/tests/config/test-site-details-index.php
+++ b/tests/config/test-site-details-index.php
@@ -17,6 +17,25 @@ require_once __DIR__ . '/../../config/class-site-details-index.php';
  * @preserveGlobalState disabled
  */
 class Site_Details_Index_Test extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+		add_filter( 'pre_http_request', function ( $result, $args, $url ) {
+			if ( false === $result ) {
+				$result = [
+					'headers'  => [],
+					'body'     => '',
+					'response' => [
+						'code'    => 418,
+						'message' => "I'm a teapot",
+					],
+					'cookies'  => [],
+				];
+			}
+
+			return $result;
+		}, 10, 3 );
+	}
+
 	public function test__data_filter_should_not_be_hooked_if_no_init() {
 		$sdi = new Site_Details_Index();
 


### PR DESCRIPTION
When our tests contact `wordpress.org`, a request may fail; that causes tests to fail.

Ideally, unit tests should not contact any external resources.

This PR fixes `Site_Details_Index_Test`; `vip_site_details_index_data` indirectly calls `wp_update_themes()`, which, in turn, tries to access `https://api.wordpress.org/themes/update-check/1.1/`.

Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/4990322583/jobs/8935370475?pr=4454
