### PR TITLE
ci: Fix triggers for Search E2E tests

### DIFF
--- a/.github/workflows/search-e2e.yml
+++ b/.github/workflows/search-e2e.yml
@@ -11,6 +11,8 @@ on:
     paths:
     - 'search/**'
     - 'tests/search/e2e/**'
+    - 'package-lock.json'
+    - '.github/workflows/search-e2e.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This PR fixes triggers for Search E2E tests.

It adds `package-lock.json` because we need to run tests when dependencies change (to avoid situations like #4456/#4462), and `.github/workflows/search-e2e.yml` because if we modify the workflow, we may want to test our changes.
