### PR TITLE
Filter blog_public sooner

### DIFF
--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -54,7 +54,6 @@ class Private_Sites {
 
 		add_filter( 'jetpack_active_modules', array( $this, 'filter_jetpack_active_modules' ) );
 		add_filter( 'jetpack_get_available_modules', array( $this, 'filter_jetpack_get_available_modules' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_options', array( $this, 'filter_blog_public_option_for_full_sync' ), 11 );
 		add_filter( 'pre_option_blog_public', fn() => '-1' );
 
 		$this->disable_core_feeds();
@@ -117,26 +116,5 @@ class Private_Sites {
 		unset( $modules['enhanced-distribution'] );
 
 		return $modules;
-	}
-
-	/**
-	 * Filter the blog_public option when syncing to JP
-	 *
-	 * @param array $args {
-	 *  Sync option values.
-	 * @type string Option name.
-	 * @type mixed Value.
-	 * }
-	 *
-	 * @return array
-	 */
-	public function filter_blog_public_option_for_full_sync( $args ) {
-		if ( ! is_array( $args ) ) {
-			return $args;
-		}
-
-		$args['blog_public'] = '-1';
-
-		return $args;
 	}
 }

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -54,10 +54,8 @@ class Private_Sites {
 
 		add_filter( 'jetpack_active_modules', array( $this, 'filter_jetpack_active_modules' ) );
 		add_filter( 'jetpack_get_available_modules', array( $this, 'filter_jetpack_get_available_modules' ) );
-		add_filter( 'jetpack_sync_before_enqueue_added_option', array( $this, 'filter_blog_public_option_for_sync' ) );
-		add_filter( 'jetpack_sync_before_enqueue_updated_option', array( $this, 'filter_blog_public_option_for_sync' ) );
-		add_filter( 'jetpack_sync_before_enqueue_deleted_option', array( $this, 'filter_blog_public_option_for_sync' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_options', array( $this, 'filter_blog_public_option_for_full_sync' ), 11 );
+		add_filter( 'pre_option_blog_public', fn() => '-1' );
 
 		$this->disable_core_feeds();
 		$this->block_unnecessary_access();
@@ -119,30 +117,6 @@ class Private_Sites {
 		unset( $modules['enhanced-distribution'] );
 
 		return $modules;
-	}
-
-	/**
-	 * Filter the blog_public option when syncing to JP
-	 *
-	 * @param array $args {
-	 *  Sync values.
-	 * @type string Option name.
-	 * @type mixed Old value.
-	 * @type mixed New value.
-	 * }
-	 *
-	 * @return array
-	 */
-	public function filter_blog_public_option_for_sync( $args ) {
-		if ( ! is_array( $args ) ) {
-			return $args;
-		}
-
-		if ( 'blog_public' === $args[0] ) {
-			$args[2] = '-1';
-		}
-
-		return $args;
 	}
 
 	/**

--- a/tests/security/test-class-private-sites.php
+++ b/tests/security/test-class-private-sites.php
@@ -100,43 +100,4 @@ class Private_Sites_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $filtered );
 	}
-
-	public function test__filter_blog_public_option_for_sync() {
-		$private = Private_Sites::instance();
-
-		$input = array( 'blog_public', 'foo', '1' );
-
-		$filtered = $private->filter_blog_public_option_for_sync( $input );
-
-		$this->assertEquals( '-1', $filtered[2] );
-	}
-
-	public function test__filter_blog_public_option_for_sync_other_option() {
-		$private = Private_Sites::instance();
-
-		$input = array( 'foo', 'bar', '1' );
-
-		$filtered = $private->filter_blog_public_option_for_sync( $input );
-
-		// Unchanged
-		$this->assertEquals( '1', $filtered[2] );
-	}
-
-	public function test__filter_blog_public_option_for_full_sync() {
-		$private = Private_Sites::instance();
-
-		$input = array(
-			'blog_public' => 1,
-			'foo'         => 'bar',
-		);
-
-		$filtered = $private->filter_blog_public_option_for_full_sync( $input );
-
-		$expected = array(
-			'blog_public' => '-1',
-			'foo'         => 'bar',
-		);
-
-		$this->assertEquals( $expected, $filtered );
-	}
 }


### PR DESCRIPTION
## Description
Filtering `blog_public` on sync could cause an issue on different syncs the JP is doing that is not invoking filters we used before.

This change moves the filter sooner to leverage core's option filter which then gets used before any access to that option.

## Changelog Description

### Plugin Updated: Jetpack

On non-production environments, we enforce `blog_public` option in a more robust way.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

This command works for me on local dev-env:
```
dev-env exec --slug vip-local -- wp eval '$opt = new Automattic\Jetpack\Sync\Modules\Options(); $opt->set_defaults(); $all_options = $opt->get_all_options(); var_dump($all_options["blog_public"]);'
```
