### PR TITLE
Update JP private site sync status option name

### DIFF
--- a/config/class-sync.php
+++ b/config/class-sync.php
@@ -13,7 +13,7 @@ class Sync {
 	const MAX_SYNCS_PER_INTERVAL = 10;
 	const LOG_FEATURE_NAME       = 'vip_config_sync';
 
-	const JETPACK_PRIVACY_SETTINGS_SYNC_STATUS_OPTION_NAME = 'vip_config_jetpack_privacy_settings_synced_value';
+	const JETPACK_PRIVACY_SETTINGS_SYNC_STATUS_OPTION_NAME = 'vip_config_jetpack_privacy_settings_synced_value_v2';
 
 	// The maximum amount of blogs we want to register immediant syncs for.
 	const BLOGS_TO_SYNC_LIMIT = 10;


### PR DESCRIPTION
## Description

Updates the option that holds sync status for JP private site settings. This is to resync this setting across all sites marked as private.

## Changelog Description

### Jetpack: Resync privacy settings for private JP sites

We want to resync the privacy settings for JP sites that have been marked as private (via the `VIP_JETPACK_IS_PRIVATE` constant), so we're updating the option name that stores this state in order to cause these sites to re-sync.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

Must be done on a sandboxed site connected to JP:

1. Check out PR
2. In `wp shell`:
3. $sync = `Automattic\VIP\Config\Sync::instance();`
4. `$sync->maybe_sync_jetpack_privacy_settings();`
5. Check PHP logs on sandbox ... should see `Inconsistent privacy settings detected, scheduled new sync`
6. Check Jetpack cache site RC, should see new events for syncing of functions + options
