### PR TITLE
ci: Workaround for failing core tests

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -50,6 +50,11 @@ jobs:
           submodules: recursive
           path: wordpress/src/wp-content/mu-plugins
 
+      - name: Patch package.json for WP 6.2.2
+        run: |
+          sed -i 's/"version": "6.2.3"/"version": "6.2.2"/' wordpress/package.json
+        if: steps.version.outputs.latest == '6.2.2'
+
       - name: Tweaks
         run: |
           echo "define( 'VIP_JETPACK_SKIP_LOAD', 'true' );" >> "wordpress/src/wp-content/mu-plugins/000-vip-init.php"


### PR DESCRIPTION
Core tests (namely, `test_package_json`) fail because of this bug:

https://github.com/WordPress/wordpress-develop/blob/6.2.2/package.json#L3

The version specified in `package.json` (6.2.3) must match the actual WP version (6.2.2): https://github.com/WordPress/wordpress-develop/blob/6.2.2/tests/phpunit/tests/basic.php#L54

We fix the test by patching `package.json` to set the correct version.
