### PR TITLE
Respect non-public option

### DIFF
--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -54,7 +54,7 @@ class Private_Sites {
 
 		add_filter( 'jetpack_active_modules', array( $this, 'filter_jetpack_active_modules' ) );
 		add_filter( 'jetpack_get_available_modules', array( $this, 'filter_jetpack_get_available_modules' ) );
-		add_filter( 'pre_option_blog_public', fn() => '-1' );
+		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
 
 		$this->disable_core_feeds();
 		$this->block_unnecessary_access();
@@ -116,5 +116,12 @@ class Private_Sites {
 		unset( $modules['enhanced-distribution'] );
 
 		return $modules;
+	}
+
+	public function filter_restrict_blog_public( $current_value ) {
+		if ( $current_value === '1' ) {
+			return '-1';
+		}
+		return $current_value;
 	}
 }

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -119,7 +119,7 @@ class Private_Sites {
 	}
 
 	public function filter_restrict_blog_public( $current_value ) {
-		if ( $current_value === '1' ) {
+		if ( '1' === $current_value ) {
 			return '-1';
 		}
 		return $current_value;

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -119,7 +119,7 @@ class Private_Sites {
 	}
 
 	public function filter_restrict_blog_public( $current_value ) {
-		if ( '1' === $current_value ) {
+		if ( '1' === $current_value || '0' === $current_value ) {
 			return '-1';
 		}
 		return $current_value;

--- a/tests/security/test-class-private-sites.php
+++ b/tests/security/test-class-private-sites.php
@@ -100,4 +100,23 @@ class Private_Sites_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $filtered );
 	}
+
+	public function test__filter_restrict_blog_public_keeps_2() {
+		$private = Private_Sites::instance();
+		$filtered = $private->filter_restrict_blog_public( '2' );
+
+		$this->assertEquals( '2', $filtered );
+	}
+	public function test__filter_restrict_blog_public_keeps_0() {
+		$private = Private_Sites::instance();
+		$filtered = $private->filter_restrict_blog_public( '0' );
+
+		$this->assertEquals( '0', $filtered );
+	}
+	public function test__filter_restrict_blog_public_changes_1() {
+		$private = Private_Sites::instance();
+		$filtered = $private->filter_restrict_blog_public( '1' );
+
+		$this->assertEquals( '-1', $filtered );
+	}
 }

--- a/tests/security/test-class-private-sites.php
+++ b/tests/security/test-class-private-sites.php
@@ -102,19 +102,19 @@ class Private_Sites_Test extends WP_UnitTestCase {
 	}
 
 	public function test__filter_restrict_blog_public_keeps_2() {
-		$private = Private_Sites::instance();
+		$private  = Private_Sites::instance();
 		$filtered = $private->filter_restrict_blog_public( '2' );
 
 		$this->assertEquals( '2', $filtered );
 	}
 	public function test__filter_restrict_blog_public_keeps_0() {
-		$private = Private_Sites::instance();
+		$private  = Private_Sites::instance();
 		$filtered = $private->filter_restrict_blog_public( '0' );
 
 		$this->assertEquals( '0', $filtered );
 	}
 	public function test__filter_restrict_blog_public_changes_1() {
-		$private = Private_Sites::instance();
+		$private  = Private_Sites::instance();
 		$filtered = $private->filter_restrict_blog_public( '1' );
 
 		$this->assertEquals( '-1', $filtered );

--- a/tests/security/test-class-private-sites.php
+++ b/tests/security/test-class-private-sites.php
@@ -111,7 +111,7 @@ class Private_Sites_Test extends WP_UnitTestCase {
 		$private  = Private_Sites::instance();
 		$filtered = $private->filter_restrict_blog_public( '0' );
 
-		$this->assertEquals( '0', $filtered );
+		$this->assertEquals( '-1', $filtered );
 	}
 	public function test__filter_restrict_blog_public_changes_1() {
 		$private  = Private_Sites::instance();


### PR DESCRIPTION
This change makes https://github.com/Automattic/vip-go-mu-plugins/pull/4494 more nuanced and respects different blog_public values.

## Changelog Description

### Plugin Updated: Private Sites

We respect other alternative methods for achieving privacy via plugins that also leverage `blog_public` option, but use other values than `-1`.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. $ dev-env exec --slug vip-local -- wp option set blog_public "2"
2. $ `dev-env exec --slug vip-local -- wp option get blog_public` => should return "2"
3. $ dev-env exec --slug vip-local -- wp option set blog_public "1"
4. $ `dev-env exec --slug vip-local -- wp option get blog_public` => should return "-1"
