### PR TITLE
chore(dev-deps): Update search-dev-tools dependencies

### DIFF
--- a/search/search-dev-tools/package-lock.json
+++ b/search/search-dev-tools/package-lock.json
@@ -1466,16 +1466,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.5.tgz",
-      "integrity": "sha512-ELdlq61FpoEkHO6gFRpfj0kUgSwQTGoaEU8eMRoS8Dv3v6e7BjEAj5WMtIBRdHUeAioMhKP5HyxNzNnP+heKbA==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.0.tgz",
+      "integrity": "sha512-Li7gdm7eGZJidME4KlXmzQdnuUwE4jhPnICgGpWN56W7GWhmCQ2LmDepyZX4zBsoSNWP9bqDcJo5wQFndcAd9Q==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.21.4",
         "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/plugin-syntax-jsx": "^7.21.4",
-        "@babel/types": "^7.21.5"
+        "@babel/types": "^7.22.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1791,9 +1791,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
-      "integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.0.tgz",
+      "integrity": "sha512-NtXlm3f6cNWIv003cETdlz9sss0VMNtplyatFohxWPz90AbwuhCbHbQopkGis6bG1vOunDLN0FF/4Uv5i8LFZQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.21.5",

--- a/search/search-dev-tools/package-lock.json
+++ b/search/search-dev-tools/package-lock.json
@@ -8625,9 +8625,9 @@
       }
     },
     "node_modules/postcss-loader": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.3.0.tgz",
-      "integrity": "sha512-qLAFjvR2BFNz1H930P7mj1iuWJFjGey/nVhimfOAAQ1ZyPpcClAxP8+A55Sl8mBvM+K2a9Pjgdj10KpANWrNfw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.3.1.tgz",
+      "integrity": "sha512-uevGt8yy2gvruNvzy8jxgYSSnyqBcA7CnS6/57qoZnUMM51XgsTqxIpWZWdHyvIyo4ov0lCgnzIbhtWwVFI8lg==",
       "dev": true,
       "dependencies": {
         "cosmiconfig": "^8.1.3",

--- a/search/search-dev-tools/package-lock.json
+++ b/search/search-dev-tools/package-lock.json
@@ -119,30 +119,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.9.tgz",
-      "integrity": "sha512-FUGed8kfhyWvbYug/Un/VPJD41rDIgoVVcR+FuzhzOYyRz5uED+Gd3SLZml0Uw2l2aHFb7ZgdW5mGA3G2cCCnQ==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.0.tgz",
+      "integrity": "sha512-OgCMbbNCD/iA8cjMt+Zhp+nIC7XKaEaTG8zjvZPjGbhkppq1NIMWiZn7EaZRxUDHn4Ul265scRqg94N2WiFaGw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
-      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.1.tgz",
+      "integrity": "sha512-Hkqu7J4ynysSXxmAahpN1jjRwVJ+NdpraFLIWflgjpVob3KNyK3/tIUc7Q7szed8WMp0JNa7Qtd1E9Oo22F9gA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.5",
-        "@babel/helper-compilation-targets": "^7.21.5",
-        "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.8",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5",
+        "@babel/generator": "^7.22.0",
+        "@babel/helper-compilation-targets": "^7.22.1",
+        "@babel/helper-module-transforms": "^7.22.1",
+        "@babel/helpers": "^7.22.0",
+        "@babel/parser": "^7.22.0",
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -192,12 +192,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.9.tgz",
-      "integrity": "sha512-F3fZga2uv09wFdEjEQIJxXALXfz0+JaOb7SabvVMmjHxeVTuGW8wgE8Vp1Hd7O+zMTYtcfEISGRzPkeiaPPsvg==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.0.tgz",
+      "integrity": "sha512-tyzR0OsH88AelgukhL2rbEUCLKBGmy2G9Th/5vpyOt0zf44Be61kvIQXjCwTSX8t+qJ/vMwZfhK6mPdrMLZXRg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.5",
+        "@babel/types": "^7.22.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -231,12 +231,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.5.tgz",
-      "integrity": "sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
+      "integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.21.5",
+        "@babel/compat-data": "^7.22.0",
         "@babel/helper-validator-option": "^7.21.0",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
@@ -307,9 +307,9 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
-      "integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz",
+      "integrity": "sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -365,19 +365,19 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.5.tgz",
-      "integrity": "sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
+      "integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/helper-environment-visitor": "^7.22.1",
         "@babel/helper-module-imports": "^7.21.4",
         "@babel/helper-simple-access": "^7.21.5",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -518,14 +518,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
-      "integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.0.tgz",
+      "integrity": "sha512-I/hZCYErxdjuUnJpJxHmCESB3AdcOAFjj+K6+of9JyWBeAhggR9NQoUHI481pRNH87cx77mbpx0cygzXlvGayA==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.0",
+        "@babel/types": "^7.22.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -546,9 +546,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.9.tgz",
-      "integrity": "sha512-q5PNg/Bi1OpGgx5jYlvWZwAorZepEudDMCLtj967aeS7WMont7dUZI46M2XwcIQqvUlMxWfdLFu4S/qSxeUu5g==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.0.tgz",
+      "integrity": "sha512-DA65VCJRetcFmJnt9/hEmRvXNCwk0V86dxG6p6N13hzDazaLRjGdTGPGgjxZOtLuFgWzOSRX4grybmRXwQ9bSg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1761,19 +1761,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
-      "integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.1.tgz",
+      "integrity": "sha512-lAWkdCoUFnmwLBhIRLciFntGYsIIoC6vIbN8zrLPqBnJmPu7Z6nzqnKd7FsxQUNAvZfVZ0x6KdNvNp8zWIOHSQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.5",
-        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/generator": "^7.22.0",
+        "@babel/helper-environment-visitor": "^7.22.1",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.5",
-        "@babel/types": "^7.21.5",
+        "@babel/parser": "^7.22.0",
+        "@babel/types": "^7.22.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1791,9 +1791,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
-      "integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.0.tgz",
+      "integrity": "sha512-NtXlm3f6cNWIv003cETdlz9sss0VMNtplyatFohxWPz90AbwuhCbHbQopkGis6bG1vOunDLN0FF/4Uv5i8LFZQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.21.5",


### PR DESCRIPTION
* Bump `@babel/core` from 7.21.8 to 7.22.1 (#4516)
* Bump `postcss-loader` from 7.3.0 to 7.3.1 (#4515)
* Bump `@babel/plugin-transform-react-jsx` from 7.21.5 to 7.22.0 (#4513)
