### PR TITLE
Blog_Public: Do not show notice for sites that have -1 for blog_public option

### DIFF
--- a/blogpublic-notice.php
+++ b/blogpublic-notice.php
@@ -15,6 +15,7 @@ function notice() {
 		! current_user_can( 'manage_options' ) ||
 		get_option( 'blogpublic_notice_dismissed', false ) ||
 		! get_option( 'blog_public' ) ||
+		'-1' === get_option( 'blog_public' ) ||
 		wp_endswith( $home_url_parsed['host'], '.go-vip.co' ) ||
 		wp_endswith( $home_url_parsed['host'], '.go-vip.net' )
 	) {
@@ -22,8 +23,8 @@ function notice() {
 	}
 
 	printf(
-		'<div id="blogpublic-notice" class="notice notice-warning is-dismissible"><p>Your site may be discoverable by search engines. You can change this in <a href="%s">Reading Settings</a>, under <strong>Search Engine Visibility</strong>.</p></div>',
-		esc_url( admin_url( 'options-reading.php' ) )
+		'<div id="blogpublic-notice" class="notice notice-warning is-dismissible"><p>Your site may be discoverable. You can change this by <a href="%s">disabling content distribution</a>.</p></div>',
+		'https://docs.wpvip.com/technical-references/restricting-site-access/controlling-content-distribution-via-jetpack/#h-disabling-content-distribution',
 	);
 	add_action( 'admin_footer', __NAMESPACE__ . '\dismiss_handler' );
 }
@@ -69,7 +70,7 @@ add_action( 'wp_ajax_blogpublic_notice_dismiss', __NAMESPACE__ . '\dismiss_callb
  * remove 'dismiss' flag to reshow the notice
  */
 function reset_notice_dismissal( $old_value, $value ) {
-	if ( ( '0' === $old_value || 0 === $old_value ) && 1 === $value ) {
+	if ( 1 === $value || '1' === $value ) {
 		delete_option( 'blogpublic_notice_dismissed' );
 	}
 }


### PR DESCRIPTION
## Description
We should not show a notice for sites that have `-1` in their `blog_public` option. 

Other changes:
- changes the dismissal reset counter when it's changed from any value to `1`
- updates messaging to not promote UI checkbox and use constant instead:
<img width="1469" alt="Screenshot 2023-05-26 at 3 57 19 PM" src="https://github.com/Automattic/vip-go-mu-plugins/assets/16962021/074f600e-798d-4d06-8703-1982687f4b84">


## Changelog Description

### Notice Updated: blog_public option

No longer show notice for sites with their `blog_public` option if `-1` or privacy constant is set. Also updates messaging.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) On a non-production site with a non-convenience domain and privacy constant, sandbox changes and expect PR notice to not be present
2) On a non-production site with a non-convenience domain and without privacy constant, sandbox changes and expect PR notice to be different