### PR TITLE
Update default version to Jetpack 12.2

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.1
+ * Version: 12.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -31,7 +31,7 @@ function vip_default_jetpack_version() {
 		return '12.0';
 	} else {
 		// WordPress 6.1 and newer.
-		return '12.1';
+		return '12.2';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '12.1';
+		$latest = '12.2';
 
 		$versions_map = [
 			// WordPress version => Jetpack version


### PR DESCRIPTION
## Description
Updates default Jetpack version to 12.2

## Changelog Description

### Plugin Updated: Jetpack 12.2

All non-pinned sites updated to using Jetpack 12.2