### PR TITLE
Search: Add lock for `sweep_jobs()`

### DIFF
--- a/search/includes/classes/queue/class-cron.php
+++ b/search/includes/classes/queue/class-cron.php
@@ -34,6 +34,11 @@ class Cron {
 	const SWEEPER_CRON_INTERVAL = 1 * \MINUTE_IN_SECONDS;
 
 	/**
+	 * The lock to prevent multiple instances of the sweeper from running
+	 */
+	const SWEEPER_CRON_LOCK = 'vip_search_queue_sweeper_lock';
+
+	/**
 	 * The name of the cron event for processing term updates
 	 */
 	const TERM_UPDATE_CRON_EVENT_NAME = 'vip_search_term_update';
@@ -247,6 +252,11 @@ class Cron {
 			$this->disable_sweeper_job();
 		}
 
+		if ( true !== wp_cache_add( self::SWEEPER_CRON_LOCK, time(), 'vip', 3 * MINUTE_IN_SECONDS ) ) {
+			// Bail if it's already running.
+			return;
+		}
+
 		$this->queue->free_deadlocked_jobs();
 
 		$job_count     = $this->get_processor_job_count();
@@ -263,6 +273,8 @@ class Cron {
 
 			$job_count = $this->get_processor_job_count();
 		}
+
+		wp_cache_delete( self::SWEEPER_CRON_LOCK, 'vip' );
 	}
 
 	/**

--- a/search/includes/classes/queue/class-cron.php
+++ b/search/includes/classes/queue/class-cron.php
@@ -252,7 +252,7 @@ class Cron {
 			$this->disable_sweeper_job();
 		}
 
-		if ( true !== wp_cache_add( self::SWEEPER_CRON_LOCK, time(), 'vip', 3 * MINUTE_IN_SECONDS ) ) {
+		if ( true !== wp_cache_add( self::SWEEPER_CRON_LOCK, time(), 'vip', 5 * MINUTE_IN_SECONDS ) ) {
 			// Bail if it's already running.
 			return;
 		}


### PR DESCRIPTION
## Description
Sometimes if `sweep_jobs()` doesn't complete within the 1 minute recurrence interval, a new one will spawn up and attempt to schedule the same job IDs resulting in a duplicate entry DB error. This PR adds a lock to prevent it from happening before it completes with a 3 minute deadline. 

Internal ref: CANTINA-928
## Changelog Description

### Plugin Updated: Enterprise Search

Add lock for `vip_search_queue_sweeper` cron job

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
0) Add a `sleep( 10000 )` to `sweep_jobs()` to ensure it takes awhile to process
1) Shell in and do:
```
$es = new \Automattic\VIP\Search\Search();
$es->init();
$cron = $es->queue->cron;
$cron->sweep_jobs()`
```
2) While `sweep_jobs()` is running, run `wp cache get vip_search_queue_sweeper_lock vip` and ensure it returns a timestamp.