### PR TITLE
Add `define_mu_plugins_constants()` 

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -13,8 +13,6 @@ use Automattic\VIP\Config\Sync;
 use Automattic\VIP\Utils\Context;
 use Automattic\VIP\Utils\WPComVIP_Restrictions;
 
-use function Automattic\VIP\Core\Constants\define_db_constants;
-
 // @codeCoverageIgnoreStart
 
 /**
@@ -87,6 +85,17 @@ if ( Context::is_vip_env() && Context::is_overdue_locked() && ! Context::is_wp_c
 		echo file_get_contents( __DIR__ . '/errors/site-shutdown.html' );
 
 		exit;
+	}
+}
+
+if ( file_exists( __DIR__ . '/001-core/constants.php' ) ) {
+	require_once __DIR__ . '/001-core/constants.php';
+
+	if ( function_exists( '\Automattic\VIP\Core\Constants\define_db_constants' ) ) {
+		\Automattic\VIP\Core\Constants\define_db_constants( $GLOBALS['wpdb'] );
+	}
+	if ( function_exists( '\Automattic\VIP\Core\Constants\define_mu_plugins_constants' ) ) {
+		\Automattic\VIP\Core\Constants\define_mu_plugins_constants();
 	}
 }
 
@@ -325,14 +334,6 @@ if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
 	//
 	// https://make.wordpress.org/core/2020/07/22/new-xml-sitemaps-functionality-in-wordpress-5-5/
 	add_filter( 'wp_sitemaps_enabled', '__return_false' );
-}
-
-if ( file_exists( __DIR__ . '/001-core/constants.php' ) ) {
-	require_once __DIR__ . '/001-core/constants.php'; // Define the DB constants
-}
-
-if ( function_exists( '\Automattic\VIP\Core\Constants\define_db_constants' ) ) {
-	define_db_constants( $GLOBALS['wpdb'] );
 }
 
 do_action( 'vip_loaded' );

--- a/001-core/constants.php
+++ b/001-core/constants.php
@@ -47,3 +47,39 @@ function define_db_constants( $hyperdb ): void {
 		}
 	}
 }
+
+/**
+ * Define VIP_MU_PLUGINS_BRANCH and VIP_MU_PLUGINS_BRANCH_ID.
+ * Uses the mu-plugins meta info from version file.
+ */
+function define_mu_plugins_constants(): void {
+	if ( defined( 'VIP_MU_PLUGINS_BRANCH' ) || defined( 'VIP_MU_PLUGINS_BRANCH_ID' ) ) {
+		return;
+	}
+
+	if ( defined( 'VIP_GO_ENV' ) && 'local' === constant( 'VIP_GO_ENV' ) ) {
+		return;
+	}
+
+	$version_file = WPMU_PLUGIN_DIR . '/.version';
+	if ( ! file_exists( $version_file ) ) {
+		return;
+	}
+
+	// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+	$info = file_get_contents( $version_file );
+	if ( ! $info ) {
+		return;
+	}
+
+	$info      = json_decode( $info );
+	$tag       = $info->tag ?? null;
+	$branch_id = $info->stack_version ?? null;
+	if ( $tag ) {
+		define( 'VIP_MU_PLUGINS_BRANCH', 'prod' === $tag ? 'production' : $tag );
+	}
+	if ( $branch_id ) {
+		define( 'VIP_MU_PLUGINS_BRANCH_ID', $branch_id );
+	}
+
+}


### PR DESCRIPTION
## Description
Adds `define_mu_plugins_constants()` to introduce `VIP_MU_PLUGINS_BRANCH` and `VIP_MU_PLUGINS_BRANCH_ID`. After this is deployed, we'll need to revise the code in https://github.com/Automattic/vip-go-mu-plugins/blob/b9fa2f014e1181be4cbb0ad63c3dd5bbe7ff9493/qm-plugins/qm-vip/class-qm-collector-vip.php#L33-L51.

Also modifies the loading order and moves `/001-core/constants.php'` before secrets.

## Changelog Description

### Constants Added: VIP_MU_PLUGINS_BRANCH, VIP_MU_PLUGINS_BRANCH_ID

Added the constants for meta info on current MU-plugins of application.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Sandbox site
2) Shell in and check that constants return as expected
3) Test PR locally in dev-env and expect constants to not be defined