### PR TITLE
Prepare for emergency reverts during object cache upgrades (better safe than sorry 😀)

### DIFF
--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -25,7 +25,7 @@ if ( ! defined( 'AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION' ) ) {
 
 if ( defined( 'VIP_USE_NEXT_OBJECT_CACHE_DROPIN' ) && true === VIP_USE_NEXT_OBJECT_CACHE_DROPIN && extension_loaded( 'memcached' ) ) {
 	require_once __DIR__ . '/wp-memcached/object-cache.php';
-} elseif ( extension_loaded( 'memcached' ) ) {
+} elseif ( extension_loaded( 'memcached' ) && ( ! defined( 'VIP_TMP_USE_LEGACY_CACHE_DROPIN' ) || true !== VIP_TMP_USE_LEGACY_CACHE_DROPIN ) ) {
 	require_once __DIR__ . '/wp-memcached/object-cache.php';
 } else {
 	require_once __DIR__ . '/object-cache/object-cache-stable.php';

--- a/drop-ins/object-cache/object-cache-stable.php
+++ b/drop-ins/object-cache/object-cache-stable.php
@@ -134,7 +134,7 @@ class WP_Object_Cache {
 
 	var $flush_group         = 'WP_Object_Cache';
 	var $global_flush_group  = 'WP_Object_Cache_global';
-	var $flush_key           = "flush_number_v4";
+	var $flush_key           = "flush_number_v5";
 	var $old_flush_key       = "flush_number";
 	var $flush_number        = array();
 	var $global_flush_number = null;


### PR DESCRIPTION
## Description

- Prepare `VIP_TMP_USE_LEGACY_CACHE_DROPIN` constant that will allow for quickly swapping back to loading the old drop-in (without having to do a revert across all sites)
- Increment the flush_key on the old drop-in just in case sites do have to be reverted. Without the flush key increment they'd possibly end up with stale cache after the revert, so this will ensure that doesn't happen.

Hopefully none of this will be needed :)