### PR TITLE
Query Monitor: Only enable on non-prods if admin bar is enabled

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -40,7 +40,8 @@ function wpcom_vip_qm_enable( $enable ) {
 		return true;
 	}
 
-	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' )
+		&& true === apply_filters( 'show_admin_bar', false ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
## Description
On non-production environment, QM shouldn't be enabled if the admin bar is not displaying (e.g. non-logged in users or a8c-debug=false). This prevents the style.css from being loaded for non-logged-in users who aren't using the a8c-debug query var.

## Changelog Description

### Plugin Updated: Query Monitor

Only enable QM on non-production environments if admin bar is enabled

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) On a non-production environment, as a non-logged in user, go to the front page and see that the `style.css` [from here](https://github.com/Automattic/vip-go-mu-plugins/blob/b9fa2f014e1181be4cbb0ad63c3dd5bbe7ff9493/qm-plugins/qm-object-cache/qm-object-cache.php#L75) is enqueued (Network > CSS).
2) Apply PR
3) Repeat step 1) and expect it to disappear on reload