### PR TITLE
Search: Fix bug where validate-contents isn't fixing when --inspect

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -714,6 +714,9 @@ class Health {
 			foreach ( $missing_from_index as $post_id ) {
 				$diffs[ 'post_' . $post_id ] = array(
 					'existence' => array(
+						'id'       => $post_id,
+						'type'     => 'post',
+						'issue'    => 'missing_from_index',
 						'expected' => sprintf( 'Post %d to be indexed', $post_id ),
 						'actual'   => null,
 					),
@@ -730,6 +733,9 @@ class Health {
 				// Grab the actual doc from
 				$diffs[ 'post_' . $document_id ] = array(
 					'existence' => array(
+						'id'       => $document_id,
+						'type'     => 'post',
+						'issue'    => 'extra_in_index',
 						'expected' => null,
 						'actual'   => sprintf( 'Post %d is currently indexed', $document_id ),
 					),
@@ -841,7 +847,17 @@ class Health {
 	 */
 	public static function reconcile_diff( array $diff ) {
 		foreach ( $diff as $obj_to_reconcile ) {
-			switch ( $obj_to_reconcile['issue'] ) {
+			if ( isset( $obj_to_reconcile['existence'] ) ) {
+				$issue = $obj_to_reconcile['existence']['issue'];
+				$id    = $obj_to_reconcile['existence']['id'];
+				$type  = $obj_to_reconcile['existence']['type'];
+			} else {
+				$issue = $obj_to_reconcile['issue'];
+				$id    = $obj_to_reconcile['id'];
+				$type  = $obj_to_reconcile['type'];
+			}
+
+			switch ( $issue ) {
 				case 'missing_from_index':
 				case 'mismatch':
 					/**
@@ -852,11 +868,11 @@ class Health {
 					 * @param string $object_type   Object type
 					 * @return int                  Job priority
 					 */
-					$priority = apply_filters( 'vip_healthcheck_reindex_priority', self::REINDEX_JOB_DEFAULT_PRIORITY, $obj_to_reconcile['id'], $obj_to_reconcile['type'] );
-					\Automattic\VIP\Search\Search::instance()->queue->queue_object( $obj_to_reconcile['id'], $obj_to_reconcile['type'], [ 'priority' => $priority ] );
+					$priority = apply_filters( 'vip_healthcheck_reindex_priority', self::REINDEX_JOB_DEFAULT_PRIORITY, $id, $type );
+					\Automattic\VIP\Search\Search::instance()->queue->queue_object( $id, $type, [ 'priority' => $priority ] );
 					break;
 				case 'extra_in_index':
-					\ElasticPress\Indexables::factory()->get( 'post' )->delete( $obj_to_reconcile['id'], false );
+					\ElasticPress\Indexables::factory()->get( $type )->delete( $id, false );
 					break;
 			}
 		}

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -713,13 +713,11 @@ class Health {
 		if ( 0 < count( $missing_from_index ) ) {
 			foreach ( $missing_from_index as $post_id ) {
 				$diffs[ 'post_' . $post_id ] = array(
-					'existence' => array(
-						'id'       => $post_id,
-						'type'     => 'post',
-						'issue'    => 'missing_from_index',
-						'expected' => sprintf( 'Post %d to be indexed', $post_id ),
-						'actual'   => null,
-					),
+					'id'       => $post_id,
+					'type'     => 'post',
+					'issue'    => 'missing_from_index',
+					'expected' => sprintf( 'Post %d to be indexed', $post_id ),
+					'actual'   => null,
 				);
 			}
 		}
@@ -732,13 +730,11 @@ class Health {
 			foreach ( $extra_in_index as $document_id ) {
 				// Grab the actual doc from
 				$diffs[ 'post_' . $document_id ] = array(
-					'existence' => array(
-						'id'       => $document_id,
-						'type'     => 'post',
-						'issue'    => 'extra_in_index',
-						'expected' => null,
-						'actual'   => sprintf( 'Post %d is currently indexed', $document_id ),
-					),
+					'id'       => $document_id,
+					'type'     => 'post',
+					'issue'    => 'extra_in_index',
+					'expected' => null,
+					'actual'   => sprintf( 'Post %d is currently indexed', $document_id ),
 				);
 			}
 		}
@@ -847,9 +843,8 @@ class Health {
 	 */
 	public static function reconcile_diff( array $diff ) {
 		foreach ( $diff as $obj_to_reconcile ) {
-			$obj_to_reconcile = $obj_to_reconcile['existence'] ?? $obj_to_reconcile;
-			$id               = $obj_to_reconcile['id'];
-			$type             = $obj_to_reconcile['type'];
+			$id   = $obj_to_reconcile['id'];
+			$type = $obj_to_reconcile['type'];
 
 			switch ( $obj_to_reconcile['issue'] ) {
 				case 'missing_from_index':

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -847,17 +847,11 @@ class Health {
 	 */
 	public static function reconcile_diff( array $diff ) {
 		foreach ( $diff as $obj_to_reconcile ) {
-			if ( isset( $obj_to_reconcile['existence'] ) ) {
-				$issue = $obj_to_reconcile['existence']['issue'];
-				$id    = $obj_to_reconcile['existence']['id'];
-				$type  = $obj_to_reconcile['existence']['type'];
-			} else {
-				$issue = $obj_to_reconcile['issue'];
-				$id    = $obj_to_reconcile['id'];
-				$type  = $obj_to_reconcile['type'];
-			}
+			$obj_to_reconcile = $obj_to_reconcile['existence'] ?? $obj_to_reconcile;
+			$id               = $obj_to_reconcile['id'];
+			$type             = $obj_to_reconcile['type'];
 
-			switch ( $issue ) {
+			switch ( $obj_to_reconcile['issue'] ) {
 				case 'missing_from_index':
 				case 'mismatch':
 					/**

--- a/search/includes/classes/commands/class-healthcommand.php
+++ b/search/includes/classes/commands/class-healthcommand.php
@@ -475,15 +475,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		// Array pop without modifying the diff array
 		$d = $this->get_last( $diff );
 
-		if ( array_key_exists( 'type', $d ) && array_key_exists( 'id', $d ) && array_key_exists( 'issue', $d ) ) {
-			\WP_CLI\Utils\format_items( $format, $diff, array( 'type', 'id', 'issue' ) );
-		} else {
-			WP_CLI::warning( 'Formatting is being ignored!' );
-			foreach ( $diff as $d ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
-				var_dump( $d );
-			}
-		}
+		\WP_CLI\Utils\format_items( $format, $diff, array_keys( $d ) );
 
 		if ( ! empty( $truncate_msg ) && ! $silent ) {
 			WP_CLI::warning( $truncate_msg );

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -54,12 +54,18 @@ class Health_Test extends WP_UnitTestCase {
 		$expected_diff = array(
 			'post_5' => array(
 				'existence' => array(
+					'id'       => 5,
+					'type'     => 'post',
+					'issue'    => 'missing_from_index',
 					'expected' => sprintf( 'Post %d to be indexed', 5 ),
 					'actual'   => null,
 				),
 			),
 			'post_7' => array(
 				'existence' => array(
+					'id'       => 7,
+					'type'     => 'post',
+					'issue'    => 'extra_in_index',
 					'expected' => null,
 					'actual'   => sprintf( 'Post %d is currently indexed', 7 ),
 				),

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -53,22 +53,18 @@ class Health_Test extends WP_UnitTestCase {
 
 		$expected_diff = array(
 			'post_5' => array(
-				'existence' => array(
-					'id'       => 5,
-					'type'     => 'post',
-					'issue'    => 'missing_from_index',
-					'expected' => sprintf( 'Post %d to be indexed', 5 ),
-					'actual'   => null,
-				),
+				'id'       => 5,
+				'type'     => 'post',
+				'issue'    => 'missing_from_index',
+				'expected' => sprintf( 'Post %d to be indexed', 5 ),
+				'actual'   => null,
 			),
 			'post_7' => array(
-				'existence' => array(
-					'id'       => 7,
-					'type'     => 'post',
-					'issue'    => 'extra_in_index',
-					'expected' => null,
-					'actual'   => sprintf( 'Post %d is currently indexed', 7 ),
-				),
+				'id'       => 7,
+				'type'     => 'post',
+				'issue'    => 'extra_in_index',
+				'expected' => null,
+				'actual'   => sprintf( 'Post %d is currently indexed', 7 ),
 			),
 		);
 


### PR DESCRIPTION
## Description

When we run `wp vip-search health validate-contents` and pass in the `--inspect` (verbose) flag, it doesn't heal as expected due to the below PHP errors:

```
Warning: Undefined array key "issue" in /chroot/var/www/wp-content/mu-plugins/search/includes/classes/class-health.php on line 844 [/chrootwp-content/mu-plugins/search/includes/classes/class-health.php:521 Automattic\VIP\Search\Health::reconcile_diff(), /chrootwp-content/mu-plugins/search/includes/classes/commands/class-healthcommand.php:420 Automattic\VIP\Search\Health->validate_index_posts_content(), Automattic\VIP\Search\Commands\HealthCommand->validate_contents(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:419 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:442 WP_CLI\Runner->run_command(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1256 WP_CLI\Runner->run_command_and_exit(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28 WP_CLI\Runner->start(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php:78 WP_CLI\Bootstrap\LaunchRunner->process(), phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php:32 WP_CLI\bootstrap(), phar:///usr/local/bin/wp/php/boot-phar.php:11 include('phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/bin/wp/php/boot-phar.php')]
```

Therefore, this part of the code doesn't get triggered properly: https://github.com/Automattic/vip-go-mu-plugins/blob/f2344c0d09900ffed4a1c6b8e47f8c2347901ad8/search/includes/classes/class-health.php#L855-L860

It looks like the `existence` key was introduced in https://github.com/Automattic/vip-go-mu-plugins/commit/fdc004231bd2240e184e880e182edf9bf9e335ff for consistency in the format of our array-keys returned from our index settings diffs. However, that's not necessary since it's not really being used anywhere.

Reproduction steps: 
1) `wp vip-search index-versions add post`
2) `wp vip-search index-versions activate post 2`
3) `wp vip-search index-versions delete post 1`
4) `wp vip-search health validate-contents --inspect`

In my testing, I've also found that `--format` and `--inspect` do not play nicely together due to the `existence` key, so we should throw an error.

## Changelog Description

### Plugin Updated: Enterprise Search

Fix healing when inspect flag is passed into `wp vip-search health validate-contents`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Do `wp vip-search health validate-contents --inspect` and ensure PHP warning doesn't trigger
