### PR TITLE
fix: Type error when callable is not a method

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2338,7 +2338,7 @@ class Search {
 			if ( isset( $wp_filter[ $ep_filter ] ) ) {
 				foreach ( $wp_filter[ $ep_filter ]->callbacks as $callback ) {
 					foreach ( $callback as $el ) {
-						if ( $el['function'] instanceof \Closure ) {
+						if ( ! is_array( $el['function'] ) || ! is_object( $el['function'][0] ) ) {
 							return $should_do_weighting;
 						} else {
 							$class = get_class( $el['function'][0] );


### PR DESCRIPTION
## Description

Fixes: #4542

## Changelog Description

### Plugin Updated: Enterprise Search

Fix type error when a callable passed to `ep_weighting_configuration_for_search`, `ep_query_weighting_fields`, `ep_weighting_configuration`, or `ep_weighting_fields_for_post_type` is not a method.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See #4542 
