### PR TITLE
fix: Broken markup when APCu cache is not enabled

### DIFF
--- a/qm-plugins/qm-apcu-cache/class-qm-output-html-apcu-cache.php
+++ b/qm-plugins/qm-apcu-cache/class-qm-output-html-apcu-cache.php
@@ -27,9 +27,9 @@ class QM_Output_Html_Apcu_Cache extends \QM_Output_Html {
 				global $apc_cache_interceptor;
 				if ( ! isset( $apc_cache_interceptor ) || ! is_object( $apc_cache_interceptor ) ) {
 					echo '<h2>APCU Hot-Caching is currently disabled</h2>';
-					return;
+				} else {
+					$apc_cache_interceptor->stats();
 				}
-				$apc_cache_interceptor->stats();
 				?>
 			</div>
 		</div>


### PR DESCRIPTION
## Description

Fixes: #4547 

## Changelog Description

### Plugin Updated: Query Monitor APCu Cache

Fix broken markup when the APCu cache is not enabled.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See #4547 
