### PR TITLE
test: Fix flaky tests

### DIFF
--- a/tests/config/test-site-details-index.php
+++ b/tests/config/test-site-details-index.php
@@ -19,7 +19,7 @@ require_once __DIR__ . '/../../config/class-site-details-index.php';
 class Site_Details_Index_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
-		add_filter( 'pre_http_request', function ( $result, $args, $url ) {
+		add_filter( 'pre_http_request', function ( $result ) {
 			if ( false === $result ) {
 				$result = [
 					'headers'  => [],
@@ -33,7 +33,7 @@ class Site_Details_Index_Test extends WP_UnitTestCase {
 			}
 
 			return $result;
-		}, 10, 3 );
+		}, 10 );
 	}
 
 	public function test__data_filter_should_not_be_hooked_if_no_init() {

--- a/tests/config/test-sync.php
+++ b/tests/config/test-sync.php
@@ -21,6 +21,22 @@ class Sync_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		Constant_Mocker::clear();
+
+		add_filter( 'pre_http_request', function ( $result ) {
+			if ( false === $result ) {
+				$result = [
+					'headers'  => [],
+					'body'     => '',
+					'response' => [
+						'code'    => 418,
+						'message' => "I'm a teapot",
+					],
+					'cookies'  => [],
+				];
+			}
+
+			return $result;
+		}, 10 );
 	}
 
 	public function tearDown(): void {


### PR DESCRIPTION
Do not let `Sync_Test` contact external sites.

```
1) Automattic\VIP\Config\Sync_Test::test__vip_site_details_siteurl_update_hook
An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)

/tmp/wordpress/wp-includes/update.php:447
/home/runner/work/vip-go-mu-plugins/vip-go-mu-plugins/config/class-site-details-index.php:143
/home/runner/work/vip-go-mu-plugins/vip-go-mu-plugins/config/class-site-details-index.php:96
/home/runner/work/vip-go-mu-plugins/vip-go-mu-plugins/config/class-site-details-index.php:76
/tmp/wordpress/wp-includes/class-wp-hook.php:308
/tmp/wordpress/wp-includes/plugin.php:205
/home/runner/work/vip-go-mu-plugins/vip-go-mu-plugins/tests/config/test-sync.php:120
/home/runner/work/vip-go-mu-plugins/vip-go-mu-plugins/tests/config/test-sync.php:35
```

Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/5215217763/jobs/9412486209?pr=4563#step:6:361