### PR TITLE
ci: Update internal actions

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -57,7 +57,7 @@ runs:
         fi
 
     - name: Set up PHP
-      uses: shivammathur/setup-php@2.22.0
+      uses: shivammathur/setup-php@2.25.2
       with:
         coverage: ${{ steps.coverage.outputs.coverage }}
         ini-values: ${{ steps.coverage.outputs.ini }}
@@ -76,7 +76,7 @@ runs:
       uses: ramsey/composer-install@2.2.0
 
     - name: Set up WordPress and WordPress Test Library
-      uses: sjinks/setup-wordpress-test-library@1.1.11
+      uses: sjinks/setup-wordpress-test-library@1.1.18
       with:
         version: ${{ inputs.wordpress }}
 
@@ -122,7 +122,7 @@ runs:
         "${PHPUNIT}" ${OPTIONS}
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v3.1.1
+      uses: codecov/codecov-action@v3.1.4
       with:
         files: ${{ inputs.coverage-file }}
         flags: ${{ inputs.coverage-flags }}


### PR DESCRIPTION
Because Dependabot does not update our internal actions, we have to do that ourselves.

This PR updates all used actions to their latest versions.
