### PR TITLE
ci: Add WP 6.1 to the Matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - { wp: 5.8.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
           - { wp: 5.9.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
           - { wp: 6.0.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
+          - { wp: 6.1.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
           - { wp: latest,  ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
           - { wp: nightly, ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
         # Jetpack, Multi-Site, PHP 7.4

--- a/tests/001-core/test-privacy.php
+++ b/tests/001-core/test-privacy.php
@@ -19,7 +19,7 @@ class Privacy_Policy_Link_Test extends WP_UnitTestCase {
 		update_option( 'wp_page_for_privacy_policy', $post->ID );
 
 		global $wp_version;
-		$rel = version_compare( $wp_version, '6.1.1', '>' ) ? ' rel="privacy-policy"' : '';
+		$rel = version_compare( $wp_version, '6.2.0', '>=' ) ? ' rel="privacy-policy"' : '';
 		// Should show the custom one
 		$expected_link = sprintf( '<div><a class="privacy-policy-link" href="%s"%s>%s</a></div>', get_permalink( $post->ID ), $rel, get_the_title( $post->ID ) );
 


### PR DESCRIPTION
We have `6.0.x` and `latest`, which is `6.2.x` now. We need to add `6.1.x`.