### PR TITLE
ci: Update Parse.ly CI workflows to use PHP 8.0

### DIFF
--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -23,20 +23,20 @@ jobs:
       matrix:
         config:
           # Oldest version of the parsely plugin
-          - { wp: latest, parsely: '3.1', mode: 'filter_enabled', php: '7.4' }
-          - { wp: latest, parsely: '3.1', mode: 'filter_disabled', php: '7.4' }
-          - { wp: latest, parsely: '3.1', mode: 'option_enabled', php: '7.4' }
-          - { wp: latest, parsely: '3.1', mode: 'option_disabled', php: '7.4' }
-          - { wp: latest, parsely: '3.1', mode: 'filter_and_option_enabled', php: '7.4' }
-          - { wp: latest, parsely: '3.1', mode: 'filter_and_option_disabled', php: '7.4' }
+          - { wp: latest, parsely: '3.1', mode: 'filter_enabled', php: '8.0' }
+          - { wp: latest, parsely: '3.1', mode: 'filter_disabled', php: '8.0' }
+          - { wp: latest, parsely: '3.1', mode: 'option_enabled', php: '8.0' }
+          - { wp: latest, parsely: '3.1', mode: 'option_disabled', php: '8.0' }
+          - { wp: latest, parsely: '3.1', mode: 'filter_and_option_enabled', php: '8.0' }
+          - { wp: latest, parsely: '3.1', mode: 'filter_and_option_disabled', php: '8.0' }
 
           # Latest version of the parsely plugin
-          - { wp: latest, mode: 'filter_enabled', php: '7.4' }
-          - { wp: latest, mode: 'filter_disabled', php: '7.4' }
-          - { wp: latest, mode: 'option_enabled', php: '7.4' }
-          - { wp: latest, mode: 'option_disabled', php: '7.4' }
-          - { wp: latest, mode: 'filter_and_option_enabled', php: '7.4' }
-          - { wp: latest, mode: 'filter_and_option_disabled', php: '7.4' }
+          - { wp: latest, mode: 'filter_enabled', php: '8.0' }
+          - { wp: latest, mode: 'filter_disabled', php: '8.0' }
+          - { wp: latest, mode: 'option_enabled', php: '8.0' }
+          - { wp: latest, mode: 'option_disabled', php: '8.0' }
+          - { wp: latest, mode: 'filter_and_option_enabled', php: '8.0' }
+          - { wp: latest, mode: 'filter_and_option_disabled', php: '8.0' }
     services:
       mysql:
         image: mysql:8


### PR DESCRIPTION
PHP 7.4 is dead. It's time to move all our workflows to PHP 8.
