### PR TITLE
ci: Fix duplicate workflow name

### DIFF
--- a/.github/workflows/search-dev-tools.yml
+++ b/.github/workflows/search-dev-tools.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Search Dev Tools
 
 on:
   push:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   search-dev-tools:
-    name: Build Search Dev Tools
+    name: Build
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
`search-dev-tools.yml` and `ci.yml` have the same workflow name; this possibly causes spurious job cancellations.