### PR TITLE
CI: Only run tag release steps on workflow for Changelog generator

### DIFF
--- a/.github/workflows/changelog-summary.yml
+++ b/.github/workflows/changelog-summary.yml
@@ -19,11 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download tag release
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.workflow.name == 'Tag Release' && github.event.workflow_run.conclusion == 'completed' }}
         uses: actions/download-artifact@v3
         with:
           name: tag-release
 
       - name: Set tag release as env var
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.workflow.name == 'Tag Release' && github.event.workflow_run.conclusion == 'completed' }}
         id: set_tag
         run: |
           RESULT=$(cat tag-release/result.txt)


### PR DESCRIPTION
## Description
Fix https://github.com/Automattic/vip-go-mu-plugins/actions/runs/5203760271/jobs/9387067724?pr=4585