### PR TITLE
CI: Move changelog summary generator to their own workflows

### DIFF
--- a/.github/workflows/changelog-summary-prod.yml
+++ b/.github/workflows/changelog-summary-prod.yml
@@ -1,4 +1,4 @@
-name: Tag Release
+name: Changelog Summary - Production
 
 on:
   push:
@@ -38,7 +38,7 @@ jobs:
               minor_version=$(echo "${tag}" | awk -F. '{print $2+1}')
           fi
 
-          echo "id=${current_date}${minor_version}" >> $GITHUB_OUTPUT
+          echo "::set-output name=id::${current_date}${minor_version}"
 
       - name: Tag release
         run: git tag ${{ steps.id-generator.outputs.id }}
@@ -53,12 +53,33 @@ jobs:
           generate_release_notes: true
           tag_name: ${{ steps.id-generator.outputs.id }}
 
-      - name: Generate tag release to file
-        run: |
-          echo ${{ steps.id-generator.outputs.id }} > result.txt
+  execute:
+    needs: tag-release
+    name: Run Summary Generator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.5.3
 
-      - name: Upload tag release as artifact
-        uses: actions/upload-artifact@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2.25.4
         with:
-          name: tag-release
-          path: result.txt
+          php-version: '7.4'
+
+      - name: Install
+        uses: ramsey/composer-install@2.2.0
+
+      - name: Execute
+        env:
+          CHANGELOG_POST_TOKEN: ${{ secrets.CHANGELOG_BEARER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          PROJECT_USERNAME: Automattic
+          PROJECT_REPONAME: vip-go-mu-plugins
+          BRANCH: ${{ github.ref_name }}
+          TAG_RELEASE: ${{ needs.tag-release.outputs.id }}
+        run: |
+          php ./ci/changelog-summary.php \
+                --wp-endpoint=https://public-api.wordpress.com/wp/v2/sites/wpvipchangelog.wordpress.com/posts \
+                --wp-status=draft \
+                --debug

--- a/.github/workflows/changelog-summary-staging.yml
+++ b/.github/workflows/changelog-summary-staging.yml
@@ -1,13 +1,9 @@
-name: Changelog Summary
+name: Changelog Summary - Staging
 
 on:
   push:
     branches:
       - staging
-  workflow_run:
-    workflows: ["Tag Release"]
-    types:
-      - completed
 
 permissions:
   contents: read
@@ -18,19 +14,6 @@ jobs:
     name: Run Summary Generator
     runs-on: ubuntu-latest
     steps:
-      - name: Download tag release
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.workflow.name == 'Tag Release' && github.event.workflow_run.conclusion == 'completed' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: tag-release
-
-      - name: Set tag release as env var
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.workflow.name == 'Tag Release' && github.event.workflow_run.conclusion == 'completed' }}
-        id: set_tag
-        run: |
-          RESULT=$(cat tag-release/result.txt)
-          echo "::set-output name=result::$RESULT"
-
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
 
@@ -50,7 +33,6 @@ jobs:
           PROJECT_USERNAME: Automattic
           PROJECT_REPONAME: vip-go-mu-plugins
           BRANCH: ${{ github.ref_name }}
-          TAG_RELEASE: ${{ steps.set_tag.outputs.result }}
         run: |
           php ./ci/changelog-summary.php \
                 --wp-endpoint=https://public-api.wordpress.com/wp/v2/sites/wpvipchangelog.wordpress.com/posts \

--- a/ci/changelog-summary.php
+++ b/ci/changelog-summary.php
@@ -59,7 +59,7 @@ define( 'LABEL_READY', '[Status] Ready to deploy' );
 define( 'LABEL_DEPLOYED_PROD', '[Status] Deployed to production' );
 define( 'LABEL_DEPLOYED_STAGING', '[Status] Deployed to staging' );
 define( 'LABEL_REVERTED', '[Status] Reverted' );
-define( 'TAG_RELEASE', $_SERVER[ 'TAG_RELEASE' ] );
+define( 'TAG_RELEASE', $_SERVER[ 'TAG_RELEASE' ] ?? '' );
 
 /**
  * Utility function for debugging.


### PR DESCRIPTION
## Description
Since it's confusing that the tag-release feeds into the changelog summary workflow for production only, we decided to split them up into their own workflows and combine the production changelog summary with the tag-release one. There isn't much duplicated code in it, so not worth making a template for the 2 same steps.