### PR TITLE
Query Monitor: Do not enable by default for non-prods

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -40,18 +40,9 @@ function wpcom_vip_qm_enable( $enable ) {
 		return true;
 	}
 
-	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-		return true;
-	}
-
 	return $enable;
 }
 add_filter( 'wpcom_vip_qm_enable', 'wpcom_vip_qm_enable' );
-
-// Enable by default for non-prod environments and only when admin bar is showing.
-if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) && true === apply_filters( 'show_admin_bar', false ) ) {
-	add_filter( 'wpcom_vip_qm_enable', '__return_true' );
-}
 
 /**
  * Require the plugin files for Query Monitor, faking a

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -48,6 +48,11 @@ function wpcom_vip_qm_enable( $enable ) {
 }
 add_filter( 'wpcom_vip_qm_enable', 'wpcom_vip_qm_enable' );
 
+// Enable by default for non-prod environments and only when admin bar is showing.
+if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) && true === apply_filters( 'show_admin_bar', false ) ) {
+	add_filter( 'wpcom_vip_qm_enable', '__return_true' );
+}
+
 /**
  * Require the plugin files for Query Monitor, faking a
  * plugin activation, if it's the first time.


### PR DESCRIPTION
## Description

Do not enable for non-prods by default. Local environments will still have it enabled by default though.

## Changelog Description

### Plugin Updated: Query Monitor

Do not enable for non-prods by default.