### PR TITLE
Streamwrapper: Move logic out into the open

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -78,7 +78,7 @@ class A8C_Files {
 			return GB_IN_BYTES * 3; 
 		} );
 
-		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER ) {
+		if ( ! defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) || constant( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) !== false ) {
 			$this->init_vip_filesystem();
 		}
 

--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -70,11 +70,11 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 		// Uploads paths can just use PHP functions when stream wrapper is enabled.
 		// This is because wp_upload_dir will return a vip:// path.
 		if ( $this->is_uploads_path( $filename ) ) {
-			if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === constant( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) ) {
-				return $this->direct;
+			if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && false === constant( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) ) {
+				return $this->uploads;
 			}
 
-			return $this->uploads;
+			return $this->direct;
 		} elseif ( $this->is_tmp_path( $filename ) ) {
 			return $this->direct;
 		} elseif ( 'read' === $context ) {

--- a/stats.php
+++ b/stats.php
@@ -49,7 +49,7 @@ function track_file_upload() {
 		return;
 	}
 
-	$using_streams = false;
+	$using_streams = true;
 	if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) ) {
 		$using_streams = (bool) VIP_FILESYSTEM_USE_STREAM_WRAPPER;
 	}
@@ -94,7 +94,7 @@ function track_file_delete() {
 		return;
 	}
 
-	$using_streams = false;
+	$using_streams = true;
 	if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) ) {
 		$using_streams = (bool) VIP_FILESYSTEM_USE_STREAM_WRAPPER;
 	}

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -287,6 +287,8 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 	}
 
 	public function test__get_transport_for_path__uploads() {
+		// Now that streamwrapper is enabled by default, we need to define it as disabled for this test.
+		define( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER', false );
 		$get_transport_for_path = self::get_method( 'get_transport_for_path' );
 
 		$result = $get_transport_for_path->invokeArgs( $this->filesystem, [ '/tmp/wordpress/wp-content/uploads/file.file', 'write' ] );

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -279,8 +279,6 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 	}
 
 	public function test__get_transport_for_path__uploads_streamwrapper() {
-		Constant_Mocker::define( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER', true );
-
 		$get_transport_for_path = self::get_method( 'get_transport_for_path' );
 
 		$result = $get_transport_for_path->invokeArgs( $this->filesystem, [ '/tmp/wordpress/wp-content/uploads/file.file', 'read' ] );

--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -57,7 +57,7 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 	 */
 	public function update_filesizes( $args, $assoc_args ) {
 		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && false === constant( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) ) {
-			WP_CLI::error( 'This script only works when the VIP Stream Wrapper is enabled. Please add `define( \'VIP_FILESYSTEM_USE_STREAM_WRAPPER\', true );` to vip-config.php and try again.' );
+			WP_CLI::error( 'This script only works when the VIP Stream Wrapper is enabled. If the constant \'VIP_FILESYSTEM_USE_STREAM_WRAPPER\' is defined as false, please remove it.' );
 			return;
 		}
 

--- a/wp-cli/vip-filesystem.php
+++ b/wp-cli/vip-filesystem.php
@@ -56,7 +56,7 @@ class VIP_Files_CLI_Command extends \WPCOM_VIP_CLI_Command {
 	 * @sypnosis [--dry-run=<dry-run>] [--batch=<batch>]
 	 */
 	public function update_filesizes( $args, $assoc_args ) {
-		if ( ! defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) || true !== VIP_FILESYSTEM_USE_STREAM_WRAPPER ) {
+		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && false === constant( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) ) {
 			WP_CLI::error( 'This script only works when the VIP Stream Wrapper is enabled. Please add `define( \'VIP_FILESYSTEM_USE_STREAM_WRAPPER\', true );` to vip-config.php and try again.' );
 			return;
 		}


### PR DESCRIPTION
## Description
Similar to #4589, we should move this logic out into the open since it is already enabled for everyone. There is still the option to disable it with the constant `VIP_FILESYSTEM_USE_STREAM_WRAPPER` though.
