### PR TITLE
Search: Remove submodule `elasticpress-next`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 [submodule "jetpack"]
 	path = jetpack
 	url = https://github.com/Automattic/jetpack-production.git
-[submodule "search/elasticpress-next"]
-	path = search/elasticpress-next
-	url = https://github.com/Automattic/ElasticPress.git
 [submodule "wp-parsely"]
 	path = wp-parsely
 	url = https://github.com/Parsely/wp-parsely.git

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -32,7 +32,6 @@
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/query-monitor/*</exclude-pattern>
 	<exclude-pattern>/search/elasticpress/*</exclude-pattern>
-	<exclude-pattern>/search/elasticpress-next/*</exclude-pattern>
 	<exclude-pattern>/search/es-wp-query/*</exclude-pattern>
 	<exclude-pattern>/shared-plugins/*</exclude-pattern>
 	<exclude-pattern>/vaultpress/*</exclude-pattern>


### PR DESCRIPTION
## Description
⚠️ https://github.com/Automattic/vip-go-mu-plugins/pull/4607 needs to be merged first!! ⚠️ 

This is the last step of Enterprise Search upgrades. This PR removes the `elasticpress-next` submodule. 
