### PR TITLE
VaultPress: Prevent overriding VIP_VAULTPRESS_SKIP_LOAD constant

### DIFF
--- a/cron/cron.php
+++ b/cron/cron.php
@@ -16,7 +16,7 @@ if ( file_exists( __DIR__ . '/action-scheduler-dynamic-queue.php' ) ) {
 // Unregister Jetpack-related cron events when disabled.
 add_action( 'cli_init', function() {
 	$jetpack_is_disabled    = defined( 'VIP_JETPACK_SKIP_LOAD' ) && true === VIP_JETPACK_SKIP_LOAD;
-	$vaultpress_is_disabled = $jetpack_is_disabled || ( defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) && true === VIP_VAULTPRESS_SKIP_LOAD );
+	$vaultpress_is_disabled = $jetpack_is_disabled || ( defined( 'VIP_VAULTPRESS_ALLOWED' ) && false === VIP_VAULTPRESS_ALLOWED ) || ( defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) && true === VIP_VAULTPRESS_SKIP_LOAD );
 
 	$events_to_unregister = [];
 	if ( $jetpack_is_disabled ) {

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -13,15 +13,15 @@
  * @package automattic/vaultpress
  */
 
-// VaultPress is deprecated. Do not load VaultPress if VIP_GO_APP_ID is not in VIP_VAULTPRESS_ALLOWED_APP_IDS
-if ( defined( 'VIP_VAULTPRESS_ALLOWED_APP_IDS' ) && defined( 'VIP_GO_APP_ID' ) && ! in_array( VIP_GO_APP_ID, VIP_VAULTPRESS_ALLOWED_APP_IDS, true ) ) {
-	return;
-}
-
 // Do not load VaultPress unless explicitly enabled via the VIP_VAULTPRESS_SKIP_LOAD constant
 // Please see this post for more information: https://lobby.vip.wordpress.com/2023/02/28/upcoming-vaultpress-deprecation/
 if ( ! defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) ) {
 	define( 'VIP_VAULTPRESS_SKIP_LOAD', true );
+}
+
+// Avoid loading VaultPress altogether if VIP_VAULTPRESS_ALLOWED is set to false
+if ( defined( 'VIP_VAULTPRESS_ALLOWED' ) && false === VIP_VAULTPRESS_ALLOWED ) {
+	return;
 }
 
 // Avoid loading VaultPress altogether if VIP_JETPACK_SKIP_LOAD is set to true (Jetpack is required for VP to work in VIP)

--- a/vaultpress.php
+++ b/vaultpress.php
@@ -13,6 +13,11 @@
  * @package automattic/vaultpress
  */
 
+// VaultPress is deprecated. Do not load VaultPress if VIP_GO_APP_ID is not in VIP_VAULTPRESS_ALLOWED_APP_IDS
+if ( defined( 'VIP_VAULTPRESS_ALLOWED_APP_IDS' ) && defined( 'VIP_GO_APP_ID' ) && ! in_array( VIP_GO_APP_ID, VIP_VAULTPRESS_ALLOWED_APP_IDS, true ) ) {
+	return;
+}
+
 // Do not load VaultPress unless explicitly enabled via the VIP_VAULTPRESS_SKIP_LOAD constant
 // Please see this post for more information: https://lobby.vip.wordpress.com/2023/02/28/upcoming-vaultpress-deprecation/
 if ( ! defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) ) {

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-cli.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-cli.php
@@ -115,9 +115,10 @@ class CLI {
 	 */
 	private function connect_vaultpress() {
 		// Do not connect to Vaultpress if the loading of the Vaultpress plugin has been skipped.
-		$skip_vp = defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) && VIP_VAULTPRESS_SKIP_LOAD;
+		$skip_vp = ( defined( 'VIP_VAULTPRESS_ALLOWED' ) && false === VIP_VAULTPRESS_ALLOWED ) || ( defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) && VIP_VAULTPRESS_SKIP_LOAD );
+
 		if ( $skip_vp ) {
-			WP_CLI::line( '☑️  Vaultpress is skipped by: VIP_VAULTPRESS_SKIP_LOAD' );
+			WP_CLI::line( '☑️  VaultPress is skipped because the plugin is not loaded' );
 			return true;
 		}
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -130,7 +130,7 @@ class Connection_Pilot {
 			}
 
 			// Attempting VaultPress connection given that Jetpack is connected
-			$skip_vaultpress = defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) && VIP_VAULTPRESS_SKIP_LOAD;
+			$skip_vaultpress = ( defined( 'VIP_VAULTPRESS_ALLOWED' ) && false === VIP_VAULTPRESS_ALLOWED ) || ( defined( 'VIP_VAULTPRESS_SKIP_LOAD' ) && VIP_VAULTPRESS_SKIP_LOAD );
 			if ( ! $skip_vaultpress ) {
 				$vaultpress_connection_attempt = Connection_Pilot\Controls::connect_vaultpress();
 				if ( is_wp_error( $vaultpress_connection_attempt ) ) {


### PR DESCRIPTION
## Description

_Follow up to https://github.com/Automattic/vip-go-mu-plugins/pull/4246_

This PR is part of the [VaultPress deprecation](https://lobby.vip.wordpress.com/2023/02/28/upcoming-vaultpress-deprecation/) plan. It allows for the prevention of overriding the `VIP_VAULTPRESS_SKIP_LOAD` constant to completely disable VaultPress. 

## Changelog Description

### VaultPress Deprecation Preparations

Adds a mechanism to prevent loading VaultPress

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 
