### PR TITLE
Add auth tokens through VIP_SERVICES_AUTH_TOKENS instead, if available

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -348,18 +348,21 @@ class Site_Details_Index {
 	 * and sends it to the site details service
 	 */
 	public function put_site_details() {
-		$site_details       = $this->get_site_details();
-		$url                = null;
-		$token              = null;
-		$auth_token_details = null;
+		$site_details      = $this->get_site_details();
+		$url               = null;
+		$token             = null;
+		$new_service_url   = null;
+		$new_service_token = null;
 
 		if ( defined( 'VIP_SERVICES_AUTH_TOKENS' ) && ! empty( VIP_SERVICES_AUTH_TOKENS ) ) {
 			$auth_token_details = json_decode( base64_decode( VIP_SERVICES_AUTH_TOKENS ), true );
+			$new_service_url    = $auth_token_details['site']['vip-site-details']['url'] ?? null;
+			$new_service_token  = $auth_token_details['site']['vip-site-details']['token'] ?? null;
 		}
 
-		if ( $auth_token_details ) {
-			$url   = rtrim( $auth_token_details['site']['vip-site-details']['url'], '/' ) . '/sites';
-			$token = $auth_token_details['site']['vip-site-details']['token'] ?? null;
+		if ( $new_service_url && $new_service_token ) {
+			$url   = rtrim( $new_service_url, '/' ) . '/sites';
+			$token = $new_service_token;
 		} elseif ( defined( 'SERVICES_API_URL' ) && defined( 'SERVICES_AUTH_TOKEN' ) && ! empty( SERVICES_AUTH_TOKEN ) ) {
 			$url   = rtrim( SERVICES_API_URL, '/' ) . '/site-details/sites';
 			$token = SERVICES_AUTH_TOKEN;

--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -348,13 +348,18 @@ class Site_Details_Index {
 	 * and sends it to the site details service
 	 */
 	public function put_site_details() {
-		$site_details = $this->get_site_details();
-		$url          = null;
-		$token        = null;
+		$site_details       = $this->get_site_details();
+		$url                = null;
+		$token              = null;
+		$auth_token_details = null;
 
-		if ( defined( 'SDS_API_URL' ) && defined( 'SDS_AUTH_TOKEN' ) && ! empty( SDS_AUTH_TOKEN ) ) {
-			$url   = rtrim( SDS_API_URL, '/' ) . '/sites';
-			$token = SDS_AUTH_TOKEN;
+		if ( defined( 'VIP_SERVICES_AUTH_TOKENS' ) && ! empty( VIP_SERVICES_AUTH_TOKENS ) ) {
+			$auth_token_details = json_decode( base64_decode( VIP_SERVICES_AUTH_TOKENS ), true );
+		}
+
+		if ( $auth_token_details ) {
+			$url   = rtrim( $auth_token_details['site']['vip-site-details']['url'], '/' ) . '/sites';
+			$token = $auth_token_details['site']['vip-site-details']['token'] ?? null;
 		} elseif ( defined( 'SERVICES_API_URL' ) && defined( 'SERVICES_AUTH_TOKEN' ) && ! empty( SERVICES_AUTH_TOKEN ) ) {
 			$url   = rtrim( SERVICES_API_URL, '/' ) . '/site-details/sites';
 			$token = SERVICES_AUTH_TOKEN;


### PR DESCRIPTION
## Description

Updates where we're getting the token from.

## Changelog Description

### Site Details Service

We added an alternative endpoint for sending data to the Site Details Service

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Get a local dev-env running with local mu-plugins
2. Get local xdebug running with `vip dev-env shell --root --slug=yourlocalslug`, then type in `phpenmod xdebug`, then `exit` and then run `vip dev-env shell`.
3. Run `XDEBUG_TRIGGER=xdebug PHP_IDE_CONFIG="serverName=server-name-in-ide" wp shell`. Alternatively, just run `wp shell` if you don't want to use xdebug.
4. `var_dump()` away/breakpoint away around the methods for this change.
5. Then, in `wp shell`, run `require_once '/wp/wp-content/mu-plugins/config/class-site-details-index.php'; $clz = new Automattic\VIP\Config\Site_Details_Index();`
6. Run `$encoded = base64_encode(json_encode(['site' => ['vip-site-details' => ['token' => 'someToken', 'url' => 'http://localhost:4002/' ]]])); define('VIP_SERVICES_AUTH_TOKENS', $encoded)` so that we set VIP_SERVICES_AUTH_TOKENS for us to test with.
7. Finally, run `$clz->put_site_details()`.