### PR TITLE
fix: Make installatoin in dev env complete without warnings

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -335,5 +335,9 @@ if ( function_exists( '\Automattic\VIP\Core\Constants\define_db_constants' ) ) {
 	define_db_constants( $GLOBALS['wpdb'] );
 }
 
+if ( ! isset( $_SERVER['HTTP_HOST'] ) ) {
+	$_SERVER['HTTP_HOST'] = null;
+}
+
 do_action( 'vip_loaded' );
 // @codeCoverageIgnoreEnd

--- a/001-cron.php
+++ b/001-cron.php
@@ -106,7 +106,7 @@ function wpcom_vip_cron_control_event_object_to_string( $event ) {
 /**
  * Should Cron Control load
  */
-if ( ! wpcom_vip_use_core_cron() ) {
+if ( ! wpcom_vip_use_core_cron() && is_blog_installed() ) {
 	/**
 	 * Prevent plugins/themes from blocking access to our routes
 	 */

--- a/cron/cron.php
+++ b/cron/cron.php
@@ -43,6 +43,10 @@ add_action( 'cli_init', function() {
 add_action( 'cli_init', '\Automattic\VIP\Cron\vip_schedule_aggregated_cron' );
 
 function vip_schedule_aggregated_cron() {
+	if ( defined( 'WP_INSTALLING' ) && true === constant( 'WP_INSTALLING' ) ) {
+		return;
+	}
+
 	if ( wp_next_scheduled( 'vip_aggregated_cron_hourly' ) ) {
 		return;
 	}

--- a/prometheus/inc/class-plugin.php
+++ b/prometheus/inc/class-plugin.php
@@ -32,6 +32,10 @@ class Plugin {
 	 * @codeCoverageIgnore -- invoked before the tests start
 	 */
 	protected function __construct() {
+		if ( Context::is_installing() ) {
+			return;
+		}
+
 		add_action( 'vip_mu_plugins_loaded', [ $this, 'init_registry' ], 9 );
 		add_action( 'vip_mu_plugins_loaded', [ $this, 'load_collectors' ] );
 		add_action( 'mu_plugins_loaded', [ $this, 'load_collectors' ] );


### PR DESCRIPTION
## Description

This PR:
* disables the Prometheus plugin when WordPress is being installed;
* suppresses Cron Control if WordPress is not installed;
* ensures `HTTP_HOST` is always set.

This should fix

```
WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('cron', 'a:2:{i:1687240563;a:1:{s:26:\"vip_aggregated_cron_hourly\";a:1:{s:32:\"40cd750bba9870f18aada2478b24840a\";a:3:{s:8:\"schedule\";s:6:\"hourly\";s:4:\"args\";a:0:{}s:8:\"interval\";i:3600;}}}s:7:\"version\";i:2;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
```

```
[20-Jun-2023 05:56:03 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('a8c_cron_control_db_version', '1', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
```

```
[20-Jun-2023 07:48:23 UTC] Warning: Undefined array key "HTTP_HOST" in /wp/wp-includes/functions.php on line 6096 [$ /usr/local/bin/wp core is-installed --debug] [wp-includes/script-loader.php:693 wp_guess_url(), wp-includes/class-wp-hook.php:308 wp_default_scripts(), wp-includes/class-wp-hook.php:332 WP_Hook->apply_filters(), wp-includes/plugin.php:565 WP_Hook->do_action(), wp-includes/class-wp-scripts.php:167 do_action_ref_array(), wp-includes/class-wp-scripts.php:142 WP_Scripts->init(), wp-includes/functions.wp-scripts.php:24 WP_Scripts->__construct(), wp-includes/functions.wp-scripts.php:176 wp_scripts(), wp-includes/blocks.php:156 wp_register_script(), wp-includes/blocks.php:425 register_block_script_handle(), wp-includes/blocks/file.php:54 register_block_type_from_metadata(), wp-includes/class-wp-hook.php:308 register_block_core_file(), wp-includes/class-wp-hook.php:332 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-settings.php:623 do_action('init'), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1349 require('wp-settings.php'), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1267 WP_CLI\Runner->load_wordpress(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28 WP_CLI\Runner->start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:83 WP_CLI\Bootstrap\LaunchRunner->process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:32 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:20 include('phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/binphp/boot-phar.php')]
```

for Dev Env.

While these errors are not fatal, they still don't look good and make an impression that something goes wrong.

## Changelog Description

### Plugin Updated: Prometheus

Disable Prometheus when WordPress is being installed.

### Plugin Updated: VIP Cron Enhancements

Do not load Cron Control if WordPress is not installed

### Plugin Updated: VIP Init

Ensure `HTTP_HOST` is always set to prevent PHP warnings in `wp_guess_url()`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out, install submodules
2. `vip dev-env create -u /path/to/vip-go-mu-plugins < /dev/null; vip dev-env start`
3. Make sure the process goes smoothly, without errors or warnings.
