### PR TITLE
CI: Remove added `v` for `shivammathur/setup-php`

### DIFF
--- a/.github/workflows/changelog-summary-prod.yml
+++ b/.github/workflows/changelog-summary-prod.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2.25.4
+        uses: shivammathur/setup-php@2.25.4
         with:
           php-version: '7.4'
 


### PR DESCRIPTION
## Description
Looks like it accidentally got added in the re-factoring and now fails: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/5322730198/jobs/9639589579

Tag doesn't exist in the `v` format for the version requested: https://github.com/shivammathur/setup-php/tags