### PR TITLE
Query Monitor: Do not enable by default for non-prods

### DIFF
--- a/query-monitor.php
+++ b/query-monitor.php
@@ -40,10 +40,6 @@ function wpcom_vip_qm_enable( $enable ) {
 		return true;
 	}
 
-	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-		return true;
-	}
-
 	return $enable;
 }
 add_filter( 'wpcom_vip_qm_enable', 'wpcom_vip_qm_enable' );


### PR DESCRIPTION
## Description

Do not enable for non-prods by default. Local environments will still have it enabled by default though.

## Changelog Description

### Plugin Updated: Query Monitor

Do not enable for non-prods by default.