### PR TITLE
CI: Add write permissions to pull-requests to fix labels adding

### DIFF
--- a/.github/workflows/changelog-summary-prod.yml
+++ b/.github/workflows/changelog-summary-prod.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   tag-release:


### PR DESCRIPTION
## Description
Another thing missed in the re-factoring, we need to add write permissions for the pull-requests for their labels to be updated accordingly.