### PR TITLE
BB8-10403: Use updated sha256 for Gravatar

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -957,7 +957,7 @@ function wpcom_vip_get_user_profile( $email_or_id ) {
 		$email = $user->user_email;
 	}
 
-	$hashed_email = md5( strtolower( trim( $email ) ) );
+	$hashed_email = hash( 'sha256', strtolower( trim( $email ) ) );
 	$profile_url  = esc_url_raw( sprintf( 'https://en.gravatar.com/%s.php', $hashed_email ), array( 'http', 'https' ) );
 
 	$profile = wpcom_vip_file_get_contents( $profile_url, 1, 900 );
@@ -984,7 +984,7 @@ function wpcom_vip_get_user_profile( $email_or_id ) {
  */
 function wpcom_vip_email_has_gravatar( $email ) {
 
-	$hash = md5( strtolower( trim( $email ) ) );
+	$hash = hash( 'sha256', strtolower( trim( $email ) ) );
 
 	// If not in the cache, check again
 	$has_gravatar = wp_cache_get( $hash, 'email_has_gravatar' );

--- a/vip-support/class-vip-support-user.php
+++ b/vip-support/class-vip-support-user.php
@@ -102,7 +102,7 @@ class User {
 	/**
 	 * The Gravatar URL for `VIP_SUPPORT_EMAIL_ADDRESS`.
 	 */
-	const VIP_SUPPORT_EMAIL_ADDRESS_GRAVATAR = 'https://secure.gravatar.com/avatar/c83fd21f1122c4d1d8677d6a7a1291d3';
+	const VIP_SUPPORT_EMAIL_ADDRESS_GRAVATAR = 'https://secure.gravatar.com/avatar/c84e75679a6342a8a28793784098c0ee57669854bc0d006b6a7a49a275177696';
 
 	/**
 	 * A flag to indicate reversion and then to prevent recursion.


### PR DESCRIPTION
## Description
Now that Gravatar supports SHA256, let's update our references to it.
