### PR TITLE
VIP Request Block: remove fastcgi_finish_request and don't block in CLI context

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -133,7 +133,10 @@ class VIP_Request_Block {
 			header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
 			header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 
-			fastcgi_finish_request();
+			if ( function_exists( 'fastcgi_finish_request' ) ) {
+				fastcgi_finish_request();
+			}
+
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
 			exit;

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -128,14 +128,16 @@ class VIP_Request_Block {
 			newrelic_ignore_transaction();
 		}
 
+		if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( sprintf( 'VIP Request Block: would block based on "%s" with value of "%s" but it\'s a CLI request', $criteria, $value ) );
+			return true;
+		}
+
 		if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
 			http_response_code( 403 );
 			header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
 			header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
-
-			if ( function_exists( 'fastcgi_finish_request' ) ) {
-				fastcgi_finish_request();
-			}
 
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -124,14 +124,12 @@ class VIP_Request_Block {
 	 * @return true|void
 	 */
 	public static function block_and_log( string $value, string $criteria ) {
-		if ( extension_loaded( 'newrelic' ) && function_exists( 'newrelic_ignore_transaction' ) ) {
-			newrelic_ignore_transaction();
+		if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
+			return true;
 		}
 
-		if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( sprintf( 'VIP Request Block: would block based on "%s" with value of "%s" but it\'s a CLI request', $criteria, $value ) );
-			return true;
+		if ( extension_loaded( 'newrelic' ) && function_exists( 'newrelic_ignore_transaction' ) ) {
+			newrelic_ignore_transaction();
 		}
 
 		if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {


### PR DESCRIPTION
## Description

1. fastcgi_finish_request is not needed here because we bail via `exit` immediately after.
2. Killing off requests running in WP-CLI due to faulty logical expression (i.e. an unintended match) is not desirable either, so rather than killing the request we bail early. 


## Changelog Description

### Library updated: VIP Request Block

We've updated VIP Request Block library not run in WP-CLI context as that potentially may lead to inability to run CLI commands in case an expression evaluated to `true` in CLI context.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out the PR, add something like 
```php
VIP_Request_Block::block_and_log( 'test', 'test' );
```

2. Open the browser verify that request is terminated
3. Spawn a CLI command and verify it works.
