### PR TITLE
Removes full-width Non-Prod Bar CSS

### DIFF
--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -40,7 +40,6 @@ function vip_do_non_prod_bar() {
 			position:fixed;
 			margin:0;
 			padding: 0 20px;
-			width: 100%;
 			height: 28px;
 		}
 		#vip-non-prod-bar span {


### PR DESCRIPTION
## Description

The Non-Prod Bar (Sandbox Bar) is not full width, but contains a "hidden" rectangle that extends the width of the site, meaning you can't click anything behind it. This is an annoyance and does not cause any actual functionality issues.

This fix removes the 100% width, thus allowing clicks on any part of the screen. The Non-Prod Bar still displays properly and still works properly when clicked on its visible portion.

Fixes #4375

## Changelog Description

### Plugin Updated: VIP Helpers

Fixed a CSS bug in the non-prod bar that did not allow clicks to pass through to a portion of the application.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Example:

1. Check out PR.
1. Sandbox a VIP Go Site, or visit a non-prod site with the non-prod bar.
1. Click anywhere to the "right" of the bar where you would expect the click to hit the application.
1. Verify the click did not "open" the non-prod bar and went to the application.

