### PR TITLE
Update fallback Jetpack submodule to 12.3

### DIFF
--- a/README-PUBLIC.md
+++ b/README-PUBLIC.md
@@ -1,6 +1,6 @@
-# VIP Go mu-plugins
+# VIP mu-plugins
 
-This is the mu-plugins folder for VIP Go, assembled without submodules for convenience.
+This is the MU-plugins folder for WordPress VIP, assembled without submodules for convenience. This is not the exact repo that gets deployed to production.
 
 Please see our documentation on setting up your [local development environment](https://docs.wpvip.com/how-tos/set-up-a-vip-go-local-development-site/).
 


### PR DESCRIPTION
## Description

In production and VIP Local Dev Env, we use versioned paths, e.g. `jetpack-x.y`, this submodule is only intended as a fallback. This brings up the submodule to 12.3.

## Changelog Description

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1) On a local env that doesn't have any versioned Jetpack in `mu-plugins`, load the site or start a CLI command `wp jetpack status` and verify that the version is 12.3
2) Add current global version (12.2) as `jetpack-12` and verify that version loaded is 12.2 now.