### PR TITLE
Remove VIP Integrations globals

### DIFF
--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -11,15 +11,6 @@ namespace Automattic\VIP\Integrations;
 
 defined( 'ABSPATH' ) || die();
 
-// Safety during the initial rollout. Can be removed later.
-if (
-	! file_exists( __DIR__ . '/integrations/integration.php' )
-	|| ! file_exists( __DIR__ . '/integrations/integrations.php' )
-	|| ! file_exists( __DIR__ . '/integrations/block-data-api.php' )
-) {
-	return;
-}
-
 require_once __DIR__ . '/integrations/integration.php';
 require_once __DIR__ . '/integrations/integrations.php';
 require_once __DIR__ . '/integrations/block-data-api.php';

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -24,10 +24,20 @@ require_once __DIR__ . '/integrations/integration.php';
 require_once __DIR__ . '/integrations/integrations.php';
 require_once __DIR__ . '/integrations/block-data-api.php';
 
-$vip_integrations = new Integrations();
+class IntegrationsSingleton {
+	private static $instance = null;
+
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new Integrations();
+		}
+
+		return self::$instance;
+	}
+}
 
 // Register VIP integrations here
-$vip_integrations->register( 'block-data-api', BlockDataApi::class );
+IntegrationsSingleton::instance()->register( 'block-data-api', BlockDataApi::class );
 
 /**
  * Activates an integration with an optional configuration value.
@@ -36,12 +46,11 @@ $vip_integrations->register( 'block-data-api', BlockDataApi::class );
  * @param array  $config An associative array of configuration values for the integration.
  */
 function activate( string $integration_slug, array $config = [] ): void {
-	global $vip_integrations;
-	$vip_integrations->activate( $integration_slug, $config );
+	IntegrationsSingleton::instance()->activate( $integration_slug, $config );
 }
 
 // Load integrations in muplugins_loaded:5 to allow integrations to hook
 // muplugins_loaded:10 or any later action
-add_action( 'muplugins_loaded', function() use ( $vip_integrations ) {
-	$vip_integrations->load_active();
+add_action( 'muplugins_loaded', function() {
+	IntegrationsSingleton::instance()->load_active();
 }, 5 );


### PR DESCRIPTION
## Description

`vip-integrations.php` currently uses [a `global` variable](https://github.com/Automattic/vip-go-mu-plugins/blob/b8cf0c6/vip-integrations.php#L39) to keep an instance of an `Integrations` collection. This was a workaround to share state with the `activate()` function.

Unfortunately, this code breaks when used inside WPCLI commands:

```
#10 {main} thrown in /wp/wp-content/mu-plugins/vip-integrations.php on line 40
Fatal error: Uncaught Error: Call to a member function activate() on null in /wp/wp-content/mu-plugins/vip-integrations.php:40
```

This is because in WPCLI [WordPress is loaded inside a function](https://github.com/wp-cli/wp-cli/issues/4019). When activate is called:

https://github.com/Automattic/vip-go-mu-plugins/blob/b8cf0c62db85f4e3c7bd983d96e26702f94e374f/vip-integrations.php#L38-L41

it references the implicitly "global" `$vip_integrations` variable defined in the same file.

https://github.com/Automattic/vip-go-mu-plugins/blob/b8cf0c62db85f4e3c7bd983d96e26702f94e374f/vip-integrations.php#L27

When WordPress is loaded in a function scope, the `$vip_integrations` variable is no longer implicitly `global`, and the `activate()` function can no longer reference the variable.

One quick way to solve this issue is to explicitly mark the outer `$vip_integrations` as global:

```diff
+ global $vip_integrations;
$vip_integrations = new Integrations();
```

However, we wanted to avoid using globals at all. In this PR, we make a small singleton wrapper for the `Integrations` instance so that it can be reused in `activate()`. Note that we do not want the core `Integrations` to be singleton instead, as we [previously removed that pattern](https://github.com/Automattic/vip-go-mu-plugins/pull/4458#issuecomment-1570731164) to address code comments and improve testing.

Thank you to @yolih and @WPprodigy for helping to identify and solve this issue.

## Changelog Description

### VIP Integrations fix

We fixed VIP integration activation when used within WPCLI.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Clone a copy of built mu-plugins:

    ```bash
    git clone git@github.com:Automattic/vip-go-mu-plugins-built.git
    ```

    This is useful for manual testing, as VIP integrations depend on [files pulled from `-ext`](https://github.com/Automattic/vip-go-mu-plugins-ext/tree/trunk/vip-integrations/vip-block-data-api-1.0) that are not present in the regular `vip-go-mu-plugins`. If you know a better way to test dependencies in `-ext`, let me know!

2. Checkout PR changes, and copy changes into `vip-go-mu-plugins-built`:

    ```bash
    cd <path-to-mu-plugins>
    git checkout fix/integrations-globals
    cp vip-integrations.php <path-to-mu-plugins-built>
    ```

3. Create a new local VIP skeleton using `vip dev-env`. Don't start it yet.

    ```bash
    git clone git@github.com:Automattic/vip-go-skeleton.git
    cd vip-go-skeleton/
    vip dev-env create --slug=test-integrations --app-code="./" --mu-plugins=<path-to-mu-plugins-built>
    ```

4. Edit your skeleton site's `client-mu-plugins/plugin.loader.php` and add the following line to activate the block data API integration:

    ```php
    \Automattic\VIP\Integrations\activate( 'block-data-api' );
    ```

5. Start up the VIP skeleton. Ensure there are no errors during startup.

    ```bash
    vip dev-env start --slug test-integrations
    ```

6. Ensure the block data API is activated by visiting http://test-integrations.vipdev.lndo.site/wp-json/vip-block-data-api/v1/posts/1/blocks. This should return a blob of JSON:

    ```json
    {"blocks":[{"name":"core\/paragraph","attributes":{"content":"Welcome to WordPress. This is your first post. Edit or delete it, then start writing!","dropCap":false}}]}
    ````

7. Ensure a WPCLI command executes without error:

    ```bash
    vip dev-env exec --slug=test-integrations -- wp cache flush

    Running validation steps...
    ✓ Check for Docker installation 
    ✓ Check for docker-compose installation 
    ✓ Check Docker connectivity 
    ✓ Check DNS resolution 
    Success: The cache was flushed.
    ```