### PR TITLE
Add more runtime metrics and update existing ones

### DIFF
--- a/prometheus-collectors/class-cache-collector.php
+++ b/prometheus-collectors/class-cache-collector.php
@@ -90,7 +90,9 @@ class Cache_Collector implements CollectorInterface {
 
 		if ( is_callable( [ $wp_object_cache, 'get_stats' ] ) ) {
 			$stats = $wp_object_cache->get_stats();
-			$this->alloptions_keys_gauge->set( count( wp_cache_get( 'alloptions', 'options' ) ), [ $this->blog_id ] );
+
+			$alloptions = wp_cache_get( 'alloptions', 'options' );
+			$this->alloptions_keys_gauge->set( is_countable( $alloptions ) ? count( $alloptions ) : 0, [ $this->blog_id ] );
 			$this->size_gauge->set( $stats['totals']['size'], [ $this->blog_id ] );
 
 			foreach ( $stats['operation_counts'] as $operation => $count ) {

--- a/prometheus-collectors/class-cache-collector.php
+++ b/prometheus-collectors/class-cache-collector.php
@@ -13,7 +13,7 @@ class Cache_Collector implements CollectorInterface {
 	private ?Counter $cache_misses_counter = null;
 	private ?Counter $operation_counter    = null;
 	private ?Gauge $alloptions_keys_gauge  = null;
-	private ?Histogram $size               = null;
+	private ?Gauge $size_gauge             = null;
 
 	private string $blog_id;
 	/**
@@ -49,12 +49,11 @@ class Cache_Collector implements CollectorInterface {
 				[ 'site_id' ]
 			);
 
-			$this->size = $registry->getOrRegisterHistogram(
+			$this->size_gauge = $registry->getOrRegisterGauge(
 				'object_cache',
 				'size',
 				'Cache size',
-				[ 'site_id' ],
-				[ 100 * KB_IN_BYTES, 500 * KB_IN_BYTES, MB_IN_BYTES, 5 * MB_IN_BYTES, 10 * MB_IN_BYTES ]
+				[ 'site_id' ]
 			);
 
 			$this->operation_counter = $registry->getOrRegisterCounter(
@@ -92,7 +91,7 @@ class Cache_Collector implements CollectorInterface {
 		if ( is_callable( [ $wp_object_cache, 'get_stats' ] ) ) {
 			$stats = $wp_object_cache->get_stats();
 			$this->alloptions_keys_gauge->set( count( wp_cache_get( 'alloptions', 'options' ) ), [ $this->blog_id ] );
-			$this->size->observe( $stats['totals']['size'], [ $this->blog_id ] );
+			$this->size_gauge->set( $stats['totals']['size'], [ $this->blog_id ] );
 
 			foreach ( $stats['operation_counts'] as $operation => $count ) {
 				$this->operation_counter->incBy( $count, [ $this->blog_id, (string) $operation ] );

--- a/prometheus-collectors/class-login-stats-collector.php
+++ b/prometheus-collectors/class-login-stats-collector.php
@@ -23,14 +23,14 @@ class Login_Stats_Collector implements CollectorInterface {
 			'security',
 			'login_limit_exceeded_total',
 			'Number of rate-limited login requests',
-			[ 'site_id' ]
+			[ 'site_id', 'reason' ]
 		);
 
 		$this->password_reset_limit_exceeded_counter = $registry->getOrRegisterCounter(
 			'security',
 			'password_reset_limit_exceeded_total',
 			'Number of rate-limited password reset requests',
-			[ 'site_id' ]
+			[ 'site_id', 'reason' ]
 		);
 
 		$this->successful_login_counter = $registry->getOrRegisterCounter(
@@ -47,18 +47,18 @@ class Login_Stats_Collector implements CollectorInterface {
 			[ 'site_id' ]
 		);
 
-		add_action( 'login_limit_exceeded', [ $this, 'login_limit_exceeded' ] );
-		add_action( 'password_reset_limit_exceeded', [ $this, 'password_reset_limit_exceeded' ] );
+		add_action( 'login_limit_exceeded', [ $this, 'login_limit_exceeded' ], 10, 2 );
+		add_action( 'password_reset_limit_exceeded', [ $this, 'password_reset_limit_exceeded' ], 10, 2 );
 		add_action( 'wp_login', [ $this, 'wp_login' ] );
 		add_action( 'wp_login_failed', [ $this, 'wp_login_failed' ] );
 	}
 
-	public function login_limit_exceeded(): void {
-		$this->login_limit_exceeded_counter->inc( [ $this->blog_id ] );
+	public function login_limit_exceeded( $username, $reason ): void {
+		$this->login_limit_exceeded_counter->inc( [ $this->blog_id, $reason ] );
 	}
 
-	public function password_reset_limit_exceeded(): void {
-		$this->password_reset_limit_exceeded_counter->inc( [ $this->blog_id ] );
+	public function password_reset_limit_exceeded( $username, $reason ): void {
+		$this->password_reset_limit_exceeded_counter->inc( [ $this->blog_id, $reason ] );
 	}
 
 	public function wp_login(): void {

--- a/security.php
+++ b/security.php
@@ -172,19 +172,19 @@ function _vip_maybe_temporary_lock_account( $username, $cache_group ) {
 	}
 
 	if ( $ip_username_count >= $ip_username_threshold || $ip_count >= $ip_threshold || $username_count >= $username_threshold ) {
-		/**
-		 * Fires when a login limit or password reset is exceeded.
-		 *
-		 * @param string $username Username of the request.
-		 */
-		do_action( "{$event_type}_exceeded", $username );
-
 		$lock_reason = 'username';
 		if ( $ip_username_count >= $ip_username_threshold ) {
 			$lock_reason = 'ip_username';
 		} elseif ( $ip_count >= $ip_threshold ) {
 			$lock_reason = 'ip';
 		}
+
+		/**
+		 * Fires when a login limit or password reset is exceeded.
+		 *
+		 * @param string $username Username of the request.
+		 */
+		do_action( "{$event_type}_limit_exceeded", $username, $lock_reason );
 
 		$default_lockout = $defaults[ "{$lock_reason}_lockout" ];
 		/**
@@ -367,13 +367,11 @@ function wpcom_vip_username_is_limited( $username, $cache_group ) {
 	if ( $is_ip_username_locked || $is_ip_locked || $is_username_locked ) {
 
 		switch ( $cache_group ) {
-
 			case CACHE_GROUP_LOST_PASSWORD_LIMIT:
 				return new WP_Error( ERROR_CODE_LOST_PASSWORD_LIMIT_EXCEEDED, __( 'You have exceeded the password reset limit.  Please wait a few minutes and try again.' ) );
 
 			case CACHE_GROUP_LOGIN_LIMIT:
 				return new WP_Error( ERROR_CODE_LOGIN_LIMIT_EXCEEDED, __( 'You have exceeded the login limit.  Please wait a few minutes and try again.' ) );
-
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR contains a few metrics enhancements.

Fix: 
- security_login_limit_exceeded_total and security_password_reset_limit_exceeed_total metrics + add the `reason` 
 label.
- object_cache_operations_total counter

Add: 
- Add object_cache_size histogram
- Add object_cache_alloptions_keys_total gauge

## Changelog Description

### Plugin Updated: Runtime metrics

We've updated a few runtime metrics that we collect.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

The quickest way to test is to spin up a local dev instance and navigate around a site, then check `/.vip-prom-endpoint`to see all the metrics.