### PR TITLE
Add "Group Stats" for QM Object Cache Plugin

### DIFF
--- a/qm-plugins/qm-object-cache/collectors/class-qm-collector-object-cache-group-stats.php
+++ b/qm-plugins/qm-object-cache/collectors/class-qm-collector-object-cache-group-stats.php
@@ -46,8 +46,10 @@ class QM_Collector_Object_Cache_Group_Stats extends QM_Collector {
 				$group_stats[ $operation_type ][ $group ]['count']++;
 
 				// Add the time and size to the group's stats.
-				$group_stats[ $operation_type ][ $group ]['time'] += $operation['time'] ?? 0;
-				$group_stats[ $operation_type ][ $group ]['size'] += $operation['size'] ?? 0;
+				$group_stats[ $operation_type ][ $group ]['time'] ??= 0;
+				$group_stats[ $operation_type ][ $group ]['size'] ??= 0;
+				$group_stats[ $operation_type ][ $group ]['time']  += $operation['time'];
+				$group_stats[ $operation_type ][ $group ]['size']  += $operation['size'];
 			}
 		}
 

--- a/qm-plugins/qm-object-cache/collectors/class-qm-collector-object-cache-group-stats.php
+++ b/qm-plugins/qm-object-cache/collectors/class-qm-collector-object-cache-group-stats.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Data collector class
+ */
+class QM_Collector_Object_Cache_Group_Stats extends QM_Collector {
+
+	public $id = 'object_cache_group_stats';
+
+	public function name() {
+		return __( 'Group Stats', 'qm-object-cache' );
+	}
+
+	/**
+	 * @return QM_Data
+	 */
+	public function get_storage(): QM_Data {
+		return new QM_Data_Object_Cache();
+	}
+
+	/**
+	 * Processes data from the global object cache variable to gather group stats.
+	 *
+	 * @return void
+	 */
+	public function process() {
+		global $wp_object_cache;
+		if ( ! method_exists( $wp_object_cache, 'get_stats' ) ) {
+			return;
+		}
+
+		$stats       = $wp_object_cache->get_stats();
+		$group_stats = array();
+
+		foreach ( (array) $stats['operations'] as $operation_type => $operations ) {
+			// We don't care about flush numbers, skip.
+			if ( 'get_flush_number' === $operation_type ) {
+				continue;
+			}
+
+			foreach ( $operations as $operation ) {
+				// Set the group or use '[unknown]' if not set; should never happen, but might as well be safe.
+				$group = $operation['group'] ?? '[unknown]';
+
+				// Initialize and increment count for each group.
+				$group_stats[ $operation_type ][ $group ]['count'] ??= 0;
+				$group_stats[ $operation_type ][ $group ]['count']++;
+
+				// Add the time and size to the group's stats.
+				$group_stats[ $operation_type ][ $group ]['time'] += $operation['time'] ?? 0;
+				$group_stats[ $operation_type ][ $group ]['size'] += $operation['size'] ?? 0;
+			}
+		}
+
+		// Assign totals, operation counts and group stats to class data.
+		$this->data->totals           = $stats['totals'] ?? null;
+		$this->data->operation_counts = $stats['operation_counts'] ?? null;
+		$this->data->group_stats      = $group_stats ?? null;
+	}
+}

--- a/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-group-stats.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-group-stats.php
@@ -163,35 +163,6 @@ class QM_Output_Html_Object_Cache_Group_Stats extends QM_Output_Html {
 	}
 
 	/**
-	 * Outputs a toggleable table cell for arrays.
-	 *
-	 * @param array $array Array to be outputted in table cell
-	 *
-	 * @return void
-	 */
-	public function maybe_output_toggle_table_cell_for_array( array $array ) {
-		if ( empty( $array ) ) {
-			return;
-		}
-
-		if ( count( $array ) === 1 ) {
-			$this->output_table_cell( $array[0] );
-			return;
-		}
-
-		echo '<td class="qm-nowrap qm-ltr qm-has-toggle">';
-		echo static::build_toggler(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo '<ol><li>' . esc_html( $array[0] ) . ' [+' . ( count( $array ) - 1 ) . ' more]</li>';
-		unset( $array[0] );
-		echo '<span class="qm-info qm-supplemental">';
-		foreach ( $array as $element ) {
-			echo '<li>' . esc_html( $element ) . '</li>';
-		}
-		echo '</span>';
-		echo '</ol></td>';
-	}
-
-	/**
 	 * Outputs a table cell.
 	 *
 	 * @param string $value Value to be outputted in table cell

--- a/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-group-stats.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-group-stats.php
@@ -85,6 +85,7 @@ class QM_Output_Html_Object_Cache_Group_Stats extends QM_Output_Html {
 				echo '<td>' . esc_html( $this->process_time( $total[ $operation_type ]['time'] ) ) . '</td>';
 				echo '<td>' . esc_html( $this->process_size( $total[ $operation_type ]['size'] ) ) . '</td>';
 
+				echo '</tr>';
 				echo '</tfoot>';
 				$this->output_after_section();
 			}

--- a/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-group-stats.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-group-stats.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Output class
+ *
+ * Class QM_Output_Html_Object_Cache_Group_Stats
+ */
+class QM_Output_Html_Object_Cache_Group_Stats extends QM_Output_Html {
+
+	/**
+	 * The constructor for the class.
+	 */
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+
+		global $wp_object_cache;
+
+		if ( ! method_exists( $wp_object_cache, 'get_stats' ) ) {
+			return;
+		}
+
+		add_filter( 'qm/output/menu_class', array( $this, 'admin_class' ) );
+		add_filter( 'qm/output/panel_menus', array( $this, 'panel_menu' ), 99 );
+	}
+
+	/**
+	 * Outputs group stats data in the footer.
+	 *
+	 * @return void
+	 */
+	public function output() {
+		$data = $this->collector->get_data();
+		if ( empty( $data ) ) {
+			return;
+		}
+
+		$ops         = $data->operations ?? [];
+		$groups      = $data->groups ?? [];
+		$group_stats = $data->group_stats ?? [];
+		$total       = array();
+
+		$this->before_non_tabular_output();
+
+		if ( $group_stats ) {
+			foreach ( $group_stats as $operation_type => $operation_stats ) {
+
+				$total[ $operation_type ] = array(
+					'count' => 0,
+					'time'  => 0,
+					'size'  => 0,
+				);
+
+				$this->output_before_section( 'Group Stats for ' . $operation_type );
+				echo '<thead>';
+				echo '<tr>';
+
+				$this->output_sortable_table_col( __( 'Group', 'qm-object-cache' ) );
+				$this->output_sortable_table_col( __( 'Count', 'qm-object-cache' ) );
+				$this->output_sortable_table_col( __( 'Time', 'qm-object-cache' ) );
+				$this->output_sortable_table_col( __( 'Size', 'qm-object-cache' ) );
+
+				echo '</tr>';
+				echo '</thead>';
+				echo '<tbody>';
+
+				foreach ( $operation_stats as $group => $value ) {
+					echo '<tr>';
+					$this->output_table_cell( $group );
+					$this->output_table_cell( $value['count'] );
+					$this->output_table_cell( $this->process_time( $value['time'] ), $value['time'] );
+					$this->output_table_cell( $this->process_size( $value['size'] ), $value['size'] );
+					echo '</tr>';
+
+					$total[ $operation_type ]['count'] += $value['count'];
+					$total[ $operation_type ]['time']  += $value['time'];
+					$total[ $operation_type ]['size']  += $value['size'];
+
+				}
+
+				echo '</tbody>';
+				echo '<tfoot>';
+				echo '<tr>';
+
+				echo '<td>Totals:</td>';
+				echo '<td>' . esc_html( $total[ $operation_type ]['count'] ) . '</td>';
+				echo '<td>' . esc_html( $this->process_time( $total[ $operation_type ]['time'] ) ) . '</td>';
+				echo '<td>' . esc_html( $this->process_size( $total[ $operation_type ]['size'] ) ) . '</td>';
+
+				echo '</tfoot>';
+				$this->output_after_section();
+			}
+
+			$this->after_non_tabular_output();
+		}
+	}
+
+	/**
+	 * Adds class names to the Query Monitor menu.
+	 *
+	 * @param array $class
+	 *
+	 * @return array
+	 */
+	public function admin_class( array $class ) {
+		$class[] = 'qm-object_cache_group_stats';
+		return $class;
+	}
+
+	/**
+	 * Adds the Group Stats child menu to Query Monitor.
+	 *
+	 * @param array $menu
+	 *
+	 * @return array
+	 */
+	public function panel_menu( array $menu ) {
+		if ( isset( $menu['object_cache'] ) ) {
+			$menu['object_cache']['children'][] = $this->menu(
+				array(
+					'id'    => 'qm-object_cache_group_stats',
+					'href'  => '#qm-object_cache_group_stats',
+					'title' => __( 'Group Stats', 'qm-object-cache' ),
+				)
+			);
+		}
+
+		return $menu;
+	}
+
+	/**
+	 * Returns bytes in human readable size format.
+	 *
+	 * @param $size int|null Raw size
+	 *
+	 * @return $size string Human readable size format
+	 */
+	public function process_size( ?int $size ) {
+		return size_format( (int) $size, 2 );
+	}
+
+	/**
+	 * Returns in human readable time format.
+	 *
+	 * @param float|null $time Time in microseconds.
+	 *
+	 * @return string $time Human readable time format in milliseconds.
+	 */
+	public function process_time( ?float $time ) {
+		return number_format_i18n( sprintf( '%0.1f', (float) $time * 1000 ), 1 ) . 'ms';
+	}
+
+	/**
+	 * Outputs a sortable table column header.
+	 *
+	 * @param string $title Title to use on column header
+	 *
+	 * @return void
+	 */
+	public function output_sortable_table_col( string $title ) {
+		echo '<th scope="col" class="qm-sortable-column" role="columnheader">';
+		echo $this->build_sorter( esc_html( $title ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '</th>';
+	}
+
+	/**
+	 * Outputs a toggleable table cell for arrays.
+	 *
+	 * @param array $array Array to be outputted in table cell
+	 *
+	 * @return void
+	 */
+	public function maybe_output_toggle_table_cell_for_array( array $array ) {
+		if ( empty( $array ) ) {
+			return;
+		}
+
+		if ( count( $array ) === 1 ) {
+			$this->output_table_cell( $array[0] );
+			return;
+		}
+
+		echo '<td class="qm-nowrap qm-ltr qm-has-toggle">';
+		echo static::build_toggler(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<ol><li>' . esc_html( $array[0] ) . ' [+' . ( count( $array ) - 1 ) . ' more]</li>';
+		unset( $array[0] );
+		echo '<span class="qm-info qm-supplemental">';
+		foreach ( $array as $element ) {
+			echo '<li>' . esc_html( $element ) . '</li>';
+		}
+		echo '</span>';
+		echo '</ol></td>';
+	}
+
+	/**
+	 * Outputs a table cell.
+	 *
+	 * @param string $value Value to be outputted in table cell
+	 * @param int|null $weight Weight by sorting priority
+	 *
+	 * @return void
+	 */
+	public function output_table_cell( ?string $value, int $weight = null ) {
+		if ( $weight ) {
+			$weight = ' data-qm-sort-weight="' . esc_attr( $weight ) . '"';
+		}
+		echo '<td class="qm-nowrap qm-ltr"' . $weight . '>' . esc_html( $value ) . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Outputs the start of a table section.
+	 *
+	 * @param string $heading The section heading to use.
+	 *
+	 * @return void
+	 */
+	public function output_before_section( string $heading = '' ) {
+		echo '<section>';
+
+		if ( '' !== $heading ) {
+			echo '<h3>' . esc_html( $heading ) . '</h3>';
+		}
+
+		echo '<table class="qm-sortable">';
+	}
+
+	/**
+	 * Outputs the end of a table section.
+	 *
+	 * @return void
+	 */
+	public function output_after_section() {
+		echo '</table>';
+		echo '</section>';
+	}
+
+}

--- a/qm-plugins/qm-object-cache/qm-object-cache.php
+++ b/qm-plugins/qm-object-cache/qm-object-cache.php
@@ -29,6 +29,11 @@ add_action( 'plugins_loaded', function() {
 			QM_Collectors::add( new QM_Collector_Object_Cache_Ops() );
 		}
 
+		if ( file_exists( __DIR__ . '/collectors/class-qm-collector-object-cache-group-stats.php' ) ) {
+			require_once __DIR__ . '/collectors/class-qm-collector-object-cache-group-stats.php';
+			QM_Collectors::add( new QM_Collector_Object_Cache_Group_Stats() );
+		}
+
 		if ( file_exists( __DIR__ . '/collectors/class-qm-collector-object-cache-slow-ops.php' ) ) {
 			require_once __DIR__ . '/collectors/class-qm-collector-object-cache-slow-ops.php';
 			QM_Collectors::add( new QM_Collector_Object_Cache_Slow_Ops() );
@@ -55,6 +60,16 @@ add_action( 'plugins_loaded', function() {
 			$collector = QM_Collectors::get( 'object_cache_ops' );
 			if ( $collector ) {
 				$output['object_cache_ops'] = new QM_Output_Html_Object_Cache_Ops( $collector );
+			}
+		}
+
+		if ( file_exists( __DIR__ . '/html/class-qm-output-html-object-cache-group-stats.php' ) ) {
+			require_once __DIR__ . '/html/class-qm-output-html-object-cache-group-stats.php';
+
+			$collector = QM_Collectors::get( 'object_cache_group_stats' );
+
+			if ( $collector ) {
+				$output['object_cache_group_stats'] = new QM_Output_Html_Object_Cache_Group_Stats( $collector );
 			}
 		}
 


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)
-->

These changes introduce a new feature to the Query Monitor plugin, which allows users to view detailed group statistics for the object cache operations. This can help in identifying the performance of different cache groups, and can provide useful insights for performance optimization.  Three files have been added or modified as follows:

* `class-qm-collector-object-cache-group-stats.php`: The `QM_Collector_Object_Cache_Group_Stats` collector class gathers statistics for the group data of object cache operations. It collects data such as operation count, time and size for each group.
* `class-qm-output-html-object-cache-group-stats.php`: The `QM_Output_Html_Object_Cache_Group_Stats` class is responsible for formatting and outputting the data collected by `QM_Collector_Object_Cache_Group_Stats`. It provides a human-readable output for the stats in the footer. It also includes helper methods to convert bytes into human-readable format, convert time to milliseconds, output sortable table columns, and handle table cell outputs.
* `qm-object-cache.php`: This file has been updated to include support for the new "Group Stats" collector and HTML output.

<img width="2274" alt="image" src="https://github.com/Automattic/vip-go-mu-plugins/assets/3060583/2977ddb3-5254-436b-aed3-e70d2a941ce1">

## Changelog Description

### Plugin Updated: qm-plugins

Added a "Group Stats" sub-panel for Object Cache to aid in development and debugging.

<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
