### PR TITLE
Remove WP-Content Writable Test Added in WordPress 6.3

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -49,15 +49,11 @@ function wpcom_vip_disable_core_update_cap( $caps, $cap ) {
 function vip_disable_unnecessary_site_health_tests( $tests ) {
 	// Disable "Background Updates" test.
 	// WordPress updates are managed by the VIP team.
-	if ( isset( $tests['async'] ) && isset( $tests['async']['background_updates'] ) ) {
-		unset( $tests['async']['background_updates'] );
-	}
+	unset( $tests['async']['background_updates'] );
 
 	// Disable "WP-Content Writable" test.
 	// Code updates are managed in GitHub.
-	if ( isset( $tests['direct'] ) && isset( $tests['direct']['update_temp_backup_writable'] ) ) {
-		unset( $tests['direct']['update_temp_backup_writable'] );
-	}
+	unset( $tests['direct']['update_temp_backup_writable'] );
 
 	return $tests;
 }

--- a/001-core.php
+++ b/001-core.php
@@ -53,6 +53,12 @@ function vip_disable_unnecessary_site_health_tests( $tests ) {
 		unset( $tests['async']['background_updates'] );
 	}
 
+	// Disable "WP-Content Writable" test.
+	// Code updates are managed in GitHub.
+	if ( isset( $tests['direct'] ) && isset( $tests['direct']['update_temp_backup_writable'] ) ) {
+		unset( $tests['direct']['update_temp_backup_writable'] );
+	}
+
 	return $tests;
 }
 


### PR DESCRIPTION
## Description
WordPress 6.3 adds the ability for failed plugin and theme updates to be automatically rolled back. The feature requires a temp directory in `wp-content/` to function.

As part of this feature, a new Health Check is added to ensure that the WordPress content directory is found and writable.  On WPVIP updates are managed via GitHub and `wp-content` is read-only so this check will always fail with a critical error stating "Unable to Locate WordPress Content Directory".

![Screenshot 2023-07-12 at 10 18 24 PM](https://github.com/Automattic/vip-go-mu-plugins/assets/150348/a0099276-023c-4d78-b719-44b00416d5ae)

This PR removes the check from the Health Check page.

See: https://core.trac.wordpress.org/ticket/51857

## Changelog Description
### Disable "WP-Content Writable" test from Health Checks

WordPress 6.3 adds the ability for failed plugin and theme updates to be automatically rolled back. The feature requires a temp directory in `wp-content/` to function.

As part of this feature, a new Health Check is added to ensure that the WordPress content directory is found and writable.  On WPVIP updates are managed via GitHub and `wp-content` is read-only so this check will always fail with a critical error stating "Unable to Locate WordPress Content Directory".

This change removes the `update_temp_backup_writable` check from the Health Checks page by default to avoid the confusing, and non-applicable critical health check warning. 

<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Update to the latest WordPress 6.3 branch or `trunk`
2. Visit the Health Check page and notice the new "Unable to Locate WordPress Content Directory" error.
3. Check out PR.
4. Verify that the content directory message no longer displays as part of the Health Checks.
