### PR TITLE
Disable "Available disk space" check added in WordPress 6.3

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -55,6 +55,10 @@ function vip_disable_unnecessary_site_health_tests( $tests ) {
 	// Code updates are managed in GitHub.
 	unset( $tests['direct']['update_temp_backup_writable'] );
 
+	// Disable "Available disk space" test.
+	// We manage the disk space, test gives bogus results.
+	unset( $tests['direct']['available_updates_disk_space'] );
+
 	return $tests;
 }
 


### PR DESCRIPTION
## Description

WordPress 6.3 adds a "Available disk space" check in the site health status section ([Trac ticket #55720](https://core.trac.wordpress.org/changeset/55720)). The check assumes self-managed and writeable filesystem.

The check fails on the WordPress VIP Platform and end-users cannot respond to this. The check is thus neither useful nor does it give a correct result. 

![disk-space-check](https://github.com/Automattic/vip-go-mu-plugins/assets/8835135/7ba3b80e-eb2a-4907-9e06-0e3ae98d019c)

This pull request disables the check.

## Changelog Description

### Disable "Available disk space" check added in WordPress 6.3

WordPress 6.3 adds a "Available disk space" check in the site health section. The check assumes self-managed and writeable filesystem. This check was disabled because it is not relevant on the WordPress VIP Platform and gives a bogus result.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [N/A] This change has relevant unit tests (if applicable).
- [N/A] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [N/A] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [N/A] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR on a sandbox.
3. Go to `wp-admin` > `Tools` > `Site Health`
4. Verify that `Disk space available to safely perform updates` does not appear in the list.
