### PR TITLE
Add WordPress 6.3 notice to wp-admin

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -47,3 +47,22 @@ add_action(
 		);
 	}
 );
+
+// WordPress 6.3 availability.
+add_action(
+	'vip_admin_notice_init',
+	function( $admin_notice_controller ) {
+		global $wp_version;
+
+		$admin_notice_controller->add(
+			new Admin_Notice(
+				'WordPress 6.3 will be released on August 8th, 2023. Please ensure your sites have been tested against the current Release Candidate.',
+				[
+					new Expression_Condition( version_compare( $wp_version, '6.3', '<' ) ),
+				],
+				'wp-version-6-3',
+				'notice'
+			)
+		);
+	}
+);


### PR DESCRIPTION
## Description

This pull request will add a notice to the `wp-admin` announcing release date of WordPress 6.3 and encourages that the most current Release Candidate is tested against customer sites. It is only displayed for sites that are using WordPress 6.3 or lower.

## Changelog Description

### WordPress 6.3 notice for wp-admin

Add a notice to the `wp-admin` announcing the availability of WordPress 6.3 and encourages that the Release Candidate is tested.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [N/A] This change has relevant unit tests (if applicable).
- [N/A] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [N/A] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [N/A] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR on a sandbox using WordPress 6.2.
2. Go to `wp-admin`.
3. A notice is displayed indicating release date and to test WP 6.3.

