### PR TITLE
Add extra protections around wp_load_alloptions()

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -9,6 +9,10 @@
 
 require_once __DIR__ . '/001-core/privacy.php';
 
+if ( file_exists( __DIR__ . '/001-core/options-api.php' ) ) {
+	require_once __DIR__ . '/001-core/options-api.php';
+}
+
 /**
  * Disable current theme validation
  *

--- a/001-core/options-api.php
+++ b/001-core/options-api.php
@@ -8,7 +8,7 @@ namespace Automattic\VIP\Core\OptionsAPI;
  * Add additional protections around the alloptions functionality.
  *
  * Note that there is one (unavoidable) core call to get_option() before this filter is registered (in wp_plugin_directory_constants()),
- * So by the time this starts filtering, there's already been one occurance of wp_load_alloptions().
+ * So by the time this starts filtering, there's already been one occurrence of wp_load_alloptions().
  *
  * Here we re-implement most of what core does in wp_load_alloptions(), with some notable adjustments:
  * - 1) Prevent spamming memcached & the DB if memcached is unable to add() the key to cache.


### PR DESCRIPTION
## Description
Re-implements `wp_load_alloptions()` using the new filter available in WP 6.2. It's pretty much a line for line replication ([seen here](https://github.com/WordPress/WordPress/blob/44629e628672a77edb1d3100546b458973854015/wp-includes/option.php#L289-L361)), except:

- Caches alloptions locally in the event where memcached can't add() or get().
- Doesn't fallback to the secondary alloptions query without accounting for autoload (seems unnecessary?)
- Prepares for killing the request if the alloptions query fails (is dangerous to continue as if there are no plugins, rewrite_rules, etc).

### Performance Improvements: alloptions > 1mb

Setup: Add a really large autoloaded option on the site:

```
update_option( 'vip_testing_large_option', 'longvalue_' . bin2hex( random_bytes( 1024 * 1024 ) ) );
```

#### Before mitigation
- 282 second (!!!) page generation time.
- 11.6 second db query time, 1201 alloptions queries
- 262 seconds memcached query time
    - 261.1s spent in adds() for options group (1252 opts)
    - 1.3s spent for gets() in options group (1255 opts)
    
#### After mitigation
- 1.82s page generation time.
- .0588 db query time, 2 alloptions queries.
- 748.7ms memcached query time
    - 679.1ms spent in adds() for options group (3 opts)
    - 1.9ms spent in gets() for options group (8 opts)
    
### Performance Improvements: memcached unavailable

Setup: hack object cache drop-in to mimic a memcached server outage just for the alloptions cache key (returning false from get() and add() whilst still performing the remote action though). Deleted the massive option added previously, this test is a normal size alloptions on a simple test site.

#### Before mitigation
- 5.2857s page generation time
- 1.04s db query time, 1200 alloptions queries
- 2.62s memcached query time
    - 2.04s spent in adds() for options group (1251 opts)
    - 572.6ms spent in gets() for options group (1254 opts)

#### After mitigation
- 0.3281s page generation time.
- .0018s db query time, 2 alloptions queries
- 18.1ms memcached query time
    - 3.7ms spent in adds() for options group (3 opts)
    - 2.3ms spent in gets() for options group (8 opts)
    
### Performance Improvements: database unavailable

While this patch currently does help this scenario by not doing the fallback query, ultimately I think we'll end up killing the request so it won't matter too much.

## Changelog Description

### Extra protections around the "alloptions" functionality

Increases performance and helps ensure stability.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
