### PR TITLE
Disable temporary backup removal logic introduced in WordPress 6.3

### DIFF
--- a/001-core.php
+++ b/001-core.php
@@ -25,8 +25,9 @@ if ( false !== WPCOM_IS_VIP_ENV ) {
 
 function wpcom_vip_init_core_restrictions() {
 	add_action( 'admin_init', 'wpcom_vip_disable_core_update_nag' );
-	add_action( 'init', 'wpcom_vip_disable_temp_backups_cleanup' );
 	add_filter( 'map_meta_cap', 'wpcom_vip_disable_core_update_cap', 100, 2 );
+
+	wpcom_vip_disable_temp_backups_cleanup();
 }
 
 function wpcom_vip_disable_core_update_nag() {

--- a/001-core.php
+++ b/001-core.php
@@ -25,12 +25,23 @@ if ( false !== WPCOM_IS_VIP_ENV ) {
 
 function wpcom_vip_init_core_restrictions() {
 	add_action( 'admin_init', 'wpcom_vip_disable_core_update_nag' );
+	add_action( 'init', 'wpcom_vip_disable_temp_backups_cleanup' );
 	add_filter( 'map_meta_cap', 'wpcom_vip_disable_core_update_cap', 100, 2 );
 }
 
 function wpcom_vip_disable_core_update_nag() {
 	remove_action( 'admin_notices', 'update_nag', 3 );
 	remove_action( 'network_admin_notices', 'update_nag', 3 );
+}
+
+/**
+ * Disables action introduced in WordPress 6.3 which, when triggered, will lead
+ * to another action being set up which will attempt to clean up a temporary
+ * backup directory.The clean up logic will fail on the WordPress VIP platform
+ * and is not necessary.
+ */
+function wpcom_vip_disable_temp_backups_cleanup() {
+	remove_action( 'wp_delete_temp_updater_backups', 'wp_delete_all_temp_backups' );
 }
 
 function wpcom_vip_disable_core_update_cap( $caps, $cap ) {

--- a/001-core.php
+++ b/001-core.php
@@ -37,8 +37,8 @@ function wpcom_vip_disable_core_update_nag() {
 /**
  * Disables action introduced in WordPress 6.3 which, when triggered, will lead
  * to another action being set up which will attempt to clean up a temporary
- * backup directory.The clean up logic will fail on the WordPress VIP platform
- * and is not necessary.
+ * backup directory used during plugin/theme updates. The clean up logic will
+ * fail on the WordPress VIP platform and is not necessary.
  */
 function wpcom_vip_disable_temp_backups_cleanup() {
 	remove_action( 'wp_delete_temp_updater_backups', 'wp_delete_all_temp_backups' );


### PR DESCRIPTION
## Description

This pull request will disable temporary backup removal logic introduced in WordPress 6.3 Core. 

The logic is needed to clean up temporary files created when attempting plugin/theme updates. However, on the WordPress VIP platform all such updates are managed by the platform, and so the clean up logic should never be needed. In addition, the logic will cause a fatal error when executed on the platform. 

The safest strategy is to disable the logic altogether, so to avoid such fatal errors.

The Core code was added in [Trac#55720](https://core.trac.wordpress.org/changeset/55720).

## Changelog Description

### Disable temporary backup removal logic introduced in WordPress 6.3

Disable temporary backup removal logic introduced in WordPress 6.3 Core as it is not needed and will lead to fatal errors when invoked.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [N/A] This change has relevant unit tests (if applicable).
- [N/A] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [N/A] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [N/A] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR on a Sandbox using WP6.3.
2. Add debug code to dump all actions loaded after initialization and verify that `wp_delete_temp_updater_backups` is not one of those.
