### PR TITLE
Temporarily disable Jetpack AI Assistant extension

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -121,6 +121,30 @@ function vip_jetpack_token_send_signature_error_headers( $error ) {
 
 add_action( 'jetpack_verify_signature_error', 'vip_jetpack_token_send_signature_error_headers' );
 
+
+/**
+ * Disable the AI Assistant until the issues are resolved
+ *
+ * @param array $extensions available extensions to load
+ * @return array filtered extensions
+ */
+function vip_set_available_jetpack_extensions( $extensions ) {
+	if ( ! is_array( $extensions ) ) {
+		return $extensions;
+	}
+
+	$ai_ext_index = array_search( 'ai-assistant', $extensions, true );
+	if ( false !== $ai_ext_index ) {
+		unset( $extensions[ $ai_ext_index ] );
+		// Re-index the array so that there won't be json_encode mix up between array and object
+		$extensions = array_values( $extensions );
+	}
+
+	return $extensions;
+}
+
+add_action( 'jetpack_set_available_extensions', 'vip_set_available_jetpack_extensions', 0 );
+
 /**
  * Load the jetpack plugin according to several defines:
  * - If VIP_JETPACK_SKIP_LOAD is true, Jetpack will not be loaded

--- a/jetpack.php
+++ b/jetpack.php
@@ -121,30 +121,6 @@ function vip_jetpack_token_send_signature_error_headers( $error ) {
 
 add_action( 'jetpack_verify_signature_error', 'vip_jetpack_token_send_signature_error_headers' );
 
-
-/**
- * Disable the AI Assistant until the issues are resolved
- *
- * @param array $extensions available extensions to load
- * @return array filtered extensions
- */
-function vip_set_available_jetpack_extensions( $extensions ) {
-	if ( ! is_array( $extensions ) ) {
-		return $extensions;
-	}
-
-	$ai_ext_index = array_search( 'ai-assistant', $extensions, true );
-	if ( false !== $ai_ext_index ) {
-		unset( $extensions[ $ai_ext_index ] );
-		// Re-index the array so that there won't be json_encode mix up between array and object
-		$extensions = array_values( $extensions );
-	}
-
-	return $extensions;
-}
-
-add_action( 'jetpack_set_available_extensions', 'vip_set_available_jetpack_extensions', 0 );
-
 /**
  * Load the jetpack plugin according to several defines:
  * - If VIP_JETPACK_SKIP_LOAD is true, Jetpack will not be loaded

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -784,7 +784,7 @@ add_filter( 'plugin_row_meta', 'vip_filter_plugin_version_jetpack', PHP_INT_MAX,
  * @return array filtered extensions
  */
 function vip_set_available_jetpack_extensions( $extensions ) {
-	if ( ! is_array( $extensions ) ) {
+	if ( ! is_array( $extensions ) || ! is_admin() || wp_doing_ajax() ) {
 		return $extensions;
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -776,3 +776,26 @@ function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file, $plugin_
 	return $plugin_meta;
 }
 add_filter( 'plugin_row_meta', 'vip_filter_plugin_version_jetpack', PHP_INT_MAX, 4 );
+
+/**
+ * Disable the AI Assistant until the issues are resolved
+ *
+ * @param array $extensions available extensions to load
+ * @return array filtered extensions
+ */
+function vip_set_available_jetpack_extensions( $extensions ) {
+	if ( ! is_array( $extensions ) ) {
+		return $extensions;
+	}
+
+	$ai_ext_index = array_search( 'ai-assistant', $extensions, true );
+	if ( false !== $ai_ext_index ) {
+		unset( $extensions[ $ai_ext_index ] );
+		// Re-index the array so that there won't be json_encode mix up between array and object
+		$extensions = array_values( $extensions );
+	}
+
+	return $extensions;
+}
+
+add_filter( 'jetpack_set_available_extensions', 'vip_set_available_jetpack_extensions', 0 );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -790,6 +790,18 @@ function vip_set_available_jetpack_extensions( $extensions ) {
 
 	$ai_ext_index = array_search( 'ai-assistant', $extensions, true );
 	if ( false !== $ai_ext_index ) {
+		if ( method_exists( 'Jetpack', 'connection' ) && defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) ) {
+			$jp_connection = Jetpack::connection();
+
+			if ( method_exists( $jp_connection, 'get_connection_owner' ) ) {
+				$owner = $jp_connection->get_connection_owner();
+
+				if ( $owner && WPCOM_VIP_MACHINE_USER_LOGIN !== $owner->user_login ) {
+					return $extensions;
+				}
+			}
+		}
+
 		unset( $extensions[ $ai_ext_index ] );
 		// Re-index the array so that there won't be json_encode mix up between array and object
 		$extensions = array_values( $extensions );


### PR DESCRIPTION
## Description

To avoid any extra confusion on anyone's behalf we should disable AI Assistant until the issue which is being worked on internally is addressed.


## Changelog Description

### Jetpack AI Assistant

We've temporarily disabled Jetpack AI Assistant, we'll re-instate it in the coming weeks. 
If, for any reason, you wish to re-enable it, please drop the following snippet in a clients-mu-plugins

```
remove_filter( 'jetpack_set_available_extensions', 'vip_set_available_jetpack_extensions', 0 );
```

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out the PR
2. Visit post editor screen, add a new block, type in "AI" and verify that Jetpack AI Assistant (experimental) is not popping up.

