### PR TITLE
test: increase timeout for E2E tests

### DIFF
--- a/__tests__/e2e/playwright.config.ts
+++ b/__tests__/e2e/playwright.config.ts
@@ -6,7 +6,7 @@ import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
     retries: 1,
     globalSetup: require.resolve( './lib/global-setup' ),
-    timeout: 60000,
+    timeout: 120000,
     reporter: process.env.CI ? [ [ 'github' ] ] : 'line',
     reportSlowTests: null,
     workers: process.env.CI ? 1 : undefined,


### PR DESCRIPTION
This PR increases the timeout for E2E tests so that they have more chances to succeed when GitHub runners are very busy.