### PR TITLE
Reduce the batch size to from 1000 to 500 and add the object count to the log entry. Limit to 1 queue processor job on non-prods

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -16,6 +16,8 @@ class Queue {
 	public $schema;
 	public $indexables;
 	public $logger;
+	/** @var Queue\Cron */
+	public $cron;
 
 	public const INDEX_COUNT_CACHE_GROUP            = 'vip_search';
 	public const INDEX_COUNT_CACHE_KEY              = 'index_op_count';

--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -9,7 +9,7 @@ class Queue {
 	const CACHE_GROUP                     = 'vip-search-index-queue';
 	const OBJECT_LAST_INDEX_TIMESTAMP_TTL = 120; // Must be at least longer than the rate limit intervals
 
-	const MAX_BATCH_SIZE = 1000;
+	const MAX_BATCH_SIZE = 500;
 	const DEADLOCK_TIME  = 5 * MINUTE_IN_SECONDS;
 
 	/** @var Queue\Schema */
@@ -929,6 +929,7 @@ class Queue {
 						'extra'    => [
 							'homeurl'    => home_url(),
 							'index_name' => $indexable->get_index_name(),
+							'count'      => count( $ids ),
 						],
 					]
 				);

--- a/search/includes/classes/queue/class-cron.php
+++ b/search/includes/classes/queue/class-cron.php
@@ -16,7 +16,7 @@ class Cron {
 	/**
 	 * How many objects to re-index at a time in a single cron job
 	 */
-	const PROCESSOR_MAX_OBJECTS_PER_CRON_EVENT = 1000;
+	const PROCESSOR_MAX_OBJECTS_PER_CRON_EVENT = 500;
 
 	/**
 	 * The name of the recurring cron event that checks for any unscheduled or deadlocked jobs
@@ -89,6 +89,10 @@ class Cron {
 	}
 
 	public function get_max_concurrent_processor_job_count() {
+		if ( defined( 'VIP_GO_ENV' ) && constant( 'VIP_GO_ENV' ) !== 'production' ) {
+			return 1;
+		}
+
 		$allowed_total_concurrency = (int) ceil( \Automattic\WP\Cron_Control\JOB_CONCURRENCY_LIMIT / 4 );
 		return min( self::MAX_PROCESSOR_JOB_COUNT, $allowed_total_concurrency );
 	}

--- a/search/includes/classes/queue/class-schema.php
+++ b/search/includes/classes/queue/class-schema.php
@@ -139,7 +139,7 @@ class Schema {
 
 		// Skip verification when running tests. We need to do this because WordPress Test Library
 		// turns CREATE TABLE into CREATE TEMPORARY TABLE, and SHOW TABLES does not list temporary tables
-		if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
+		if ( ! \defined( 'WP_TESTS_DOMAIN' ) ) {
 			// Confirm that the table was created, and set the option to prevent further updates.
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$table_count = count( $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) );

--- a/tests/mock-constants.php
+++ b/tests/mock-constants.php
@@ -128,6 +128,22 @@ namespace Automattic\VIP\Search {
 	}
 }
 
+namespace Automattic\VIP\Search\Queue {
+	use Automattic\Test\Constant_Mocker;
+
+	function defined( $constant ) {
+		return Constant_Mocker::defined( $constant );
+	}
+
+	function constant( $constant ) {
+		return Constant_Mocker::constant( $constant );
+	}
+
+	function define( $constant, $value ) {
+		Constant_Mocker::define( $constant, $value );
+	}
+}
+
 namespace Automattic\VIP\Helpers\WP_CLI_DB {
 	use Automattic\Test\Constant_Mocker;
 

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -17,6 +17,10 @@ class Cron_Test extends WP_UnitTestCase {
 			define( 'VIP_SEARCH_ENABLE_ASYNC_INDEXING', true );
 		}
 
+		if ( ! defined( 'VIP_GO_ENV' ) ) {
+			define( 'VIP_GO_ENV', 'production' );
+		}
+
 		require_once __DIR__ . '/../../../../../search/search.php';
 
 		$this->es = Search::instance();

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -271,7 +271,7 @@ class Cron_Test extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_configure_concurrency( $cron_limit, $expected ) {
-		define( 'Automattic\WP\Cron_Control\JOB_CONCURRENCY_LIMIT', $cron_limit );
+		\define( 'Automattic\WP\Cron_Control\JOB_CONCURRENCY_LIMIT', $cron_limit );
 
 		$result = $this->cron->configure_concurrency( [] );
 

--- a/tests/search/includes/classes/queue/test-class-cron.php
+++ b/tests/search/includes/classes/queue/test-class-cron.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Search\Queue;
 
+use Automattic\Test\Constant_Mocker;
+use Automattic\VIP\Search\Queue;
 use Automattic\VIP\Search\Queue\Cron;
 use Automattic\VIP\Search\Search;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -12,7 +14,15 @@ class Cron_Test extends WP_UnitTestCase {
 	/** @var Search */
 	private $es;
 
+	/** @var Queue */
+	private $queue;
+
+	/** @var Cron */
+	private $cron;
+
 	public function setUp(): void {
+		Constant_Mocker::clear();
+
 		if ( ! defined( 'VIP_SEARCH_ENABLE_ASYNC_INDEXING' ) ) {
 			define( 'VIP_SEARCH_ENABLE_ASYNC_INDEXING', true );
 		}
@@ -33,6 +43,11 @@ class Cron_Test extends WP_UnitTestCase {
 		$this->queue->empty_queue();
 
 		$this->cron = $this->queue->cron;
+	}
+
+	public function tearDown(): void {
+		Constant_Mocker::clear();
+		parent::tearDown();
 	}
 
 	public function test_filter_cron_schedules() {


### PR DESCRIPTION
## Description

To reduce potential indexing pressure this PR changes the max batch size from 1000 to 500 and limits to just a single process for non-production environments

## Changelog Description

### Plugin Updated: Enterprise Search

We've reduced the batch size for async indexing queue from 1000 to 500 documents.

Additionally, for non-production environments only one queue processor job will run per per site (or a network site in a multisite).

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

