### PR TITLE
Force QM when we should enable Search Dev Tools

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -497,11 +497,10 @@ class Search {
 	 */
 	protected function maybe_enable_ep_query_logging() {
 		add_action( 'plugins_loaded', [ $this, 'enable_ep_query_logging_if_query_monitor_enabled' ] );
-		add_action( 'plugins_loaded', [ $this, 'load_ep_debug_bar_panel' ] );
+		add_action( 'plugins_loaded', [ $this, 'load_ep_get_query_log_function' ] );
 	}
 
-	public function load_ep_debug_bar_panel() {
-		// Load query log override function to remove Authorization header from requests
+	public function load_ep_get_query_log_function() {
 		require_once __DIR__ . '/../functions/ep-get-query-log.php';
 	}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -497,20 +497,25 @@ class Search {
 	 */
 	protected function maybe_enable_ep_query_logging() {
 		add_action( 'plugins_loaded', [ $this, 'enable_ep_query_logging_if_query_monitor_enabled' ] );
+		add_action( 'plugins_loaded', [ $this, 'load_ep_debug_bar_panel' ] );
+	}
+
+	public function load_ep_debug_bar_panel() {
+		// Load query log override function to remove Authorization header from requests
+		require_once __DIR__ . '/../functions/ep-get-query-log.php';
 	}
 
 	/**
 	 * Check if query monitor or debug bar are enabled. Also check for the debug mode being enabled.
-	 * If so, define WP_EP_DEBUG as true so ElasticPress enables query logging and then load the ElasticPress debug bar panel.
+	 * If so, define WP_EP_DEBUG as true so ElasticPress enables query logging.
 	 */
 	public function enable_ep_query_logging_if_query_monitor_enabled() {
-		if ( apply_filters( 'wpcom_vip_qm_enable', false ) || ( function_exists( 'is_debug_mode_enabled' ) && is_debug_mode_enabled() ) ) {
-			if ( ! defined( 'WP_EP_DEBUG' ) ) {
-				define( 'WP_EP_DEBUG', true );
-			}
+		if ( defined( 'WP_EP_DEBUG' ) ) {
+			return;
+		}
 
-			// Load query log override function to remove Authorization header from requests
-			require_once __DIR__ . '/../functions/ep-get-query-log.php';
+		if ( apply_filters( 'wpcom_vip_qm_enable', false ) || ( function_exists( 'is_debug_mode_enabled' ) && is_debug_mode_enabled() ) ) {
+			define( 'WP_EP_DEBUG', true );
 		}
 	}
 

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -25,7 +25,6 @@ add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 11 );
 add_filter( 'js_do_concat', __NAMESPACE__ . '\skip_js_do_concat', 10, 2 );
 add_action( 'wp_footer', __NAMESPACE__ . '\print_data', 5 );
 add_action( 'admin_footer', __NAMESPACE__ . '\print_data', 5 );
-add_filter( 'wpcom_vip_qm_enable', __NAMESPACE__ . '\enforce_query_monitor', 10 );
 
 /**
  * Register Dev Tools Endpoint.
@@ -102,17 +101,6 @@ function rest_callback( \WP_REST_Request $request ) {
  */
 function should_enable_search_dev_tools(): bool {
 	return ( current_user_can( SEARCH_DEV_TOOLS_CAP ) || is_debug_mode_enabled() );
-}
-
-/**
- * Make sure QM is enabled if Dev Tools are enabled. QM is dependecy for Dev Tools.
- */
-function enforce_query_monitor( $enabled ) {
-	if ( $enabled || ! should_enable_search_dev_tools() ) {
-		return $enabled;
-	}
-
-	return true;
 }
 
 /**

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -100,7 +100,7 @@ function rest_callback( \WP_REST_Request $request ) {
  * @return boolean
  */
 function should_enable_search_dev_tools(): bool {
-	return ( current_user_can( SEARCH_DEV_TOOLS_CAP ) || is_debug_mode_enabled() );
+	return ( current_user_can( SEARCH_DEV_TOOLS_CAP ) || is_debug_mode_enabled() ) && function_exists( 'ep_get_query_log' );
 }
 
 /**

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -108,7 +108,7 @@ function should_enable_search_dev_tools(): bool {
  * Make sure QM is enabled if Dev Tools are enabled. QM is dependecy for Dev Tools.
  */
 function enforce_query_monitor( $enabled ) {
-	if ( $enabled || ! should_enable_search_dev_tools()) {
+	if ( $enabled || ! should_enable_search_dev_tools() ) {
 		return $enabled;
 	}
 

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -25,6 +25,7 @@ add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 11 );
 add_filter( 'js_do_concat', __NAMESPACE__ . '\skip_js_do_concat', 10, 2 );
 add_action( 'wp_footer', __NAMESPACE__ . '\print_data', 5 );
 add_action( 'admin_footer', __NAMESPACE__ . '\print_data', 5 );
+add_filter( 'wpcom_vip_qm_enable', __NAMESPACE__ . '\enforce_query_monitor', 10 );
 
 /**
  * Register Dev Tools Endpoint.
@@ -100,7 +101,18 @@ function rest_callback( \WP_REST_Request $request ) {
  * @return boolean
  */
 function should_enable_search_dev_tools(): bool {
-	return ( current_user_can( SEARCH_DEV_TOOLS_CAP ) || is_debug_mode_enabled() ) && function_exists( 'ep_get_query_log' );
+	return ( current_user_can( SEARCH_DEV_TOOLS_CAP ) || is_debug_mode_enabled() );
+}
+
+/**
+ * Make sure QM is enabled if Dev Tools are enabled. QM is dependecy for Dev Tools.
+ */
+function enforce_query_monitor( $enabled ) {
+	if ( $enabled || ! should_enable_search_dev_tools()) {
+		return $enabled;
+	}
+
+	return true;
 }
 
 /**


### PR DESCRIPTION
## Description

On Multisite we would not enable Search Dev Tools for non Super Admins. The reason is that the `ep_get_query_log` function would not be available. 

That function is [loaded](https://github.com/Automattic/vip-go-mu-plugins/blob/develop/search/includes/classes/class-search.php#L513) if  `wpcom_vip_qm_enable` is true. 

`wpcom_vip_qm_enable` would check the same permission as we (`manage_options`) BUT only for [singlesite](https://github.com/Automattic/vip-go-mu-plugins/blob/develop/query-monitor/classes/QueryMonitor.php#L115)

This change makes it so that `ep_get_query_log` is always available.

## Changelog Description

### Plugin Updated: VIP Search

This change enables Search Dev Tools for all Administrators on multisite installations.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1) Create multisite dev-env
2) Create a new subsite test
3) Create a new Admin user - vip dev-env exec --slug multisite -- wp user create --url=http://test.multisite.vipdev.lndo.site/ test2 test2@gmail.com --role='administrator' --user_pass=testtest
4) Log out and login as the new user test2
5) Disable debug mode by making [this method](https://github.com/Automattic/vip-go-mu-plugins/blob/b6eae073c07b2f4683929fd398f393e4ca6ffbf3/000-debug/debug-mode.php#L39) return false 
6) Search dev tools should still be visible
