### PR TITLE
Fix deprecation warnings

### DIFF
--- a/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-group-stats.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-group-stats.php
@@ -132,7 +132,7 @@ class QM_Output_Html_Object_Cache_Group_Stats extends QM_Output_Html {
 	 *
 	 * @param $size int|null Raw size
 	 *
-	 * @return $size string Human readable size format
+	 * @return string Human readable size format
 	 */
 	public function process_size( ?int $size ) {
 		return size_format( (int) $size, 2 );
@@ -166,11 +166,11 @@ class QM_Output_Html_Object_Cache_Group_Stats extends QM_Output_Html {
 	 * Outputs a table cell.
 	 *
 	 * @param string $value Value to be outputted in table cell
-	 * @param int|null $weight Weight by sorting priority
+	 * @param float|null $weight Weight by sorting priority
 	 *
 	 * @return void
 	 */
-	public function output_table_cell( ?string $value, int $weight = null ) {
+	public function output_table_cell( ?string $value, ?float $weight = null ) {
 		if ( $weight ) {
 			$weight = ' data-qm-sort-weight="' . esc_attr( $weight ) . '"';
 		}


### PR DESCRIPTION

## Description
Fixes a deprecation warning in `qm-object-cache`.

## Changelog Description
Updated `QM_Output_Html_Object_Cache_Group_Stats::output_table_cell` `$weight` parameter to type hint `float` instead of `int`.
 
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change works and has been tested on a Go sandbox.
- [X] This change has relevant unit tests (if applicable).
- [X] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [X] This change has relevant documentation additions / updates (if applicable).
- [X] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
Load a site using PHP 8.2 and confirm there are no deprecation warnings like `Deprecated: Implicit conversion from float 1.2345678908765432E-5 to int loses precision`