### PR TITLE
Harden Prometheus collectors 

### DIFF
--- a/prometheus-collectors/class-post-stats-collector.php
+++ b/prometheus-collectors/class-post-stats-collector.php
@@ -34,7 +34,12 @@ class Post_Stats_Collector implements CollectorInterface {
 
 		foreach ( $metrics as $type => $metric ) {
 			foreach ( $metric as $status => $count ) {
-				$this->post_gauge->set( $count, [ $this->blog_id, $type, $status ] );
+				try {
+					$this->post_gauge->set( $count, [ $this->blog_id, $type, $status ] );
+				} catch ( \TypeError $ex ) {
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					trigger_error( 'Prometheus: metric collection exception: ' . $ex->getMessage(), E_USER_WARNING );
+				}
 			}
 		}
 	}
@@ -58,7 +63,9 @@ class Post_Stats_Collector implements CollectorInterface {
 			$posts        = wp_count_posts( $type );
 			$ret[ $type ] = [];
 			foreach ( $posts as $status => $count ) {
-				$ret[ $type ][ $status ] = $count;
+				if ( is_string( $status ) ) {
+					$ret[ $type ][ $status ] = $count;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description

This should protect from unexpected TypeErrors when the data is malformed

Post stats collector: check if a post status is indeed a string and catch the TypeError.

## Changelog Description
### Plugin Updated: Prometheus

We improved type safety and instituted some extra protections against unexpected data types.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
