### PR TITLE
fix(qm-plugins): fix PHP warnings in QM_Output_Html_DB_Connections

### DIFF
--- a/qm-plugins/qm-db-connections/class-qm-output-html-db-connections.php
+++ b/qm-plugins/qm-db-connections/class-qm-output-html-db-connections.php
@@ -64,11 +64,11 @@ class QM_Output_Html_DB_Connections extends QM_Output_Html {
 			echo '<td>' . esc_html( $connection['port'] ) . '</td>';
 			echo '<td>' . esc_html( $connection['user'] ) . '</td>';
 			echo '<td>' . esc_html( $connection['name'] ) . '</td>';
-			echo '<td>' . esc_html( $connection['server_state'] ) . '</td>';
+			echo '<td>' . esc_html( $connection['server_state'] ?? 'N/A' ) . '</td>';
 			echo '<td>' . esc_html( $this->format_elapsed_time( $connection['elapsed'] ) ) . '</td>';
 			echo '<td>' . esc_html( $connection['success'] ? 'true' : 'false' ) . '</td>';
-			echo '<td>' . esc_html( $connection['queries'] ) . '</td>';
-			echo '<td>' . esc_html( $connection['lag'] ) . '</td></tr>';
+			echo '<td>' . esc_html( $connection['queries'] ?? 'N/A' ) . '</td>';
+			echo '<td>' . esc_html( $connection['lag'] ?? 'N/A' ) . '</td></tr>';
 		}
 		echo '</tbody></table>';
 	}


### PR DESCRIPTION
## Description

This PR fixes the following warnings:

```
nginx_1          | 2023-08-12T00:48:39.926353368Z 2023/08/12 00:48:39 [error] 79#79: *1 FastCGI sent in stderr: "PHP message: Warning: Undefined array key "server_state" in /wp/wp-content/mu-plugins/qm-plugins/qm-db-connections/class-qm-output-html-db-connections.php on line 67 [e2e-test-site.vipdev.lndo.site/2023/08/12/hello-world/] [wp-content/mu-plugins/qm-plugins/qm-db-connections/class-qm-output-html-db-connections.php:29 QM_Output_Html_DB_Connections->display_connections(), wp-content/mu-plugins/query-monitor/dispatchers/Html.php:326 QM_Output_Html_DB_Connections->output(), wp-includes/class-wp-hook.php:310 QM_Dispatcher_Html->dispatch(), wp-includes/class-wp-hook.php:334 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-includes/load.php:1252 do_action('shutdown'), shutdown_action_hook()]" while reading upstream, client: 172.19.0.2, server: localhost, request: "GET /2023/08/12/hello-world/ HTTP/1.1", upstream: "fastcgi://172.27.0.3:9000", host: "e2e-test-site.vipdev.lndo.site"
nginx_1          | 2023-08-12T00:48:39.926355469Z 2023/08/12 00:48:39 [error] 79#79: *1 FastCGI sent in stderr: "PHP message: Warning: Undefined array key "queries" in /wp/wp-content/mu-plugins/qm-plugins/qm-db-connections/class-qm-output-html-db-connections.php on line 70 [e2e-test-site.vipdev.lndo.site/2023/08/12/hello-world/] [wp-content/mu-plugins/qm-plugins/qm-db-connections/class-qm-output-html-db-connections.php:29 QM_Output_Html_DB_Connections->display_connections(), wp-content/mu-plugins/query-monitor/dispatchers/Html.php:326 QM_Output_Html_DB_Connections->output(), wp-includes/class-wp-hook.php:310 QM_Dispatcher_Html->dispatch(), wp-includes/class-wp-hook.php:334 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-includes/load.php:1252 do_action('shutdown'), shutdown_action_hook()]" while reading upstream, client: 172.19.0.2, server: localhost, request: "GET /2023/08/12/hello-world/ HTTP/1.1", upstream: "fastcgi://172.27.0.3:9000", host: "e2e-test-site.vipdev.lndo.site"
nginx_1          | 2023-08-12T00:48:39.926357577Z 2023/08/12 00:48:39 [error] 79#79: *1 FastCGI sent in stderr: "PHP message: Warning: Undefined array key "lag" in /wp/wp-content/mu-plugins/qm-plugins/qm-db-connections/class-qm-output-html-db-connections.php on line 71 [e2e-test-site.vipdev.lndo.site/2023/08/12/hello-world/] [wp-content/mu-plugins/qm-plugins/qm-db-connections/class-qm-output-html-db-connections.php:29 QM_Output_Html_DB_Connections->display_connections(), wp-content/mu-plugins/query-monitor/dispatchers/Html.php:326 QM_Output_Html_DB_Connections->output(), wp-includes/class-wp-hook.php:310 QM_Dispatcher_Html->dispatch(), wp-includes/class-wp-hook.php:334 WP_Hook->apply_filters(), wp-includes/plugin.php:517 WP_Hook->do_action(), wp-includes/load.php:1252 do_action('shutdown'), shutdown_action_hook()]" while reading upstream, client: 172.19.0.2, server: localhost, request: "GET /2023/08/12/hello-world/ HTTP/1.1", upstream: "fastcgi://172.27.0.3:9000", host: "e2e-test-site.vipdev.lndo.site"
```

## Changelog Description

### Plugin Updated: Query Monitor DB Connections

Fix PHP warnings.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Run E2E tests locally and watch the output of `vip dev-env logs -f -s e2e-test-site`.
