### PR TITLE
test(e2e): fix E2E tests

### DIFF
--- a/__tests__/e2e/bin/setup-env.sh
+++ b/__tests__/e2e/bin/setup-env.sh
@@ -26,7 +26,7 @@ fi
 vip dev-env destroy --slug=e2e-test-site || true
 
 # Create and run test site
-vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --mailpit false --wordpress=trunk --multisite=false --app-code="${clientCodePath}" --php 8.0 --xdebug false --phpmyadmin false --elasticsearch true
+vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --mailpit false --wordpress=trunk --multisite=false --app-code="${clientCodePath}" --php 8.0 --xdebug false --phpmyadmin false --elasticsearch true < /dev/null
 vip dev-env start --slug e2e-test-site --skip-wp-versions-check
 vip dev-env shell --root --slug e2e-test-site -- chown -R www-data:www-data /wp
 vip dev-env exec --slug e2e-test-site --quiet -- wp plugin install --activate classic-editor

--- a/__tests__/e2e/lib/playwright-helpers.ts
+++ b/__tests__/e2e/lib/playwright-helpers.ts
@@ -22,7 +22,7 @@ export async function getClassList( locator: Locator ): Promise<string[]> {
  */
 export function goToPage( page: Page, url: string ): Promise<unknown> {
     return Promise.all( [
-        page.waitForNavigation( { waitUntil: 'networkidle' } ),
         page.goto( url, { waitUntil: 'load' } ),
+        page.waitForURL( url, { waitUntil: 'load' } ),
     ] );
 }


### PR DESCRIPTION
This PR fixes the following error:

```
page.waitForURL: Timeout 30000ms exceeded.
=========================== logs ===========================
waiting for navigation to "http://e2e-test-site.vipdev.lndo.site/wp-admin/post-new.php" until "networkidle"
  navigated to "http://e2e-test-site.vipdev.lndo.site/wp-admin/options-writing.php"
  navigated to "http://e2e-test-site.vipdev.lndo.site/wp-admin/post-new.php"
  "load" event fired
  "domcontentloaded" event fired
============================================================
    at goToPage (/home/volodymyr/work/vip-go-mu-plugins/__tests__/e2e/lib/playwright-helpers.ts:26:14)
    at globalSetup (/home/volodymyr/work/vip-go-mu-plugins/__tests__/e2e/lib/global-setup.ts:47:23) {
  name: 'TimeoutError'
Error: Setup unsuccessful - Tests will not run

   at lib/global-setup.ts:67

  65 |     } else {
  66 |         // Stop test run if login fails
> 67 |         throw new Error( 'Setup unsuccessful - Tests will not run' );
     |               ^
  68 |     }
  69 | }
  70 |

    at globalSetup (/home/volodymyr/work/vip-go-mu-plugins/__tests__/e2e/lib/global-setup.ts:67:15)
```
