### PR TITLE
fix(two-factor): send code when SMS is configured as a backup 2FA

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -26,7 +26,7 @@ function wpcom_vip_should_force_two_factor() {
 	if ( ! WPCOM_IS_VIP_ENV && ! apply_filters( 'wpcom_vip_is_two_factor_local_testing', false ) ) {
 		return false;
 	}
-	
+
 	// The proxy is the second factor for VIP Support users
 	if ( is_proxied_automattician() ) {
 		return false;
@@ -138,7 +138,7 @@ function wpcom_vip_enforce_two_factor_plugin() {
 	if ( is_user_logged_in() ) {
 		$cap     = apply_filters( 'wpcom_vip_two_factor_enforcement_cap', 'manage_options' );
 		$limited = current_user_can( $cap );
-		
+
 		// Calculate current_user_can outside map_meta_cap to avoid callback loop
 		add_filter( 'wpcom_vip_is_two_factor_forced', function() use ( $limited ) {
 			return $limited;
@@ -148,7 +148,7 @@ function wpcom_vip_enforce_two_factor_plugin() {
 		// see: https://github.com/Automattic/vip-go-mu-plugins/pull/1445#issuecomment-592124810
 		$is_user_using_two_factor = Two_Factor_Core::is_user_using_two_factor();
 
-		add_filter( 
+		add_filter(
 			'wpcom_vip_is_user_using_two_factor',
 			function() use ( $is_user_using_two_factor ) {
 				return $is_user_using_two_factor;
@@ -167,7 +167,7 @@ if ( ! defined( 'WP_INSTALLING' ) ) {
 function wpcom_enable_two_factor_plugin() {
 	$enable_two_factor = apply_filters( 'wpcom_vip_enable_two_factor', true );
 	if ( true !== $enable_two_factor ) {
-		return; 
+		return;
 	}
 
 	// We loaded the two-factor plugin using wpcom_vip_load_plugin but that skips when skip-plugins is set.
@@ -259,7 +259,7 @@ function wpcom_vip_two_factor_admin_notice() {
 					</a>
 
 					<a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/" class="button" target="_blank">Learn More</a>
-				</p> 
+				</p>
 			</div>
 	</div>
 	<?php

--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -121,7 +121,12 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce is not available
-		if ( ! isset( $_GET['action'] ) || 'validate_2fa' !== $_GET['action'] ) {
+		$action = sanitize_key( $_GET['action'] ?? '' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce is not available
+		$provider = sanitize_text_field( $_GET['provider'] ?? '' );
+		$method   = sanitize_text_field( $_SERVER['REQUEST_METHOD'] ?? '' );
+
+		if ( ( 'POST' === $method && 'validate_2fa' !== $action ) || ( 'GET' === $method || 'Two_Factor_SMS' === $provider ) ) {
 			$this->generate_and_send_token( $user );
 		}
 


### PR DESCRIPTION
## Description

Fixes: #4590

## Changelog Description

### Plugin Updated: VIP Force Two Factor

Send a code when SMS is configured as a backup second-factor method

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. See #4590 
2. Same as above, but set SMS as a primary second factor and verify that everything works.
