### PR TITLE
fix(files): account for upgrade-temp-backup directory

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -144,26 +144,26 @@ class VIP_Filesystem {
 		 * then be removed.
 		 * - Hanif
 		 */
-		$pos = stripos( $params['path'], LOCAL_UPLOADS );
+		$pos = stripos( $params['path'], constant( 'LOCAL_UPLOADS' ) );
 		if ( false !== $pos ) {
 			$params['path']    = substr_replace( $params['path'],
 				self::PROTOCOL . '://wp-content/uploads',
 				$pos,
-			strlen( LOCAL_UPLOADS ) );
+			strlen( constant( 'LOCAL_UPLOADS' ) ) );
 			$params['basedir'] = substr_replace( $params['basedir'],
 				self::PROTOCOL . '://wp-content/uploads',
 				$pos,
-			strlen( LOCAL_UPLOADS ) );
+			strlen( constant( 'LOCAL_UPLOADS' ) ) );
 		} else {
-			$pos               = stripos( $params['path'], WP_CONTENT_DIR );
+			$pos               = stripos( $params['path'], constant( 'WP_CONTENT_DIR' ) );
 			$params['path']    = substr_replace( $params['path'],
 				self::PROTOCOL . '://wp-content',
 				$pos,
-			strlen( WP_CONTENT_DIR ) );
+			strlen( constant( 'WP_CONTENT_DIR' ) ) );
 			$params['basedir'] = substr_replace( $params['basedir'],
 				self::PROTOCOL . '://wp-content',
 				$pos,
-			strlen( WP_CONTENT_DIR ) );
+			strlen( constant( 'WP_CONTENT_DIR' ) ) );
 		}
 
 		return $params;

--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -116,7 +116,7 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 	}
 
 	private function is_upgrade_path( $file_path ) {
-		return $this->is_wp_content_subfolder_path( $file_path, 'upgrade' );
+		return $this->is_wp_content_subfolder_path( $file_path, 'upgrade' ) || $this->is_wp_content_subfolder_path( $file_path, 'upgrade-temp-backup' );
 	}
 
 	private function is_plugins_path( $file_path ) {

--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -111,7 +111,7 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 	}
 
 	private function is_wp_content_subfolder_path( $file_path, $subfolder ) {
-		$upgrade_base = sprintf( '%s/%s', WP_CONTENT_DIR, $subfolder );
+		$upgrade_base = sprintf( '%s/%s', constant( 'WP_CONTENT_DIR' ), $subfolder );
 		return 0 === strpos( $file_path, $upgrade_base . '/' ) || $file_path === $upgrade_base;
 	}
 

--- a/tests/files/test-image-sizes.php
+++ b/tests/files/test-image-sizes.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Test\Constant_Mocker;
+
 require_once __DIR__ . '/../../files/class-image.php';
 require_once __DIR__ . '/../../files/class-image-sizes.php';
 
@@ -49,6 +51,10 @@ class A8C_Files_ImageSizes_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
+		Constant_Mocker::clear();
+		Constant_Mocker::define( 'LOCAL_UPLOADS', '/tmp/uploads' );
+		Constant_Mocker::define( 'WP_CONTENT_DIR', '/tmp/wordpress/wp-content' );
+
 		// Add filters so we have consistent filesize meta handling.
 		// (backporting WP 6.0 feature: https://core.trac.wordpress.org/ticket/49412)
 		$this->vip_filesystem = new Automattic\VIP\Files\VIP_Filesystem();
@@ -65,6 +71,8 @@ class A8C_Files_ImageSizes_Test extends WP_UnitTestCase {
 	 * Remove added uploads.
 	 */
 	public function tearDown(): void {
+		Constant_Mocker::clear();
+
 		// Remove vip filesystem filters.
 		$remove_filters = self::getVIPFilesystemMethod( 'remove_filters' );
 		$remove_filters->invoke( $this->vip_filesystem );

--- a/tests/files/test-image.php
+++ b/tests/files/test-image.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Test\Constant_Mocker;
+
 require_once __DIR__ . '/../../files/class-image.php';
 
 /**
@@ -36,12 +38,15 @@ class A8C_Files_Image_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
+		Constant_Mocker::clear();
+		Constant_Mocker::define( 'LOCAL_UPLOADS', '/tmp/uploads' );
+		Constant_Mocker::define( 'WP_CONTENT_DIR', '/tmp/wordpress/wp-content' );
+
 		// Add filters so we have consistent filesize meta handling.
 		// (backporting WP 6.0 feature: https://core.trac.wordpress.org/ticket/49412)
 		$this->vip_filesystem = new Automattic\VIP\Files\VIP_Filesystem();
 		$add_filters          = self::getVIPFilesystemMethod( 'add_filters' );
 		$add_filters->invoke( $this->vip_filesystem );
-
 
 		$this->enable_a8c_files();
 	}
@@ -52,6 +57,8 @@ class A8C_Files_Image_Test extends WP_UnitTestCase {
 	 * Remove added uploads.
 	 */
 	public function tearDown(): void {
+		Constant_Mocker::clear();
+
 		// Remove vip filesystem filters.
 		$remove_filters = self::getVIPFilesystemMethod( 'remove_filters' );
 		$remove_filters->invoke( $this->vip_filesystem );

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -2,10 +2,17 @@
 
 namespace Automattic\VIP\Files;
 
+use Automattic\Test\Constant_Mocker;
+use ErrorException;
 use WP_Error;
+use WP_Filesystem_Base;
+use WP_Filesystem_Direct;
 use WP_UnitTestCase;
 
 require_once __DIR__ . '/../../files/class-vip-filesystem.php';
+VIP_Filesystem_Test::configure_constant_mocker();
+
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
 
 class VIP_Filesystem_Test extends WP_UnitTestCase {
 	const TEST_IMAGE_PATH = VIP_GO_MUPLUGINS_TESTS__DIR__ . '/fixtures/image.jpg';
@@ -15,29 +22,45 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 	 */
 	protected $vip_filesystem;
 
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
+	/** @var int */
+	private $original_error_reporting;
 
-		// make sure needed constants are defined
-		if ( ! defined( 'LOCAL_UPLOADS' ) ) {
-			define( 'LOCAL_UPLOADS', '/tmp/uploads' );
-		}
-		if ( ! defined( 'WP_CONTENT_DIR' ) ) {
-			define( 'WP_CONTENT_DIR', '/tmp/wordpress/wp-content' );
-		}
+	public static $actor;
+
+	public static function configure_constant_mocker(): void {
+		Constant_Mocker::clear();
+		define( 'LOCAL_UPLOADS', '/wp/uploads' );
+		define( 'WP_CONTENT_DIR', '/wp/wordpress/wp-content' );
 	}
 
 	public function setUp(): void {
 		parent::setUp();
+
+		self::$actor = null;
+		self::configure_constant_mocker();
 
 		$this->vip_filesystem = new VIP_Filesystem();
 
 		// add the filters for upload dir tests
 		$add_filters = self::get_method( 'add_filters' );
 		$add_filters->invoke( $this->vip_filesystem );
+
+		$this->original_error_reporting = error_reporting();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		set_error_handler( static function ( int $errno, string $errstr ) {
+			if ( $errno & error_reporting() ) {
+				throw new ErrorException( $errstr, $errno );
+			}
+
+			return false;
+		}, E_ALL );
 	}
 
 	public function tearDown(): void {
+		restore_error_handler();
+		error_reporting( $this->original_error_reporting );
+		Constant_Mocker::clear();
+
 		// remove the filters
 		$remove_filters = self::get_method( 'remove_filters' );
 		$remove_filters->invoke( $this->vip_filesystem );
@@ -69,10 +92,10 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		return [
 			'local-uploads' => [
 				[
-					'path'    => LOCAL_UPLOADS . '/2019/1',
+					'path'    => constant( 'LOCAL_UPLOADS' ) . '/2019/1',
 					'url'     => 'http://test.com/wp-content/uploads/2019/1',
 					'subdir'  => '/2019/1',
-					'basedir' => LOCAL_UPLOADS,
+					'basedir' => constant( 'LOCAL_UPLOADS' ),
 				],
 				[
 					'path'    => 'vip://wp-content/uploads/2019/1',
@@ -83,10 +106,10 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 			],
 			'wp-content'    => [
 				[
-					'path'    => WP_CONTENT_DIR . '/uploads/2019/1',
+					'path'    => constant( 'WP_CONTENT_DIR' ) . '/uploads/2019/1',
 					'url'     => 'http://test.com/wp-content/uploads/2019/1',
 					'subdir'  => '/2019/1',
-					'basedir' => WP_CONTENT_DIR . '/uploads',
+					'basedir' => constant( 'WP_CONTENT_DIR' ) . '/uploads',
 				],
 				[
 					'path'    => 'vip://wp-content/uploads/2019/1',
@@ -136,6 +159,9 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 	 * @dataProvider get_test_data__clean_file_path
 	 */
 	public function test__clean_file_path( $file_path, $expected ) {
+		Constant_Mocker::undefine( 'WP_CONTENT_DIR' );
+		Constant_Mocker::define( 'WP_CONTENT_DIR', WP_CONTENT_DIR );
+
 		$clean_file_path = self::get_method( 'clean_file_path' );
 
 		$actual = $clean_file_path->invokeArgs( $this->vip_filesystem, [ $file_path ] );
@@ -296,5 +322,42 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 			'Failed to generate new unique file name `testfile.exe` (response code: 400)',
 			$actual['error']
 		);
+	}
+
+	/**
+	 * @dataProvider data_get_transport_for_path
+	 */
+	public function test_get_transport_for_path( string $file, string $expected ): void {
+		$direct = new class( '' ) extends WP_Filesystem_Direct {
+			public function put_contents( $file, $contents, $mode = false ) {
+				VIP_Filesystem_Test::$actor = 'direct';
+				return true;
+			}
+		};
+
+		$uploads = new class() extends WP_Filesystem_Base {
+			public function put_contents( $file, $contents, $mode = false ) {
+				VIP_Filesystem_Test::$actor = 'uploads';
+				return true;
+			}
+		};
+
+		$vipfs  = new WP_Filesystem_VIP( [ $uploads, $direct ] );
+		$result = $vipfs->put_contents( $file, 'xxx' );
+		self::assertTrue( $result );
+		self::assertEquals( $expected, self::$actor );
+		self::assertEmpty( $vipfs->errors->get_error_messages() );
+	}
+
+	public function data_get_transport_for_path(): iterable {
+		return [
+			[ ABSPATH . '.maintenance', 'direct' ],
+			[ get_temp_dir() . '/test.txt', 'direct' ],
+			[ constant( 'WP_CONTENT_DIR' ) . '/upgrade/test.txt', 'direct' ],
+			[ constant( 'WP_CONTENT_DIR' ) . '/upgrade-temp-backup/test.txt', 'direct' ],
+			[ constant( 'WP_CONTENT_DIR' ) . '/themes/test.txt', 'direct' ],
+			[ constant( 'WP_CONTENT_DIR' ) . '/plugins/test.txt', 'direct' ],
+			[ constant( 'WP_CONTENT_DIR' ) . '/languages/test.txt', 'direct' ],
+		];
 	}
 }

--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -20,6 +20,8 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		Constant_Mocker::clear();
+		Constant_Mocker::define( 'LOCAL_UPLOADS', '/tmp/uploads' );
+		Constant_Mocker::define( 'WP_CONTENT_DIR', '/tmp/wordpress/wp-content' );
 
 		$this->fs_uploads_mock = $this->createMock( WP_Filesystem_VIP_Uploads::class );
 		$this->fs_direct_mock  = $this->createMock( WP_Filesystem_Direct::class );

--- a/tests/mock-constants.php
+++ b/tests/mock-constants.php
@@ -37,6 +37,10 @@ namespace Automattic\Test {
 
 			return self::$constants[ $constant ][0];
 		}
+
+		public static function undefine( string $constant ): void {
+			unset( self::$constants[ $constant ] );
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

This PR should fix issues like

> `/wp/wp-content/upgrade-temp-backup/plugins/ads-txt` file cannot be managed by
`Automattic\VIP\Files\WP_Filesystem_VIP` class. Writes are only allowed for the `/tmp/` and `/wp/wp-content/uploads` directories

## Changelog Description

### Plugin Updated: VIP File Service

Allow for writes to `wp-content/upgrade-temp-backup` directory in local environments.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 
