### PR TITLE
Sunrise: Allow setting WP-CLI context via blog_id

### DIFF
--- a/lib/sunrise/sunrise.php
+++ b/lib/sunrise/sunrise.php
@@ -25,38 +25,38 @@ unset( $mu_plugin_dir );
 use Automattic\VIP\Utils\Context;
 
 /**
- * Adds support for loading blog context via the `--load-blog-id` param.
+ * Adds support for loading network site (aka blog) context via the `--load-network-site-id` param.
  *
  * Borrowed from WP.com. This does a reverse lookup for the URL based on the specified ID and passes that to WP-CLI.
  * This ensures that the correct context is loaded. It's helpful in cases where you have an ID but not a URL.
  *
- * Usage: `wp --load-blog-id=3 option get home`
+ * Usage: `wp --load-network-site-id=3 option get home`
  *
  * @see https://github.com/wp-cli/wp-cli/issues/5649#issuecomment-1227814680
  */
-function wp_cli_load_via_blog_id() {
+function wp_cli_load_via_network_site_id() {
 	if ( ! class_exists( 'WP_CLI' ) ) {
 		return;
 	}
 
-	$load_blog_id = WP_CLI::get_runner()->config['load-blog-id'] ?? null;
+	$load_network_site_id = WP_CLI::get_runner()->config['load-network-site-id'] ?? null;
 
-	if ( empty( $load_blog_id ) ) {
+	if ( empty( $load_network_site_id ) ) {
 		return;
 	}
 
-	if ( ! is_numeric( $load_blog_id ) ) {
-		return WP_CLI::error( 'The --load-blog-id parameter is expected to be a numeric ID.' );
+	if ( ! is_numeric( $load_network_site_id ) ) {
+		return WP_CLI::error( 'The --load-network-site-id parameter is expected to be a numeric ID.' );
 	}
 
-	$blog = get_site( $blog_id );
-	if ( ! $blog ) {
-		return WP_CLI::error( 'The --load-blog-id value is not a valid blog.' );
+	$network_site = get_site( $load_network_site_id );
+	if ( ! $network_site ) {
+		return WP_CLI::error( 'The specified network site was not found.' );
 	}
 
-	$url = $blog->domain;
-	if ( $blog->path ) {
-		$url .= $blog->path;
+	$url = $network_site->domain;
+	if ( $network_site->path ) {
+		$url .= $network_site->path;
 	}
 
 	WP_CLI::set_url( $url );
@@ -135,9 +135,13 @@ function handle_not_found_error( $error_type ) {
 	}
 }
 
+/**
+ * Run the rest of the sunrise code.
+ */
+
 // Overrides related to WP-CLI
 if ( Context::is_wp_cli() ) {
-	wp_cli_load_via_blog_id();
+	wp_cli_load_via_network_site_id();
 }
 
 /**


### PR DESCRIPTION
Adds a new param `--load-blog-id` which allows loading blog context via a blog_id value instead of a URL.

Based on https://github.com/wp-cli/wp-cli/issues/5649#issuecomment-1227814680

## Changelog Description

### WP-CLI: Add new --load-blog-id global param

We've added a new global param (`--load-blog-id`) to WP-CLI, which allows loading blog context via a blog_id value instead of a URL. This is helpful in cases where you have an ID but not a URL.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

TODO