### PR TITLE
Fix fatal error in tracks widget updated event when return value is false

### DIFF
--- a/vip-parsely/Telemetry/Events/track-widget-updated.php
+++ b/vip-parsely/Telemetry/Events/track-widget-updated.php
@@ -18,10 +18,11 @@ use WP_Widget;
  * @param array|null $new_instance Array of new widget settings.
  * @param array|null $old_instance Array of old widget settings.
  * @param WP_Widget $widget_obj The current widget instance.
- * @param Telemetry_System $telemetry_system
- * @return array Updated widget settings
+ * @param Telemetry_System $telemetry_system The telemetry system to use.
+ *
+ * @return array|false Updated widget settings or false.
  */
-function track_widget_updated( $instance, ?array $new_instance, ?array $old_instance, WP_Widget $widget_obj, Telemetry_System $telemetry_system ): array {
+function track_widget_updated( $instance, ?array $new_instance, ?array $old_instance, WP_Widget $widget_obj, Telemetry_System $telemetry_system ) {
 	if ( ! is_array( $instance ) ) {
 		return $instance;
 	}


### PR DESCRIPTION
## Description
We received the following report:
> When we try to update a widget, we sometimes are unable to do so. We get the fatal error shown below. It looks like this happens when the widget update function returns false, which according to WordPress core, is an acceptable value. The wp-includes/class-wp-widget.php says the update function has a `@return array Settings to save or bool false to cancel saving.`

> Fatal error: Uncaught Error: track_widget_updated(): Return value must be of type array, bool returned in track-widget-updated.php on line 26

## Changelog Description

### Fixed error in the "widget updated" event, when the return value was false

We fixed a fatal error that could occur in the "widget updated" event when the return value was false.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 