### PR TITLE
test: do not perform external requests in `WPCOM_VIP_Utils_Vip_Is_Jetpack_Request_Test`

### DIFF
--- a/tests/vip-helpers/vip-utils/test-vip-utils-vip-is-jetpack-request.php
+++ b/tests/vip-helpers/vip-utils/test-vip-utils-vip-is-jetpack-request.php
@@ -1,6 +1,27 @@
 <?php
 
+use Automattic\VIP\Utils\Jetpack_IP_Manager;
+
 class WPCOM_VIP_Utils_Vip_Is_Jetpack_Request_Test extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'pre_http_request', function ( $response, $args, $url ) {
+			if ( Jetpack_IP_Manager::ENDPOINT === $url ) {
+				$response = [
+					'headers'  => [],
+					'body'     => '["122.248.245.244\/32","54.217.201.243\/32","54.232.116.4\/32","192.0.80.0\/20","192.0.96.0\/20","192.0.112.0\/20","195.234.108.0\/22"]',
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+				];
+			}
+
+			return $response;
+		}, 10, 3 );
+	}
 
 	public function test__vip_is_jetpack_request__shortcut() {
 		//phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__


### PR DESCRIPTION
Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/5883462222/job/15964952080?pr=4791#step:5:341

```
1) WPCOM_VIP_Utils_Vip_Is_Jetpack_Request_Test::test__vip_is_jetpack_request__true
Failed asserting that false is true.

/home/runner/work/vip-go-mu-plugins/vip-go-mu-plugins/tests/vip-helpers/vip-utils/test-vip-utils-vip-is-jetpack-request.php:18
```

Tests invoke `get_jetpack_ips()` which may issue an external call to `https://jetpack.com/ips-v4.json`, which is not a good idea.