### PR TITLE
Fix 2FA setup process when TOTP is the first method being activated

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -191,7 +191,7 @@ function wpcom_vip_two_factor_filter_caps( $caps, $cap, $user_id, $args ) {
 		];
 
 		// You can edit your own user account (required to set up 2FA)
-		if ( 'edit_user' === $cap && ! empty( $args ) && $user_id === $args[0] ) {
+		if ( 'edit_user' === $cap && ! empty( $args ) && (int) $user_id === (int) $args[0] ) {
 			$subscriber_caps[] = 'edit_user';
 		}
 


### PR DESCRIPTION
## Description

When TOTP is the first 2FA method being activated, it fails to allow the code to be validated due to the capability checks failing in the rest endpoint: https://github.com/Automattic/vip-go-mu-plugins-built/blob/09e2cde1496a173a694ed383ea329eb185d3b26f/shared-plugins/two-factor/providers/class-two-factor-totp.php#L94C1-L95C1

This is because between `$user_id` and `$args[0]`, one is an integer and one is a double. And the triple equals doesn't appreciate that.

## Changelog Description

### Fixed bug when setting up TOTP as the first 2FA method on an account

Was previously not possible to activate TOTP as the first method due to a bug in the capabilities logic.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.


## Steps to Test

- Make a new account, enforce 2fa, and try to setup TOTP.
- More details in BB8-10578
