### PR TITLE
JP Connection Pilot: Fix fatal from wrong namespace on WP_Error

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Jetpack;
 
 use Automattic\VIP\Utils\Alerts;
 use DateTime;
+use WP_Error;
 
 require_once __DIR__ . '/class-jetpack-connection-controls.php';
 


### PR DESCRIPTION
> PHP Fatal error: Caught Error: Class "Automattic\VIP\Jetpack\WP_Error" not found

Introduced here: https://github.com/Automattic/vip-go-mu-plugins/pull/4771/files#diff-2e8afd16cc8ce020a84de51d55e31b1d1e79d096ec093ea17ed73de79f2ddeedR283