### PR TITLE
Adds "is_managed" key in Parse.ly Integration if integration is managed by VIP

### DIFF
--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -41,15 +41,21 @@ class ParselyIntegration extends Integration {
 	 * @return array
 	 */
 	public function wp_parsely_credentials_callback( $original_credentials ) {
-		$config = $this->get_config();
+		$config      = $this->get_config();
+		$credentials = array();
 
+		// If config provided by VIP is empty then take original credentials else take config.
 		if ( empty( $config ) ) {
-			return $original_credentials;
+			$credentials = $original_credentials;
+		} else {
+			$credentials = array(
+				'site_id'    => $config['site_id'] ?? null,
+				'api_secret' => $config['api_secret'] ?? null,
+			);
 		}
 
-		return array(
-			'site_id'    => $config['site_id'] ?? null,
-			'api_secret' => $config['api_secret'] ?? null,
-		);
+		// Adds `is_managed` flag to indicate that platform is managing this integration
+		// and we have to hide the credential banner warning or more.
+		return array_merge( array( 'is_managed' => true ), $credentials );
 	}
 }

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -44,15 +44,12 @@ class ParselyIntegration extends Integration {
 		$config      = $this->get_config();
 		$credentials = array();
 
-		// If config provided by VIP is empty then take original credentials else take config.
-		if ( empty( $config ) ) {
-			$credentials = $original_credentials;
-		} else {
-			$credentials = array(
-				'site_id'    => $config['site_id'] ?? null,
-				'api_secret' => $config['api_secret'] ?? null,
-			);
-		}
+		// If config provided by VIP is empty then take original credentials else take
+		// credentials from config.
+		$credentials = empty( $config ) ? $original_credentials : array(
+			'site_id'    => $config['site_id'] ?? null,
+			'api_secret' => $config['api_secret'] ?? null,
+		);
 
 		// Adds `is_managed` flag to indicate that platform is managing this integration
 		// and we have to hide the credential banner warning or more.

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -9,7 +9,6 @@ namespace Automattic\VIP\Integrations;
 
 use WP_UnitTestCase;
 
-use function Automattic\Test\Utils\get_class_method_as_public;
 use function Automattic\Test\Utils\get_class_property_as_public;
 use function Automattic\Test\Utils\is_parsely_disabled;
 use function Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin;
@@ -37,18 +36,21 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( has_filter( 'wp_parsely_credentials' ) );
 	}
 
-	public function test__wp_parsely_credentials_callback_returns_original_credentials_of_the_integration(): void {
+	public function test__wp_parsely_credentials_callback_returns_original_credentials_of_the_integration_if_platform_config_is_empty(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
 		get_class_property_as_public( Integration::class, 'options' )->setValue( $parsely_integration, [
 			'config' => [],
 		] );
 
-		$callback_value = get_class_method_as_public( ParselyIntegration::class, 'wp_parsely_credentials_callback' )->invoke( $parsely_integration, [ 'original' ] );
+		$callback_value = $parsely_integration->wp_parsely_credentials_callback( [ 'credential_1' => 'value' ] );
 
-		$this->assertEquals( [ 'original' ], $callback_value );
+		$this->assertEquals( [
+			'is_managed'   => true,
+			'credential_1' => 'value',
+		], $callback_value );
 	}
 
-	public function test__wp_parsely_credentials_callback_returns_platform_credentials_of_the_integration(): void {
+	public function test__wp_parsely_credentials_callback_returns_platform_credentials_of_the_integration_if_platform_config_exists(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
 		get_class_property_as_public( Integration::class, 'options' )->setValue( $parsely_integration, [
 			'config' => [
@@ -57,9 +59,10 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 			],
 		] );
 
-		$callback_value = get_class_method_as_public( ParselyIntegration::class, 'wp_parsely_credentials_callback' )->invoke( $parsely_integration, array() );
+		$callback_value = $parsely_integration->wp_parsely_credentials_callback( array() );
 
 		$this->assertEquals( [
+			'is_managed' => true,
 			'site_id'    => 'value',
 			'api_secret' => null,
 		], $callback_value );


### PR DESCRIPTION
## Description

By default we shows a banner on the plugin which let customers know to add credentials but for integration enabled via VIP we don't want to show this banner because if the site is yet to launch then we don't have its domain and without domain we cannot setup Parse.ly credentials so enabling the integration properly is a two step process:

1. Enable the integration when environment is init so that customers are already aware of Parse.ly and don't have surprises or unexpected behavior during launch.

2. Configure the integration ( i.e. setup credentials ) after the launch.

## Changes Made

- While forwarding credentials from platform we have added `is_managed' key which will give signal to the plugin that platform is managing this integration so don't show any banner.

## Changelog Description

Adds "is_managed" key in Parse.ly Integration if managed by VIP

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR
1. Clone wp-parsely which is ready for v3.9 and `wp_parsely_credentials` filter (`git clone git@github.com:Parsely/wp-parsely.git wp-parsely-3.8`)
1. Add Parse.ly integration config as mentioned in this PR (https://github.com/Automattic/vip-go-mu-plugins/pull/4660) but have some without config / credentials
1. Make sure that the Parse.ly warning banner is not appearing on sites that are enabled but does not have credentials
