### PR TITLE
Adds wp_parsely_managed_options filter in Parse.ly integration

### DIFF
--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -23,7 +23,7 @@ class BlockDataApiIntegration extends Integration {
 	protected string $version = '1.0';
 
 	/**
-	 * Returns `true` if `Block Data API` is already available via customer code. We will use
+	 * Returns `true` if `Block Data API` is already available e.g. via customer code. We will use
 	 * this function to prevent activating of integration from platform side.
 	 */
 	public function is_loaded(): bool {
@@ -38,6 +38,14 @@ class BlockDataApiIntegration extends Integration {
 	public function load(): void {
 		// Wait until plugins_loaded to give precedence to the plugin in the customer repo.
 		add_action( 'plugins_loaded', function() {
+			// Return if the integration is already loaded.
+			//
+			// In activate() method we do make sure to not activate the integration if its already loaded
+			// but still adding it here as a safety measure i.e. if load() is called directly.
+			if ( $this->is_loaded() ) {
+				return;
+			}
+
 			// Load the version of the plugin that should be set to the latest version, otherwise if it's not found deactivate the integration.
 			$load_path = WPMU_PLUGIN_DIR . '/vip-integrations/vip-block-data-api-' . $this->version . '/vip-block-data-api.php';
 			if ( file_exists( $load_path ) ) {

--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -26,7 +26,7 @@ class BlockDataApiIntegration extends Integration {
 	 * Returns `true` if `Block Data API` is already available via customer code. We will use
 	 * this function to prevent activating of integration from platform side.
 	 */
-	public function is_integration_already_available_via_customer(): bool {
+	public function is_loaded(): bool {
 		return defined( 'VIP_BLOCK_DATA_API_LOADED' );
 	}
 
@@ -51,5 +51,5 @@ class BlockDataApiIntegration extends Integration {
 	/**
 	 * Configure `Block Data API` for VIP Platform.
 	 */
-	public function configure_for_vip(): void {}
+	public function configure(): void {}
 }

--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -23,6 +23,14 @@ class BlockDataApiIntegration extends Integration {
 	protected string $version = '1.0';
 
 	/**
+	 * Returns `true` if `Block Data API` is already available via customer code. We will use
+	 * this function to prevent activating of integration from platform side.
+	 */
+	public function is_integration_already_available_via_customer(): bool {
+		return defined( 'VIP_BLOCK_DATA_API_LOADED' );
+	}
+
+	/**
 	 * Applies hooks to load Block Data API plugin.
 	 *
 	 * @private
@@ -30,11 +38,6 @@ class BlockDataApiIntegration extends Integration {
 	public function load(): void {
 		// Wait until plugins_loaded to give precedence to the plugin in the customer repo.
 		add_action( 'plugins_loaded', function() {
-			// Do not load plugin if already loaded by customer code.
-			if ( defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
-				return;
-			}
-
 			// Load the version of the plugin that should be set to the latest version, otherwise if it's not found deactivate the integration.
 			$load_path = WPMU_PLUGIN_DIR . '/vip-integrations/vip-block-data-api-' . $this->version . '/vip-block-data-api.php';
 			if ( file_exists( $load_path ) ) {
@@ -44,4 +47,9 @@ class BlockDataApiIntegration extends Integration {
 			}
 		} );
 	}
+
+	/**
+	 * Configure `Block Data API` for VIP Platform.
+	 */
+	public function configure_for_vip(): void {}
 }

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -63,6 +63,15 @@ abstract class Integration {
 	 * @private
 	 */
 	public function activate( array $options = [] ): void {
+		// If integration is already available in customer code then don't activate it from platform side.
+		if ( $this->is_integration_already_available_via_customer() ) {
+			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				sprintf( 'Prevented activating of integration with slug "%s" because it is already available via customer code.', esc_html( $this->slug ) ),
+				E_USER_WARNING
+			);
+			return;
+		}
+
 		// Don't do anything if integration is already activated.
 		if ( $this->is_active() ) {
 			trigger_error( sprintf( 'VIP Integration with slug "%s" is already activated.', esc_html( $this->get_slug() ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
@@ -103,6 +112,14 @@ abstract class Integration {
 	}
 
 	/**
+	 * Returns `true` if the integration is already available via customer code. We will use
+	 * this function to prevent activating of integration from platform side.
+	 *
+	 * @private
+	 */
+	abstract public function is_integration_already_available_via_customer(): bool;
+
+	/**
 	 * Implement custom action and filter calls to load integration here.
 	 *
 	 * For plugins / integrations that can be added to customer repos, 
@@ -112,4 +129,14 @@ abstract class Integration {
 	 * @private
 	 */
 	abstract public function load(): void;
+
+	/**
+	 * Configure the integration for VIP platform.
+	 *
+	 * If we want to implement functionality only if the integration is enabled via VIP
+	 * then we will use this function.
+	 *
+	 * @private
+	 */
+	abstract public function configure_for_vip(): void;
 }

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -69,13 +69,11 @@ abstract class Integration {
 				sprintf( 'Prevented activating of integration with slug "%s" because it is already available via customer code.', esc_html( $this->slug ) ),
 				E_USER_WARNING
 			);
-			return;
 		}
 
 		// Don't do anything if integration is already activated.
 		if ( $this->is_active() ) {
 			trigger_error( sprintf( 'VIP Integration with slug "%s" is already activated.', esc_html( $this->get_slug() ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			return;
 		}
 
 		$this->is_active = true;

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -64,7 +64,7 @@ abstract class Integration {
 	 */
 	public function activate( array $options = [] ): void {
 		// If integration is already available in customer code then don't activate it from platform side.
-		if ( $this->is_integration_already_available_via_customer() ) {
+		if ( $this->is_loaded() ) {
 			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				sprintf( 'Prevented activating of integration with slug "%s" because it is already available via customer code.', esc_html( $this->slug ) ),
 				E_USER_WARNING
@@ -110,12 +110,12 @@ abstract class Integration {
 	}
 
 	/**
-	 * Returns `true` if the integration is already available via customer code. We will use
-	 * this function to prevent activating of integration from platform side.
+	 * Returns `true` if the integration is already available e.g. via customer code. We will use
+	 * this function to prevent activating of integration again.
 	 *
 	 * @private
 	 */
-	abstract public function is_integration_already_available_via_customer(): bool;
+	abstract public function is_loaded(): bool;
 
 	/**
 	 * Implement custom action and filter calls to load integration here.
@@ -136,5 +136,5 @@ abstract class Integration {
 	 *
 	 * @private
 	 */
-	abstract public function configure_for_vip(): void;
+	abstract public function configure(): void;
 }

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -66,7 +66,7 @@ abstract class Integration {
 		// If integration is already available in customer code then don't activate it from platform side.
 		if ( $this->is_loaded() ) {
 			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-				sprintf( 'Prevented activating of integration with slug "%s" because it is already available via customer code.', esc_html( $this->slug ) ),
+				sprintf( 'Prevented activating of integration with slug "%s" because it is already loaded.', esc_html( $this->slug ) ),
 				E_USER_WARNING
 			);
 		}

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -115,7 +115,6 @@ class Integrations {
 
 		if ( null === $integration ) {
 			trigger_error( sprintf( 'VIP Integration with slug "%s" is not a registered integration.', esc_html( $slug ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			return;
 		}
 
 		$integration->activate( $options );

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -70,7 +70,7 @@ class Integrations {
 					'config' => $vip_config->get_site_config(),
 				] );
 
-				// If integration is activated successfully without any error then configure it for VIP.
+				// If integration is activated successfully without any error then configure.
 				if ( $integration->is_active() ) {
 					$integration->configure();
 				}

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -69,6 +69,11 @@ class Integrations {
 				$this->activate( $slug, [
 					'config' => $vip_config->get_site_config(),
 				] );
+
+				// If integration is activated successfully without any error then configure it for VIP.
+				if ( $integration->is_active() ) {
+					$integration->configure_for_vip();
+				}
 			}
 		}
 	}
@@ -110,6 +115,7 @@ class Integrations {
 
 		if ( null === $integration ) {
 			trigger_error( sprintf( 'VIP Integration with slug "%s" is not a registered integration.', esc_html( $slug ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			return;
 		}
 
 		$integration->activate( $options );

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -72,7 +72,7 @@ class Integrations {
 
 				// If integration is activated successfully without any error then configure it for VIP.
 				if ( $integration->is_active() ) {
-					$integration->configure_for_vip();
+					$integration->configure();
 				}
 			}
 		}

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -17,7 +17,7 @@ class ParselyIntegration extends Integration {
 	 * Returns `true` if `Parse.ly` is already available via customer code. We will use
 	 * this function to prevent loading of integration again from platform side.
 	 */
-	public function is_integration_already_available_via_customer(): bool {
+	public function is_loaded(): bool {
 		return class_exists( 'Parsely' ) || class_exists( 'Parsely\Parsely' );
 	}
 
@@ -41,7 +41,7 @@ class ParselyIntegration extends Integration {
 	 *
 	 * @private
 	 */
-	public function configure_for_vip(): void {
+	public function configure(): void {
 		add_filter( 'wp_parsely_credentials', array( $this, 'wp_parsely_credentials_callback' ) );
 		add_filter( 'wp_parsely_managed_options', array( $this, 'wp_parsely_managed_options_callback' ) );
 	}

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -31,7 +31,9 @@ class ParselyIntegration extends Integration {
 		// handled via Automattic\VIP\WP_Parsely_Integration (ideally we should move
 		// all the implementation here such that there will be only one way of managing
 		// the plugin).
-		define( 'VIP_PARSELY_ENABLED', true );
+		if ( ! defined( 'VIP_PARSELY_ENABLED' ) ) {
+			define( 'VIP_PARSELY_ENABLED', true );
+		}
 	}
 
 	/**

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -31,6 +31,7 @@ class ParselyIntegration extends Integration {
 		define( 'VIP_PARSELY_ENABLED', true );
 
 		add_filter( 'wp_parsely_credentials', array( $this, 'wp_parsely_credentials_callback' ) );
+		add_filter( 'wp_parsely_managed_options', array( $this, 'wp_parsely_managed_options_callback' ) );
 	}
 
 	/**
@@ -54,5 +55,25 @@ class ParselyIntegration extends Integration {
 		// Adds `is_managed` flag to indicate that platform is managing this integration
 		// and we have to hide the credential banner warning or more.
 		return array_merge( array( 'is_managed' => true ), $credentials );
+	}
+
+	/**
+	 * Callback for `wp_parsely_managed_options` filter.
+	 *
+	 * @param array $value Value passed to filter.
+	 *
+	 * @return array
+	 */
+	public function wp_parsely_managed_options_callback( $value ) {
+		return array(
+			'force_https_canonicals' => true,
+			'meta_type'              => 'repeated_metas',
+			// Managed options that will obey the values on database.
+			'cats_as_tags'           => null,
+			'content_id_prefix'      => null,
+			'logo'                   => null,
+			'lowercase_tags'         => null,
+			'use_top_level_cats'     => null,
+		);
 	}
 }

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -14,7 +14,7 @@ namespace Automattic\VIP\Integrations;
  */
 class ParselyIntegration extends Integration {
 	/**
-	 * Returns `true` if `Parse.ly` is already available via customer code. We will use
+	 * Returns `true` if `Parse.ly` is already available e.g. customer code. We will use
 	 * this function to prevent loading of integration again from platform side.
 	 */
 	public function is_loaded(): bool {
@@ -27,6 +27,14 @@ class ParselyIntegration extends Integration {
 	 * @private
 	 */
 	public function load(): void {
+		// Return if the integration is already loaded.
+			//
+			// In activate() method we do make sure to not activate the integration if its already loaded
+			// but still adding it here as a safety measure i.e. if load() is called directly.
+		if ( $this->is_loaded() ) {
+			return;
+		}
+
 		// Activating the integration via setting constant whose implementation is already
 		// handled via Automattic\VIP\WP_Parsely_Integration (ideally we should move
 		// all the implementation here such that there will be only one way of managing

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -14,22 +14,32 @@ namespace Automattic\VIP\Integrations;
  */
 class ParselyIntegration extends Integration {
 	/**
+	 * Returns `true` if `Parse.ly` is already available via customer code. We will use
+	 * this function to prevent loading of integration again from platform side.
+	 */
+	public function is_integration_already_available_via_customer(): bool {
+		return class_exists( 'Parsely\Parsely' );
+	}
+
+	/**
 	 * Loads the plugin.
 	 *
 	 * @private
 	 */
 	public function load(): void {
-		// Do not load plugin if already loaded by customer code.
-		if ( class_exists( 'Parsely\Parsely' ) ) {
-			return;
-		}
-
 		// Activating the integration via setting constant whose implementation is already
 		// handled via Automattic\VIP\WP_Parsely_Integration (ideally we should move
 		// all the implementation here such that there will be only one way of managing
 		// the plugin).
 		define( 'VIP_PARSELY_ENABLED', true );
+	}
 
+	/**
+	 * Configure `Parse.ly` for VIP Platform.
+	 *
+	 * @private
+	 */
+	public function configure_for_vip(): void {
 		add_filter( 'wp_parsely_credentials', array( $this, 'wp_parsely_credentials_callback' ) );
 		add_filter( 'wp_parsely_managed_options', array( $this, 'wp_parsely_managed_options_callback' ) );
 	}

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -18,7 +18,7 @@ class ParselyIntegration extends Integration {
 	 * this function to prevent loading of integration again from platform side.
 	 */
 	public function is_integration_already_available_via_customer(): bool {
-		return class_exists( 'Parsely\Parsely' );
+		return class_exists( 'Parsely' ) || class_exists( 'Parsely\Parsely' );
 	}
 
 	/**

--- a/tests/integrations/fake-integration.php
+++ b/tests/integrations/fake-integration.php
@@ -11,11 +11,11 @@ namespace Automattic\VIP\Integrations;
 
 class FakeIntegration extends Integration {
 
-	public function is_integration_already_available_via_customer(): bool {
+	public function is_loaded(): bool {
 		return false;
 	}
 
 	public function load(): void { }
 
-	public function configure_for_vip(): void { }
+	public function configure(): void { }
 }

--- a/tests/integrations/fake-integration.php
+++ b/tests/integrations/fake-integration.php
@@ -11,5 +11,11 @@ namespace Automattic\VIP\Integrations;
 
 class FakeIntegration extends Integration {
 
+	public function is_integration_already_available_via_customer(): bool {
+		return false;
+	}
+
 	public function load(): void { }
+
+	public function configure_for_vip(): void { }
 }

--- a/tests/integrations/test-integration.php
+++ b/tests/integrations/test-integration.php
@@ -39,7 +39,7 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 
 	public function test__calling_activate_when_the_integration_is_already_loaded_does_not_activate_the_integration_again(): void {
 		$this->expectException( 'PHPUnit_Framework_Error_Warning' ); 
-		$this->expectExceptionMessage( 'Prevented activating of integration with slug "fake" because it is already available via customer code.' );
+		$this->expectExceptionMessage( 'Prevented activating of integration with slug "fake" because it is already loaded.' );
 		/**
 		 * Integration mock.
 		 *

--- a/tests/integrations/test-integration.php
+++ b/tests/integrations/test-integration.php
@@ -9,6 +9,7 @@ namespace Automattic\VIP\Integrations;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.FunctionComment.MissingParamComment
 
+use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 
 require_once __DIR__ . '/fake-integration.php';
@@ -36,6 +37,22 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 		$this->assertEquals( [ 'config_test' ], $integration->get_config() );
 	}
 
+	public function test__calling_activate_when_the_integration_is_already_loaded_does_not_activate_the_integration_again(): void {
+		$this->expectException( 'PHPUnit_Framework_Error_Warning' ); 
+		$this->expectExceptionMessage( 'Prevented activating of integration with slug "fake" because it is already available via customer code.' );
+		/**
+		 * Integration mock.
+		 *
+		 * @var MockObject|FakeIntegration
+		 */
+		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'is_integration_already_available_via_customer' ] )->getMock();
+		$integration_mock->expects( $this->once() )->method( 'is_integration_already_available_via_customer' )->willReturn( true );
+
+		$integration_mock->activate();
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
 	public function test__calling_activate_twice_on_same_integration_does_not_activate_the_plugin_second_time(): void {
 		$this->expectException( 'PHPUnit_Framework_Error_Warning' ); 
 		$this->expectExceptionMessage( 'VIP Integration with slug "fake" is already activated.' );
@@ -44,6 +61,8 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 
 		$integration->activate();
 		$integration->activate();
+
+		$this->assertFalse( $integration->is_active() );
 	}
 
 	public function test__is_active_returns_false_when_integration_is_not_active(): void {

--- a/tests/integrations/test-integration.php
+++ b/tests/integrations/test-integration.php
@@ -45,8 +45,8 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 		 *
 		 * @var MockObject|FakeIntegration
 		 */
-		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'is_integration_already_available_via_customer' ] )->getMock();
-		$integration_mock->expects( $this->once() )->method( 'is_integration_already_available_via_customer' )->willReturn( true );
+		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'is_loaded' ] )->getMock();
+		$integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( true );
 
 		$integration_mock->activate();
 

--- a/tests/integrations/test-integrations.php
+++ b/tests/integrations/test-integrations.php
@@ -52,7 +52,7 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 		$this->assertEquals( [], $integration_3->get_config() );
 	}
 
-	public function test__configure_for_vip_is_getting_called_when_the_integration_is_activated_via_vip_config(): void {
+	public function test__configure_is_getting_called_when_the_integration_is_activated_via_vip_config(): void {
 		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->setMethods( [ 'is_active_via_vip' ] )->getMock();
 		$config_mock->expects( $this->once() )->method( 'is_active_via_vip' )->willReturn( true );
 		/**
@@ -67,8 +67,8 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 		 *
 		 * @var MockObject|FakeIntegration
 		 */
-		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'configure_for_vip' ] )->getMock();
-		$integration_mock->expects( $this->once() )->method( 'configure_for_vip' );
+		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'configure' ] )->getMock();
+		$integration_mock->expects( $this->once() )->method( 'configure' );
 
 		$integrations_mock->register( $integration_mock );
 		$integrations_mock->activate_platform_integrations();

--- a/tests/integrations/test-integrations.php
+++ b/tests/integrations/test-integrations.php
@@ -52,6 +52,31 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 		$this->assertEquals( [], $integration_3->get_config() );
 	}
 
+	public function test__configure_for_vip_is_getting_called_when_the_integration_is_activated_via_vip_config(): void {
+		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->setMethods( [ 'is_active_via_vip' ] )->getMock();
+		$config_mock->expects( $this->once() )->method( 'is_active_via_vip' )->willReturn( true );
+		/**
+		 * Integrations mock.
+		 *
+		 * @var MockObject|Integrations
+		 */
+		$integrations_mock = $this->getMockBuilder( Integrations::class )->setMethods( [ 'get_integration_vip_config' ] )->getMock();
+		$integrations_mock->expects( $this->once() )->method( 'get_integration_vip_config' )->willReturn( $config_mock );
+		/**
+		 * Integration mock.
+		 *
+		 * @var MockObject|FakeIntegration
+		 */
+		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'configure_for_vip' ] )->getMock();
+		$integration_mock->expects( $this->once() )->method( 'configure_for_vip' );
+
+		$integrations_mock->register( $integration_mock );
+		$integrations_mock->activate_platform_integrations();
+
+		$this->assertTrue( $integration_mock->is_active() );
+		$this->assertEquals( [], $integration_mock->get_config() );
+	}
+
 	public function test__get_integration_vip_config_returns_instance_of_IntegrationVipConfig(): void {
 		$integrations = new Integrations();
 

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -16,11 +16,11 @@ use function Automattic\Test\Utils\get_class_property_as_public;
 class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
 
-	public function test_is_integration_already_available_via_customer_returns_true_if_parsley_exist(): void {
+	public function test_is_loaded_returns_true_if_parsley_exist(): void {
 		require_once __DIR__ . '/../../wp-parsely/wp-parsely.php';
 
 		$parsely_integration = new ParselyIntegration( $this->slug );
-		$this->assertTrue( $parsely_integration->is_integration_already_available_via_customer() );
+		$this->assertTrue( $parsely_integration->is_loaded() );
 	}
 
 	public function test__load_call_is_setting_the_enabled_constant_if_no_constant_is_defined(): void {
@@ -36,10 +36,10 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		}
 	}
 
-	public function test__configure_for_vip_is_adding_necessary_hooks_need_for_configuration_on_vip_platform(): void {
+	public function test__configure_is_adding_necessary_hooks_need_for_configuration_on_vip_platform(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
 
-		$parsely_integration->configure_for_vip();
+		$parsely_integration->configure();
 
 		$this->assertEquals( 10, has_filter( 'wp_parsely_credentials', [ $parsely_integration, 'wp_parsely_credentials_callback' ] ) );
 		$this->assertEquals( 10, has_filter( 'wp_parsely_managed_options', [ $parsely_integration, 'wp_parsely_managed_options_callback' ] ) );

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -18,7 +18,7 @@ use function Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin;
 class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
 
-	public function test__load_call_is_defining_the_enabled_constant_and_adding_filter_if_plugin_is_not_enabled_already(): void {
+	public function test__load_call_is_defining_the_enabled_constant_and_adding_filters_if_plugin_is_not_enabled_already(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
 
 		maybe_load_plugin();
@@ -27,6 +27,7 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		if ( is_parsely_disabled() ) {
 			$this->assertTrue( defined( 'VIP_PARSELY_ENABLED' ) );
 			$this->assertEquals( 10, has_filter( 'wp_parsely_credentials', [ $parsely_integration, 'wp_parsely_credentials_callback' ] ) );
+			$this->assertEquals( 10, has_filter( 'wp_parsely_managed_options', [ $parsely_integration, 'wp_parsely_managed_options_callback' ] ) );
 
 			return;
 		}
@@ -34,6 +35,7 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		// Indicates enablement via filter or option.
 		$this->assertFalse( defined( 'VIP_PARSELY_ENABLED' ) );
 		$this->assertFalse( has_filter( 'wp_parsely_credentials' ) );
+		$this->assertFalse( has_filter( 'wp_parsely_managed_options' ) );
 	}
 
 	public function test__wp_parsely_credentials_callback_returns_original_credentials_of_the_integration_if_platform_config_is_empty(): void {
@@ -65,6 +67,21 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 			'is_managed' => true,
 			'site_id'    => 'value',
 			'api_secret' => null,
+		], $callback_value );
+	}
+
+	public function test__wp_parsely_managed_options_callback_returns_all_managed_options(): void {
+		$parsely_integration = new ParselyIntegration( $this->slug );
+		$callback_value      = $parsely_integration->wp_parsely_managed_options_callback( false );
+
+		$this->assertEquals( [
+			'force_https_canonicals' => true,
+			'meta_type'              => 'repeated_metas',
+			'cats_as_tags'           => null,
+			'content_id_prefix'      => null,
+			'logo'                   => null,
+			'lowercase_tags'         => null,
+			'use_top_level_cats'     => null,
 		], $callback_value );
 	}
 }

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -25,10 +25,16 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test__load_call_returns_without_setting_constant_if_parsely_is_already_loaded(): void {
-		$parsely_integration = new ParselyIntegration( $this->slug );
-		$preload_state       = defined( 'VIP_PARSELY_ENABLED' );
+		/**
+		 * Integration mock.
+		 *
+		 * @var MockObject|ParselyIntegration
+		 */
+		$parsely_integration_mock = $this->getMockBuilder( ParselyIntegration::class )->setConstructorArgs( [ 'parsely' ] )->setMethods( [ 'is_loaded' ] )->getMock();
+		$parsely_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( true );
+		$preload_state = defined( 'VIP_PARSELY_ENABLED' );
 
-		$parsely_integration->load();
+		$parsely_integration_mock->load();
 
 		$this->assertEquals( $preload_state, defined( 'VIP_PARSELY_ENABLED' ) );
 	}

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -10,25 +10,11 @@ namespace Automattic\VIP\Integrations;
 use WP_UnitTestCase;
 
 use function Automattic\Test\Utils\get_class_property_as_public;
-use function Automattic\Test\Utils\is_parsely_disabled;
-use function Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
-
-	public function test_is_integration_already_available_via_customer_returns_expected_value(): void {
-		$parsely_integration = new ParselyIntegration( $this->slug );
-
-		if ( is_parsely_disabled() ) {
-			$this->assertFalse( $parsely_integration->is_integration_already_available_via_customer() );
-			return;
-		}
-
-		// Indicates enablement via filter or option.
-		$this->assertTrue( $parsely_integration->is_integration_already_available_via_customer() );
-	}
 
 	public function test__configure_for_vip_is_adding_necessary_hooks_need_for_configuration_on_vip_platform(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
@@ -37,21 +23,6 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 10, has_filter( 'wp_parsely_credentials', [ $parsely_integration, 'wp_parsely_credentials_callback' ] ) );
 		$this->assertEquals( 10, has_filter( 'wp_parsely_managed_options', [ $parsely_integration, 'wp_parsely_managed_options_callback' ] ) );
-	}
-
-	public function test__load_call_is_defining_the_enabled_constant_if_plugin_is_not_loaded_already(): void {
-		$parsely_integration = new ParselyIntegration( $this->slug );
-
-		maybe_load_plugin();
-		$parsely_integration->load( [] );
-
-		if ( is_parsely_disabled() ) {
-			$this->assertTrue( defined( 'VIP_PARSELY_ENABLED' ) );
-			return;
-		}
-
-		// Indicates enablement via filter or option.
-		$this->assertFalse( defined( 'VIP_PARSELY_ENABLED' ) );
 	}
 
 	public function test__wp_parsely_credentials_callback_returns_original_credentials_of_the_integration_if_platform_config_is_empty(): void {

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -10,24 +10,21 @@ namespace Automattic\VIP\Integrations;
 use WP_UnitTestCase;
 
 use function Automattic\Test\Utils\get_class_property_as_public;
-use function Automattic\Test\Utils\is_parsely_disabled;
-use function Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
 
-	public function test_is_integration_already_available_via_customer_returns_expected_value(): void {
-		maybe_load_plugin();
+	public function test_is_integration_already_available_via_customer_returns_false_if_parsley_does_not_exist(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
+		$this->assertFalse( $parsely_integration->is_integration_already_available_via_customer() );
+	}
 
-		if ( is_parsely_disabled() ) {
-			$this->assertFalse( $parsely_integration->is_integration_already_available_via_customer() );
-			return;
-		}
+	public function test_is_integration_already_available_via_customer_returns_true_if_parsley_exist(): void {
+		require_once __DIR__ . '/../../wp-parsely/wp-parsely.php';
 
-		// Indicates enablement via filter or option.
+		$parsely_integration = new ParselyIntegration( $this->slug );
 		$this->assertTrue( $parsely_integration->is_integration_already_available_via_customer() );
 	}
 

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -32,6 +32,19 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		$this->assertTrue( $parsely_integration->is_integration_already_available_via_customer() );
 	}
 
+	public function test__load_call_is_setting_the_enabled_constant_if_no_constant_is_defined(): void {
+		$parsely_integration = new ParselyIntegration( $this->slug );
+		$existing_value      = defined( 'VIP_PARSELY_ENABLED' ) ? VIP_PARSELY_ENABLED : null;
+
+		$parsely_integration->load();
+
+		if ( is_null( $existing_value ) || true == $existing_value ) {
+			$this->assertTrue( VIP_PARSELY_ENABLED );
+		} else {
+			$this->assertFalse( defined( 'VIP_PARSELY_ENABLED' ) );
+		}
+	}
+
 	public function test__configure_for_vip_is_adding_necessary_hooks_need_for_configuration_on_vip_platform(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
 

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -19,9 +19,8 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
 
 	public function test_is_integration_already_available_via_customer_returns_expected_value(): void {
-		$parsely_integration = new ParselyIntegration( $this->slug );
-
 		maybe_load_plugin();
+		$parsely_integration = new ParselyIntegration( $this->slug );
 
 		if ( is_parsely_disabled() ) {
 			$this->assertFalse( $parsely_integration->is_integration_already_available_via_customer() );

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -16,11 +16,6 @@ use function Automattic\Test\Utils\get_class_property_as_public;
 class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
 
-	public function test_is_integration_already_available_via_customer_returns_false_if_parsley_does_not_exist(): void {
-		$parsely_integration = new ParselyIntegration( $this->slug );
-		$this->assertFalse( $parsely_integration->is_integration_already_available_via_customer() );
-	}
-
 	public function test_is_integration_already_available_via_customer_returns_true_if_parsley_exist(): void {
 		require_once __DIR__ . '/../../wp-parsely/wp-parsely.php';
 

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -18,6 +18,27 @@ use function Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin;
 class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
 
+	public function test_is_integration_already_available_via_customer_returns_expected_value(): void {
+		$parsely_integration = new ParselyIntegration( $this->slug );
+
+		if ( is_parsely_disabled() ) {
+			$this->assertFalse( $parsely_integration->is_integration_already_available_via_customer() );
+			return;
+		}
+
+		// Indicates enablement via filter or option.
+		$this->assertTrue( $parsely_integration->is_integration_already_available_via_customer() );
+	}
+
+	public function test__configure_for_vip_is_adding_necessary_hooks_need_for_configuration_on_vip_platform(): void {
+		$parsely_integration = new ParselyIntegration( $this->slug );
+
+		$parsely_integration->configure_for_vip();
+
+		$this->assertEquals( 10, has_filter( 'wp_parsely_credentials', [ $parsely_integration, 'wp_parsely_credentials_callback' ] ) );
+		$this->assertEquals( 10, has_filter( 'wp_parsely_managed_options', [ $parsely_integration, 'wp_parsely_managed_options_callback' ] ) );
+	}
+
 	public function test__load_call_is_defining_the_enabled_constant_if_plugin_is_not_loaded_already(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
 

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\VIP\Integrations;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 
 use function Automattic\Test\Utils\get_class_property_as_public;
@@ -23,11 +24,26 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		$this->assertTrue( $parsely_integration->is_loaded() );
 	}
 
-	public function test__load_call_is_setting_the_enabled_constant_if_no_constant_is_defined(): void {
+	public function test__load_call_returns_without_setting_constant_if_parsely_is_already_loaded(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
-		$existing_value      = defined( 'VIP_PARSELY_ENABLED' ) ? VIP_PARSELY_ENABLED : null;
+		$preload_state       = defined( 'VIP_PARSELY_ENABLED' );
 
 		$parsely_integration->load();
+
+		$this->assertEquals( $preload_state, defined( 'VIP_PARSELY_ENABLED' ) );
+	}
+
+	public function test__load_call_is_setting_the_enabled_constant_if_no_constant_is_defined(): void {
+		/**
+		 * Integration mock.
+		 *
+		 * @var MockObject|ParselyIntegration
+		 */
+		$parsely_integration_mock = $this->getMockBuilder( ParselyIntegration::class )->setConstructorArgs( [ 'parsely' ] )->setMethods( [ 'is_loaded' ] )->getMock();
+		$parsely_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( false );
+		$existing_value = defined( 'VIP_PARSELY_ENABLED' ) ? VIP_PARSELY_ENABLED : null;
+
+		$parsely_integration_mock->load();
 
 		if ( is_null( $existing_value ) || true == $existing_value ) {
 			$this->assertTrue( VIP_PARSELY_ENABLED );

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -18,7 +18,7 @@ use function Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin;
 class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
 
-	public function test__load_call_is_defining_the_enabled_constant_and_adding_filters_if_plugin_is_not_enabled_already(): void {
+	public function test__load_call_is_defining_the_enabled_constant_if_plugin_is_not_loaded_already(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );
 
 		maybe_load_plugin();
@@ -26,16 +26,11 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 
 		if ( is_parsely_disabled() ) {
 			$this->assertTrue( defined( 'VIP_PARSELY_ENABLED' ) );
-			$this->assertEquals( 10, has_filter( 'wp_parsely_credentials', [ $parsely_integration, 'wp_parsely_credentials_callback' ] ) );
-			$this->assertEquals( 10, has_filter( 'wp_parsely_managed_options', [ $parsely_integration, 'wp_parsely_managed_options_callback' ] ) );
-
 			return;
 		}
 
 		// Indicates enablement via filter or option.
 		$this->assertFalse( defined( 'VIP_PARSELY_ENABLED' ) );
-		$this->assertFalse( has_filter( 'wp_parsely_credentials' ) );
-		$this->assertFalse( has_filter( 'wp_parsely_managed_options' ) );
 	}
 
 	public function test__wp_parsely_credentials_callback_returns_original_credentials_of_the_integration_if_platform_config_is_empty(): void {

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -10,11 +10,27 @@ namespace Automattic\VIP\Integrations;
 use WP_UnitTestCase;
 
 use function Automattic\Test\Utils\get_class_property_as_public;
+use function Automattic\Test\Utils\is_parsely_disabled;
+use function Automattic\VIP\WP_Parsely_Integration\maybe_load_plugin;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'parsely';
+
+	public function test_is_integration_already_available_via_customer_returns_expected_value(): void {
+		$parsely_integration = new ParselyIntegration( $this->slug );
+
+		maybe_load_plugin();
+
+		if ( is_parsely_disabled() ) {
+			$this->assertFalse( $parsely_integration->is_integration_already_available_via_customer() );
+			return;
+		}
+
+		// Indicates enablement via filter or option.
+		$this->assertTrue( $parsely_integration->is_integration_already_available_via_customer() );
+	}
 
 	public function test__configure_for_vip_is_adding_necessary_hooks_need_for_configuration_on_vip_platform(): void {
 		$parsely_integration = new ParselyIntegration( $this->slug );


### PR DESCRIPTION
## Description

In `wp-parsely v3.9` we introduced `wp_parsely_managed_options` filter which will disable some plugin settings options and show `Update` call to action link, now we need to use that filter in our Parse.ly integration to customise the settings if the plugin is managed by VIP.

## Changes Made

- Added `wp_parsely_managed_options` filter in parsely integration.
- After adding filter I noticed that it is getting called even if the integration is not enabled via VIP so to resolve this issue following things has been done.
  - Added `configure_for_vip` function in our base integration class which only get called if the integration is enabled via VIP config.
  - Added `is_integration_already_available_via_customer` function in our base class and used it inside `activate` method to avoid activating the plugin if the plugin is already loaded via customer code.

## Changelog Description

Adds `wp_parsely_managed_options` filter in Parse.ly integration

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR
1. Clone wp-parsely (`git clone git@github.com:Parsely/wp-parsely.git wp-parsely-3.8`)
1. Add VIP config of Parse.ly integration with only status attribute as mentioned in this PR (https://github.com/Automattic/vip-go-mu-plugins/pull/4660) 
1. Verify `wp-parsely` is enabled if status is `enabled` and UI is showing upgrade links
1. Verify `wp-parsely` is disbaled if status is not `enabled` and UI not showing any upgrade links
1. Verify that status attribute of VIP config have no effect if the integration is activated via customer manually or already loaded via customer code.