### PR TITLE
FORNO-1668: Add Prometheus network site count collector

### DIFF
--- a/prometheus-collectors/class-multisite-stats-collector.php
+++ b/prometheus-collectors/class-multisite-stats-collector.php
@@ -9,7 +9,7 @@ use Prometheus\RegistryInterface;
  * @codeCoverageIgnore
  */
 class Multisite_Stats_Collector implements CollectorInterface {
-	private Gauge $network_site_gauge;
+	private ?Gauge $network_site_gauge = null;
 
 	public function initialize( RegistryInterface $registry ): void {
 		if ( is_multisite() ) {

--- a/prometheus-collectors/class-multisite-stats-collector.php
+++ b/prometheus-collectors/class-multisite-stats-collector.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Automattic\VIP\Prometheus;
+
+use Prometheus\Gauge;
+use Prometheus\RegistryInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class Multisite_Stats_Collector implements CollectorInterface {
+	private Gauge $network_site_gauge;
+
+	public function initialize( RegistryInterface $registry ): void {
+		if ( is_multisite() ) {
+			$this->network_site_gauge = $registry->getOrRegisterGauge(
+				'site',
+				'count',
+				'Number of network sites',
+				[ 'status' ]
+			);
+		}
+	}
+
+	public function collect_metrics(): void {
+		if ( ! $this->network_site_gauge ) {
+			return;
+		}
+
+		$sites_count = wp_count_sites();
+
+		if ( ! empty( $sites_count ) ) {
+			foreach ( $sites_count as $status => $count ) {
+				if ( 'all' !== $status ) {
+					$this->network_site_gauge->set( $count, [ $status ] );
+				}
+			}
+		}
+	}
+
+	public function process_metrics(): void {
+		/* Do nothing */
+	}
+}

--- a/prometheus.php
+++ b/prometheus.php
@@ -8,6 +8,7 @@ use Automattic\VIP\Prometheus\Post_Stats_Collector;
 use Automattic\VIP\Prometheus\User_Stats_Collector;
 use Automattic\VIP\Prometheus\Error_Stats_Collector;
 use Automattic\VIP\Prometheus\Potential_Multi_Dataset_Queries_Collector;
+use Automattic\VIP\Prometheus\Multisite_Stats_Collector;
 // @codeCoverageIgnoreStart -- this file is loaded before tests start
 if ( defined( 'ABSPATH' ) ) {
 	require_once __DIR__ . '/prometheus/index.php';
@@ -18,6 +19,7 @@ if ( defined( 'ABSPATH' ) ) {
 		'/prometheus-collectors/class-opcache-collector.php',
 		'/prometheus-collectors/class-login-stats-collector.php',
 		'/prometheus-collectors/class-error-stats-collector.php',
+		'/prometheus-collectors/class-multisite-stats-collector.php',
 	];
 
 	$should_enable_post_collector = Feature::is_enabled( 'prom-post-collection' );
@@ -53,6 +55,7 @@ if ( defined( 'ABSPATH' ) ) {
 			'post'                            => Post_Stats_Collector::class,
 			'user'                            => User_Stats_Collector::class,
 			'potential_multi_dataset_queries' => Potential_Multi_Dataset_Queries_Collector::class,
+			'multisite'                       => Multisite_Stats_Collector::class,
 		];
 
 		foreach ( $to_init as $slug => $class ) {


### PR DESCRIPTION
## Description
Adds a Prometheus collector to count sites on a multisite network.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
