### PR TITLE
chore: update wordpress-importer to 0.8.1

### DIFF
--- a/wordpress-importer/class-wp-import.php
+++ b/wordpress-importer/class-wp-import.php
@@ -16,26 +16,26 @@ class WP_Import extends WP_Importer {
 
 	// information to import from WXR file
 	var $version;
-	var $authors = array();
-	var $posts = array();
-	var $terms = array();
+	var $authors    = array();
+	var $posts      = array();
+	var $terms      = array();
 	var $categories = array();
-	var $tags = array();
-	var $base_url = '';
+	var $tags       = array();
+	var $base_url   = '';
 
 	// mappings from old information to new
-	var $processed_authors = array();
-	var $author_mapping = array();
-	var $processed_terms = array();
-	var $processed_posts = array();
-	var $post_orphans = array();
+	var $processed_authors    = array();
+	var $author_mapping       = array();
+	var $processed_terms      = array();
+	var $processed_posts      = array();
+	var $post_orphans         = array();
 	var $processed_menu_items = array();
-	var $menu_item_orphans = array();
-	var $missing_menu_items = array();
+	var $menu_item_orphans    = array();
+	var $missing_menu_items   = array();
 
 	var $fetch_attachments = false;
-	var $url_remap = array();
-	var $featured_images = array();
+	var $url_remap         = array();
+	var $featured_images   = array();
 
 	/**
 	 * Registered callback function for the WordPress Importer
@@ -52,15 +52,16 @@ class WP_Import extends WP_Importer {
 				break;
 			case 1:
 				check_admin_referer( 'import-upload' );
-				if ( $this->handle_upload() )
+				if ( $this->handle_upload() ) {
 					$this->import_options();
+				}
 				break;
 			case 2:
 				check_admin_referer( 'import-wordpress' );
 				$this->fetch_attachments = ( ! empty( $_POST['fetch_attachments'] ) && $this->allow_fetch_attachments() );
-				$this->id = (int) $_POST['import_id'];
-				$file = get_attached_file( $this->id );
-				set_time_limit(0);
+				$this->id                = (int) $_POST['import_id'];
+				$file                    = get_attached_file( $this->id );
+				set_time_limit( 0 );
 				$this->import( $file );
 				break;
 		}
@@ -102,7 +103,7 @@ class WP_Import extends WP_Importer {
 	 * @param string $file Path to the WXR file for importing
 	 */
 	function import_start( $file ) {
-		if ( ! is_file($file) ) {
+		if ( ! is_file( $file ) ) {
 			echo '<p><strong>' . __( 'Sorry, there has been an error.', 'wordpress-importer' ) . '</strong><br />';
 			echo __( 'The file does not exist, please try again.', 'wordpress-importer' ) . '</p>';
 			$this->footer();
@@ -120,11 +121,11 @@ class WP_Import extends WP_Importer {
 
 		$this->version = $import_data['version'];
 		$this->get_authors_from_import( $import_data );
-		$this->posts = $import_data['posts'];
-		$this->terms = $import_data['terms'];
+		$this->posts      = $import_data['posts'];
+		$this->terms      = $import_data['terms'];
 		$this->categories = $import_data['categories'];
-		$this->tags = $import_data['tags'];
-		$this->base_url = esc_url( $import_data['base_url'] );
+		$this->tags       = $import_data['tags'];
+		$this->base_url   = esc_url( $import_data['base_url'] );
 
 		wp_defer_term_counting( true );
 		wp_defer_comment_counting( true );
@@ -166,14 +167,14 @@ class WP_Import extends WP_Importer {
 			echo '<p><strong>' . __( 'Sorry, there has been an error.', 'wordpress-importer' ) . '</strong><br />';
 			echo esc_html( $file['error'] ) . '</p>';
 			return false;
-		} else if ( ! file_exists( $file['file'] ) ) {
+		} elseif ( ! file_exists( $file['file'] ) ) {
 			echo '<p><strong>' . __( 'Sorry, there has been an error.', 'wordpress-importer' ) . '</strong><br />';
 			printf( __( 'The export file could not be found at <code>%s</code>. It is likely that this was caused by a permissions problem.', 'wordpress-importer' ), esc_html( $file['file'] ) );
 			echo '</p>';
 			return false;
 		}
 
-		$this->id = (int) $file['id'];
+		$this->id    = (int) $file['id'];
 		$import_data = $this->parse( $file['file'] );
 		if ( is_wp_error( $import_data ) ) {
 			echo '<p><strong>' . __( 'Sorry, there has been an error.', 'wordpress-importer' ) . '</strong><br />';
@@ -184,7 +185,7 @@ class WP_Import extends WP_Importer {
 		$this->version = $import_data['version'];
 		if ( $this->version > $this->max_wxr_version ) {
 			echo '<div class="error"><p><strong>';
-			printf( __( 'This WXR file (version %s) may not be supported by this version of the importer. Please consider updating.', 'wordpress-importer' ), esc_html($import_data['version']) );
+			printf( __( 'This WXR file (version %s) may not be supported by this version of the importer. Please consider updating.', 'wordpress-importer' ), esc_html( $import_data['version'] ) );
 			echo '</strong></p></div>';
 		}
 
@@ -204,7 +205,7 @@ class WP_Import extends WP_Importer {
 	function get_authors_from_import( $import_data ) {
 		if ( ! empty( $import_data['authors'] ) ) {
 			$this->authors = $import_data['authors'];
-		// no author information, grab it from the posts
+			// no author information, grab it from the posts
 		} else {
 			foreach ( $import_data['posts'] as $post ) {
 				$login = sanitize_user( $post['post_author'], true );
@@ -214,11 +215,12 @@ class WP_Import extends WP_Importer {
 					continue;
 				}
 
-				if ( ! isset($this->authors[$login]) )
-					$this->authors[$login] = array(
-						'author_login' => $login,
-						'author_display_name' => $post['post_author']
+				if ( ! isset( $this->authors[ $login ] ) ) {
+					$this->authors[ $login ] = array(
+						'author_login'        => $login,
+						'author_display_name' => $post['post_author'],
 					);
+				}
 			}
 		}
 	}
@@ -229,7 +231,8 @@ class WP_Import extends WP_Importer {
 	 */
 	function import_options() {
 		$j = 0;
-?>
+		// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect
+		?>
 <form action="<?php echo admin_url( 'admin.php?import=wordpress&amp;step=2' ); ?>" method="post">
 	<?php wp_nonce_field( 'import-wordpress' ); ?>
 	<input type="hidden" name="import_id" value="<?php echo $this->id; ?>" />
@@ -238,7 +241,7 @@ class WP_Import extends WP_Importer {
 	<h3><?php _e( 'Assign Authors', 'wordpress-importer' ); ?></h3>
 	<p><?php _e( 'To make it simpler for you to edit and save the imported content, you may want to reassign the author of the imported item to an existing user of this site, such as your primary administrator account.', 'wordpress-importer' ); ?></p>
 <?php if ( $this->allow_create_users() ) : ?>
-	<p><?php printf( __( 'If a new user is created by WordPress, a new password will be randomly generated and the new user&#8217;s role will be set as %s. Manually changing the new user&#8217;s details will be necessary.', 'wordpress-importer' ), esc_html( get_option('default_role') ) ); ?></p>
+	<p><?php printf( __( 'If a new user is created by WordPress, a new password will be randomly generated and the new user&#8217;s role will be set as %s. Manually changing the new user&#8217;s details will be necessary.', 'wordpress-importer' ), esc_html( get_option( 'default_role' ) ) ); ?></p>
 <?php endif; ?>
 	<ol id="authors">
 <?php foreach ( $this->authors as $author ) : ?>
@@ -257,7 +260,8 @@ class WP_Import extends WP_Importer {
 
 	<p class="submit"><input type="submit" class="button" value="<?php esc_attr_e( 'Submit', 'wordpress-importer' ); ?>" /></p>
 </form>
-<?php
+		<?php
+		// phpcs:enable Generic.WhiteSpace.ScopeIndent.Incorrect
 	}
 
 	/**
@@ -270,16 +274,19 @@ class WP_Import extends WP_Importer {
 	function author_select( $n, $author ) {
 		_e( 'Import author:', 'wordpress-importer' );
 		echo ' <strong>' . esc_html( $author['author_display_name'] );
-		if ( $this->version != '1.0' ) echo ' (' . esc_html( $author['author_login'] ) . ')';
+		if ( '1.0' != $this->version ) {
+			echo ' (' . esc_html( $author['author_login'] ) . ')';
+		}
 		echo '</strong><br />';
 
-		if ( $this->version != '1.0' )
+		if ( '1.0' != $this->version ) {
 			echo '<div style="margin-left:18px">';
+		}
 
 		$create_users = $this->allow_create_users();
 		if ( $create_users ) {
-			echo '<label for="user_new_'. $n . '">';
-			if ( $this->version != '1.0' ) {
+			echo '<label for="user_new_' . $n . '">';
+			if ( '1.0' != $this->version ) {
 				_e( 'or create new user with login name:', 'wordpress-importer' );
 				$value = '';
 			} else {
@@ -288,30 +295,33 @@ class WP_Import extends WP_Importer {
 			}
 			echo '</label>';
 
-			echo ' <input type="text" id="user_new_' . $n . '" name="user_new['.$n.']" value="'. $value .'" /><br />';
+			echo ' <input type="text" id="user_new_' . $n . '" name="user_new[' . $n . ']" value="' . $value . '" /><br />';
 		}
 
-		echo '<label for="imported_authors_'. $n . '">';
-		if ( ! $create_users && $this->version == '1.0' ) {
+		echo '<label for="imported_authors_' . $n . '">';
+		if ( ! $create_users && '1.0' == $this->version ) {
 			_e( 'assign posts to an existing user:', 'wordpress-importer' );
 		} else {
 			_e( 'or assign posts to an existing user:', 'wordpress-importer' );
 		}
 		echo '</label>';
 
-		echo ' ' . wp_dropdown_users( array(
-			'name'            => "user_map[$n]",
-			'id'              => 'imported_authors_' . $n,
-			'multi'           => true,
-			'show_option_all' => __( '- Select -', 'wordpress-importer' ),
-			'show'            => 'display_name_with_login',
-			'echo'            => 0,
-		) );
+		echo ' ' . wp_dropdown_users(
+			array(
+				'name'            => "user_map[$n]",
+				'id'              => 'imported_authors_' . $n,
+				'multi'           => true,
+				'show_option_all' => __( '- Select -', 'wordpress-importer' ),
+				'show'            => 'display_name_with_login',
+				'echo'            => 0,
+			)
+		);
 
-		echo '<input type="hidden" name="imported_authors['.$n.']" value="' . esc_attr( $author['author_login'] ) . '" />';
+		echo '<input type="hidden" name="imported_authors[' . $n . ']" value="' . esc_attr( $author['author_login'] ) . '" />';
 
-		if ( $this->version != '1.0' )
+		if ( '1.0' != $this->version ) {
 			echo '</div>';
+		}
 	}
 
 	/**
@@ -320,55 +330,60 @@ class WP_Import extends WP_Importer {
 	 * or falls back to the current user in case of error with either of the previous
 	 */
 	function get_author_mapping() {
-		if ( ! isset( $_POST['imported_authors'] ) )
+		if ( ! isset( $_POST['imported_authors'] ) ) {
 			return;
+		}
 
 		$create_users = $this->allow_create_users();
 
 		foreach ( (array) $_POST['imported_authors'] as $i => $old_login ) {
 			// Multisite adds strtolower to sanitize_user. Need to sanitize here to stop breakage in process_posts.
 			$santized_old_login = sanitize_user( $old_login, true );
-			$old_id = isset( $this->authors[$old_login]['author_id'] ) ? intval($this->authors[$old_login]['author_id']) : false;
+			$old_id             = isset( $this->authors[ $old_login ]['author_id'] ) ? intval( $this->authors[ $old_login ]['author_id'] ) : false;
 
-			if ( ! empty( $_POST['user_map'][$i] ) ) {
-				$user = get_userdata( intval($_POST['user_map'][$i]) );
+			if ( ! empty( $_POST['user_map'][ $i ] ) ) {
+				$user = get_userdata( intval( $_POST['user_map'][ $i ] ) );
 				if ( isset( $user->ID ) ) {
-					if ( $old_id )
-						$this->processed_authors[$old_id] = $user->ID;
-					$this->author_mapping[$santized_old_login] = $user->ID;
+					if ( $old_id ) {
+						$this->processed_authors[ $old_id ] = $user->ID;
+					}
+					$this->author_mapping[ $santized_old_login ] = $user->ID;
 				}
-			} else if ( $create_users ) {
-				if ( ! empty($_POST['user_new'][$i]) ) {
-					$user_id = wp_create_user( $_POST['user_new'][$i], wp_generate_password() );
-				} else if ( $this->version != '1.0' ) {
+			} elseif ( $create_users ) {
+				if ( ! empty( $_POST['user_new'][ $i ] ) ) {
+					$user_id = wp_create_user( $_POST['user_new'][ $i ], wp_generate_password() );
+				} elseif ( '1.0' != $this->version ) {
 					$user_data = array(
-						'user_login' => $old_login,
-						'user_pass' => wp_generate_password(),
-						'user_email' => isset( $this->authors[$old_login]['author_email'] ) ? $this->authors[$old_login]['author_email'] : '',
-						'display_name' => $this->authors[$old_login]['author_display_name'],
-						'first_name' => isset( $this->authors[$old_login]['author_first_name'] ) ? $this->authors[$old_login]['author_first_name'] : '',
-						'last_name' => isset( $this->authors[$old_login]['author_last_name'] ) ? $this->authors[$old_login]['author_last_name'] : '',
+						'user_login'   => $old_login,
+						'user_pass'    => wp_generate_password(),
+						'user_email'   => isset( $this->authors[ $old_login ]['author_email'] ) ? $this->authors[ $old_login ]['author_email'] : '',
+						'display_name' => $this->authors[ $old_login ]['author_display_name'],
+						'first_name'   => isset( $this->authors[ $old_login ]['author_first_name'] ) ? $this->authors[ $old_login ]['author_first_name'] : '',
+						'last_name'    => isset( $this->authors[ $old_login ]['author_last_name'] ) ? $this->authors[ $old_login ]['author_last_name'] : '',
 					);
-					$user_id = wp_insert_user( $user_data );
+					$user_id   = wp_insert_user( $user_data );
 				}
 
 				if ( ! is_wp_error( $user_id ) ) {
-					if ( $old_id )
-						$this->processed_authors[$old_id] = $user_id;
-					$this->author_mapping[$santized_old_login] = $user_id;
+					if ( $old_id ) {
+						$this->processed_authors[ $old_id ] = $user_id;
+					}
+					$this->author_mapping[ $santized_old_login ] = $user_id;
 				} else {
-					printf( __( 'Failed to create new user for %s. Their posts will be attributed to the current user.', 'wordpress-importer' ), esc_html($this->authors[$old_login]['author_display_name']) );
-					if ( defined('IMPORT_DEBUG') && IMPORT_DEBUG )
+					printf( __( 'Failed to create new user for %s. Their posts will be attributed to the current user.', 'wordpress-importer' ), esc_html( $this->authors[ $old_login ]['author_display_name'] ) );
+					if ( defined( 'IMPORT_DEBUG' ) && IMPORT_DEBUG ) {
 						echo ' ' . $user_id->get_error_message();
+					}
 					echo '<br />';
 				}
 			}
 
 			// failsafe: if the user_id was invalid, default to the current user
-			if ( ! isset( $this->author_mapping[$santized_old_login] ) ) {
-				if ( $old_id )
-					$this->processed_authors[$old_id] = (int) get_current_user_id();
-				$this->author_mapping[$santized_old_login] = (int) get_current_user_id();
+			if ( ! isset( $this->author_mapping[ $santized_old_login ] ) ) {
+				if ( $old_id ) {
+					$this->processed_authors[ $old_id ] = (int) get_current_user_id();
+				}
+				$this->author_mapping[ $santized_old_login ] = (int) get_current_user_id();
 			}
 		}
 	}
@@ -381,16 +396,20 @@ class WP_Import extends WP_Importer {
 	function process_categories() {
 		$this->categories = apply_filters( 'wp_import_categories', $this->categories );
 
-		if ( empty( $this->categories ) )
+		if ( empty( $this->categories ) ) {
 			return;
+		}
 
 		foreach ( $this->categories as $cat ) {
 			// if the category already exists leave it alone
 			$term_id = term_exists( $cat['category_nicename'], 'category' );
 			if ( $term_id ) {
-				if ( is_array($term_id) ) $term_id = $term_id['term_id'];
-				if ( isset($cat['term_id']) )
-					$this->processed_terms[intval($cat['term_id'])] = (int) $term_id;
+				if ( is_array( $term_id ) ) {
+					$term_id = $term_id['term_id'];
+				}
+				if ( isset( $cat['term_id'] ) ) {
+					$this->processed_terms[ intval( $cat['term_id'] ) ] = (int) $term_id;
+				}
 				continue;
 			}
 
@@ -404,14 +423,16 @@ class WP_Import extends WP_Importer {
 				'category_description' => wp_slash( $description ),
 			);
 
-			$id = wp_insert_category( $data );
+			$id = wp_insert_category( $data, true );
 			if ( ! is_wp_error( $id ) && $id > 0 ) {
-				if ( isset($cat['term_id']) )
-					$this->processed_terms[intval($cat['term_id'])] = $id;
+				if ( isset( $cat['term_id'] ) ) {
+					$this->processed_terms[ intval( $cat['term_id'] ) ] = $id;
+				}
 			} else {
-				printf( __( 'Failed to import category %s', 'wordpress-importer' ), esc_html($cat['category_nicename']) );
-				if ( defined('IMPORT_DEBUG') && IMPORT_DEBUG )
+				printf( __( 'Failed to import category %s', 'wordpress-importer' ), esc_html( $cat['category_nicename'] ) );
+				if ( defined( 'IMPORT_DEBUG' ) && IMPORT_DEBUG ) {
 					echo ': ' . $id->get_error_message();
+				}
 				echo '<br />';
 				continue;
 			}
@@ -430,16 +451,20 @@ class WP_Import extends WP_Importer {
 	function process_tags() {
 		$this->tags = apply_filters( 'wp_import_tags', $this->tags );
 
-		if ( empty( $this->tags ) )
+		if ( empty( $this->tags ) ) {
 			return;
+		}
 
 		foreach ( $this->tags as $tag ) {
 			// if the tag already exists leave it alone
 			$term_id = term_exists( $tag['tag_slug'], 'post_tag' );
 			if ( $term_id ) {
-				if ( is_array($term_id) ) $term_id = $term_id['term_id'];
-				if ( isset($tag['term_id']) )
-					$this->processed_terms[intval($tag['term_id'])] = (int) $term_id;
+				if ( is_array( $term_id ) ) {
+					$term_id = $term_id['term_id'];
+				}
+				if ( isset( $tag['term_id'] ) ) {
+					$this->processed_terms[ intval( $tag['term_id'] ) ] = (int) $term_id;
+				}
 				continue;
 			}
 
@@ -451,12 +476,14 @@ class WP_Import extends WP_Importer {
 
 			$id = wp_insert_term( wp_slash( $tag['tag_name'] ), 'post_tag', $args );
 			if ( ! is_wp_error( $id ) ) {
-				if ( isset($tag['term_id']) )
-					$this->processed_terms[intval($tag['term_id'])] = $id['term_id'];
+				if ( isset( $tag['term_id'] ) ) {
+					$this->processed_terms[ intval( $tag['term_id'] ) ] = $id['term_id'];
+				}
 			} else {
-				printf( __( 'Failed to import post tag %s', 'wordpress-importer' ), esc_html($tag['tag_name']) );
-				if ( defined('IMPORT_DEBUG') && IMPORT_DEBUG )
+				printf( __( 'Failed to import post tag %s', 'wordpress-importer' ), esc_html( $tag['tag_name'] ) );
+				if ( defined( 'IMPORT_DEBUG' ) && IMPORT_DEBUG ) {
 					echo ': ' . $id->get_error_message();
+				}
 				echo '<br />';
 				continue;
 			}
@@ -475,16 +502,20 @@ class WP_Import extends WP_Importer {
 	function process_terms() {
 		$this->terms = apply_filters( 'wp_import_terms', $this->terms );
 
-		if ( empty( $this->terms ) )
+		if ( empty( $this->terms ) ) {
 			return;
+		}
 
 		foreach ( $this->terms as $term ) {
 			// if the term already exists in the correct taxonomy leave it alone
 			$term_id = term_exists( $term['slug'], $term['term_taxonomy'] );
 			if ( $term_id ) {
-				if ( is_array($term_id) ) $term_id = $term_id['term_id'];
-				if ( isset($term['term_id']) )
-					$this->processed_terms[intval($term['term_id'])] = (int) $term_id;
+				if ( is_array( $term_id ) ) {
+					$term_id = $term_id['term_id'];
+				}
+				if ( isset( $term['term_id'] ) ) {
+					$this->processed_terms[ intval( $term['term_id'] ) ] = (int) $term_id;
+				}
 				continue;
 			}
 
@@ -501,17 +532,19 @@ class WP_Import extends WP_Importer {
 			$args        = array(
 				'slug'        => $term['slug'],
 				'description' => wp_slash( $description ),
-				'parent'      => (int) $parent
+				'parent'      => (int) $parent,
 			);
 
 			$id = wp_insert_term( wp_slash( $term['term_name'] ), $term['term_taxonomy'], $args );
 			if ( ! is_wp_error( $id ) ) {
-				if ( isset($term['term_id']) )
-					$this->processed_terms[intval($term['term_id'])] = $id['term_id'];
+				if ( isset( $term['term_id'] ) ) {
+					$this->processed_terms[ intval( $term['term_id'] ) ] = $id['term_id'];
+				}
 			} else {
-				printf( __( 'Failed to import %s %s', 'wordpress-importer' ), esc_html($term['term_taxonomy']), esc_html($term['term_name']) );
-				if ( defined('IMPORT_DEBUG') && IMPORT_DEBUG )
+				printf( __( 'Failed to import %1$s %2$s', 'wordpress-importer' ), esc_html( $term['term_taxonomy'] ), esc_html( $term['term_name'] ) );
+				if ( defined( 'IMPORT_DEBUG' ) && IMPORT_DEBUG ) {
 					echo ': ' . $id->get_error_message();
+				}
 				echo '<br />';
 				continue;
 			}
@@ -531,10 +564,6 @@ class WP_Import extends WP_Importer {
 	 * @param int   $term_id ID of the newly created term.
 	 */
 	protected function process_termmeta( $term, $term_id ) {
-		if ( ! function_exists( 'add_term_meta' ) ) {
-			return;
-		}
-
 		if ( ! isset( $term['termmeta'] ) ) {
 			$term['termmeta'] = array();
 		}
@@ -602,18 +631,23 @@ class WP_Import extends WP_Importer {
 			$post = apply_filters( 'wp_import_post_data_raw', $post );
 
 			if ( ! post_type_exists( $post['post_type'] ) ) {
-				printf( __( 'Failed to import &#8220;%s&#8221;: Invalid post type %s', 'wordpress-importer' ),
-					esc_html($post['post_title']), esc_html($post['post_type']) );
+				printf(
+					__( 'Failed to import &#8220;%1$s&#8221;: Invalid post type %2$s', 'wordpress-importer' ),
+					esc_html( $post['post_title'] ),
+					esc_html( $post['post_type'] )
+				);
 				echo '<br />';
 				do_action( 'wp_import_post_exists', $post );
 				continue;
 			}
 
-			if ( isset( $this->processed_posts[$post['post_id']] ) && ! empty( $post['post_id'] ) )
+			if ( isset( $this->processed_posts[ $post['post_id'] ] ) && ! empty( $post['post_id'] ) ) {
 				continue;
+			}
 
-			if ( $post['status'] == 'auto-draft' )
+			if ( 'auto-draft' == $post['status'] ) {
 				continue;
+			}
 
 			if ( 'nav_menu_item' == $post['post_type'] ) {
 				$this->process_menu_item( $post );
@@ -639,85 +673,105 @@ class WP_Import extends WP_Importer {
 			$post_exists = apply_filters( 'wp_import_existing_post', $post_exists, $post );
 
 			if ( $post_exists && get_post_type( $post_exists ) == $post['post_type'] ) {
-				printf( __('%s &#8220;%s&#8221; already exists.', 'wordpress-importer'), $post_type_object->labels->singular_name, esc_html($post['post_title']) );
+				printf( __( '%1$s &#8220;%2$s&#8221; already exists.', 'wordpress-importer' ), $post_type_object->labels->singular_name, esc_html( $post['post_title'] ) );
 				echo '<br />';
-				$comment_post_ID = $post_id = $post_exists;
+				$comment_post_id = $post_exists;
+				$post_id         = $post_exists;
 				$this->processed_posts[ intval( $post['post_id'] ) ] = intval( $post_exists );
 			} else {
 				$post_parent = (int) $post['post_parent'];
 				if ( $post_parent ) {
 					// if we already know the parent, map it to the new local ID
-					if ( isset( $this->processed_posts[$post_parent] ) ) {
-						$post_parent = $this->processed_posts[$post_parent];
-					// otherwise record the parent for later
+					if ( isset( $this->processed_posts[ $post_parent ] ) ) {
+						$post_parent = $this->processed_posts[ $post_parent ];
+						// otherwise record the parent for later
 					} else {
-						$this->post_orphans[intval($post['post_id'])] = $post_parent;
-						$post_parent = 0;
+						$this->post_orphans[ intval( $post['post_id'] ) ] = $post_parent;
+						$post_parent                                      = 0;
 					}
 				}
 
 				// map the post author
 				$author = sanitize_user( $post['post_author'], true );
-				if ( isset( $this->author_mapping[$author] ) )
-					$author = $this->author_mapping[$author];
-				else
+				if ( isset( $this->author_mapping[ $author ] ) ) {
+					$author = $this->author_mapping[ $author ];
+				} else {
 					$author = (int) get_current_user_id();
+				}
 
 				$postdata = array(
-					'import_id' => $post['post_id'], 'post_author' => $author, 'post_date' => $post['post_date'],
-					'post_date_gmt' => $post['post_date_gmt'], 'post_content' => $post['post_content'],
-					'post_excerpt' => $post['post_excerpt'], 'post_title' => $post['post_title'],
-					'post_status' => $post['status'], 'post_name' => $post['post_name'],
-					'comment_status' => $post['comment_status'], 'ping_status' => $post['ping_status'],
-					'guid' => $post['guid'], 'post_parent' => $post_parent, 'menu_order' => $post['menu_order'],
-					'post_type' => $post['post_type'], 'post_password' => $post['post_password']
+					'import_id'      => $post['post_id'],
+					'post_author'    => $author,
+					'post_date'      => $post['post_date'],
+					'post_date_gmt'  => $post['post_date_gmt'],
+					'post_content'   => $post['post_content'],
+					'post_excerpt'   => $post['post_excerpt'],
+					'post_title'     => $post['post_title'],
+					'post_status'    => $post['status'],
+					'post_name'      => $post['post_name'],
+					'comment_status' => $post['comment_status'],
+					'ping_status'    => $post['ping_status'],
+					'guid'           => $post['guid'],
+					'post_parent'    => $post_parent,
+					'menu_order'     => $post['menu_order'],
+					'post_type'      => $post['post_type'],
+					'post_password'  => $post['post_password'],
 				);
 
-				$original_post_ID = $post['post_id'];
-				$postdata = apply_filters( 'wp_import_post_data_processed', $postdata, $post );
+				$original_post_id = $post['post_id'];
+				$postdata         = apply_filters( 'wp_import_post_data_processed', $postdata, $post );
 
 				$postdata = wp_slash( $postdata );
 
 				if ( 'attachment' == $postdata['post_type'] ) {
-					$remote_url = ! empty($post['attachment_url']) ? $post['attachment_url'] : $post['guid'];
+					$remote_url = ! empty( $post['attachment_url'] ) ? $post['attachment_url'] : $post['guid'];
 
 					// try to use _wp_attached file for upload folder placement to ensure the same location as the export site
 					// e.g. location is 2003/05/image.jpg but the attachment post_date is 2010/09, see media_handle_upload()
 					$postdata['upload_date'] = $post['post_date'];
 					if ( isset( $post['postmeta'] ) ) {
-						foreach( $post['postmeta'] as $meta ) {
-							if ( $meta['key'] == '_wp_attached_file' ) {
-								if ( preg_match( '%^[0-9]{4}/[0-9]{2}%', $meta['value'], $matches ) )
+						foreach ( $post['postmeta'] as $meta ) {
+							if ( '_wp_attached_file' == $meta['key'] ) {
+								if ( preg_match( '%^[0-9]{4}/[0-9]{2}%', $meta['value'], $matches ) ) {
 									$postdata['upload_date'] = $matches[0];
+								}
 								break;
 							}
 						}
 					}
 
-					$comment_post_ID = $post_id = $this->process_attachment( $postdata, $remote_url );
+					$comment_post_id = $this->process_attachment( $postdata, $remote_url );
+					$post_id         = $comment_post_id;
 				} else {
-					$comment_post_ID = $post_id = wp_insert_post( $postdata, true );
-					do_action( 'wp_import_insert_post', $post_id, $original_post_ID, $postdata, $post );
+					$comment_post_id = wp_insert_post( $postdata, true );
+					$post_id         = $comment_post_id;
+					do_action( 'wp_import_insert_post', $post_id, $original_post_id, $postdata, $post );
 				}
 
 				if ( is_wp_error( $post_id ) ) {
-					printf( __( 'Failed to import %s &#8220;%s&#8221;', 'wordpress-importer' ),
-						$post_type_object->labels->singular_name, esc_html($post['post_title']) );
-					if ( defined('IMPORT_DEBUG') && IMPORT_DEBUG )
+					printf(
+						__( 'Failed to import %1$s &#8220;%2$s&#8221;', 'wordpress-importer' ),
+						$post_type_object->labels->singular_name,
+						esc_html( $post['post_title'] )
+					);
+					if ( defined( 'IMPORT_DEBUG' ) && IMPORT_DEBUG ) {
 						echo ': ' . $post_id->get_error_message();
+					}
 					echo '<br />';
 					continue;
 				}
 
-				if ( $post['is_sticky'] == 1 )
+				if ( 1 == $post['is_sticky'] ) {
 					stick_post( $post_id );
+				}
 			}
 
 			// map pre-import ID to local ID
-			$this->processed_posts[intval($post['post_id'])] = (int) $post_id;
+			$this->processed_posts[ intval( $post['post_id'] ) ] = (int) $post_id;
 
-			if ( ! isset( $post['terms'] ) )
+			if ( ! isset( $post['terms'] ) ) {
 				$post['terms'] = array();
+			}
 
 			$post['terms'] = apply_filters( 'wp_import_post_terms', $post['terms'], $post_id, $post );
 
@@ -726,24 +780,25 @@ class WP_Import extends WP_Importer {
 				$terms_to_set = array();
 				foreach ( $post['terms'] as $term ) {
 					// back compat with WXR 1.0 map 'tag' to 'post_tag'
-					$taxonomy = ( 'tag' == $term['domain'] ) ? 'post_tag' : $term['domain'];
+					$taxonomy    = ( 'tag' == $term['domain'] ) ? 'post_tag' : $term['domain'];
 					$term_exists = term_exists( $term['slug'], $taxonomy );
-					$term_id = is_array( $term_exists ) ? $term_exists['term_id'] : $term_exists;
+					$term_id     = is_array( $term_exists ) ? $term_exists['term_id'] : $term_exists;
 					if ( ! $term_id ) {
 						$t = wp_insert_term( $term['name'], $taxonomy, array( 'slug' => $term['slug'] ) );
 						if ( ! is_wp_error( $t ) ) {
 							$term_id = $t['term_id'];
 							do_action( 'wp_import_insert_term', $t, $term, $post_id, $post );
 						} else {
-							printf( __( 'Failed to import %s %s', 'wordpress-importer' ), esc_html($taxonomy), esc_html($term['name']) );
-							if ( defined('IMPORT_DEBUG') && IMPORT_DEBUG )
+							printf( __( 'Failed to import %1$s %2$s', 'wordpress-importer' ), esc_html( $taxonomy ), esc_html( $term['name'] ) );
+							if ( defined( 'IMPORT_DEBUG' ) && IMPORT_DEBUG ) {
 								echo ': ' . $t->get_error_message();
+							}
 							echo '<br />';
 							do_action( 'wp_import_insert_term_failed', $t, $term, $post_id, $post );
 							continue;
 						}
 					}
-					$terms_to_set[$taxonomy][] = intval( $term_id );
+					$terms_to_set[ $taxonomy ][] = intval( $term_id );
 				}
 
 				foreach ( $terms_to_set as $tax => $ids ) {
@@ -753,38 +808,40 @@ class WP_Import extends WP_Importer {
 				unset( $post['terms'], $terms_to_set );
 			}
 
-			if ( ! isset( $post['comments'] ) )
+			if ( ! isset( $post['comments'] ) ) {
 				$post['comments'] = array();
+			}
 
 			$post['comments'] = apply_filters( 'wp_import_post_comments', $post['comments'], $post_id, $post );
 
 			// add/update comments
 			if ( ! empty( $post['comments'] ) ) {
-				$num_comments = 0;
+				$num_comments      = 0;
 				$inserted_comments = array();
 				foreach ( $post['comments'] as $comment ) {
-					$comment_id	= $comment['comment_id'];
-					$newcomments[$comment_id]['comment_post_ID']      = $comment_post_ID;
-					$newcomments[$comment_id]['comment_author']       = $comment['comment_author'];
-					$newcomments[$comment_id]['comment_author_email'] = $comment['comment_author_email'];
-					$newcomments[$comment_id]['comment_author_IP']    = $comment['comment_author_IP'];
-					$newcomments[$comment_id]['comment_author_url']   = $comment['comment_author_url'];
-					$newcomments[$comment_id]['comment_date']         = $comment['comment_date'];
-					$newcomments[$comment_id]['comment_date_gmt']     = $comment['comment_date_gmt'];
-					$newcomments[$comment_id]['comment_content']      = $comment['comment_content'];
-					$newcomments[$comment_id]['comment_approved']     = $comment['comment_approved'];
-					$newcomments[$comment_id]['comment_type']         = $comment['comment_type'];
-					$newcomments[$comment_id]['comment_parent'] 	  = $comment['comment_parent'];
-					$newcomments[$comment_id]['commentmeta']          = isset( $comment['commentmeta'] ) ? $comment['commentmeta'] : array();
-					if ( isset( $this->processed_authors[$comment['comment_user_id']] ) )
-						$newcomments[$comment_id]['user_id'] = $this->processed_authors[$comment['comment_user_id']];
+					$comment_id                                    = $comment['comment_id'];
+					$newcomments[ $comment_id ]['comment_post_ID'] = $comment_post_id;
+					$newcomments[ $comment_id ]['comment_author']  = $comment['comment_author'];
+					$newcomments[ $comment_id ]['comment_author_email'] = $comment['comment_author_email'];
+					$newcomments[ $comment_id ]['comment_author_IP']    = $comment['comment_author_IP'];
+					$newcomments[ $comment_id ]['comment_author_url']   = $comment['comment_author_url'];
+					$newcomments[ $comment_id ]['comment_date']         = $comment['comment_date'];
+					$newcomments[ $comment_id ]['comment_date_gmt']     = $comment['comment_date_gmt'];
+					$newcomments[ $comment_id ]['comment_content']      = $comment['comment_content'];
+					$newcomments[ $comment_id ]['comment_approved']     = $comment['comment_approved'];
+					$newcomments[ $comment_id ]['comment_type']         = $comment['comment_type'];
+					$newcomments[ $comment_id ]['comment_parent']       = $comment['comment_parent'];
+					$newcomments[ $comment_id ]['commentmeta']          = isset( $comment['commentmeta'] ) ? $comment['commentmeta'] : array();
+					if ( isset( $this->processed_authors[ $comment['comment_user_id'] ] ) ) {
+						$newcomments[ $comment_id ]['user_id'] = $this->processed_authors[ $comment['comment_user_id'] ];
+					}
 				}
 				ksort( $newcomments );
 
 				foreach ( $newcomments as $key => $comment ) {
 					// if this is a new post we can skip the comment_exists() check
 					if ( ! $post_exists || ! comment_exists( $comment['comment_author'], $comment['comment_date'] ) ) {
-						if ( isset( $inserted_comments[$comment['comment_parent']] ) ) {
+						if ( isset( $inserted_comments[ $comment['comment_parent'] ] ) ) {
 							$comment['comment_parent'] = $inserted_comments[ $comment['comment_parent'] ];
 						}
 
@@ -794,9 +851,9 @@ class WP_Import extends WP_Importer {
 
 						$inserted_comments[ $key ] = wp_insert_comment( $comment_data );
 
-						do_action( 'wp_import_insert_comment', $inserted_comments[ $key ], $comment, $comment_post_ID, $post );
+						do_action( 'wp_import_insert_comment', $inserted_comments[ $key ], $comment, $comment_post_id, $post );
 
-						foreach( $comment['commentmeta'] as $meta ) {
+						foreach ( $comment['commentmeta'] as $meta ) {
 							$value = maybe_unserialize( $meta['value'] );
 
 							add_comment_meta( $inserted_comments[ $key ], wp_slash( $meta['key'] ), wp_slash_strings_only( $value ) );
@@ -808,22 +865,24 @@ class WP_Import extends WP_Importer {
 				unset( $newcomments, $inserted_comments, $post['comments'] );
 			}
 
-			if ( ! isset( $post['postmeta'] ) )
+			if ( ! isset( $post['postmeta'] ) ) {
 				$post['postmeta'] = array();
+			}
 
 			$post['postmeta'] = apply_filters( 'wp_import_post_meta', $post['postmeta'], $post_id, $post );
 
 			// add/update post meta
 			if ( ! empty( $post['postmeta'] ) ) {
 				foreach ( $post['postmeta'] as $meta ) {
-					$key = apply_filters( 'import_post_meta_key', $meta['key'], $post_id, $post );
+					$key   = apply_filters( 'import_post_meta_key', $meta['key'], $post_id, $post );
 					$value = false;
 
 					if ( '_edit_last' == $key ) {
-						if ( isset( $this->processed_authors[intval($meta['value'])] ) )
-							$value = $this->processed_authors[intval($meta['value'])];
-						else
+						if ( isset( $this->processed_authors[ intval( $meta['value'] ) ] ) ) {
+							$value = $this->processed_authors[ intval( $meta['value'] ) ];
+						} else {
 							$key = false;
+						}
 					}
 
 					if ( $key ) {
@@ -837,8 +896,9 @@ class WP_Import extends WP_Importer {
 						do_action( 'import_post_meta', $post_id, $key, $value );
 
 						// if the post has a featured image, take note of this in case of remap
-						if ( '_thumbnail_id' == $key )
-							$this->featured_images[$post_id] = (int) $value;
+						if ( '_thumbnail_id' == $key ) {
+							$this->featured_images[ $post_id ] = (int) $value;
+						}
 					}
 				}
 			}
@@ -859,11 +919,12 @@ class WP_Import extends WP_Importer {
 	 */
 	function process_menu_item( $item ) {
 		// skip draft, orphaned menu items
-		if ( 'draft' == $item['status'] )
+		if ( 'draft' == $item['status'] ) {
 			return;
+		}
 
 		$menu_slug = false;
-		if ( isset($item['terms']) ) {
+		if ( isset( $item['terms'] ) ) {
 			// loop through terms, assume first nav_menu term is correct menu
 			foreach ( $item['terms'] as $term ) {
 				if ( 'nav_menu' == $term['domain'] ) {
@@ -889,50 +950,53 @@ class WP_Import extends WP_Importer {
 			$menu_id = is_array( $menu_id ) ? $menu_id['term_id'] : $menu_id;
 		}
 
-		foreach ( $item['postmeta'] as $meta )
+		foreach ( $item['postmeta'] as $meta ) {
 			${$meta['key']} = $meta['value'];
+		}
 
-		if ( 'taxonomy' == $_menu_item_type && isset( $this->processed_terms[intval($_menu_item_object_id)] ) ) {
-			$_menu_item_object_id = $this->processed_terms[intval($_menu_item_object_id)];
-		} else if ( 'post_type' == $_menu_item_type && isset( $this->processed_posts[intval($_menu_item_object_id)] ) ) {
-			$_menu_item_object_id = $this->processed_posts[intval($_menu_item_object_id)];
-		} else if ( 'custom' != $_menu_item_type ) {
+		if ( 'taxonomy' == $_menu_item_type && isset( $this->processed_terms[ intval( $_menu_item_object_id ) ] ) ) {
+			$_menu_item_object_id = $this->processed_terms[ intval( $_menu_item_object_id ) ];
+		} elseif ( 'post_type' == $_menu_item_type && isset( $this->processed_posts[ intval( $_menu_item_object_id ) ] ) ) {
+			$_menu_item_object_id = $this->processed_posts[ intval( $_menu_item_object_id ) ];
+		} elseif ( 'custom' != $_menu_item_type ) {
 			// associated object is missing or not imported yet, we'll retry later
 			$this->missing_menu_items[] = $item;
 			return;
 		}
 
-		if ( isset( $this->processed_menu_items[intval($_menu_item_menu_item_parent)] ) ) {
-			$_menu_item_menu_item_parent = $this->processed_menu_items[intval($_menu_item_menu_item_parent)];
-		} else if ( $_menu_item_menu_item_parent ) {
-			$this->menu_item_orphans[intval($item['post_id'])] = (int) $_menu_item_menu_item_parent;
-			$_menu_item_menu_item_parent = 0;
+		if ( isset( $this->processed_menu_items[ intval( $_menu_item_menu_item_parent ) ] ) ) {
+			$_menu_item_menu_item_parent = $this->processed_menu_items[ intval( $_menu_item_menu_item_parent ) ];
+		} elseif ( $_menu_item_menu_item_parent ) {
+			$this->menu_item_orphans[ intval( $item['post_id'] ) ] = (int) $_menu_item_menu_item_parent;
+			$_menu_item_menu_item_parent                           = 0;
 		}
 
 		// wp_update_nav_menu_item expects CSS classes as a space separated string
 		$_menu_item_classes = maybe_unserialize( $_menu_item_classes );
-		if ( is_array( $_menu_item_classes ) )
+		if ( is_array( $_menu_item_classes ) ) {
 			$_menu_item_classes = implode( ' ', $_menu_item_classes );
+		}
 
 		$args = array(
-			'menu-item-object-id' => $_menu_item_object_id,
-			'menu-item-object' => $_menu_item_object,
-			'menu-item-parent-id' => $_menu_item_menu_item_parent,
-			'menu-item-position' => intval( $item['menu_order'] ),
-			'menu-item-type' => $_menu_item_type,
-			'menu-item-title' => $item['post_title'],
-			'menu-item-url' => $_menu_item_url,
+			'menu-item-object-id'   => $_menu_item_object_id,
+			'menu-item-object'      => $_menu_item_object,
+			'menu-item-parent-id'   => $_menu_item_menu_item_parent,
+			'menu-item-position'    => intval( $item['menu_order'] ),
+			'menu-item-type'        => $_menu_item_type,
+			'menu-item-title'       => $item['post_title'],
+			'menu-item-url'         => $_menu_item_url,
 			'menu-item-description' => $item['post_content'],
-			'menu-item-attr-title' => $item['post_excerpt'],
-			'menu-item-target' => $_menu_item_target,
-			'menu-item-classes' => $_menu_item_classes,
-			'menu-item-xfn' => $_menu_item_xfn,
-			'menu-item-status' => $item['status']
+			'menu-item-attr-title'  => $item['post_excerpt'],
+			'menu-item-target'      => $_menu_item_target,
+			'menu-item-classes'     => $_menu_item_classes,
+			'menu-item-xfn'         => $_menu_item_xfn,
+			'menu-item-status'      => $item['status'],
 		);
 
 		$id = wp_update_nav_menu_item( $menu_id, 0, $args );
-		if ( $id && ! is_wp_error( $id ) )
-			$this->processed_menu_items[intval($item['post_id'])] = (int) $id;
+		if ( $id && ! is_wp_error( $id ) ) {
+			$this->processed_menu_items[ intval( $item['post_id'] ) ] = (int) $id;
+		}
 	}
 
 	/**
@@ -943,22 +1007,29 @@ class WP_Import extends WP_Importer {
 	 * @return int|WP_Error Post ID on success, WP_Error otherwise
 	 */
 	function process_attachment( $post, $url ) {
-		if ( ! $this->fetch_attachments )
-			return new WP_Error( 'attachment_processing_error',
-				__( 'Fetching attachments is not enabled', 'wordpress-importer' ) );
+		if ( ! $this->fetch_attachments ) {
+			return new WP_Error(
+				'attachment_processing_error',
+				__( 'Fetching attachments is not enabled', 'wordpress-importer' )
+			);
+		}
 
 		// if the URL is absolute, but does not contain address, then upload it assuming base_site_url
-		if ( preg_match( '|^/[\w\W]+$|', $url ) )
+		if ( preg_match( '|^/[\w\W]+$|', $url ) ) {
 			$url = rtrim( $this->base_url, '/' ) . $url;
+		}
 
 		$upload = $this->fetch_remote_file( $url, $post );
-		if ( is_wp_error( $upload ) )
+		if ( is_wp_error( $upload ) ) {
 			return $upload;
+		}
 
-		if ( $info = wp_check_filetype( $upload['file'] ) )
+		$info = wp_check_filetype( $upload['file'] );
+		if ( $info ) {
 			$post['post_mime_type'] = $info['type'];
-		else
-			return new WP_Error( 'attachment_processing_error', __('Invalid file type', 'wordpress-importer') );
+		} else {
+			return new WP_Error( 'attachment_processing_error', __( 'Invalid file type', 'wordpress-importer' ) );
+		}
 
 		$post['guid'] = $upload['url'];
 
@@ -969,12 +1040,12 @@ class WP_Import extends WP_Importer {
 		// remap resized image URLs, works by stripping the extension and remapping the URL stub.
 		if ( preg_match( '!^image/!', $info['type'] ) ) {
 			$parts = pathinfo( $url );
-			$name = basename( $parts['basename'], ".{$parts['extension']}" ); // PATHINFO_FILENAME in PHP 5.2
+			$name  = basename( $parts['basename'], ".{$parts['extension']}" ); // PATHINFO_FILENAME in PHP 5.2
 
 			$parts_new = pathinfo( $upload['url'] );
-			$name_new = basename( $parts_new['basename'], ".{$parts_new['extension']}" );
+			$name_new  = basename( $parts_new['basename'], ".{$parts_new['extension']}" );
 
-			$this->url_remap[$parts['dirname'] . '/' . $name] = $parts_new['dirname'] . '/' . $name_new;
+			$this->url_remap[ $parts['dirname'] . '/' . $name ] = $parts_new['dirname'] . '/' . $name_new;
 		}
 
 		return $post_id;
@@ -989,7 +1060,11 @@ class WP_Import extends WP_Importer {
 	 */
 	function fetch_remote_file( $url, $post ) {
 		// Extract the file name from the URL.
-		$file_name = basename( parse_url( $url, PHP_URL_PATH ) );
+		$path      = parse_url( $url, PHP_URL_PATH );
+		$file_name = '';
+		if ( is_string( $path ) ) {
+			$file_name = basename( $path );
+		}
 
 		if ( ! $file_name ) {
 			$file_name = md5( $url );
@@ -1001,14 +1076,17 @@ class WP_Import extends WP_Importer {
 		}
 
 		// Fetch the remote URL and write it to the placeholder file.
-		$remote_response = wp_safe_remote_get( $url, array(
-			'timeout'    => 300,
-			'stream'     => true,
-			'filename'   => $tmp_file_name,
-			'headers'    => array(
-				'Accept-Encoding' => 'identity',
-			),
-		) );
+		$remote_response = wp_safe_remote_get(
+			$url,
+			array(
+				'timeout'  => 300,
+				'stream'   => true,
+				'filename' => $tmp_file_name,
+				'headers'  => array(
+					'Accept-Encoding' => 'identity',
+				),
+			)
+		);
 
 		if ( is_wp_error( $remote_response ) ) {
 			@unlink( $tmp_file_name );
@@ -1044,25 +1122,25 @@ class WP_Import extends WP_Importer {
 		// Request failed.
 		if ( ! $headers ) {
 			@unlink( $tmp_file_name );
-			return new WP_Error( 'import_file_error', __('Remote server did not respond', 'wordpress-importer') );
+			return new WP_Error( 'import_file_error', __( 'Remote server did not respond', 'wordpress-importer' ) );
 		}
 
 		$filesize = (int) filesize( $tmp_file_name );
 
 		if ( 0 === $filesize ) {
 			@unlink( $tmp_file_name );
-			return new WP_Error( 'import_file_error', __('Zero size file downloaded', 'wordpress-importer') );
+			return new WP_Error( 'import_file_error', __( 'Zero size file downloaded', 'wordpress-importer' ) );
 		}
 
 		if ( ! isset( $headers['content-encoding'] ) && isset( $headers['content-length'] ) && $filesize !== (int) $headers['content-length'] ) {
 			@unlink( $tmp_file_name );
-			return new WP_Error( 'import_file_error', __('Downloaded file has incorrect size', 'wordpress-importer' ) );
+			return new WP_Error( 'import_file_error', __( 'Downloaded file has incorrect size', 'wordpress-importer' ) );
 		}
 
 		$max_size = (int) $this->max_attachment_size();
 		if ( ! empty( $max_size ) && $filesize > $max_size ) {
 			@unlink( $tmp_file_name );
-			return new WP_Error( 'import_file_error', sprintf(__('Remote file is too large, limit is %s', 'wordpress-importer' ), size_format($max_size) ) );
+			return new WP_Error( 'import_file_error', sprintf( __( 'Remote file is too large, limit is %s', 'wordpress-importer' ), size_format( $max_size ) ) );
 		}
 
 		// Override file name with Content-Disposition header value.
@@ -1125,11 +1203,12 @@ class WP_Import extends WP_Importer {
 		);
 
 		// keep track of the old and new urls so we can substitute them later
-		$this->url_remap[$url] = $upload['url'];
-		$this->url_remap[$post['guid']] = $upload['url']; // r13735, really needed?
+		$this->url_remap[ $url ]          = $upload['url'];
+		$this->url_remap[ $post['guid'] ] = $upload['url']; // r13735, really needed?
 		// keep track of the destination if the remote url is redirected somewhere else
-		if ( isset($headers['x-final-location']) && $headers['x-final-location'] != $url )
-			$this->url_remap[$headers['x-final-location']] = $upload['url'];
+		if ( isset( $headers['x-final-location'] ) && $headers['x-final-location'] != $url ) {
+			$this->url_remap[ $headers['x-final-location'] ] = $upload['url'];
+		}
 
 		return $upload;
 	}
@@ -1146,11 +1225,14 @@ class WP_Import extends WP_Importer {
 
 		// find parents for post orphans
 		foreach ( $this->post_orphans as $child_id => $parent_id ) {
-			$local_child_id = $local_parent_id = false;
-			if ( isset( $this->processed_posts[$child_id] ) )
-				$local_child_id = $this->processed_posts[$child_id];
-			if ( isset( $this->processed_posts[$parent_id] ) )
-				$local_parent_id = $this->processed_posts[$parent_id];
+			$local_child_id  = false;
+			$local_parent_id = false;
+			if ( isset( $this->processed_posts[ $child_id ] ) ) {
+				$local_child_id = $this->processed_posts[ $child_id ];
+			}
+			if ( isset( $this->processed_posts[ $parent_id ] ) ) {
+				$local_parent_id = $this->processed_posts[ $parent_id ];
+			}
 
 			if ( $local_child_id && $local_parent_id ) {
 				$wpdb->update( $wpdb->posts, array( 'post_parent' => $local_parent_id ), array( 'ID' => $local_child_id ), '%d', '%d' );
@@ -1160,19 +1242,24 @@ class WP_Import extends WP_Importer {
 
 		// all other posts/terms are imported, retry menu items with missing associated object
 		$missing_menu_items = $this->missing_menu_items;
-		foreach ( $missing_menu_items as $item )
+		foreach ( $missing_menu_items as $item ) {
 			$this->process_menu_item( $item );
+		}
 
 		// find parents for menu item orphans
 		foreach ( $this->menu_item_orphans as $child_id => $parent_id ) {
-			$local_child_id = $local_parent_id = 0;
-			if ( isset( $this->processed_menu_items[$child_id] ) )
-				$local_child_id = $this->processed_menu_items[$child_id];
-			if ( isset( $this->processed_menu_items[$parent_id] ) )
-				$local_parent_id = $this->processed_menu_items[$parent_id];
+			$local_child_id  = 0;
+			$local_parent_id = 0;
+			if ( isset( $this->processed_menu_items[ $child_id ] ) ) {
+				$local_child_id = $this->processed_menu_items[ $child_id ];
+			}
+			if ( isset( $this->processed_menu_items[ $parent_id ] ) ) {
+				$local_parent_id = $this->processed_menu_items[ $parent_id ];
+			}
 
-			if ( $local_child_id && $local_parent_id )
+			if ( $local_child_id && $local_parent_id ) {
 				update_post_meta( $local_child_id, '_menu_item_menu_item_parent', (int) $local_parent_id );
+			}
 		}
 	}
 
@@ -1182,13 +1269,13 @@ class WP_Import extends WP_Importer {
 	function backfill_attachment_urls() {
 		global $wpdb;
 		// make sure we do the longest urls first, in case one is a substring of another
-		uksort( $this->url_remap, array(&$this, 'cmpr_strlen') );
+		uksort( $this->url_remap, array( &$this, 'cmpr_strlen' ) );
 
 		foreach ( $this->url_remap as $from_url => $to_url ) {
 			// remap urls in post_content
-			$wpdb->query( $wpdb->prepare("UPDATE {$wpdb->posts} SET post_content = REPLACE(post_content, %s, %s)", $from_url, $to_url) );
+			$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->posts} SET post_content = REPLACE(post_content, %s, %s)", $from_url, $to_url ) );
 			// remap enclosure urls
-			$result = $wpdb->query( $wpdb->prepare("UPDATE {$wpdb->postmeta} SET meta_value = REPLACE(meta_value, %s, %s) WHERE meta_key='enclosure'", $from_url, $to_url) );
+			$result = $wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->postmeta} SET meta_value = REPLACE(meta_value, %s, %s) WHERE meta_key='enclosure'", $from_url, $to_url ) );
 		}
 	}
 
@@ -1198,11 +1285,12 @@ class WP_Import extends WP_Importer {
 	function remap_featured_images() {
 		// cycle through posts that have a featured image
 		foreach ( $this->featured_images as $post_id => $value ) {
-			if ( isset( $this->processed_posts[$value] ) ) {
-				$new_id = $this->processed_posts[$value];
+			if ( isset( $this->processed_posts[ $value ] ) ) {
+				$new_id = $this->processed_posts[ $value ];
 				// only update if there's a difference
-				if ( $new_id != $value )
+				if ( $new_id != $value ) {
 					update_post_meta( $post_id, '_thumbnail_id', $new_id );
+				}
 			}
 		}
 	}
@@ -1223,10 +1311,10 @@ class WP_Import extends WP_Importer {
 		echo '<div class="wrap">';
 		echo '<h2>' . __( 'Import WordPress', 'wordpress-importer' ) . '</h2>';
 
-		$updates = get_plugin_updates();
-		$basename = plugin_basename(__FILE__);
-		if ( isset( $updates[$basename] ) ) {
-			$update = $updates[$basename];
+		$updates  = get_plugin_updates();
+		$basename = plugin_basename( __FILE__ );
+		if ( isset( $updates[ $basename ] ) ) {
+			$update = $updates[ $basename ];
 			echo '<div class="error"><p><strong>';
 			printf( __( 'A new version of this importer is available. Please update to version %s to ensure compatibility with newer export files.', 'wordpress-importer' ), $update->update->new_version );
 			echo '</strong></p></div>';
@@ -1243,8 +1331,8 @@ class WP_Import extends WP_Importer {
 	 */
 	function greet() {
 		echo '<div class="narrow">';
-		echo '<p>'.__( 'Howdy! Upload your WordPress eXtended RSS (WXR) file and we&#8217;ll import the posts, pages, comments, custom fields, categories, and tags into this site.', 'wordpress-importer' ).'</p>';
-		echo '<p>'.__( 'Choose a WXR (.xml) file to upload, then click Upload file and import.', 'wordpress-importer' ).'</p>';
+		echo '<p>' . __( 'Howdy! Upload your WordPress eXtended RSS (WXR) file and we&#8217;ll import the posts, pages, comments, custom fields, categories, and tags into this site.', 'wordpress-importer' ) . '</p>';
+		echo '<p>' . __( 'Choose a WXR (.xml) file to upload, then click Upload file and import.', 'wordpress-importer' ) . '</p>';
 		wp_import_upload_form( 'admin.php?import=wordpress&amp;step=1' );
 		echo '</div>';
 	}
@@ -1258,8 +1346,9 @@ class WP_Import extends WP_Importer {
 	function is_valid_meta_key( $key ) {
 		// skip attachment metadata since we'll regenerate it from scratch
 		// skip _edit_lock as not relevant for import
-		if ( in_array( $key, array( '_wp_attached_file', '_wp_attachment_metadata', '_edit_lock' ) ) )
+		if ( in_array( $key, array( '_wp_attached_file', '_wp_attachment_metadata', '_edit_lock' ), true ) ) {
 			return false;
+		}
 		return $key;
 	}
 
@@ -1304,7 +1393,7 @@ class WP_Import extends WP_Importer {
 
 	// return the difference in length between two strings
 	function cmpr_strlen( $a, $b ) {
-		return strlen($b) - strlen($a);
+		return strlen( $b ) - strlen( $a );
 	}
 
 	/**

--- a/wordpress-importer/compat.php
+++ b/wordpress-importer/compat.php
@@ -37,33 +37,3 @@ if ( ! function_exists( 'addslashes_strings_only' ) ) {
 		return is_string( $value ) ? addslashes( $value ) : $value;
 	}
 }
-
-if ( ! function_exists( 'map_deep' ) ) {
-	/**
-	 * Maps a function to all non-iterable elements of an array or an object.
-	 *
-	 * Compat for WordPress < 4.4.0.
-	 *
-	 * @since 0.7.0
-	 *
-	 * @param mixed    $value    The array, object, or scalar.
-	 * @param callable $callback The function to map onto $value.
-	 * @return mixed The value with the callback applied to all non-arrays and non-objects inside it.
-	 */
-	function map_deep( $value, $callback ) {
-		if ( is_array( $value ) ) {
-			foreach ( $value as $index => $item ) {
-				$value[ $index ] = map_deep( $item, $callback );
-			}
-		} elseif ( is_object( $value ) ) {
-			$object_vars = get_object_vars( $value );
-			foreach ( $object_vars as $property_name => $property_value ) {
-				$value->$property_name = map_deep( $property_value, $callback );
-			}
-		} else {
-			$value = call_user_func( $callback, $value );
-		}
-
-		return $value;
-	}
-}

--- a/wordpress-importer/parsers/class-wxr-parser-simplexml.php
+++ b/wordpress-importer/parsers/class-wxr-parser-simplexml.php
@@ -11,13 +11,17 @@
  */
 class WXR_Parser_SimpleXML {
 	function parse( $file ) {
-		$authors = $posts = $categories = $tags = $terms = array();
+		$authors    = array();
+		$posts      = array();
+		$categories = array();
+		$tags       = array();
+		$terms      = array();
 
-		$internal_errors = libxml_use_internal_errors(true);
+		$internal_errors = libxml_use_internal_errors( true );
 
-		$dom = new DOMDocument;
+		$dom       = new DOMDocument;
 		$old_value = null;
-		if ( function_exists( 'libxml_disable_entity_loader' ) ) {
+		if ( function_exists( 'libxml_disable_entity_loader' ) && PHP_VERSION_ID < 80000 ) {
 			$old_value = libxml_disable_entity_loader( true );
 		}
 		$success = $dom->loadXML( file_get_contents( $file ) );
@@ -33,23 +37,25 @@ class WXR_Parser_SimpleXML {
 		unset( $dom );
 
 		// halt if loading produces an error
-		if ( ! $xml )
+		if ( ! $xml ) {
 			return new WP_Error( 'SimpleXML_parse_error', __( 'There was an error when reading this WXR file', 'wordpress-importer' ), libxml_get_errors() );
+		}
 
-		$wxr_version = $xml->xpath('/rss/channel/wp:wxr_version');
-		if ( ! $wxr_version )
+		$wxr_version = $xml->xpath( '/rss/channel/wp:wxr_version' );
+		if ( ! $wxr_version ) {
 			return new WP_Error( 'WXR_parse_error', __( 'This does not appear to be a WXR file, missing/invalid WXR version number', 'wordpress-importer' ) );
+		}
 
 		$wxr_version = (string) trim( $wxr_version[0] );
 		// confirm that we are dealing with the correct file format
-		if ( ! preg_match( '/^\d+\.\d+$/', $wxr_version ) )
+		if ( ! preg_match( '/^\d+\.\d+$/', $wxr_version ) ) {
 			return new WP_Error( 'WXR_parse_error', __( 'This does not appear to be a WXR file, missing/invalid WXR version number', 'wordpress-importer' ) );
+		}
 
-		$base_url = $xml->xpath('/rss/channel/wp:base_site_url');
+		$base_url = $xml->xpath( '/rss/channel/wp:base_site_url' );
 		$base_url = (string) trim( isset( $base_url[0] ) ? $base_url[0] : '' );
 
-
-		$base_blog_url = $xml->xpath('/rss/channel/wp:base_blog_url');
+		$base_blog_url = $xml->xpath( '/rss/channel/wp:base_blog_url' );
 		if ( $base_blog_url ) {
 			$base_blog_url = (string) trim( $base_blog_url[0] );
 		} else {
@@ -57,80 +63,82 @@ class WXR_Parser_SimpleXML {
 		}
 
 		$namespaces = $xml->getDocNamespaces();
-		if ( ! isset( $namespaces['wp'] ) )
+		if ( ! isset( $namespaces['wp'] ) ) {
 			$namespaces['wp'] = 'http://wordpress.org/export/1.1/';
-		if ( ! isset( $namespaces['excerpt'] ) )
+		}
+		if ( ! isset( $namespaces['excerpt'] ) ) {
 			$namespaces['excerpt'] = 'http://wordpress.org/export/1.1/excerpt/';
+		}
 
 		// grab authors
-		foreach ( $xml->xpath('/rss/channel/wp:author') as $author_arr ) {
-			$a = $author_arr->children( $namespaces['wp'] );
-			$login = (string) $a->author_login;
-			$authors[$login] = array(
-				'author_id' => (int) $a->author_id,
-				'author_login' => $login,
-				'author_email' => (string) $a->author_email,
+		foreach ( $xml->xpath( '/rss/channel/wp:author' ) as $author_arr ) {
+			$a                 = $author_arr->children( $namespaces['wp'] );
+			$login             = (string) $a->author_login;
+			$authors[ $login ] = array(
+				'author_id'           => (int) $a->author_id,
+				'author_login'        => $login,
+				'author_email'        => (string) $a->author_email,
 				'author_display_name' => (string) $a->author_display_name,
-				'author_first_name' => (string) $a->author_first_name,
-				'author_last_name' => (string) $a->author_last_name
+				'author_first_name'   => (string) $a->author_first_name,
+				'author_last_name'    => (string) $a->author_last_name,
 			);
 		}
 
 		// grab cats, tags and terms
-		foreach ( $xml->xpath('/rss/channel/wp:category') as $term_arr ) {
-			$t = $term_arr->children( $namespaces['wp'] );
+		foreach ( $xml->xpath( '/rss/channel/wp:category' ) as $term_arr ) {
+			$t        = $term_arr->children( $namespaces['wp'] );
 			$category = array(
-				'term_id' => (int) $t->term_id,
-				'category_nicename' => (string) $t->category_nicename,
-				'category_parent' => (string) $t->category_parent,
-				'cat_name' => (string) $t->cat_name,
-				'category_description' => (string) $t->category_description
+				'term_id'              => (int) $t->term_id,
+				'category_nicename'    => (string) $t->category_nicename,
+				'category_parent'      => (string) $t->category_parent,
+				'cat_name'             => (string) $t->cat_name,
+				'category_description' => (string) $t->category_description,
 			);
 
 			foreach ( $t->termmeta as $meta ) {
 				$category['termmeta'][] = array(
-					'key' => (string) $meta->meta_key,
-					'value' => (string) $meta->meta_value
+					'key'   => (string) $meta->meta_key,
+					'value' => (string) $meta->meta_value,
 				);
 			}
 
 			$categories[] = $category;
 		}
 
-		foreach ( $xml->xpath('/rss/channel/wp:tag') as $term_arr ) {
-			$t = $term_arr->children( $namespaces['wp'] );
+		foreach ( $xml->xpath( '/rss/channel/wp:tag' ) as $term_arr ) {
+			$t   = $term_arr->children( $namespaces['wp'] );
 			$tag = array(
-				'term_id' => (int) $t->term_id,
-				'tag_slug' => (string) $t->tag_slug,
-				'tag_name' => (string) $t->tag_name,
-				'tag_description' => (string) $t->tag_description
+				'term_id'         => (int) $t->term_id,
+				'tag_slug'        => (string) $t->tag_slug,
+				'tag_name'        => (string) $t->tag_name,
+				'tag_description' => (string) $t->tag_description,
 			);
 
 			foreach ( $t->termmeta as $meta ) {
 				$tag['termmeta'][] = array(
-					'key' => (string) $meta->meta_key,
-					'value' => (string) $meta->meta_value
+					'key'   => (string) $meta->meta_key,
+					'value' => (string) $meta->meta_value,
 				);
 			}
 
 			$tags[] = $tag;
 		}
 
-		foreach ( $xml->xpath('/rss/channel/wp:term') as $term_arr ) {
-			$t = $term_arr->children( $namespaces['wp'] );
+		foreach ( $xml->xpath( '/rss/channel/wp:term' ) as $term_arr ) {
+			$t    = $term_arr->children( $namespaces['wp'] );
 			$term = array(
-				'term_id' => (int) $t->term_id,
-				'term_taxonomy' => (string) $t->term_taxonomy,
-				'slug' => (string) $t->term_slug,
-				'term_parent' => (string) $t->term_parent,
-				'term_name' => (string) $t->term_name,
-				'term_description' => (string) $t->term_description
+				'term_id'          => (int) $t->term_id,
+				'term_taxonomy'    => (string) $t->term_taxonomy,
+				'slug'             => (string) $t->term_slug,
+				'term_parent'      => (string) $t->term_parent,
+				'term_name'        => (string) $t->term_name,
+				'term_description' => (string) $t->term_description,
 			);
 
 			foreach ( $t->termmeta as $meta ) {
 				$term['termmeta'][] = array(
-					'key' => (string) $meta->meta_key,
-					'value' => (string) $meta->meta_value
+					'key'   => (string) $meta->meta_key,
+					'value' => (string) $meta->meta_value,
 				);
 			}
 
@@ -141,48 +149,50 @@ class WXR_Parser_SimpleXML {
 		foreach ( $xml->channel->item as $item ) {
 			$post = array(
 				'post_title' => (string) $item->title,
-				'guid' => (string) $item->guid,
+				'guid'       => (string) $item->guid,
 			);
 
-			$dc = $item->children( 'http://purl.org/dc/elements/1.1/' );
+			$dc                  = $item->children( 'http://purl.org/dc/elements/1.1/' );
 			$post['post_author'] = (string) $dc->creator;
 
-			$content = $item->children( 'http://purl.org/rss/1.0/modules/content/' );
-			$excerpt = $item->children( $namespaces['excerpt'] );
+			$content              = $item->children( 'http://purl.org/rss/1.0/modules/content/' );
+			$excerpt              = $item->children( $namespaces['excerpt'] );
 			$post['post_content'] = (string) $content->encoded;
 			$post['post_excerpt'] = (string) $excerpt->encoded;
 
-			$wp = $item->children( $namespaces['wp'] );
-			$post['post_id'] = (int) $wp->post_id;
-			$post['post_date'] = (string) $wp->post_date;
-			$post['post_date_gmt'] = (string) $wp->post_date_gmt;
+			$wp                     = $item->children( $namespaces['wp'] );
+			$post['post_id']        = (int) $wp->post_id;
+			$post['post_date']      = (string) $wp->post_date;
+			$post['post_date_gmt']  = (string) $wp->post_date_gmt;
 			$post['comment_status'] = (string) $wp->comment_status;
-			$post['ping_status'] = (string) $wp->ping_status;
-			$post['post_name'] = (string) $wp->post_name;
-			$post['status'] = (string) $wp->status;
-			$post['post_parent'] = (int) $wp->post_parent;
-			$post['menu_order'] = (int) $wp->menu_order;
-			$post['post_type'] = (string) $wp->post_type;
-			$post['post_password'] = (string) $wp->post_password;
-			$post['is_sticky'] = (int) $wp->is_sticky;
+			$post['ping_status']    = (string) $wp->ping_status;
+			$post['post_name']      = (string) $wp->post_name;
+			$post['status']         = (string) $wp->status;
+			$post['post_parent']    = (int) $wp->post_parent;
+			$post['menu_order']     = (int) $wp->menu_order;
+			$post['post_type']      = (string) $wp->post_type;
+			$post['post_password']  = (string) $wp->post_password;
+			$post['is_sticky']      = (int) $wp->is_sticky;
 
-			if ( isset($wp->attachment_url) )
+			if ( isset( $wp->attachment_url ) ) {
 				$post['attachment_url'] = (string) $wp->attachment_url;
+			}
 
 			foreach ( $item->category as $c ) {
 				$att = $c->attributes();
-				if ( isset( $att['nicename'] ) )
+				if ( isset( $att['nicename'] ) ) {
 					$post['terms'][] = array(
-						'name' => (string) $c,
-						'slug' => (string) $att['nicename'],
-						'domain' => (string) $att['domain']
+						'name'   => (string) $c,
+						'slug'   => (string) $att['nicename'],
+						'domain' => (string) $att['domain'],
 					);
+				}
 			}
 
 			foreach ( $wp->postmeta as $meta ) {
 				$post['postmeta'][] = array(
-					'key' => (string) $meta->meta_key,
-					'value' => (string) $meta->meta_value
+					'key'   => (string) $meta->meta_key,
+					'value' => (string) $meta->meta_value,
 				);
 			}
 
@@ -191,26 +201,26 @@ class WXR_Parser_SimpleXML {
 				if ( isset( $comment->commentmeta ) ) {
 					foreach ( $comment->commentmeta as $m ) {
 						$meta[] = array(
-							'key' => (string) $m->meta_key,
-							'value' => (string) $m->meta_value
+							'key'   => (string) $m->meta_key,
+							'value' => (string) $m->meta_value,
 						);
 					}
 				}
 
 				$post['comments'][] = array(
-					'comment_id' => (int) $comment->comment_id,
-					'comment_author' => (string) $comment->comment_author,
+					'comment_id'           => (int) $comment->comment_id,
+					'comment_author'       => (string) $comment->comment_author,
 					'comment_author_email' => (string) $comment->comment_author_email,
-					'comment_author_IP' => (string) $comment->comment_author_IP,
-					'comment_author_url' => (string) $comment->comment_author_url,
-					'comment_date' => (string) $comment->comment_date,
-					'comment_date_gmt' => (string) $comment->comment_date_gmt,
-					'comment_content' => (string) $comment->comment_content,
-					'comment_approved' => (string) $comment->comment_approved,
-					'comment_type' => (string) $comment->comment_type,
-					'comment_parent' => (string) $comment->comment_parent,
-					'comment_user_id' => (int) $comment->comment_user_id,
-					'commentmeta' => $meta,
+					'comment_author_IP'    => (string) $comment->comment_author_IP,
+					'comment_author_url'   => (string) $comment->comment_author_url,
+					'comment_date'         => (string) $comment->comment_date,
+					'comment_date_gmt'     => (string) $comment->comment_date_gmt,
+					'comment_content'      => (string) $comment->comment_content,
+					'comment_approved'     => (string) $comment->comment_approved,
+					'comment_type'         => (string) $comment->comment_type,
+					'comment_parent'       => (string) $comment->comment_parent,
+					'comment_user_id'      => (int) $comment->comment_user_id,
+					'commentmeta'          => $meta,
 				);
 			}
 
@@ -218,14 +228,14 @@ class WXR_Parser_SimpleXML {
 		}
 
 		return array(
-			'authors' => $authors,
-			'posts' => $posts,
-			'categories' => $categories,
-			'tags' => $tags,
-			'terms' => $terms,
-			'base_url' => $base_url,
+			'authors'       => $authors,
+			'posts'         => $posts,
+			'categories'    => $categories,
+			'tags'          => $tags,
+			'terms'         => $terms,
+			'base_url'      => $base_url,
 			'base_blog_url' => $base_blog_url,
-			'version' => $wxr_version
+			'version'       => $wxr_version,
 		);
 	}
 }

--- a/wordpress-importer/parsers/class-wxr-parser-xml.php
+++ b/wordpress-importer/parsers/class-wxr-parser-xml.php
@@ -10,23 +10,82 @@
  * WXR Parser that makes use of the XML Parser PHP extension.
  */
 class WXR_Parser_XML {
-	var $wp_tags = array(
-		'wp:post_id', 'wp:post_date', 'wp:post_date_gmt', 'wp:comment_status', 'wp:ping_status', 'wp:attachment_url',
-		'wp:status', 'wp:post_name', 'wp:post_parent', 'wp:menu_order', 'wp:post_type', 'wp:post_password',
-		'wp:is_sticky', 'wp:term_id', 'wp:category_nicename', 'wp:category_parent', 'wp:cat_name', 'wp:category_description',
-		'wp:tag_slug', 'wp:tag_name', 'wp:tag_description', 'wp:term_taxonomy', 'wp:term_parent',
-		'wp:term_name', 'wp:term_description', 'wp:author_id', 'wp:author_login', 'wp:author_email', 'wp:author_display_name',
-		'wp:author_first_name', 'wp:author_last_name',
+	public $wp_tags     = array(
+		'wp:post_id',
+		'wp:post_date',
+		'wp:post_date_gmt',
+		'wp:comment_status',
+		'wp:ping_status',
+		'wp:attachment_url',
+		'wp:status',
+		'wp:post_name',
+		'wp:post_parent',
+		'wp:menu_order',
+		'wp:post_type',
+		'wp:post_password',
+		'wp:is_sticky',
+		'wp:term_id',
+		'wp:category_nicename',
+		'wp:category_parent',
+		'wp:cat_name',
+		'wp:category_description',
+		'wp:tag_slug',
+		'wp:tag_name',
+		'wp:tag_description',
+		'wp:term_taxonomy',
+		'wp:term_parent',
+		'wp:term_name',
+		'wp:term_description',
+		'wp:author_id',
+		'wp:author_login',
+		'wp:author_email',
+		'wp:author_display_name',
+		'wp:author_first_name',
+		'wp:author_last_name',
 	);
-	var $wp_sub_tags = array(
-		'wp:comment_id', 'wp:comment_author', 'wp:comment_author_email', 'wp:comment_author_url',
-		'wp:comment_author_IP',	'wp:comment_date', 'wp:comment_date_gmt', 'wp:comment_content',
-		'wp:comment_approved', 'wp:comment_type', 'wp:comment_parent', 'wp:comment_user_id',
+	public $wp_sub_tags = array(
+		'wp:comment_id',
+		'wp:comment_author',
+		'wp:comment_author_email',
+		'wp:comment_author_url',
+		'wp:comment_author_IP',
+		'wp:comment_date',
+		'wp:comment_date_gmt',
+		'wp:comment_content',
+		'wp:comment_approved',
+		'wp:comment_type',
+		'wp:comment_parent',
+		'wp:comment_user_id',
 	);
 
+	public $wxr_version;
+	public $in_post;
+	public $cdata;
+	public $data;
+	public $sub_data;
+	public $in_tag;
+	public $in_sub_tag;
+	public $authors;
+	public $posts;
+	public $term;
+	public $category;
+	public $tag;
+	public $base_url;
+	public $base_blog_url;
+
 	function parse( $file ) {
-		$this->wxr_version = $this->in_post = $this->cdata = $this->data = $this->sub_data = $this->in_tag = $this->in_sub_tag = false;
-		$this->authors = $this->posts = $this->term = $this->category = $this->tag = array();
+		$this->wxr_version = false;
+		$this->in_post     = false;
+		$this->cdata       = false;
+		$this->data        = false;
+		$this->sub_data    = false;
+		$this->in_tag      = false;
+		$this->in_sub_tag  = false;
+		$this->authors     = array();
+		$this->posts       = array();
+		$this->term        = array();
+		$this->category    = array();
+		$this->tag         = array();
 
 		$xml = xml_parser_create( 'UTF-8' );
 		xml_parser_set_option( $xml, XML_OPTION_SKIP_WHITE, 1 );
@@ -36,63 +95,89 @@ class WXR_Parser_XML {
 		xml_set_element_handler( $xml, 'tag_open', 'tag_close' );
 
 		if ( ! xml_parse( $xml, file_get_contents( $file ), true ) ) {
-			$current_line = xml_get_current_line_number( $xml );
+			$current_line   = xml_get_current_line_number( $xml );
 			$current_column = xml_get_current_column_number( $xml );
-			$error_code = xml_get_error_code( $xml );
-			$error_string = xml_error_string( $error_code );
+			$error_code     = xml_get_error_code( $xml );
+			$error_string   = xml_error_string( $error_code );
 			return new WP_Error( 'XML_parse_error', 'There was an error when reading this WXR file', array( $current_line, $current_column, $error_string ) );
 		}
 		xml_parser_free( $xml );
 
-		if ( ! preg_match( '/^\d+\.\d+$/', $this->wxr_version ) )
+		if ( ! preg_match( '/^\d+\.\d+$/', $this->wxr_version ) ) {
 			return new WP_Error( 'WXR_parse_error', __( 'This does not appear to be a WXR file, missing/invalid WXR version number', 'wordpress-importer' ) );
+		}
 
 		return array(
-			'authors' => $this->authors,
-			'posts' => $this->posts,
-			'categories' => $this->category,
-			'tags' => $this->tag,
-			'terms' => $this->term,
-			'base_url' => $this->base_url,
+			'authors'       => $this->authors,
+			'posts'         => $this->posts,
+			'categories'    => $this->category,
+			'tags'          => $this->tag,
+			'terms'         => $this->term,
+			'base_url'      => $this->base_url,
 			'base_blog_url' => $this->base_blog_url,
-			'version' => $this->wxr_version
+			'version'       => $this->wxr_version,
 		);
 	}
 
 	function tag_open( $parse, $tag, $attr ) {
-		if ( in_array( $tag, $this->wp_tags ) ) {
+		if ( in_array( $tag, $this->wp_tags, true ) ) {
 			$this->in_tag = substr( $tag, 3 );
 			return;
 		}
 
-		if ( in_array( $tag, $this->wp_sub_tags ) ) {
+		if ( in_array( $tag, $this->wp_sub_tags, true ) ) {
 			$this->in_sub_tag = substr( $tag, 3 );
 			return;
 		}
 
 		switch ( $tag ) {
 			case 'category':
-				if ( isset($attr['domain'], $attr['nicename']) ) {
+				if ( isset( $attr['domain'], $attr['nicename'] ) ) {
+					if ( false === $this->sub_data ) {
+						$this->sub_data = array();
+					}
+
 					$this->sub_data['domain'] = $attr['domain'];
-					$this->sub_data['slug'] = $attr['nicename'];
+					$this->sub_data['slug']   = $attr['nicename'];
 				}
 				break;
-			case 'item': $this->in_post = true;
-			case 'title': if ( $this->in_post ) $this->in_tag = 'post_title'; break;
-			case 'guid': $this->in_tag = 'guid'; break;
-			case 'dc:creator': $this->in_tag = 'post_author'; break;
-			case 'content:encoded': $this->in_tag = 'post_content'; break;
-			case 'excerpt:encoded': $this->in_tag = 'post_excerpt'; break;
+			case 'item':
+				$this->in_post = true;
+				break;
+			case 'title':
+				if ( $this->in_post ) {
+					$this->in_tag = 'post_title';
+				}
+				break;
+			case 'guid':
+				$this->in_tag = 'guid';
+				break;
+			case 'dc:creator':
+				$this->in_tag = 'post_author';
+				break;
+			case 'content:encoded':
+				$this->in_tag = 'post_content';
+				break;
+			case 'excerpt:encoded':
+				$this->in_tag = 'post_excerpt';
+				break;
 
-			case 'wp:term_slug': $this->in_tag = 'slug'; break;
-			case 'wp:meta_key': $this->in_sub_tag = 'key'; break;
-			case 'wp:meta_value': $this->in_sub_tag = 'value'; break;
+			case 'wp:term_slug':
+				$this->in_tag = 'slug';
+				break;
+			case 'wp:meta_key':
+				$this->in_sub_tag = 'key';
+				break;
+			case 'wp:meta_value':
+				$this->in_sub_tag = 'value';
+				break;
 		}
 	}
 
 	function cdata( $parser, $cdata ) {
-		if ( ! trim( $cdata ) )
+		if ( ! trim( $cdata ) ) {
 			return;
+		}
 
 		if ( false !== $this->in_tag || false !== $this->in_sub_tag ) {
 			$this->cdata .= $cdata;
@@ -105,31 +190,33 @@ class WXR_Parser_XML {
 		switch ( $tag ) {
 			case 'wp:comment':
 				unset( $this->sub_data['key'], $this->sub_data['value'] ); // remove meta sub_data
-				if ( ! empty( $this->sub_data ) )
+				if ( ! empty( $this->sub_data ) ) {
 					$this->data['comments'][] = $this->sub_data;
+				}
 				$this->sub_data = false;
 				break;
 			case 'wp:commentmeta':
 				$this->sub_data['commentmeta'][] = array(
-					'key' => $this->sub_data['key'],
-					'value' => $this->sub_data['value']
+					'key'   => $this->sub_data['key'],
+					'value' => $this->sub_data['value'],
 				);
 				break;
 			case 'category':
 				if ( ! empty( $this->sub_data ) ) {
 					$this->sub_data['name'] = $this->cdata;
-					$this->data['terms'][] = $this->sub_data;
+					$this->data['terms'][]  = $this->sub_data;
 				}
 				$this->sub_data = false;
 				break;
 			case 'wp:postmeta':
-				if ( ! empty( $this->sub_data ) )
+				if ( ! empty( $this->sub_data ) ) {
 					$this->data['postmeta'][] = $this->sub_data;
+				}
 				$this->sub_data = false;
 				break;
 			case 'item':
 				$this->posts[] = $this->data;
-				$this->data = false;
+				$this->data    = false;
 				break;
 			case 'wp:category':
 			case 'wp:tag':
@@ -145,8 +232,9 @@ class WXR_Parser_XML {
 				$this->sub_data = false;
 				break;
 			case 'wp:author':
-				if ( ! empty($this->data['author_login']) )
-					$this->authors[$this->data['author_login']] = $this->data;
+				if ( ! empty( $this->data['author_login'] ) ) {
+					$this->authors[ $this->data['author_login'] ] = $this->data;
+				}
 				$this->data = false;
 				break;
 			case 'wp:base_site_url':
@@ -164,11 +252,19 @@ class WXR_Parser_XML {
 
 			default:
 				if ( $this->in_sub_tag ) {
-					$this->sub_data[$this->in_sub_tag] = ! empty( $this->cdata ) ? $this->cdata : '';
-					$this->in_sub_tag = false;
-				} else if ( $this->in_tag ) {
-					$this->data[$this->in_tag] = ! empty( $this->cdata ) ? $this->cdata : '';
-					$this->in_tag = false;
+					if ( false === $this->sub_data ) {
+						$this->sub_data = array();
+					}
+
+					$this->sub_data[ $this->in_sub_tag ] = ! empty( $this->cdata ) ? $this->cdata : '';
+					$this->in_sub_tag                    = false;
+				} elseif ( $this->in_tag ) {
+					if ( false === $this->data ) {
+						$this->data = array();
+					}
+
+					$this->data[ $this->in_tag ] = ! empty( $this->cdata ) ? $this->cdata : '';
+					$this->in_tag                = false;
 				}
 		}
 

--- a/wordpress-importer/parsers/class-wxr-parser.php
+++ b/wordpress-importer/parsers/class-wxr-parser.php
@@ -17,24 +17,27 @@ class WXR_Parser {
 			$result = $parser->parse( $file );
 
 			// If SimpleXML succeeds or this is an invalid WXR file then return the results
-			if ( ! is_wp_error( $result ) || 'SimpleXML_parse_error' != $result->get_error_code() )
+			if ( ! is_wp_error( $result ) || 'SimpleXML_parse_error' != $result->get_error_code() ) {
 				return $result;
-		} else if ( extension_loaded( 'xml' ) ) {
+			}
+		} elseif ( extension_loaded( 'xml' ) ) {
 			$parser = new WXR_Parser_XML;
 			$result = $parser->parse( $file );
 
 			// If XMLParser succeeds or this is an invalid WXR file then return the results
-			if ( ! is_wp_error( $result ) || 'XML_parse_error' != $result->get_error_code() )
+			if ( ! is_wp_error( $result ) || 'XML_parse_error' != $result->get_error_code() ) {
 				return $result;
+			}
 		}
 
 		// We have a malformed XML file, so display the error and fallthrough to regex
-		if ( isset($result) && defined('IMPORT_DEBUG') && IMPORT_DEBUG ) {
+		if ( isset( $result ) && defined( 'IMPORT_DEBUG' ) && IMPORT_DEBUG ) {
 			echo '<pre>';
 			if ( 'SimpleXML_parse_error' == $result->get_error_code() ) {
-				foreach  ( $result->get_error_data() as $error )
+				foreach ( $result->get_error_data() as $error ) {
 					echo $error->line . ':' . $error->column . ' ' . esc_html( $error->message ) . "\n";
-			} else if ( 'XML_parse_error' == $result->get_error_code() ) {
+				}
+			} elseif ( 'XML_parse_error' == $result->get_error_code() ) {
 				$error = $result->get_error_data();
 				echo $error[0] . ':' . $error[1] . ' ' . esc_html( $error[2] );
 			}

--- a/wordpress-importer/readme.txt
+++ b/wordpress-importer/readme.txt
@@ -2,9 +2,10 @@
 Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
-Requires at least: 3.7
-Tested up to: 5.4
-Stable tag: 0.7
+Requires at least: 5.2
+Tested up to: 6.2
+Requires PHP: 5.6
+Stable tag: 0.8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +39,20 @@ If you would prefer to do things manually then follow these instructions:
 1. Go to the Tools -> Import screen, click on WordPress
 
 == Changelog ==
+
+= 0.8.1 =
+
+* Update compatibility tested-up-to to WordPress 6.2.
+* Update paths to build status badges.
+
+= 0.8 =
+* Update minimum WordPress requirement to 5.2.
+* Update minimum PHP requirement to 5.6.
+* Update compatibility tested-up-to to WordPress 6.1.
+* PHP 8.0, 8.1, and 8.2 compatibility fixes.
+* Fix a bug causing blank lines in content to be ignored when using the Regex Parser.
+* Fix a bug resulting in a PHP fatal error when IMPORT_DEBUG is enabled and a category creation error occurs.
+* Improved Unit testing & automated testing.
 
 = 0.7 =
 * Update minimum WordPress requirement to 3.7 and ensure compatibility with PHP 7.4.

--- a/wordpress-importer/wordpress-importer.php
+++ b/wordpress-importer/wordpress-importer.php
@@ -1,15 +1,18 @@
 <?php
 /*
-Plugin Name: WordPress Importer
-Plugin URI: https://wordpress.org/plugins/wordpress-importer/
-Description: Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
-Author: wordpressdotorg
-Author URI: https://wordpress.org/
-Version: 0.7
-Text Domain: wordpress-importer
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-*/
+ * @wordpress-plugin
+ * Plugin Name:       WordPress Importer
+ * Plugin URI:        https://wordpress.org/plugins/wordpress-importer/
+ * Description:       Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
+ * Author:            wordpressdotorg
+ * Author URI:        https://wordpress.org/
+ * Version:           0.8.1
+ * Requires at least: 5.2
+ * Requires PHP:      5.6
+ * Text Domain:       wordpress-importer
+ * License:           GPLv2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ */
 
 if ( ! defined( 'WP_LOAD_IMPORTERS' ) ) {
 	return;
@@ -25,8 +28,9 @@ require_once ABSPATH . 'wp-admin/includes/import.php';
 
 if ( ! class_exists( 'WP_Importer' ) ) {
 	$class_wp_importer = ABSPATH . 'wp-admin/includes/class-wp-importer.php';
-	if ( file_exists( $class_wp_importer ) )
+	if ( file_exists( $class_wp_importer ) ) {
 		require $class_wp_importer;
+	}
 }
 
 /** Functions missing in older WordPress versions. */
@@ -55,6 +59,7 @@ function wordpress_importer_init() {
 	 * @global WP_Import $wp_import
 	 */
 	$GLOBALS['wp_import'] = new WP_Import();
-	register_importer( 'wordpress', 'WordPress', __('Import <strong>posts, pages, comments, custom fields, categories, and tags</strong> from a WordPress export file.', 'wordpress-importer'), array( $GLOBALS['wp_import'], 'dispatch' ) );
+	// phpcs:ignore WordPress.WP.CapitalPDangit
+	register_importer( 'wordpress', 'WordPress', __( 'Import <strong>posts, pages, comments, custom fields, categories, and tags</strong> from a WordPress export file.', 'wordpress-importer' ), array( $GLOBALS['wp_import'], 'dispatch' ) );
 }
 add_action( 'admin_init', 'wordpress_importer_init' );


### PR DESCRIPTION
## Description

Fixes: #4848 

## Changelog Description

### Plugin Updated: WordPress Importer

We updated WordPress Importer from 0.7 to 0.8.1.

* [0.8.1](https://github.com/WordPress/wordpress-importer/releases/tag/0.8.1):
  * Update compatibility tested-up-to to WordPress 6.2
* [0.8](https://github.com/WordPress/wordpress-importer/releases/tag/0.8):
  * Update minimum WordPress requirement to 5.2.
  * Update minimum PHP requirement to 5.6.
  * Update compatibility tested-up-to to WordPress 6.0.
  * PHP 8.0, 8.1, and 8.2 compatibility fixes.
  * Fix a bug causing blank lines in content to be ignored when using the Regex Parser.
  * Fix a bug resulting in a PHP fatal error when IMPORT_DEBUG is enabled and a category creation error occurs.
  * Improved Unit testing & automated testing.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 
