### PR TITLE
Fixes fatal error while reading config file of the integration

### DIFF
--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -89,7 +89,7 @@ class IntegrationVipConfig {
 		 * PHP cache can hold a reference to the old symlink that can cause fatal if we use require
 		 * on it.
 		 */
-		if ( false === file_get_contents( $config_file_path ) ) {
+		if ( false === @file_get_contents( $config_file_path ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			clearstatcache( true, $config_file_directory . '/' . $config_file_name );
 			// Clears cache for files created by k8s ConfigMap.
 			clearstatcache( true, $config_file_directory . '/..data' );


### PR DESCRIPTION
## Description

When we update integration via VIP Internal CLI then first it update the k8s configmap and then after few seconds changes are reflected in our config file, this update under the hood doesn't replace the file but pointed the file to the new symlink (this is how configmap works in k8s) but PHP uses file status cache which can become stale if symlink is updated.

In our particular case fatal error was occuring because `is_readable()` check was returning `true` because of cache but the file itself was not there i.e. symlink got updated.

## Changes Made

- Uses `clearstatcache` to clear the cache and make sure we read from latest available config file.

## Changelog Description

Fixes fatal error while reading config file of the integration

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

No change in functionality, just fixing the stale cache issue.
