### PR TITLE
Don’t close the ES index before updating settings

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1128,7 +1128,7 @@ class Health {
 		$desired_settings_to_heal = self::limit_index_settings_to_keys( $desired_settings, self::INDEX_SETTINGS_HEALTH_AUTO_HEAL_KEYS );
 		$index_name               = $indexable->get_index_name();
 		if ( method_exists( '\Automattic\VIP\Search\Search', 'should_load_new_ep' ) && \Automattic\VIP\Search\Search::should_load_new_ep() ) {
-			$result = $this->elasticsearch->update_index_settings( $index_name, $desired_settings_to_heal, true );
+			$result = $this->elasticsearch->update_index_settings( $index_name, $desired_settings_to_heal, false );
 		} else {
 			$result = $indexable->update_index_settings( $desired_settings_to_heal );
 		}

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -1182,7 +1182,7 @@ class Health_Test extends WP_UnitTestCase {
 
 		$health->elasticsearch->expects( $this->once() )
 			->method( 'update_index_settings' )
-			->with( $index_name, $expected_updated_settings, true );
+			->with( $index_name, $expected_updated_settings, false );
 
 		$result = $health->heal_index_settings_for_indexable( $mocked_indexable, $options );
 


### PR DESCRIPTION
The [only settings that we auto-fix](https://github.com/Automattic/vip-go-mu-plugins/blob/0e070ada69ce076d36126acfc94f11f0e9d1b218/search/includes/classes/class-health.php#L38-L47) are dynamic settings, and we don’t need to close the index first before changing those ([#](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings), [#](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-slowlog.html), [#](https://www.elastic.co/guide/en/elasticsearch/reference/current/shard-allocation-filtering.html)). Closing/opening an index appears to cause quite a bit of stress on the clusters.

This was introduced in https://github.com/Automattic/vip-go-mu-plugins/pull/3879. Before that the default was to not $close_first.