### PR TITLE
Don't skip wpcom_vip_load_plugin for wp-activate.php under subdirectories

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1291,9 +1291,8 @@ function wpcom_vip_should_load_plugins() {
 	}
 
 	$should_load_plugins = true;
-
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	if ( wp_installing() && strtok( $_SERVER['REQUEST_URI'] ?? '', '?' ) !== '/wp-activate.php' ) {
+	if ( wp_installing() && basename( (string) parse_url( $_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH ) ) !== 'wp-activate.php' ) {
 		$should_load_plugins = false;
 	} elseif ( defined( 'WP_CLI' ) && WP_CLI ) {
 		// WP-CLI loaded with --skip-plugins flag


### PR DESCRIPTION
## Description

#4247 introduced a regression that resulted in `client-mu-plugins` not being loaded in `wp-activate.php`.

#4328 addressed the regression by explicitly checking whether current page is `/wp-activate.php` or not.

This pull request continues #4328's spirit and handle `wp-activate.php` under subdirectories, e.g: `https://example.com/foo/wp-activate.php`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.


## Steps to Test


1. Check out the PR
1. Add a dummy plugin under `client-mu-plugins` to make sure it's loaded during the further testing steps
1. On a multisite with **subdirectory** setup and open registration, go to register page `https://example.com/foo/wp-login.php?action=register`
1. Create a new account
1. In the verification email, click on the link to `wp-activate.php`, e.g. `https://example.com/foo/wp-activate.php?key=123456789` - make sure the dummy plugin is loaded
1. Also, visit a link directly at `/wp-activate.php` and make sure the plugin is loaded

---

Props to @gmazzap 