### PR TITLE
Fixes Integration::get_config() to return correct value for Multisite case

### DIFF
--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -147,6 +147,10 @@ class IntegrationVipConfig {
 	 * @private
 	 */
 	public function get_site_config() {
+		if ( is_network_admin() ) {
+			return array(); // As of now multisite doesn't support config on environment level.
+		}
+
 		if ( is_multisite() ) {
 			$config = $this->get_value_from_config( 'network_sites', 'config' );
 		} else {

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -147,10 +147,6 @@ class IntegrationVipConfig {
 	 * @private
 	 */
 	public function get_site_config() {
-		if ( is_network_admin() ) {
-			return array(); // As of now multisite doesn't support config on environment level.
-		}
-
 		if ( is_multisite() ) {
 			$config = $this->get_value_from_config( 'network_sites', 'config' );
 		} else {

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -70,16 +70,6 @@ abstract class Integration {
 	}
 
 	/**
-	 * Callback for `switch_blog` filter.
-	 */
-	public function switch_blog_callback(): void {
-		// Updating config to make sure `get_config()` returns config of current blog instead of main site.
-		if ( isset( $this->vip_config ) ) {
-			$this->options['config'] = $this->vip_config->get_site_config();
-		}
-	}
-
-	/**
 	 * Activates this integration with given options array.
 	 *
 	 * @param array $options An associative options array for the integration.
@@ -103,6 +93,16 @@ abstract class Integration {
 
 		$this->is_active = true;
 		$this->options   = $options;
+	}
+
+	/**
+	 * Callback for `switch_blog` filter.
+	 */
+	public function switch_blog_callback(): void {
+		// Updating config to make sure `get_config()` returns config of current blog instead of main site.
+		if ( isset( $this->vip_config ) ) {
+			$this->options['config'] = $this->vip_config->get_site_config();
+		}
 	}
 
 	/**
@@ -142,6 +142,10 @@ abstract class Integration {
 	 * @return void
 	 */
 	public function set_vip_config( IntegrationVipConfig $vip_config ): void {
+		if ( ! $this->is_active() ) {
+			trigger_error( sprintf( 'Configuration info can only assigned if integration is active.' ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		}
+
 		$this->vip_config = $vip_config;
 	}
 

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -73,6 +73,7 @@ class Integrations {
 				// If integration is activated successfully without any error then configure.
 				if ( $integration->is_active() ) {
 					$integration->configure();
+					$integration->set_vip_config( $vip_config );
 				}
 			}
 		}

--- a/tests/integrations/test-integration.php
+++ b/tests/integrations/test-integration.php
@@ -9,6 +9,8 @@ namespace Automattic\VIP\Integrations;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.FunctionComment.MissingParamComment
 
+use Automattic\VIP\Integrations\IntegrationVipConfig;
+use Env_Integration_Status;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 
@@ -19,6 +21,12 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 		$integration = new FakeIntegration( 'fake' );
 
 		$this->assertEquals( 'fake', $integration->get_slug() );
+	}
+
+	public function test__switch_blog_action_is_added_on_instantiation(): void {
+		$integration = new FakeIntegration( 'fake' );
+
+		$this->assertEquals( 10, has_action( 'switch_blog', [ $integration, 'switch_blog_callback' ] ) );
 	}
 
 	public function test__activate_is_marking_the_integration_as_active(): void {
@@ -65,9 +73,65 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( $integration->is_active() );
 	}
 
+	public function test__switch_blog_callback_is_setting_the_correct_config_for_network_site(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Only valid for multisite' );
+		}
+
+		$integration = new FakeIntegration( 'fake' );
+		$integration->activate( [ 'config' => [ 'activate_config' ] ] );
+		$blog_2_id = $this->factory()->blog->create_object( [ 'domain' => 'integration-test.site/2' ] );
+		/**
+		 * Intgration Config Mock.
+		 *
+		 * @var IntegrationVipConfig|MockObject
+		 */
+		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->setMethods( [ 'get_vip_config_from_file' ] )->getMock();
+		$config_mock->method( 'get_vip_config_from_file' )->willReturn( [
+			'network_sites' => [
+				get_current_blog_id() => [
+					'status' => Env_Integration_Status::ENABLED,
+					'config' => array( 'network_site_1_config' ),
+				],
+				$blog_2_id            => [
+					'status' => Env_Integration_Status::ENABLED,
+					'config' => array( 'network_site_2_config' ),
+				],
+			],
+		] );
+		$config_mock->__construct( 'slug' );
+		$integration->set_vip_config( $config_mock );
+
+		// By default return config passed via activate().
+		$this->assertEquals( array( 'activate_config' ), $integration->get_config() );
+		
+		// If blog is switched then return config of current network site.
+		switch_to_blog( $blog_2_id );
+		$this->assertEquals( array( 'network_site_2_config' ), $integration->get_config() );
+
+		// If blog is restored then return config of the main site.
+		restore_current_blog();
+		$this->assertEquals( array( 'network_site_1_config' ), $integration->get_config() );
+	}
+
 	public function test__is_active_returns_false_when_integration_is_not_active(): void {
 		$integration = new FakeIntegration( 'fake' );
 
 		$this->assertFalse( $integration->is_active() );
+	}
+
+	public function test__set_vip_config_function_throws_error_if_integration_is_not_active(): void {
+		$this->expectException( 'PHPUnit_Framework_Error_Warning' ); 
+		$this->expectExceptionMessage( 'Configuration info can only assigned if integration is active.' );
+
+		$integration = new FakeIntegration( 'fake' );
+		/**
+		 * Intgration Config Mock.
+		 *
+		 * @var IntegrationVipConfig|MockObject
+		 */
+		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->getMock();
+
+		$this->assertFalse( $integration->set_vip_config( $config_mock ) );
 	}
 }

--- a/tests/integrations/test-integrations.php
+++ b/tests/integrations/test-integrations.php
@@ -52,7 +52,7 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 		$this->assertEquals( [], $integration_3->get_config() );
 	}
 
-	public function test__configure_is_getting_called_when_the_integration_is_activated_via_vip_config(): void {
+	public function test__expected_methods_are_getting_called_when_the_integration_is_activated_via_vip_config(): void {
 		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->setMethods( [ 'is_active_via_vip' ] )->getMock();
 		$config_mock->expects( $this->once() )->method( 'is_active_via_vip' )->willReturn( true );
 		/**
@@ -67,8 +67,9 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 		 *
 		 * @var MockObject|FakeIntegration
 		 */
-		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'configure' ] )->getMock();
+		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'configure', 'set_vip_config' ] )->getMock();
 		$integration_mock->expects( $this->once() )->method( 'configure' );
+		$integration_mock->expects( $this->once() )->method( 'set_vip_config' );
 
 		$integrations_mock->register( $integration_mock );
 		$integrations_mock->activate_platform_integrations();


### PR DESCRIPTION
## Description

In Multisite case `get_config()` always returns config of the main site even when `switch_to_blog()` is used instead it should return config of the current network site.

## Changes Made

- Used `switch_blog` action to set the right config when blog is switched.

## Changelog Description

Fixes Integration::get_config() to return correct value for Multisite case

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Use following config for activating parsely.
	```php
	// File: /config/integrations-config/parsely-config.php
	
	<?php
	
	return array(
		'env' => array('status' => 'enabled'),
		'network_sites' => array(
			'1' => array(
				'status' => 'enabled',
				'config' => array(
					'site_id' => 'site_id_value_1',
					'api_secret' => 'api_secret_value_1'
				)
			),
			'2' => array(
				'status' => 'blocked',
				'config' => array(
					'site_id' => 'site_id_value_2',
					'api_secret' => 'api_secret_value_2'
				)
			),
			'3' => array(
				'status' => 'disabled',
				'config' => array(
					'site_id' => 'site_id_value_3',
					'api_secret' => 'api_secret_value_3'
				)
			)
		)
	);
	```
1. On Network Admin site navigate to `/wp-admin/network/sites`
1. Verify that `Parse.ly Site ID` column is showing different Site ID for each network site and it matches with the provided config

## Screenshot

![image](https://github.com/Automattic/vip-go-mu-plugins/assets/31419912/b52983ce-ea92-46ea-b6a5-c29dacb9132c)

