### PR TITLE
fix(vip-helpers): load mu-plugins for wp-activate.php in subdireсtories

### DIFF
--- a/tests/vip-helpers/vip-utils/test-wpcom-vip-should-load-plugins.php
+++ b/tests/vip-helpers/vip-utils/test-wpcom-vip-should-load-plugins.php
@@ -1,0 +1,40 @@
+<?php
+
+class WPCOM_VIP_Should_Load_Plugins_Test extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+		wp_installing( true );
+	}
+
+	public function tearDown(): void {
+		wp_installing( false );
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider data_load_in_wp_activate
+	 */
+	public function test_load_in_wp_activate( string $request_uri, bool $expected ): void {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$saved = $_SERVER['REQUEST_URI'] ?? null;
+		try {
+			$_SERVER['REQUEST_URI'] = $request_uri;
+			$actual                 = wpcom_vip_should_load_plugins( true );
+
+			self::assertSame( $expected, $actual );
+		} finally {
+			$_SERVER['REQUEST_URI'] = $saved;
+		}
+	}
+
+	public function data_load_in_wp_activate(): iterable {
+		return [
+			[ '/wp-activate.php', true ],
+			[ '/wp-activate.php?something', true ],
+			[ '/wp-activate.php/path', false ],
+			[ '/?/wp-activate.php', false ],
+			[ '/dir/wp-activate.php', true ],
+			[ '/dir/subdir/wp-activate.php', true ],
+		];
+	}
+}

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1283,17 +1283,17 @@ function wpcom_vip_can_use_shared_plugin( $plugin ) {
 /**
  * Helper function to check if we can load plugins or not.
  */
-function wpcom_vip_should_load_plugins() {
+function wpcom_vip_should_load_plugins( $_reset = false ) {
 	static $should_load_plugins;
 
-	if ( isset( $should_load_plugins ) ) {
+	if ( ! $_reset && isset( $should_load_plugins ) ) {
 		return $should_load_plugins;
 	}
 
 	$should_load_plugins = true;
 
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	if ( wp_installing() && strtok( $_SERVER['REQUEST_URI'] ?? '', '?' ) !== '/wp-activate.php' ) {
+	if ( wp_installing() && ! str_ends_with( strtok( $_SERVER['REQUEST_URI'] ?? '', '?' ), '/wp-activate.php' ) ) {
 		$should_load_plugins = false;
 	} elseif ( defined( 'WP_CLI' ) && WP_CLI ) {
 		// WP-CLI loaded with --skip-plugins flag


### PR DESCRIPTION
## Description

Supersedes: #4861

## Changelog Description

### Plugin Updated: VIP Helpers

Load mu-plugins for `wp-activate.php` located in a subdirectory (or for a subdirectory-based multisite installation).

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

This change has unit tests.
