### PR TITLE
fix(vip-helpers): detect codespace as a non-prod environment

### DIFF
--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -13,10 +13,15 @@ function vip_do_non_prod_bar() {
 	}
 
 	if ( apply_filters( 'vip_show_non_prod_bar', true ) ) :
+		$environment = constant( 'VIP_GO_APP_ENVIRONMENT' );
+		if ( 'local' === $environment && 'true' === getenv( 'CODESPACES' ) ) {
+			$environment = 'codespaces';
+		}
+
 		?>
 		<div id="vip-non-prod-bar">
 			<span>
-				<strong><?php echo esc_html( constant( 'VIP_GO_APP_ENVIRONMENT' ) ); ?></strong>
+				<strong><?php echo esc_html( $environment ); ?></strong>
 			</span>
 		</div>
 		<script>


### PR DESCRIPTION
## Description

This PR changes "local" to "codespaces" for Codespaces:

![image](https://github.com/Automattic/vip-go-mu-plugins/assets/7810770/a5bca11d-3495-40b4-99a0-e480006e3c92)

## Changelog Description

### Plugin Updated: VIP Helpers

Detect Codespaces and show the respective label when running in a codespace.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Run mu-plugins in a codespace and observe that the non-production environment label reflects that.
