### PR TITLE
Fixes warning while reading integration config for PHP 8+

### DIFF
--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -83,29 +83,16 @@ class IntegrationVipConfig {
 		$config_file_path      = $config_file_directory . '/' . $config_file_name;
 
 		/**
-		 * Temporarily disable warnings by clearing the E_WARNING bit.
-		 *
-		 * Reading config file via `file_get_contents()` even with `@` operator generate warnings on PHP 8+.
-		 */
-		$current_error_reporting = error_reporting(); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
-		error_reporting( $current_error_reporting & ~E_WARNING ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
-
-		/**
 		 * Clear cache to always read data from latest config file.
 		 *
 		 * Kubernetes ConfigMap updates the file via symlink instead of actually replacing the file and
 		 * PHP cache can hold a reference to the old symlink that can cause fatal if we use require
 		 * on it.
 		 */
-		if ( false === file_get_contents( $config_file_path ) ) {
-			clearstatcache( true, $config_file_directory . '/' . $config_file_name );
-			// Clears cache for files created by k8s ConfigMap.
-			clearstatcache( true, $config_file_directory . '/..data' );
-			clearstatcache( true, $config_file_directory . '/..data/' . $config_file_name );
-		}
-
-		// Restore the original error reporting.
-		error_reporting( $current_error_reporting ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+		clearstatcache( true, $config_file_directory . '/' . $config_file_name );
+		// Clears cache for files created by k8s ConfigMap.
+		clearstatcache( true, $config_file_directory . '/..data' );
+		clearstatcache( true, $config_file_directory . '/..data/' . $config_file_name );
 
 		if ( ! is_readable( $config_file_path ) ) {
 			return null;

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -83,18 +83,29 @@ class IntegrationVipConfig {
 		$config_file_path      = $config_file_directory . '/' . $config_file_name;
 
 		/**
+		 * Temporarily disable warnings by clearing the E_WARNING bit.
+		 *
+		 * Reading config file via `file_get_contents()` even with `@` operator generate warnings on PHP 8+.
+		 */
+		$current_error_reporting = error_reporting(); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+		error_reporting( $current_error_reporting & ~E_WARNING ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+
+		/**
 		 * Clear cache to always read data from latest config file.
 		 *
 		 * Kubernetes ConfigMap updates the file via symlink instead of actually replacing the file and
 		 * PHP cache can hold a reference to the old symlink that can cause fatal if we use require
 		 * on it.
 		 */
-		if ( false === @file_get_contents( $config_file_path ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( false === file_get_contents( $config_file_path ) ) {
 			clearstatcache( true, $config_file_directory . '/' . $config_file_name );
 			// Clears cache for files created by k8s ConfigMap.
 			clearstatcache( true, $config_file_directory . '/..data' );
 			clearstatcache( true, $config_file_directory . '/..data/' . $config_file_name );
 		}
+
+		// Restore the original error reporting.
+		error_reporting( $current_error_reporting ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
 
 		if ( ! is_readable( $config_file_path ) ) {
 			return null;


### PR DESCRIPTION
## Description

In VIP Integrations we used `@file_get_contents` to read config file of each integration. We expected that `@` will suppress all warnings but for PHP 8+ it is still producing a warning if file doesn't exist.

Closes: https://github.com/Automattic/vip-go-mu-plugins/issues/4878

## Changelog Description

Fixes warning while reading integration config file for PHP 8+

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. If needed setup new environment via `vip dev-env create`
1. Open dev site on browser
1. Use `vip dev-env logs --slug vip-single-site -S php -d -f` to verify that no warning is generated while reloading or navigating dev site.
