### PR TITLE
Make Jetpack 12.6 the default

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -29,9 +29,12 @@ function vip_default_jetpack_version() {
 	} elseif ( version_compare( $wp_version, '6.1', '<' ) ) {
 		// WordPress 6.0.x
 		return '12.0';
-	} else {
-		// WordPress 6.1 and newer.
+	} elseif ( version_compare( $wp_version, '6.2', '<' ) ) {
+		// WordPress 6.1.x
 		return '12.5';
+	} else {
+		// WordPress 6.2 and newer.
+		return '12.6';
 	}
 }
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.5
+ * Version: 12.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '12.5';
+		$latest = '12.6';
 
 		$versions_map = [
 			// WordPress version => Jetpack version
@@ -15,7 +15,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 			'5.9'   => '11.4',
 			'5.9.5' => '11.4',
 			'6.0'   => '12.0',
-			'6.1'   => $latest,
+			'6.1'   => '12.5',
 			'6.2'   => $latest,
 			'6.3'   => $latest,
 			'6.3.1' => $latest,


### PR DESCRIPTION
## Description
Makes Jetpack 12.6 the default for WP sites 6.2+.

## Changelog Description

### Plugin Updated: Jetpack 12.6

We upgraded Jetpack 12.5 to Jetpack 12.6 for sites running WP 6.2+


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

