### PR TITLE
CANTINA-944: For private sites, force disable blog_public UI toggle buttons in Reading Settings to avoid confusion

### DIFF
--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -85,12 +85,22 @@ class Private_Sites {
 				}
 			}
 
+			function updateDescription(message) {
+				var description = document.querySelector('tr.option-site-visibility p.description');
+				if (description) {
+					description.textContent = message;
+				}
+			}
+
 			var checkbox = 'tr.option-site-visibility input#blog_public[type=\"checkbox\"]';
+			var description = document.querySelector('tr.option-site-visibility p.description');
 			if (document.querySelector(checkbox)) {
 				disableButton(checkbox);
+				updateDescription('This option is disabled when the constant \"VIP_JETPACK_IS_PRIVATE\" is enabled.');
 			} else {
 				disableButton('tr.option-site-visibility input#blog-public[type=\"radio\"]');
 				disableButton('tr.option-site-visibility input#blog-norobots[type=\"radio\"]');
+				updateDescription('These options are disabled when \"VIP_JETPACK_IS_PRIVATE\" is enabled.');
 			}
 		});" );
 	}

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -71,11 +71,27 @@ class Private_Sites {
 	}
 
 	/**
-	 * Force the blog_public option to be -1 and disable checkbox/radio UI in Reading Settings
+	 * Force the blog_public option to be -1 and disable UI
 	 */
 	public function force_blog_public_option() {
 		add_filter( 'blog_privacy_selector', '__return_true' );
 		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'disable_blog_public_ui' ) );
+	}
+
+	/**
+	 * Disable checkbox/radio UI in Reading Settings
+	 */
+	public function disable_blog_public_ui() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		if ( 'options-reading' !== $screen->base ) {
+			return;
+		}
+
 		wp_register_script( 'vip-disable-blog-public-option-ui', false, array(), '0.1', true );
 		wp_enqueue_script( 'vip-disable-blog-public-option-ui' );
 		$js_code       = <<<JS

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -78,7 +78,8 @@ class Private_Sites {
 		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
 		wp_register_script( 'vip-disable-blog-public-option-ui', false, array(), '0.1', true );
 		wp_enqueue_script( 'vip-disable-blog-public-option-ui' );
-		wp_add_inline_script( 'vip-disable-blog-public-option-ui', "document.addEventListener(\"DOMContentLoaded\", function() {
+		$js_code       = <<<JS
+		document.addEventListener("DOMContentLoaded", function() {
 			function updateProperty(selector, property, value) {
 				const element = document.querySelector(selector);
 				if (element) {
@@ -86,15 +87,19 @@ class Private_Sites {
 				}
 			}
 
-			var checkbox = 'tr.option-site-visibility input#blog_public[type=\"checkbox\"]';
+			var checkbox = 'tr.option-site-visibility input#blog_public[type="checkbox"]';
 			if (document.querySelector(checkbox)) {
 				updateProperty(checkbox, 'disabled', true);
 			} else {
-				updateProperty('tr.option-site-visibility input#blog-public[type=\"radio\"]', 'disabled', true);
-				updateProperty('tr.option-site-visibility input#blog-norobots[type=\"radio\"]', 'disabled', true);
+				updateProperty('tr.option-site-visibility input#blog-public[type="radio"]', 'disabled', true);
+				updateProperty('tr.option-site-visibility input#blog-norobots[type="radio"]', 'disabled', true);
 			}
-			updateProperty('tr.option-site-visibility p.description', 'textContent', 'This option is disabled when the constant \"VIP_JETPACK_IS_PRIVATE\" is enabled.');
-		});" );
+			updateProperty('tr.option-site-visibility p.description', 'textContent', '%s');
+		});
+		JS;
+		$description   = esc_html__( 'This option is disabled when the constant VIP_JETPACK_IS_PRIVATE is enabled.', 'vip' );
+		$final_js_code = sprintf( $js_code, $description );
+		wp_add_inline_script( 'vip-disable-blog-public-option-ui', $final_js_code );
 	}
 
 	/*

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -54,8 +54,7 @@ class Private_Sites {
 
 		add_filter( 'jetpack_active_modules', array( $this, 'filter_jetpack_active_modules' ) );
 		add_filter( 'jetpack_get_available_modules', array( $this, 'filter_jetpack_get_available_modules' ) );
-		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
-
+		$this->force_blog_public_option();
 		$this->disable_core_feeds();
 		$this->block_unnecessary_access();
 	}
@@ -69,6 +68,31 @@ class Private_Sites {
 		add_action( 'do_feed_rss', array( $this, 'action_do_feed' ), -1 );
 		add_action( 'do_feed_rss2', array( $this, 'action_do_feed' ), -1 );
 		add_action( 'do_feed_atom', array( $this, 'action_do_feed' ), -1 );
+	}
+
+	/**
+	 * Force the blog_public option to be -1 and disable checkbox/radio UI in Reading Settings
+	 */
+	public function force_blog_public_option() {
+		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
+		wp_register_script( 'vip-disable-blog-public-option-ui', false, array(), '0.1', true );
+		wp_enqueue_script( 'vip-disable-blog-public-option-ui' );
+		wp_add_inline_script( 'vip-disable-blog-public-option-ui', "document.addEventListener(\"DOMContentLoaded\", function() {
+			function disableButton(selector) {
+				var element = document.querySelector(selector);
+				if (element) {
+					element.disabled = true;
+				}
+			}
+
+			var checkbox = 'tr.option-site-visibility input#blog_public[type=\"checkbox\"]';
+			if (document.querySelector(checkbox)) {
+				disableButton(checkbox);
+			} else {
+				disableButton('tr.option-site-visibility input#blog-public[type=\"radio\"]');
+				disableButton('tr.option-site-visibility input#blog-norobots[type=\"radio\"]');
+			}
+		});" );
 	}
 
 	/*

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -74,34 +74,26 @@ class Private_Sites {
 	 * Force the blog_public option to be -1 and disable checkbox/radio UI in Reading Settings
 	 */
 	public function force_blog_public_option() {
+		add_filter( 'blog_privacy_selector', '__return_true' );
 		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
 		wp_register_script( 'vip-disable-blog-public-option-ui', false, array(), '0.1', true );
 		wp_enqueue_script( 'vip-disable-blog-public-option-ui' );
 		wp_add_inline_script( 'vip-disable-blog-public-option-ui', "document.addEventListener(\"DOMContentLoaded\", function() {
-			function disableButton(selector) {
-				var element = document.querySelector(selector);
+			function updateProperty(selector, property, value) {
+				const element = document.querySelector(selector);
 				if (element) {
-					element.disabled = true;
-				}
-			}
-
-			function updateDescription(message) {
-				var description = document.querySelector('tr.option-site-visibility p.description');
-				if (description) {
-					description.textContent = message;
+					element[property] = value;
 				}
 			}
 
 			var checkbox = 'tr.option-site-visibility input#blog_public[type=\"checkbox\"]';
-			var description = document.querySelector('tr.option-site-visibility p.description');
 			if (document.querySelector(checkbox)) {
-				disableButton(checkbox);
-				updateDescription('This option is disabled when the constant \"VIP_JETPACK_IS_PRIVATE\" is enabled.');
+				updateProperty(checkbox, 'disabled', true);
 			} else {
-				disableButton('tr.option-site-visibility input#blog-public[type=\"radio\"]');
-				disableButton('tr.option-site-visibility input#blog-norobots[type=\"radio\"]');
-				updateDescription('These options are disabled when \"VIP_JETPACK_IS_PRIVATE\" is enabled.');
+				updateProperty('tr.option-site-visibility input#blog-public[type=\"radio\"]', 'disabled', true);
+				updateProperty('tr.option-site-visibility input#blog-norobots[type=\"radio\"]', 'disabled', true);
 			}
+			updateProperty('tr.option-site-visibility p.description', 'textContent', 'This option is disabled when the constant \"VIP_JETPACK_IS_PRIVATE\" is enabled.');
 		});" );
 	}
 

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -95,14 +95,21 @@ class Private_Sites {
 		wp_register_script( 'vip-disable-blog-public-option-ui', false, array(), '0.1', true );
 		wp_enqueue_script( 'vip-disable-blog-public-option-ui' );
 		$js_code       = <<<JS
-		document.addEventListener("DOMContentLoaded", function() {
+		function onContentLoaded(callback) {
+			if (document.readyState !== 'loading') {
+				callback();
+			} else {
+				document.addEventListener('DOMContentLoaded', callback);
+			}
+		}
+
+		onContentLoaded(function() {
 			function updateProperty(selector, property, value) {
 				const element = document.querySelector(selector);
 				if (element) {
 					element[property] = value;
 				}
 			}
-
 			var checkbox = 'tr.option-site-visibility input#blog_public[type="checkbox"]';
 			if (document.querySelector(checkbox)) {
 				updateProperty(checkbox, 'disabled', true);

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -74,7 +74,6 @@ class Private_Sites {
 	 * Force the blog_public option to be -1 and disable UI
 	 */
 	public function force_blog_public_option() {
-		add_filter( 'blog_privacy_selector', '__return_true' );
 		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'disable_blog_public_ui' ) );
 	}

--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -54,7 +54,11 @@ class Private_Sites {
 
 		add_filter( 'jetpack_active_modules', array( $this, 'filter_jetpack_active_modules' ) );
 		add_filter( 'jetpack_get_available_modules', array( $this, 'filter_jetpack_get_available_modules' ) );
-		$this->force_blog_public_option();
+
+		// Force the blog_public option to be -1 and disable UI
+		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'disable_blog_public_ui' ) );
+
 		$this->disable_core_feeds();
 		$this->block_unnecessary_access();
 	}
@@ -68,14 +72,6 @@ class Private_Sites {
 		add_action( 'do_feed_rss', array( $this, 'action_do_feed' ), -1 );
 		add_action( 'do_feed_rss2', array( $this, 'action_do_feed' ), -1 );
 		add_action( 'do_feed_atom', array( $this, 'action_do_feed' ), -1 );
-	}
-
-	/**
-	 * Force the blog_public option to be -1 and disable UI
-	 */
-	public function force_blog_public_option() {
-		add_filter( 'option_blog_public', array( $this, 'filter_restrict_blog_public' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'disable_blog_public_ui' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
For private sites, force disable blog_public UI toggle buttons in Reading Settings to avoid confusion, as we already force it to -1 in https://github.com/Automattic/vip-go-mu-plugins/blame/c3be5f418a23223b89931d000528f5c312f55f09/security/class-private-sites.php#L57

<img width="828" alt="Screenshot 2023-09-22 at 3 14 34 PM" src="https://github.com/Automattic/vip-go-mu-plugins/assets/16962021/9a240ff3-75ad-4500-9e33-1109cc04d90b">

When hooked onto `blog_privacy_selector`:

![image](https://github.com/Automattic/vip-go-mu-plugins/assets/16962021/9bae9410-b21b-43b7-a8e8-fc60ae07cfc3)

## Changelog Description

### Plugin Updated: Private Sites

Force disable blog_public UI toggle buttons in Reading Settings to avoid confusion

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) If constant not set already, set it `define( 'VIP_JETPACK_IS_PRIVATE', true );` in vip-config
2) Go to wp-admin > Settings > Reading Settings and scroll down to ensure box is grayed out like in screenshot
3) Add `add_filter( 'blog_privacy_selector', '__return_true' );` and repeat step 2)