### PR TITLE
Set WP_TEMP_DIR for Contact Form 7 uploads

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -19,6 +19,27 @@ if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) ) {
 }
 
 /**
+ * Contact Form 7 (https://wordpress.org/plugins/contact-form-7/)
+ *
+ * The plugin ignores the value of `WPCF7_UPLOADS_TMP_DIR` if it is not
+ * within a set of paths allowed by the plugin. The plugin allows the path
+ * defined in `WP_TEMP_DIR`, so this fix uses the plugin's `wpcf7_upload_dir`
+ * filter to set `WP_TEMP_DIR` to `/tmp/` so that the plugin will allow the
+ * path that we defined earlier in `WPCF7_UPLOADS_TMP_DIR`.
+ *
+ * @param array $uploads See wp_upload_dir() for description.
+ * @return array Information about the upload directory.
+ */
+function vip_wpcf7_upload_dir( $uploads ) {
+	if ( ! defined( 'WP_TEMP_DIR' ) ) {
+		define( 'WP_TEMP_DIR', get_temp_dir() );
+	}
+
+	return $uploads;
+}
+add_filter( 'wpcf7_upload_dir', 'vip_wpcf7_upload_dir', 10, 1 );
+
+/**
  * Recent versions of CF7 attempt to clean-up uploaded attachments
  * somewhere within `wp-content`, ignoring the value of WPCF7_UPLOADS_TMP_DIR if
  * it is not within `wp-content`. This does not work because we disable `open_dir()`,


### PR DESCRIPTION
## Description

In 2021, Contact Form 7 changed the way it handles the `WPCF7_UPLOADS_TMP_DIR` constant (see https://github.com/rocklobster-in/contact-form-7/commit/90e87ab044ce6b4ff4e4df755576795908340181), which resulted in [our fix](https://github.com/Automattic/vip-go-mu-plugins/blob/524a46de14a6e5b0bc733348c1866b8a344468a5/plugin-fixes.php#L10-L19) no longer working.

The issue is that the plugin only returns `WPCF7_UPLOADS_TMP_DIR` [when the value is inside `WP_CONTENT_DIR`](https://github.com/rocklobster-in/contact-form-7/blob/2cfaa472fa485c6d3366fcdd80701fdaf7f9e425/includes/file.php#L322). When it's not (as in our case where we set it to `/tmp/cf7`), the plugin ignores the value of `WPCF7_UPLOADS_TMP_DIR` and [instead uses its own `wpcf7_upload_dir()` function](https://github.com/rocklobster-in/contact-form-7/blob/2cfaa472fa485c6d3366fcdd80701fdaf7f9e425/includes/file.php#L327) to build the uploads path, setting it to a path inside `wp-content/` and trying to write there, which fails on the VIP platform due to that path being an object store.

Version v5.8.1 of Contact Form 7 modified [the `wpcf7_is_file_path_in_content_dir()` function](https://github.com/rocklobster-in/contact-form-7/blob/2cfaa472fa485c6d3366fcdd80701fdaf7f9e425/includes/validation-functions.php#L245-L272) to also allow paths within `WP_TEMP_DIR`:

- https://github.com/rocklobster-in/contact-form-7/commit/42b605abd6560a5bf72c5fabcf4346f90d1ad805

This PR uses the plugin's `wpcf7_upload_dir` filter to set `WP_TEMP_DIR` to `/tmp/` so that the plugin will allow the path that we defined earlier in `WPCF7_UPLOADS_TMP_DIR`.

## Changelog Description

### Plugin fixes updated to improve Contact Form 7 upload compatibility 

Set WP_TEMP_DIR so that Contact Form 7 will allow uploads to the temp directory.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Install [Contact Form 7 v5.8.1](https://wordpress.org/plugins/contact-form-7/) on a VIP test site.
2. Create a contact form that includes a field for uploading an attachment.
3. Submit the form with the attachment and notice how the form submission hangs and fails to submit due to CF7 trying to write to `wp-content/`.
4. Checkout this PR and switch the site to use the version of mu-plugins that includes this patch.
5. Perform the same test with submitting a form that includes an attachment and observe that the form submits as expected since [CF7 v5.8.1 now allows writing to paths defined in `WP_TEMP_DIR`](https://github.com/rocklobster-in/contact-form-7/commit/42b605abd6560a5bf72c5fabcf4346f90d1ad805).
6. Confirm that the uploaded file is included in the test email that was sent by the form submission (make sure that the file mail-tag is included in the "File attachments" field for the contact form's mail template).
