### PR TITLE
test: address `http_api_transports` deprecation in WP 6.4

### DIFF
--- a/tests/files/test-curl-streamer.php
+++ b/tests/files/test-curl-streamer.php
@@ -31,6 +31,13 @@ class Curl_Streamer_Test extends WP_UnitTestCase {
 	}
 
 	public function test__init() {
+		global $wp_version;
+
+		$version = preg_replace( '/-.*$/', '', $wp_version );
+		if ( version_compare( $version, '6.4', '>=' ) ) {
+			$this->setExpectedDeprecated( 'http_api_transports' );
+		}
+
 		$expected_transport = 'WP_Http_Curl';
 
 		$wp_http          = new \WP_Http();


### PR DESCRIPTION
Fixes: #4902 
