### PR TITLE
Search e2e Tests: Fix b0rked WooCommerce test

### DIFF
--- a/tests/search/e2e/integration/features/woocommerce.spec.js
+++ b/tests/search/e2e/integration/features/woocommerce.spec.js
@@ -110,11 +110,11 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			cy.get('.woocommerce-orders-table tbody tr').should('have.length', 1);
 
 			// VIP: Use Search Dev Tools instead of Debug Bar
-			// cy.searchDevToolsResponseOK('shop_order');
+			cy.searchDevToolsResponseOK('shop_order', 2);
 			cy.get('#vip-search-dev-tools-mount').click();
-			cy.get('h3.vip-h3').first().click();
-			cy.get('strong.vip-h4.wp_query').first().click();
-			cy.get('ol.wp_query.vip-collapse-ol').first().should('contain.text','orderby: "date"');
+			cy.get('h3.vip-h3').eq(2).click();
+			cy.get('strong.vip-h4.wp_query').eq(2).click();
+			cy.get('ol.wp_query.vip-collapse-ol').eq(2).should('contain.text','orderby: "date"');
 			cy.get('#vip-search-dev-tools-mount').click();
 
 			cy.logout();

--- a/tests/search/e2e/support/commands.js
+++ b/tests/search/e2e/support/commands.js
@@ -461,11 +461,12 @@ Cypress.Commands.add('createUser', (userData) => {
 });
 
 // VIP: Check that Search Dev Tools returns a 200 status and a certain text in the response body
-Cypress.Commands.add('searchDevToolsResponseOK', (bodyText) => {
+// If there's more than one ES query, use the index to select the correct one
+Cypress.Commands.add('searchDevToolsResponseOK', (bodyText, index = 0) => {
 	cy.get('#vip-search-dev-tools-mount').click();
-	cy.get('h3.vip-h3').first().should('contain.text','(200)');
+	cy.get('h3.vip-h3').eq( index ).should('contain.text','(200)');
 	if ( bodyText ) {
-		cy.get('.line-numbers').first().should('contain.text', bodyText);
+		cy.get('.line-numbers').eq( index ).should('contain.text', bodyText);
 	}
 	cy.get('#vip-search-dev-tools-mount').click();
 });


### PR DESCRIPTION
## Description
Looks like a WooCommerce update added some extra queries, so we need to take that into account in the tests and check the third one. Follows up on https://github.com/Automattic/vip-go-mu-plugins/pull/4729/files#r1279557202.
