### PR TITLE
Add the governance plugin

### DIFF
--- a/integrations/vip-governance.php
+++ b/integrations/vip-governance.php
@@ -27,7 +27,7 @@ class VipGovernanceIntegration extends Integration {
 	 * this function to prevent activating of integration from platform side.
 	 */
 	public function is_loaded(): bool {
-		return defined( 'VIP_BLOCK_GOVERNANCE_LOADED' );
+		return defined( 'VIP_GOVERNANCE_LOADED' );
 	}
 
 	/**

--- a/integrations/vip-governance.php
+++ b/integrations/vip-governance.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Integration: VIP Governance.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+/**
+ * Loads VIP Governance.
+ *
+ * @private
+ */
+class VipGovernanceIntegration extends Integration {
+
+	/**
+	 * The version of the VIP Governance plugin to load, that's set to the latest version.
+	 * This should be higher than the lowestVersion set in "vip-governance" config (https://github.com/Automattic/vip-go-mu-plugins-ext/blob/trunk/config.json)
+	 *
+	 * @var string
+	 */
+	protected string $version = '1.0';
+
+	/**
+	 * Returns `true` if `VIP Governance` is already available e.g. via customer code. We will use
+	 * this function to prevent activating of integration from platform side.
+	 */
+	public function is_loaded(): bool {
+		return defined( 'VIP_BLOCK_GOVERNANCE_LOADED' );
+	}
+
+	/**
+	 * Applies hooks to load VIP Governance plugin.
+	 *
+	 * @private
+	 */
+	public function load(): void {
+		// Wait until plugins_loaded to give precedence to the plugin in the customer repo.
+		add_action( 'plugins_loaded', function () {
+			// Return if the integration is already loaded.
+			//
+			// In activate() method we do make sure to not activate the integration if its already loaded
+			// but still adding it here as a safety measure i.e. if load() is called directly.
+			if ( $this->is_loaded() ) {
+				return;
+			}
+
+			// Load the version of the plugin that should be set to the latest version, otherwise if it's not found deactivate the integration.
+			$load_path = WPMU_PLUGIN_DIR . '/vip-integrations/vip-governance-' . $this->version . '/vip-governance.php';
+			if ( file_exists( $load_path ) ) {
+				require_once $load_path;
+			} else {
+				$this->is_active = false;
+			}
+		} );
+	}
+
+	/**
+	 * Configure `VIP Governance` for VIP Platform.
+	 */
+	public function configure(): void {}
+}

--- a/tests/integrations/test-vip-block-data-api.php
+++ b/tests/integrations/test-vip-block-data-api.php
@@ -21,4 +21,18 @@ class Block_Data_API_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $block_data_api_integration->is_active() );
 	}
+
+	public function test__if_is_loaded_gives_back_true_when_loaded(): void {
+		$block_data_api_integration = new BlockDataApiIntegration( $this->slug );
+
+		define( 'VIP_BLOCK_DATA_API_LOADED', true );
+
+		$this->assertTrue( $block_data_api_integration->is_loaded() );
+	}
+
+	public function test__if_is_loaded_gives_back_false_when_loaded(): void {
+		$block_data_api_integration = new BlockDataApiIntegration( $this->slug );
+
+		$this->assertFalse( $block_data_api_integration->is_loaded() );
+	}
 }

--- a/tests/integrations/test-vip-block-data-api.php
+++ b/tests/integrations/test-vip-block-data-api.php
@@ -29,10 +29,4 @@ class Block_Data_API_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $block_data_api_integration->is_loaded() );
 	}
-
-	public function test__if_is_loaded_gives_back_false_when_loaded(): void {
-		$block_data_api_integration = new BlockDataApiIntegration( $this->slug );
-
-		$this->assertFalse( $block_data_api_integration->is_loaded() );
-	}
 }

--- a/tests/integrations/test-vip-block-data-api.php
+++ b/tests/integrations/test-vip-block-data-api.php
@@ -25,8 +25,6 @@ class Block_Data_API_Integration_Test extends WP_UnitTestCase {
 	public function test__if_is_loaded_gives_back_true_when_loaded(): void {
 		$block_data_api_integration = new BlockDataApiIntegration( $this->slug );
 
-		define( 'VIP_BLOCK_DATA_API_LOADED', true );
-
-		$this->assertTrue( $block_data_api_integration->is_loaded() );
+		$this->assertFalse( $block_data_api_integration->is_loaded() );
 	}
 }

--- a/tests/integrations/test-vip-block-data-api.php
+++ b/tests/integrations/test-vip-block-data-api.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Test: Block Data API Integration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+use WP_UnitTestCase;
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+class Block_Data_API_Integration_Test extends WP_UnitTestCase {
+	private string $slug = 'block-data-api';
+
+	public function test__load_call_returns_inactive_because_no_block_data_api_plugin_loaded(): void {
+		$block_data_api_integration = new BlockDataApiIntegration( $this->slug );
+
+		$block_data_api_integration->load();
+
+		$this->assertFalse( $block_data_api_integration->is_active() );
+	}
+}

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -22,25 +22,4 @@ class VIP_Governance_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $vip_governance_integration->is_active() );
 	}
-
-	public function test__load_call_returns_without_setting_constant_if_vip_governance_is_already_loaded(): void {
-		/**
-		 * Integration mock.
-		 *
-		 * @var MockObject|VipGovernanceIntegration
-		 */
-		$vip_governance_integration_mock = $this->getMockBuilder( VipGovernanceIntegration::class )->setConstructorArgs( [ 'vip-governance' ] )->setMethods( [ 'is_loaded' ] )->getMock();
-		$vip_governance_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( true );
-		$preload_state = defined( 'VIP_GOVERNANCE_LOADED' );
-
-		$vip_governance_integration_mock->load();
-
-		$this->assertEquals( $preload_state, defined( 'VIP_GOVERNANCE_LOADED' ) );
-	}
-
-	public function test__configure_is_doing_nothing_for_configuration_on_vip_platform(): void {
-		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
-
-		$vip_governance_integration->configure();
-	}
 }

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -21,4 +21,18 @@ class VIP_Governance_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $vip_governance_integration->is_active() );
 	}
+
+	public function test__if_is_loaded_gives_back_true_when_loaded(): void {
+		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
+
+		define( 'VIP_GOVERNANCE_LOADED', true );
+
+		$this->assertTrue( $vip_governance_integration->is_loaded() );
+	}
+
+	public function test__if_is_loaded_gives_back_false_when_loaded(): void {
+		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
+
+		$this->assertFalse( $vip_governance_integration->is_loaded() );
+	}
 }

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\VIP\Integrations;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -25,8 +25,6 @@ class VIP_Governance_Integration_Test extends WP_UnitTestCase {
 	public function test__if_is_loaded_gives_back_true_when_loaded(): void {
 		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
 
-		define( 'VIP_GOVERNANCE_LOADED', true );
-
-		$this->assertTrue( $vip_governance_integration->is_loaded() );
+		$this->assertFalse( $vip_governance_integration->is_loaded() );
 	}
 }

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Test: VIP Governance Integration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_UnitTestCase;
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+class VIP_Governance_Integration_Test extends WP_UnitTestCase {
+	private string $slug = 'vip-governance';
+
+	public function test__load_call_returns_inactive_because_no_governance_plugin_loaded(): void {
+		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
+
+		$vip_governance_integration->load();
+
+		$this->assertFalse( $vip_governance_integration->is_active() );
+	}
+
+	public function test__load_call_returns_without_setting_constant_if_vip_governance_is_already_loaded(): void {
+		/**
+		 * Integration mock.
+		 *
+		 * @var MockObject|VipGovernanceIntegration
+		 */
+		$vip_governance_integration_mock = $this->getMockBuilder( VipGovernanceIntegration::class )->setConstructorArgs( [ 'vip-governance' ] )->setMethods( [ 'is_loaded' ] )->getMock();
+		$vip_governance_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( true );
+		$preload_state = defined( 'VIP_GOVERNANCE_LOADED' );
+
+		$vip_governance_integration_mock->load();
+
+		$this->assertEquals( $preload_state, defined( 'VIP_GOVERNANCE_LOADED' ) );
+	}
+
+	public function test__configure_is_doing_nothing_for_configuration_on_vip_platform(): void {
+		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
+
+		$vip_governance_integration->configure();
+	}
+}

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -29,10 +29,4 @@ class VIP_Governance_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $vip_governance_integration->is_loaded() );
 	}
-
-	public function test__if_is_loaded_gives_back_false_when_loaded(): void {
-		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
-
-		$this->assertFalse( $vip_governance_integration->is_loaded() );
-	}
 }

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -22,12 +22,16 @@ require_once __DIR__ . '/integrations/enums.php';
 require_once __DIR__ . '/integrations/integration-vip-config.php';
 require_once __DIR__ . '/integrations/block-data-api.php';
 require_once __DIR__ . '/integrations/parsely.php';
-require_once __DIR__ . '/integrations/vip-governance.php';
 
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
-IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
+
+// ToDo: Remove this after the initial deployment of the VIP Governance integration.
+if ( file_exists( __DIR__ . '/integrations/vip-governance.php' ) ) {
+	require_once __DIR__ . '/integrations/vip-governance.php';
+	IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
+}
 
 // @codeCoverageIgnoreEnd
 

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -19,13 +19,13 @@ require_once __DIR__ . '/integrations/integrations.php';
 require_once __DIR__ . '/integrations/enums.php';
 require_once __DIR__ . '/integrations/integration-vip-config.php';
 require_once __DIR__ . '/integrations/block-data-api.php';
-require_once __DIR__ . '/integrations/vip-governance.php';
 require_once __DIR__ . '/integrations/parsely.php';
+require_once __DIR__ . '/integrations/vip-governance.php';
 
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
-IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
+IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
 
 /**
  * Activates an integration with an optional configuration value.

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -19,10 +19,12 @@ require_once __DIR__ . '/integrations/integrations.php';
 require_once __DIR__ . '/integrations/enums.php';
 require_once __DIR__ . '/integrations/integration-vip-config.php';
 require_once __DIR__ . '/integrations/block-data-api.php';
+require_once __DIR__ . '/integrations/vip-governance.php';
 require_once __DIR__ . '/integrations/parsely.php';
 
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
+IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
 
 /**

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -14,6 +14,8 @@ namespace Automattic\VIP\Integrations;
 
 defined( 'ABSPATH' ) || die();
 
+// @codeCoverageIgnoreStart - the actual code here is tested individually in the unit tests.
+
 require_once __DIR__ . '/integrations/integration.php';
 require_once __DIR__ . '/integrations/integrations.php';
 require_once __DIR__ . '/integrations/enums.php';
@@ -26,6 +28,8 @@ require_once __DIR__ . '/integrations/vip-governance.php';
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
 IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
+
+// @codeCoverageIgnoreEnd
 
 /**
  * Activates an integration with an optional configuration value.


### PR DESCRIPTION
## Description

This is meant to add the [VIP governance plugin](https://github.com/Automattic/vip-governance-plugin/tree/trunk) as an integration in mu-plugins, alongside the Block Data API. It's using the existing VIP integrations framework that's already in place for the Block Data API and Parsely to do this.

I have also added 2 test for the Block Data API and the VIP Governance plugin that simply tries to load them, and then verifies if they are inactive. It also calls their `is_loaded` function which checks if their constant is defined which should be false. Unlike the parsely plugin, their code isn't there so the code that can be tested is limited unfortunately.

The corresponding PR in mu-plugins-ext has been made [here](https://github.com/Automattic/vip-go-mu-plugins-ext/pull/44). That should be merged first.

## Changelog Description

### Plugin Added: VIP Governance 1.0

We added VIP Governance Plugin 1.0 for VIP customers.

This is a plugin that adds additional governance capabilities to the block editor.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Example:

1. Check out PR, along with [this](https://github.com/Automattic/vip-go-mu-plugins-ext/pull/44) PR as well.
2. Use this as your mu-plugins in a local dev-env instance
3. Activate using the following:
```php
// client-mu-plugins/plugin-loader.php

\Automattic\VIP\Integrations\activate( 'vip-governance' );
```
4. Go to `wp-admin` > `Plugin` and ensure VIP Governance shows up
5. Go to `wp-admin` > `VIP Governance` and ensure that loads correctly
6. Go to the a new post page and ensure everything loads fine.
