### PR TITLE
Add potential multi-dataset logger

### DIFF
--- a/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
+++ b/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
@@ -59,7 +59,7 @@ class Potential_Multi_Dataset_Queries_Collector implements CollectorInterface {
 					'message'  => 'Potential multi dataset query detected',
 					'blog_id'  => get_current_blog_id(),
 					'extra'    => [
-						'uri'       => isset( $_SERVER['REQUEST_URI'] ) ? sanitize_url( $_SERVER['REQUEST_URI'] ) : '',
+						'uri'       => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',
 						'method'    => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',
 						'backtrace' => $backtrace,
 					],

--- a/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
+++ b/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
@@ -60,7 +60,7 @@ class Potential_Multi_Dataset_Queries_Collector implements CollectorInterface {
 					'blog_id'  => get_current_blog_id(),
 					'extra'    => [
 						'uri'       => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',
-						'method'    => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',
+						'http_method'    => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',
 						'backtrace' => $backtrace,
 					],
 				]

--- a/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
+++ b/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Prometheus;
 
 use Prometheus\Counter;
 use Prometheus\RegistryInterface;
+use function Automattic\VIP\Logstash\log2logstash;
 
 class Potential_Multi_Dataset_Queries_Collector implements CollectorInterface {
 	private Counter $potential_multi_dataset_queries_collector;
@@ -47,6 +48,21 @@ class Potential_Multi_Dataset_Queries_Collector implements CollectorInterface {
 					$last_global_table ?? 'null',
 					$last_blog_table,
 					$blog_ids_count >= 3 ? '3+' : (string) $blog_ids_count,
+				]
+			);
+
+			$backtrace = function_exists( 'wp_debug_backtrace_summary' ) ? wp_debug_backtrace_summary( null, 4, false ) : []; // phpcs:ignore
+			\Automattic\VIP\Logstash\log2logstash(
+				[
+					'severity' => 'debug',
+					'feature'  => 'potential_multi_dataset_queries',
+					'message'  => 'Potential multi dataset query detected',
+					'blog_id'  => get_current_blog_id(),
+					'extra'    => [
+						'uri'       => $_SERVER['REQUEST_URI'] ?? '',
+						'method'    => $_SERVER['REQUEST_METHOD'] ?? '',
+						'backtrace' => $backtrace,
+					],
 				]
 			);
 		}

--- a/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
+++ b/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
@@ -59,8 +59,8 @@ class Potential_Multi_Dataset_Queries_Collector implements CollectorInterface {
 					'message'  => 'Potential multi dataset query detected',
 					'blog_id'  => get_current_blog_id(),
 					'extra'    => [
-						'uri'       => $_SERVER['REQUEST_URI'] ?? '',
-						'method'    => $_SERVER['REQUEST_METHOD'] ?? '',
+						'uri'       => isset( $_SERVER['REQUEST_URI'] ) ? sanitize_url( $_SERVER['REQUEST_URI'] ) : '',
+						'method'    => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',
 						'backtrace' => $backtrace,
 					],
 				]

--- a/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
+++ b/prometheus-collectors/class-potential-multi-dataset-queries-collector.php
@@ -51,17 +51,23 @@ class Potential_Multi_Dataset_Queries_Collector implements CollectorInterface {
 				]
 			);
 
+			if ( ! function_exists( '\Automattic\VIP\Logstash\log2logstash' ) ) {
+				return;
+			}
+
 			$backtrace = function_exists( 'wp_debug_backtrace_summary' ) ? wp_debug_backtrace_summary( null, 4, false ) : []; // phpcs:ignore
 			\Automattic\VIP\Logstash\log2logstash(
 				[
 					'severity' => 'debug',
 					'feature'  => 'potential_multi_dataset_queries',
 					'message'  => 'Potential multi dataset query detected',
-					'blog_id'  => get_current_blog_id(),
 					'extra'    => [
-						'uri'       => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',
-						'http_method'    => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',
-						'backtrace' => $backtrace,
+						'uri'               => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',
+						'http_method'       => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',
+						'backtrace'         => $backtrace,
+						'last_global_table' => $last_global_table,
+						'last_blog_table'   => $last_blog_table,
+						'blog_ids_count'    => $blog_ids_count,
 					],
 				]
 			);


### PR DESCRIPTION
## Description

This PR adds a log entry containing the request information and backtrace when a potential multi-dataset query is detected.


## Changelog Description

N/A

## Pre-review checklist

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Perform a SQL query across multiple datasets
3. Observe logstash logs
