### PR TITLE
Simplify implementation of configure method in VIP Integrations

### DIFF
--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -55,9 +55,4 @@ class BlockDataApiIntegration extends Integration {
 			}
 		} );
 	}
-
-	/**
-	 * Configure `Block Data API` for VIP Platform.
-	 */
-	public function configure(): void {}
 }

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -170,11 +170,13 @@ abstract class Integration {
 
 	/**
 	 * Configure the integration for VIP platform.
-	 *
+	 * 
 	 * If we want to implement functionality only if the integration is enabled via VIP
 	 * then we will use this function.
-	 *
+	 * 
+	 * By default, the implementation of this function will be empty.
+	 * 
 	 * @private
 	 */
-	abstract public function configure(): void;
+	public function configure(): void {}
 }

--- a/integrations/vip-governance.php
+++ b/integrations/vip-governance.php
@@ -55,9 +55,4 @@ class VipGovernanceIntegration extends Integration {
 			}
 		} );
 	}
-
-	/**
-	 * Configure `VIP Governance` for VIP Platform.
-	 */
-	public function configure(): void {}
 }

--- a/tests/integrations/test-vip-block-data-api.php
+++ b/tests/integrations/test-vip-block-data-api.php
@@ -22,7 +22,7 @@ class Block_Data_API_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( $block_data_api_integration->is_active() );
 	}
 
-	public function test__if_is_loaded_gives_back_true_when_loaded(): void {
+	public function test__if_is_loaded_gives_back_false_when_not_loaded(): void {
 		$block_data_api_integration = new BlockDataApiIntegration( $this->slug );
 
 		$this->assertFalse( $block_data_api_integration->is_loaded() );

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -22,7 +22,7 @@ class VIP_Governance_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( $vip_governance_integration->is_active() );
 	}
 
-	public function test__if_is_loaded_gives_back_true_when_loaded(): void {
+	public function test__if_is_loaded_gives_back_false_when_not_loaded(): void {
 		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
 
 		$this->assertFalse( $vip_governance_integration->is_loaded() );

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -14,7 +14,7 @@ namespace Automattic\VIP\Integrations;
 
 defined( 'ABSPATH' ) || die();
 
-// @codeCoverageIgnoreStart - the actual code here is tested individually in the unit tests.
+// @codeCoverageIgnoreStart -- the actual code here is tested individually in the unit tests.
 
 require_once __DIR__ . '/integrations/integration.php';
 require_once __DIR__ . '/integrations/integrations.php';

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -12,9 +12,8 @@
 
 namespace Automattic\VIP\Integrations;
 
-defined( 'ABSPATH' ) || die();
-
 // @codeCoverageIgnoreStart -- the actual code here is tested individually in the unit tests.
+defined( 'ABSPATH' ) || die();
 
 require_once __DIR__ . '/integrations/integration.php';
 require_once __DIR__ . '/integrations/integrations.php';
@@ -28,7 +27,6 @@ require_once __DIR__ . '/integrations/vip-governance.php';
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
 IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
-
 // @codeCoverageIgnoreEnd
 
 /**

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -22,16 +22,12 @@ require_once __DIR__ . '/integrations/enums.php';
 require_once __DIR__ . '/integrations/integration-vip-config.php';
 require_once __DIR__ . '/integrations/block-data-api.php';
 require_once __DIR__ . '/integrations/parsely.php';
+require_once __DIR__ . '/integrations/vip-governance.php';
 
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
-
-// ToDo: Remove this after the initial deployment of the VIP Governance integration.
-if ( file_exists( __DIR__ . '/integrations/vip-governance.php' ) ) {
-	require_once __DIR__ . '/integrations/vip-governance.php';
-	IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
-}
+IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
 
 // @codeCoverageIgnoreEnd
 


### PR DESCRIPTION
## Description

This PR stems from a discussion I had with @WPprodigy. It simplifies the implementation of new VIP Integrations, by not requiring the configure method to be implemented unless it's truly necessary. The default implementation will now be empty.

The Block Data API and the Governance Plugin will not override it while the parsely plugin would override it.

In addition, the guard that was put in place for the initial deployment of the governance plugin has been removed since the deployment of the governance plugin has started already.

## Changelog Description

### Tooling Changes

We simplified the way new integrations are introduced into mu-plugins.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR + ensure that `vip-integrations` and wp-parsely` from [here](https://github.com/Automattic/vip-go-mu-plugins-built/blob/master) are included. 
2. Use this as your mu-plugins in a local dev-env instance
3. Activate using the following:
```
// client-mu-plugins/plugin-loader.php
\Automattic\VIP\Integrations\activate( 'vip-governance' );
```
4. Go to wp-admin > Plugin and ensure VIP Governance shows up
5. Go to wp-admin > VIP Governance and ensure that loads correctly
6. Go to the a new post page and ensure everything loads fine.