### PR TITLE
Fix broken category links when removing category base

### DIFF
--- a/vip-helpers/vip-permastructs.php
+++ b/vip-helpers/vip-permastructs.php
@@ -46,7 +46,7 @@ function wpcom_vip_load_category_base( $new_category_base ) {
 	// For empty category base, remove the '/category/' from the base, but include the parent category if it's a child
 	if ( '' === $new_category_base ) {
 		add_filter( 'category_link', function ( $link, $term_id ) {
-			return '/' . get_category_parents( $term_id, false, '/', true );
+			return home_url( '/' . get_category_parents( $term_id, false, '/', true ) );
 		}, 9, 2 );
 	}
 }


### PR DESCRIPTION
## Description

Calls to get_term_link() and get_category_link() should always return a full URL, but wpcom_vip_load_category_base() has been breaking that behaviour. This fix restores the correct functioning by using `home_url()` to ensure there is a full URL.

Fixes #4541

## Changelog Description

### Fix broken category links when removing category base

Calls to get_term_link() and get_category_link() should always return a full URL, but wpcom_vip_load_category_base() has been breaking that behaviour. This fix restores the correct functioning by using `home_url()` to ensure there is a full URL.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Using WP-CLI or theme code, call `get_category_link(CATEGORYID)` with a valid category ID and note the absolute URL.
2. Add `wpcom_vip_load_category_base('');` to the themes function file or an mu-plugin.
3. Repeat step 1 and note that you now get a relative URL returned instead of an absolute one.
4. Apply this patch and repeat step 1 and observe you now have a full URL again