### PR TITLE
Removes hardcoded VIP_PARSELY_ENABLED constant for FedRAMP sites

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -133,11 +133,6 @@ if ( method_exists( Context::class, 'is_fedramp' ) && Context::is_fedramp() ) {
 	if ( ! defined( 'VIP_JETPACK_SKIP_LOAD' ) ) {
 		define( 'VIP_JETPACK_SKIP_LOAD', true );
 	}
-
-	// FedRAMP sites do not load Parse.ly by default
-	if ( ! defined( 'VIP_PARSELY_ENABLED' ) ) {
-		define( 'VIP_PARSELY_ENABLED', false );
-	}
 }
 
 $private_dir_path = WP_CONTENT_DIR . '/private'; // Local fallback

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -109,32 +109,24 @@ class IntegrationVipConfig {
 	 * @private
 	 */
 	public function is_active_via_vip(): bool {
-		// Return false if blocked on org.
+		return Env_Integration_Status::ENABLED === $this->get_site_status();
+	}
+
+	/**
+	 * Get site status.
+	 *
+	 * @return string|null
+	 *
+	 * @private
+	 */
+	public function get_site_status() {
 		if ( $this->get_value_from_config( 'org', 'status' ) === Org_Integration_Status::BLOCKED ) {
-			return false;
+			return Org_Integration_Status::BLOCKED;
 		}
 
-		$env_status = $this->get_value_from_config( 'env', 'status' );
-
-		// Return false if blocked on env.
-		if ( Env_Integration_Status::BLOCKED === $env_status ) {
-			return false;
-		}
-
-		// Look into network_sites config before because if not present we will fallback to env config.
-		$network_site_status = $this->get_value_from_config( 'network_sites', 'status' );
-
-		if ( Env_Integration_Status::ENABLED === $network_site_status ) {
-			return true;
-		}
-
-		// Return false if status is defined but other than enabled. If status is not defined then fallback to env config.
-		if ( null !== $network_site_status ) {
-			return false;
-		}
-
-		// Return true if enabled on env.
-		return Env_Integration_Status::ENABLED === $env_status;
+		// Look into network_sites config before and then fallback to env config.
+		return $this->get_value_from_config( 'network_sites', 'status' ) ??
+			$this->get_value_from_config( 'env', 'status' );
 	}
 
 	/**

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -28,9 +28,9 @@ class ParselyIntegration extends Integration {
 	 */
 	public function load(): void {
 		// Return if the integration is already loaded.
-			//
-			// In activate() method we do make sure to not activate the integration if its already loaded
-			// but still adding it here as a safety measure i.e. if load() is called directly.
+		//
+		// In activate() method we do make sure to not activate the integration if its already loaded
+		// but still adding it here as a safety measure i.e. if load() is called directly.
 		if ( $this->is_loaded() ) {
 			return;
 		}


### PR DESCRIPTION
## Description

Currently we are hardcoding `VIP_PARSELY_ENABLED` constant as `false` for FedRAMP sites but now we are enforcing it from GOOP so we can remove it from here and only have the GOOP as source of truth.

## Changelog Description

### Update `VIP_PARSELY_ENABLED` constant for FedRAMP sites

Removes hardcoded `VIP_PARSELY_ENABLED` constant for FedRAMP sites because validations are available on backend now.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 
