### PR TITLE
Fix connection pilot’s backoff logic

### DIFF
--- a/tests/vip-jetpack/connection-pilot/test-class-jetpack-connection-pilot.php
+++ b/tests/vip-jetpack/connection-pilot/test-class-jetpack-connection-pilot.php
@@ -89,11 +89,13 @@ class Connection_Pilot_Test extends WP_UnitTestCase {
 
 	public function get_test_data__update_backoff_factor() {
 		return [
-			'null' => [ null, 1 ],
-			'zero' => [ 0, 1 ],
-			'one'  => [ 1, 2 ],
-			'two'  => [ 2, 4 ],
-			'max'  => [ 2048, 2048 ],
+			'null'       => [ null, 1 ],
+			'zero'       => [ 0, 1 ],
+			'one_hour'   => [ 1, 2 ],
+			'two_hours'  => [ 2, 4 ],
+			'three_days' => [ 72, 144 ],
+			'max'        => [ 168, 168 ],
+			'over_max'   => [ 2000, 168 ],
 		];
 	}
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -188,7 +188,7 @@ class Connection_Pilot {
 			}
 
 			if ( $backoff_factor > 0 ) {
-				$seconds_elapsed = time() - $last_heartbeat_timestamp;
+				$seconds_elapsed = time() - $this->last_heartbeat['timestamp'];
 				$hours_elapsed   = $seconds_elapsed / HOUR_IN_SECONDS;
 
 				if ( $backoff_factor > $hours_elapsed ) {

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -189,7 +189,7 @@ class Connection_Pilot {
 
 			if ( $backoff_factor > 0 ) {
 				$seconds_elapsed = time() - $last_heartbeat_timestamp;
-				$hours_elapsed   = (int) round( $seconds_elapsed / HOUR_IN_SECONDS );
+				$hours_elapsed   = $seconds_elapsed / HOUR_IN_SECONDS;
 
 				if ( $backoff_factor > $hours_elapsed ) {
 					// We're still in the backoff period.


### PR DESCRIPTION
DateTime->diff() gives a result like this:

```
$diff = $dt_now->diff( $dt_heartbeat, true );
=> object(DateInterval)#8069 (16) {
  ["y"]=>
  int(0)
  ["m"]=>
  int(1)
  ["d"]=>
  int(17)
  ["h"]=>
  int(2)
  ["i"]=>
  int(20)
  ["s"]=>
  int(3)
```

So checking only `$diff->h` is not sufficient once days, or even months/years have passed. Checking hours alone for sure will never work after the backoff is greater than 24h. And the max backoff period currently set is 7 days.

Also removed an extra `update_heartbeat()` call that kind of gets in the way of the backoff logic and could refresh the timestamp and cause inaccurate backoff checks to follow. Instead, can just enforce the `MAX_BACKOFF_FACTOR` in the `update_backoff_factor()` method, while also ensuring a call to that method always refreshes the timestamp appropriately.