### PR TITLE
Remove my-jetpack page from wp-admin

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -75,11 +75,21 @@ add_filter( 'jetpack_get_available_modules', function ( $modules ) {
 /**
  * Do not initialize my jetpack admin page for VIP Machine User
  */
-$connection_owner  = Jetpack::connection()->get_connection_owner();
-$is_vip_connection = $connection_owner && WPCOM_VIP_MACHINE_USER_LOGIN === $connection_owner->user_login;
-if ( $is_vip_connection ) {
-	add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
-}
+add_action( 'plugins_loaded', function () {
+	if ( ! is_admin() || wp_doing_ajax() || ! method_exists( 'Jetpack', 'connection' ) || ! defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) ) {
+		return;
+	}
+
+	$jp_connection = Jetpack::connection();
+	if ( method_exists( $jp_connection, 'get_connection_owner' ) ) {
+		$connection_owner  = $jp_connection->get_connection_owner();
+		$is_vip_connection = isset( $connection_owner->user_login ) && WPCOM_VIP_MACHINE_USER_LOGIN === $connection_owner->user_login;
+
+		if ( $is_vip_connection ) {
+			add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
+		}
+	}
+} );
 
 /**
  * Lock down the jetpack_sync_settings_max_queue_size to an allowed range

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -73,9 +73,13 @@ add_filter( 'jetpack_get_available_modules', function ( $modules ) {
 }, 999 );
 
 /**
- * Do not initialize my jetpack admin page
+ * Do not initialize my jetpack admin page for VIP Machine User
  */
-add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
+$connection_owner  = Jetpack::connection()->get_connection_owner();
+$is_vip_connection = $connection_owner && WPCOM_VIP_MACHINE_USER_LOGIN === $connection_owner->user_login;
+if ( $is_vip_connection ) {
+	add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
+}
 
 /**
  * Lock down the jetpack_sync_settings_max_queue_size to an allowed range

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -73,6 +73,11 @@ add_filter( 'jetpack_get_available_modules', function ( $modules ) {
 }, 999 );
 
 /**
+ * Do not initialize my jetpack admin page
+ */
+add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
+
+/**
  * Lock down the jetpack_sync_settings_max_queue_size to an allowed range
  *
  * Still allows changing the value per site, but locks it into the range


### PR DESCRIPTION
## Description

We are removing My Jetpack page from the wp-admin. It's not relevant to VIP customers since the Jetpack experience is highly tailored and the page can create confusion.

## Changelog Description

The "My Jetpack" page is being disabled. The page is not relevant to VIP environment since the Jetpack experience is highly tailored and the page can create confusion.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Check out PR.
2. Run an environment locally using VIP-CLI.
1. Go to `wp-admin`
1. See that my-jetpack page does not appear anymore
