### PR TITLE
Remove deprecated filter `http_api_transports`

### DIFF
--- a/files/class-curl-streamer.php
+++ b/files/class-curl-streamer.php
@@ -10,17 +10,11 @@ class Curl_Streamer {
 	}
 
 	public function init() {
-		add_filter( 'http_api_transports', [ $this, 'enforce_curl_transport' ] );
 		add_action( 'http_api_curl', [ $this, 'init_upload' ], 10 );
 	}
 
 	public function deinit() {
-		remove_filter( 'http_api_transports', [ $this, 'enforce_curl_transport' ] );
 		remove_action( 'http_api_curl', [ $this, 'init_upload' ] );
-	}
-
-	public function enforce_curl_transport() {
-		return [ 'curl' ];
 	}
 
 	public function init_upload( $curl_handle ) {

--- a/tests/files/test-curl-streamer.php
+++ b/tests/files/test-curl-streamer.php
@@ -30,22 +30,6 @@ class Curl_Streamer_Test extends WP_UnitTestCase {
 		parent::tearDown();
 	}
 
-	public function test__init() {
-		global $wp_version;
-
-		$version = preg_replace( '/-.*$/', '', $wp_version );
-		if ( version_compare( $version, '6.4', '>=' ) ) {
-			$this->setExpectedDeprecated( 'http_api_transports' );
-		}
-
-		$expected_transport = 'WP_Http_Curl';
-
-		$wp_http          = new \WP_Http();
-		$actual_transport = $wp_http->_get_first_available_transport( [] );
-
-		$this->assertEquals( $expected_transport, $actual_transport );
-	}
-
 	public function test__init_upload() {
 		$this->markTestSkipped( 'Cannot get `curl` opts, making this hard to test. We can look into using a test webserver in the future.' );
 	}


### PR DESCRIPTION
## Description
Deprecated in https://core.trac.wordpress.org/changeset/56723.

Looks like the filter no longer fires since uploads now go directly through the Requests library: https://github.com/WordPress/WordPress/blob/915f28e18ed883cd706545cefd16b4d19b841c47/wp-includes/Requests/src/Requests.php#L225

## Changelog Description

### Remove deprecated filter `http_api_transports`

Removes filter `http_api_transports` that will be deprecated in WP 6.4

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
