### PR TITLE
Increase priority of wp_mail_from filter for VIP Support contact form

### DIFF
--- a/vip-dashboard/vip-dashboard.php
+++ b/vip-dashboard/vip-dashboard.php
@@ -178,11 +178,11 @@ function vip_contact_form_handler() {
 	// Filter from name/email. NOTE - not un-hooking the filter because we die() immediately after wp_mail()
 	add_filter( 'wp_mail_from', function () use ( $email ) {
 		return $email;
-	});
+	}, 999 );
 
 	add_filter( 'wp_mail_from_name', function () use ( $name ) {
 		return $name;
-	});
+	}, 999 );
 
 	$headers = "From: \"$name\" <$email>\r\n";
 	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail

--- a/vip-dashboard/vip-dashboard.php
+++ b/vip-dashboard/vip-dashboard.php
@@ -178,11 +178,11 @@ function vip_contact_form_handler() {
 	// Filter from name/email. NOTE - not un-hooking the filter because we die() immediately after wp_mail()
 	add_filter( 'wp_mail_from', function () use ( $email ) {
 		return $email;
-	}, 999 );
+	}, PHP_INT_MAX );
 
 	add_filter( 'wp_mail_from_name', function () use ( $name ) {
 		return $name;
-	}, 999 );
+	}, PHP_INT_MAX );
 
 	$headers = "From: \"$name\" <$email>\r\n";
 	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail


### PR DESCRIPTION
## Description
To prevent any unintentional overriding.

## Changelog Description

### VIP Dashboard Filters Updated: `wp_mail` and `wp_mail_from`

Increase priority of `wp_mail_from` and `wp_mail_from_name` filter in VIP dashboard to prevent unintentional overriding.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
