### PR TITLE
CANTINA-955: Deprecate `SEARCH_DEV_TOOLS_CAP` and use `vip_search_dev_tools_cap` filter instead. Also decouples query monitor

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -498,7 +498,7 @@ class Search {
 	 * This is separate from setup_hooks because some parts of setup_hooks require ElasticPress.
 	 */
 	protected function maybe_enable_ep_query_logging() {
-		add_action( 'plugins_loaded', [ $this, 'enable_ep_query_logging_if_query_monitor_enabled' ] );
+		add_action( 'plugins_loaded', [ $this, 'enable_ep_query_logging_if_debug_or_has_cap' ] );
 		add_action( 'plugins_loaded', [ $this, 'load_ep_get_query_log_function' ] );
 	}
 
@@ -507,15 +507,15 @@ class Search {
 	}
 
 	/**
-	 * Check if query monitor or debug bar are enabled. Also check for the debug mode being enabled.
+	 * Check if debug mode is enabled or has search dev tools cap.
 	 * If so, define WP_EP_DEBUG as true so ElasticPress enables query logging.
 	 */
-	public function enable_ep_query_logging_if_query_monitor_enabled() {
+	public function enable_ep_query_logging_if_debug_or_has_cap() {
 		if ( defined( 'WP_EP_DEBUG' ) ) {
 			return;
 		}
 
-		if ( apply_filters( 'wpcom_vip_qm_enable', false ) || ( function_exists( 'is_debug_mode_enabled' ) && is_debug_mode_enabled() ) ) {
+		if ( current_user_can( apply_filters( 'vip_search_dev_tools_cap', 'manage_options' ) ) || ( function_exists( 'is_debug_mode_enabled' ) && is_debug_mode_enabled() ) ) {
 			define( 'WP_EP_DEBUG', true );
 		}
 	}

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -99,7 +99,7 @@ function rest_callback( \WP_REST_Request $request ) {
  */
 function should_enable_search_dev_tools(): bool {
 	$cap = apply_filters( 'vip_search_dev_tools_cap', 'manage_options' );
-	return ( current_user_can( $cap ) || is_debug_mode_enabled() ) && function_exists( 'ep_get_query_log' );
+	return ( current_user_can( $cap ) || ( function_exists( 'is_debug_mode_enabled' ) && is_debug_mode_enabled() ) ) && function_exists( 'ep_get_query_log' );
 }
 
 /**

--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -16,8 +16,6 @@ namespace Automattic\VIP\Search\Dev_Tools;
 
 use Automattic\VIP\Search\Search;
 
-define( 'SEARCH_DEV_TOOLS_CAP', 'manage_options' );
-
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes' );
 add_action( 'admin_bar_menu', __NAMESPACE__ . '\admin_bar_node', PHP_INT_MAX );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 11 );
@@ -100,7 +98,8 @@ function rest_callback( \WP_REST_Request $request ) {
  * @return boolean
  */
 function should_enable_search_dev_tools(): bool {
-	return ( current_user_can( SEARCH_DEV_TOOLS_CAP ) || is_debug_mode_enabled() ) && function_exists( 'ep_get_query_log' );
+	$cap = apply_filters( 'vip_search_dev_tools_cap', 'manage_options' );
+	return ( current_user_can( $cap ) || is_debug_mode_enabled() ) && function_exists( 'ep_get_query_log' );
 }
 
 /**

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2489,33 +2489,23 @@ class Search_Test extends WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test__maybe_enable_ep_query_logging_no_debug_tools_enabled() {
-		add_filter( 'wpcom_vip_qm_enable', '__return_false', PHP_INT_MAX );
+	public function test__maybe_enable_ep_query_logging_no_cap() {
+		wp_set_current_user( 0 );
 
 		$this->init_es();
 
-		$this->assertFalse( defined( 'WP_EP_DEBUG' ) );
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( Constant_Mocker::defined( 'WP_EP_DEBUG' ) );
 	}
 
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test__maybe_enable_ep_query_logging_qm_enabled() {
-		add_filter( 'wpcom_vip_qm_enable', '__return_true' );
-
-		$this->init_es();
-
-		$this->assertTrue( Constant_Mocker::defined( 'WP_EP_DEBUG' ) );
-		$this->assertTrue( Constant_Mocker::constant( 'WP_EP_DEBUG' ) );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test__maybe_enable_ep_query_logging_and_qm_enabled() {
-		add_filter( 'wpcom_vip_qm_enable', '__return_true' );
+	public function test__maybe_enable_ep_query_logging_has_cap() {
+		$super_admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $super_admin->ID );
 
 		$this->init_es();
 
@@ -2524,6 +2514,26 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertTrue( Constant_Mocker::defined( 'WP_EP_DEBUG' ) );
 		$this->assertTrue( Constant_Mocker::constant( 'WP_EP_DEBUG' ) );
 	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test__maybe_enable_ep_query_logging_filtered_cap() {
+		add_filter( 'vip_search_dev_tools_cap', function () {
+			return 'edit_posts';
+		} );
+		$editor = $this->factory()->user->create_and_get( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor->ID );
+
+		$this->init_es();
+
+		do_action( 'plugins_loaded' );
+
+		$this->assertTrue( Constant_Mocker::defined( 'WP_EP_DEBUG' ) );
+		$this->assertTrue( Constant_Mocker::constant( 'WP_EP_DEBUG' ) );
+	}
+
 	public function limit_max_result_window_data() {
 		return [
 			[


### PR DESCRIPTION
## Description
We need to decouple Search Dev Tools from Query Monitor since it shouldn't matter if Query Monitor is enabled or not. Also, deprecates `SEARCH_DEV_TOOLS_CAP` and uses `vip_search_dev_tools_cap` filter in case someone wanted to customize it.

This PR also fixes a bug where a user does not have the Query Monitor cap (or if they have QM disabled), but has the Search Dev Tools cap resulting in Search Dev Tools running, but the query not being logged for an ES query. To reproduce on dev-env:

1) Comment out https://github.com/Automattic/vip-go-mu-plugins/blob/0448c54199036143aac42d5f28b09a2bb4602d64/000-debug/debug-mode.php#L42-L44
2) Log in with a user with `manage_options` cap, e.g. an administrator
3) Remove `view_query_monitor` cap via CLI: `wp user remove-caps username view_query_monitor`
4) Perform an ES query and see 
<img width="192" alt="Screenshot 2023-10-23 at 8 24 14 PM" src="https://github.com/Automattic/vip-go-mu-plugins/assets/16962021/732d6947-25f9-4d21-a2d5-77be00ab7e99">

Only issue I might see is that users who had Search Dev Tools cap but didn't have Query Monitor enabled may see Search Dev Tools now, when they didn't before.

## Changelog Description

### Plugin Updated: Enterprise Search

Decouples the reliance of enabling Search Dev Tools on query monitor and allows for filtering of capabilities for Search Dev Tools.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Do reproduction steps in Description
2) Apply patch and do an ES query, e.g. `?s=hello`
3) See Search Dev Tools bar change to:
<img width="157" alt="Screenshot 2023-10-23 at 8 25 21 PM" src="https://github.com/Automattic/vip-go-mu-plugins/assets/16962021/e2af1f69-2170-47e9-a26c-cee6fcd82d87">
