### PR TITLE
fix(files): better handle directories in `move()`

### DIFF
--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -218,6 +218,10 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 			return false;
 		}
 
+		if ( $source_transport instanceof WP_Filesystem_Direct && $destination_transport instanceof WP_Filesystem_Direct ) {
+			return $source_transport->copy( $source, $destination, $overwrite, $mode );
+		}
+
 		$destination_exists = $destination_transport->exists( $destination );
 		if ( ! $overwrite && $destination_exists ) {
 			/* translators: 1: destination file path 2: overwrite param 3: `true` boolean value */
@@ -248,13 +252,24 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 	 * @return bool
 	 */
 	public function move( $source, $destination, $overwrite = false ) {
-		$copy_results = $this->copy( $source, $destination, $overwrite );
-		if ( false === $copy_results ) {
-			return false;
+		$source_transport      = $this->get_transport_for_path( $source );
+		$destination_transport = $this->get_transport_for_path( $destination, 'write' );
+		if ( $source_transport instanceof WP_Filesystem_Direct && $destination_transport instanceof WP_Filesystem_Direct ) {
+			return $source_transport->move( $source, $destination, $overwrite );
 		}
 
-		// We don't need to set the errors here since delete() will take care of it
-		return $this->delete( $source );
+		// WP_Filesystem_Direct::get_contents() invoked by copy() will return '' for directories; this will result in directories being copied as empty files.
+		if ( $source_transport->is_file( $source ) ) {
+			$copy_results = $this->copy( $source, $destination, $overwrite );
+			if ( false === $copy_results ) {
+				return false;
+			}
+
+			// We don't need to set the errors here since delete() will take care of it
+			return $this->delete( $source );
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR does two things:
* for `copy()` and `move()` operations, if both `$source` and `$destination` are instances of `WP_Filesystem_Direct`, use `WP_Filesystem_Direct`'s implementation for those operations. This is faster because it can use `rename()` to move files within the same filesystem instead of `copy() + unlink()`.
* for `move()`, give up if `$source` is not a file. `move()` uses `copy() + delete()`; `copy()` is `get_contents() + put_contents()`. `WP_Filesystem_Direct::get_contents()` uses `file_get_contents()` under the hood; it returns an empty string if applied to a directory. As a result, directories are copied as empty files. This caused issues with the upgrader. It tried to move directories to `wp-content/upgrade-temp-backup`, which did not work. It then tried to fall back to recursive copying, but that failed when it tried to create a directory (because `move()` has already created it as a file).

## Changelog Description

### Plugin Updated: VIP File Service

* Improve performance of `WP_Filesystem_VIP`'s `copy()` and `move()` when the source and the destination are handled by `WP_Filesystem_Direct`
* `WP_Filesystem_VIP::move()` gives up when the source is not a file; this prevents directories from being copied as empty files.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See CANTINA-970
