### PR TITLE
CANTINA-954: Security: Use ambiguous error message in forgot password

### DIFF
--- a/security/login-error.php
+++ b/security/login-error.php
@@ -57,12 +57,13 @@ add_filter( 'login_errors', __NAMESPACE__ . '\use_ambiguous_login_error', 99, 1 
  */
 function use_ambiguous_confirmation( $errors ): WP_Error {
 	if ( isset( $_GET['checkemail'] ) && 'confirm' === $_GET['checkemail'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		foreach ( $errors as &$err ) {
-			if ( isset( $err['confirm'][0] ) ) {
-				$err['confirm'][0] = FORGET_PWD_MESSAGE;
-			}
+		$messages = $errors->get_error_messages( 'confirm' );
+		if ( ! empty( $messages ) ) {
+			$errors->remove( 'confirm' );
+			$errors->add( 'confirm', FORGET_PWD_MESSAGE, 'message' );
 		}
 	}
+
 	return $errors;
 }
 add_filter( 'wp_login_errors', __NAMESPACE__ . '\use_ambiguous_confirmation', 99 );

--- a/security/login-error.php
+++ b/security/login-error.php
@@ -7,11 +7,11 @@ const FORGET_PWD_MESSAGE = 'If there is an account associated with the username/
 
 /**
  * Use a login message that does not reveal the type of login error in an attempted brute-force.
- * 
+ *
  * @param string $error Login error message.
- * 
+ *
  * @return string $error Login error message.
- * 
+ *
  * @since 1.1
  */
 function use_ambiguous_login_error( $error ): string {
@@ -48,11 +48,11 @@ add_filter( 'login_errors', __NAMESPACE__ . '\use_ambiguous_login_error', 99, 1 
 
 /**
  * Use a message that does not reveal the type of login error in an attempted brute-force on forget password.
- * 
+ *
  * @param WP_Error $errors WP Error object.
- * 
+ *
  * @return WP_Error $errors WP Error object.
- * 
+ *
  * @since 1.1
  */
 function use_ambiguous_confirmation( $errors ): WP_Error {

--- a/security/login-error.php
+++ b/security/login-error.php
@@ -1,5 +1,8 @@
 <?php
 namespace Automattic\VIP\Security;
+use WP_Error;
+
+const FORGET_PWD_MESSAGE = 'If there is an account associated with the username/email address, you will receive an email with a link to reset your password.';
 
 /**
  * Use a login message that does not reveal the type of login error in an attempted brute-force.
@@ -15,6 +18,11 @@ function use_ambiguous_login_error( $error ): string {
 
 	if ( ! is_wp_error( $errors ) ) {
 		return (string) $error;
+	}
+
+	// For lostpassword action, use different message.
+	if ( isset( $_GET['action'] ) && 'lostpassword' === $_GET['action'] ) {
+		return FORGET_PWD_MESSAGE;
 	}
 
 	$err_codes = $errors->get_error_codes();
@@ -35,5 +43,25 @@ function use_ambiguous_login_error( $error ): string {
 
 	return (string) $error;
 }
-
 add_filter( 'login_errors', __NAMESPACE__ . '\use_ambiguous_login_error', 99, 1 );
+
+/**
+ * Use a message that does not reveal the type of login error in an attempted brute-force on forget password.
+ * 
+ * @param WP_Error $errors WP Error object.
+ * 
+ * @return WP_Error $errors WP Error object.
+ * 
+ * @since 1.1
+ */
+function use_ambiguous_confirmation( $errors ): WP_Error {
+	if ( isset( $_GET['checkemail'] ) && 'confirm' === $_GET['checkemail'] ) {
+		foreach ( $errors as &$err ) {
+			if ( isset( $err['confirm'][0] ) ) {
+				$err['confirm'][0] = FORGET_PWD_MESSAGE;
+			}
+		}
+	}
+	return $errors;
+}
+add_filter( 'wp_login_errors', __NAMESPACE__ . '\use_ambiguous_confirmation', 99 );

--- a/security/login-error.php
+++ b/security/login-error.php
@@ -1,5 +1,6 @@
 <?php
 namespace Automattic\VIP\Security;
+
 use WP_Error;
 
 const FORGET_PWD_MESSAGE = 'If there is an account associated with the username/email address, you will receive an email with a link to reset your password.';
@@ -21,7 +22,7 @@ function use_ambiguous_login_error( $error ): string {
 	}
 
 	// For lostpassword action, use different message.
-	if ( isset( $_GET['action'] ) && 'lostpassword' === $_GET['action'] ) {
+	if ( isset( $_GET['action'] ) && 'lostpassword' === $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return FORGET_PWD_MESSAGE;
 	}
 
@@ -55,7 +56,7 @@ add_filter( 'login_errors', __NAMESPACE__ . '\use_ambiguous_login_error', 99, 1 
  * @since 1.1
  */
 function use_ambiguous_confirmation( $errors ): WP_Error {
-	if ( isset( $_GET['checkemail'] ) && 'confirm' === $_GET['checkemail'] ) {
+	if ( isset( $_GET['checkemail'] ) && 'confirm' === $_GET['checkemail'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		foreach ( $errors as &$err ) {
 			if ( isset( $err['confirm'][0] ) ) {
 				$err['confirm'][0] = FORGET_PWD_MESSAGE;

--- a/tests/security/test-login-error.php
+++ b/tests/security/test-login-error.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Automattic\VIP\Security;
+
+use WP_Error;
+use WP_UnitTestCase;
+
+class Login_Error_Test extends WP_UnitTestCase {
+	public function tearDown(): void {
+		global $errors;
+
+		unset( $errors );
+		parent::tearDown();
+	}
+
+	public function test_has_filters(): void {
+		self::assertEquals( 99, has_filter( 'login_errors', __NAMESPACE__ . '\use_ambiguous_login_error' ) );
+		self::assertEquals( 99, has_filter( 'wp_login_errors', __NAMESPACE__ . '\use_ambiguous_confirmation' ) );
+	}
+
+	public function test_use_ambiguous_confirmation(): void {
+		$errors = new WP_Error();
+		$errors->add(
+			'confirm',
+			sprintf(
+				'Check your email for the confirmation link, then visit the <a href="%s">login page</a>.',
+				wp_login_url()
+			),
+			'message'
+		);
+
+		$_GET['checkemail'] = 'confirm';
+		$actual             = apply_filters( 'wp_login_errors', $errors, admin_url() );
+
+		self::assertInstanceOf( WP_Error::class, $actual );
+		self::assertContains( FORGET_PWD_MESSAGE, $actual->get_error_messages( 'confirm' ) );
+	}
+
+	public function test_ambiguous_reset(): void {
+		global $errors;
+
+		$message = 'Something went terribly wrong';
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$errors = new WP_Error();
+		$errors->add( 'error', $message );
+
+		$_GET['action'] = 'lostpassword';
+
+		$actual = apply_filters( 'login_errors', $message );
+		self::assertSame( FORGET_PWD_MESSAGE, $actual );
+	}
+}


### PR DESCRIPTION
## Description
We should use an ambiguous error message in the Forgot Password, since the messages confirm if a user has entered a correct username or email in the "Forgot Password" form.

## Changelog Description

### Updated: Forgot Password

When users hit the Forgot Password in wp-login, it will no longer confirm if their email or username exists.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Go to wp-admin > Forgot password
2) Test with an invalid email e.g. `test@test.com`
3) Test with a valid username e.g. `vipgo`
4) Both should display the same error message