### PR TITLE
CANTINA-967 Jetpack: Disable loading scan related code

### DIFF
--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -50,6 +50,8 @@ class WPCOM_VIP_Jetpack_Mandatory {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'filter_jetpack_get_default_modules' ), 99 );
 		// @TODO: Add VIP scanner check to watch for people unhooking this
 		add_filter( 'pre_update_option_jetpack_active_modules', array( $this, 'filter_pre_update_option_jetpack_active_modules' ), 99, 2 );
+
+		add_filter( 'jetpack_disable_scan', '__return_true' ); // Disables loading of scan related code since we don't use it on VIP
 	}
 
 	// HOOKS


### PR DESCRIPTION
## Description
https://github.com/Automattic/jetpack/pull/33764 Just got merged and will go out with 12.8.

The scan module isn't compatible with VIP, so we should disable loading it.

## Changelog Description

### Plugin Updated: Jetpack

Disable loading scan module

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
