### PR TITLE
CANTINA-953: Add `vip_block_wp_mail` filter

### DIFF
--- a/tests/mock-constants.php
+++ b/tests/mock-constants.php
@@ -200,3 +200,19 @@ namespace Automattic\VIP\Core\Constants {
 		return Constant_Mocker::constant( $constant );
 	}
 }
+
+namespace Automattic\VIP\Mail {
+	use Automattic\Test\Constant_Mocker;
+
+	function define( $constant, $value ) {
+		return Constant_Mocker::define( $constant, $value );
+	}
+
+	function defined( $constant ) {
+		return Constant_Mocker::defined( $constant );
+	}
+
+	function constant( $constant ) {
+		return Constant_Mocker::constant( $constant );
+	}
+}

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -10,6 +10,7 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- needs refactoring
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- PHPMailer does not follow the conventions
+namespace Automattic\VIP\Mail;
 
 use PHPMailer\PHPMailer\PHPMailer;
 

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -80,7 +80,12 @@ final class VIP_SMTP {
 	 * @param PHPMailer $phpmailer 
 	 */
 	public function phpmailer_init( &$phpmailer ): void {
-		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && true === constant( 'VIP_BLOCK_WP_MAIL' ) ) {
+		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && true === constant( 'VIP_BLOCK_WP_MAIL' ) ) { // Constant will take precedence over filter
+			$phpmailer = new VIP_Noop_Mailer( $phpmailer );
+			return;
+		}
+
+		if ( true === apply_filters( 'vip_block_wp_mail', false ) ) {
 			$phpmailer = new VIP_Noop_Mailer( $phpmailer );
 			return;
 		}

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -46,6 +46,17 @@ if ( defined( 'USE_VIP_PHPMAILER' ) && true === constant( 'USE_VIP_PHPMAILER' ) 
 }
 
 class VIP_Noop_Mailer {
+
+	/**
+	 * @var string
+	 */
+	public $subject;
+
+	/**
+	 * @var string
+	 */
+	public $recipients;
+
 	public function __construct( $phpmailer ) {
 		$this->subject    = $phpmailer->Subject ?? '[No Subject]';
 		$this->recipients = implode( ', ', array_keys( $phpmailer->getAllRecipientAddresses() ) );


### PR DESCRIPTION
## Description
This PR introduces a filter `vip_block_wp_mail` which can be used on the application level in client-mu-plugins to disable email. However, the existing constant `VIP_BLOCK_WP_MAIL` which is for VIP internal use will take precedence.

## Changelog Description

### Filter Added: vip_block_wp_mail

New filter `vip_block_wp_mail` which can be used on the application level in client-mu-plugins to disable email.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Use `add_filter( 'vip_block_wp_mail','__return_true );` in client-mu-plugins
2) expect Noop Mailer