### PR TITLE
Follow up to PR 4973: Make login error strings translatable

### DIFF
--- a/security/login-error.php
+++ b/security/login-error.php
@@ -22,8 +22,7 @@ function use_ambiguous_login_error( $error ): string {
 	// For lostpassword action, use different message.
 	if ( isset( $_GET['action'] ) && 'lostpassword' === $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return esc_html__(
-			'If there is an account associated with the username/email address, you will receive an email with a 
-			link to reset your password.',
+			'If there is an account associated with the username/email address, you will receive an email with a link to reset your password.',
 			'vip'
 		);
 	}

--- a/security/login-error.php
+++ b/security/login-error.php
@@ -3,8 +3,6 @@ namespace Automattic\VIP\Security;
 
 use WP_Error;
 
-const FORGET_PWD_MESSAGE = 'If there is an account associated with the username/email address, you will receive an email with a link to reset your password.';
-
 /**
  * Use a login message that does not reveal the type of login error in an attempted brute-force.
  *
@@ -23,7 +21,11 @@ function use_ambiguous_login_error( $error ): string {
 
 	// For lostpassword action, use different message.
 	if ( isset( $_GET['action'] ) && 'lostpassword' === $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		return FORGET_PWD_MESSAGE;
+		return esc_html__(
+			'If there is an account associated with the username/email address, you will receive an email with a 
+			link to reset your password.',
+			'vip'
+		);
 	}
 
 	$err_codes = $errors->get_error_codes();
@@ -37,7 +39,8 @@ function use_ambiguous_login_error( $error ): string {
 
 	foreach ( $err_types as $err ) {
 		if ( in_array( $err, $err_codes, true ) ) {
-			$error = '<strong>Error</strong>: The username/email address or password is incorrect. Please try again.';
+			$error = '<strong>' . esc_html__( 'Error', 'vip' ) . '</strong>: ' . 
+			esc_html__( 'The username/email address or password is incorrect. Please try again.', 'vip' );
 			break;
 		}
 	}
@@ -60,7 +63,12 @@ function use_ambiguous_confirmation( $errors ): WP_Error {
 		$messages = $errors->get_error_messages( 'confirm' );
 		if ( ! empty( $messages ) ) {
 			$errors->remove( 'confirm' );
-			$errors->add( 'confirm', FORGET_PWD_MESSAGE, 'message' );
+			$errors->add(
+				'confirm',
+				esc_html__( 'If there is an account associated with the username/email address, you will receive an email with a 
+				link to reset your password.', 'vip' ),
+				'message'
+			);
 		}
 	}
 

--- a/security/login-error.php
+++ b/security/login-error.php
@@ -64,8 +64,7 @@ function use_ambiguous_confirmation( $errors ): WP_Error {
 			$errors->remove( 'confirm' );
 			$errors->add(
 				'confirm',
-				esc_html__( 'If there is an account associated with the username/email address, you will receive an email with a 
-				link to reset your password.', 'vip' ),
+				esc_html__( 'If there is an account associated with the username/email address, you will receive an email with a link to reset your password.', 'vip' ),
 				'message'
 			);
 		}

--- a/tests/security/test-login-error.php
+++ b/tests/security/test-login-error.php
@@ -33,7 +33,10 @@ class Login_Error_Test extends WP_UnitTestCase {
 		$actual             = apply_filters( 'wp_login_errors', $errors, admin_url() );
 
 		self::assertInstanceOf( WP_Error::class, $actual );
-		self::assertContains( FORGET_PWD_MESSAGE, $actual->get_error_messages( 'confirm' ) );
+		self::assertContains(
+			'If there is an account associated with the username/email address, you will receive an email with a link to reset your password.',
+			$actual->get_error_messages( 'confirm' )
+		);
 	}
 
 	public function test_ambiguous_reset(): void {
@@ -48,6 +51,9 @@ class Login_Error_Test extends WP_UnitTestCase {
 		$_GET['action'] = 'lostpassword';
 
 		$actual = apply_filters( 'login_errors', $message );
-		self::assertSame( FORGET_PWD_MESSAGE, $actual );
+		self::assertSame(
+			'If there is an account associated with the username/email address, you will receive an email with a link to reset your password.',
+			$actual
+		);
 	}
 }


### PR DESCRIPTION
## Description
https://github.com/Automattic/vip-go-mu-plugins/pull/4973/files#r1372386037

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
