### PR TITLE
Disable SAVEQUERIES in WP CLI commands

### DIFF
--- a/wp-cli.php
+++ b/wp-cli.php
@@ -49,7 +49,7 @@ function maybe_toggle_is_ssl() {
  * Disable the SAVEQUERIES for all the WP CLI interactions, unless already defined.
  * SAVEQUERIES tracks is quite expensive if turned on and can lead to OOM and performance issues, it should be enabled only when needed.
  */
-function maybe_disable_savequeries(){
+function maybe_disable_savequeries() {
 	if ( ! defined( 'SAVEQUERIES' ) ) {
 		define( 'SAVEQUERIES', false );
 	}

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -46,6 +46,16 @@ function maybe_toggle_is_ssl() {
 }
 
 /**
+ * Disable the SAVEQUERIES for all the WP CLI interactions, unless already defined.
+ * SAVEQUERIES tracks is quite expensive if turned on and can lead to OOM and performance issues, it should be enabled only when needed.
+ */
+function maybe_disable_savequeries(){
+	if ( ! defined( 'SAVEQUERIES' ) ) {
+		define( 'SAVEQUERIES', false );
+	}
+}
+
+/**
  * Disable `display_errors` for all wp-cli interactions on production servers.
  *
  * Warnings and notices can break things like JSON output,
@@ -70,6 +80,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	disable_display_errors();
 
 	init_is_ssl_toggle();
+
+	maybe_disable_savequeries();
 
 	foreach ( glob( __DIR__ . '/wp-cli/*.php' ) as $command ) {
 		require $command;


### PR DESCRIPTION
## Description

`SAVEQUERIES` is quite memory-heavy, disabling it in the WP CLI commands should result in faster operations and less OOM. 
The change will only disable it unless already defined, so it still allows customers to override this flag.

## Changelog Description

### Disable SAVEQUERIES in WP CLI Commands

For all the WP CLI commands we're now setting the `SAVEQUERIES` to false, to improve the performance. 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
- Checkout the PR and run a local `vip dev-env` with this change.
- Run `vip dev-env exec -- wp eval "echo SAVEQUERIES ? 'true' : 'false';"` 
- It should return `false`. 
- If you comment the `maybe_disable_savequeries()` function in the `wp-cli.php` and run the same command again it should return `true`