### PR TITLE
CANTINA-985: Deprecate `wpcom_vip_get_page_by_path()`, `wpcom_vip_term_exists()` and `wpcom_vip_get_page_by_title()`

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -4,8 +4,6 @@
  */
 
 // phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
-// phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_title_get_page_by_title
-// phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
 // phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.attachment_url_to_postid_attachment_url_to_postid
 // phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid
 // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
@@ -97,92 +95,6 @@ function wpcom_vip_get_term_link( $term, $taxonomy = null ) {
 
 	$term_object = get_term_by( 'slug', $term, $taxonomy );
 	return get_term_link( $term_object );
-}
-
-/**
- * Cached version of get_page_by_title so that we're not making unnecessary SQL all the time
- *
- * @param string $page_title Page title
- * @param string $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
- * @param string $post_type Optional. Post type; default is 'page'.
- * @return WP_Post|null WP_Post on success or null on failure
- * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/ Uncached Functions
- */
-function wpcom_vip_get_page_by_title( $title, $output = OBJECT, $post_type = 'page' ) {
-	global $wp_version;
-	if ( version_compare( $wp_version, '6.2', '<' ) ) {
-		_deprecated_function( __FUNCTION__, '6.2', 'WP_Query' );
-	}
-
-	$cache_key = $post_type . '_' . sanitize_key( $title );
-	$page_id   = wp_cache_get( $cache_key, 'get_page_by_title' );
-
-	if ( false === $page_id ) {
-		if ( ! function_exists( 'is_user_logged_in' ) ) {
-			// If too early to call `WP_Query`, fallback to deprecated `get_page_by_title`
-			// phpcs:ignore WordPress.WP.DeprecatedFunctions.get_page_by_titleFound
-			$page    = get_page_by_title( $title, OBJECT, $post_type );
-			$page_id = $page ? $page->ID : 0;
-		} else {
-			// WP 6.2 deprecates `get_page_by_title` in favor of `WP_Query`
-			$query   = new WP_Query(
-				array(
-					'title'          => $title,
-					'post_type'      => $post_type,
-					'posts_per_page' => 1,
-					'orderby'        => 'ID',
-					'order'          => 'ASC',
-					'no_found_rows'  => true,
-					'fields'         => 'ids',
-				),
-			);
-			$page_id = ! empty( $query->posts ) ? $query->posts[0] : 0;
-		}
-		wp_cache_set( $cache_key, $page_id, 'get_page_by_title', 3 * HOUR_IN_SECONDS ); // We only store the ID to keep our footprint small
-	}
-
-	if ( $page_id ) {
-		return get_post( $page_id, $output );
-	}
-
-	return null;
-}
-
-/**
- * Cached version of get_page_by_path so that we're not making unnecessary SQL all the time
- *
- * @param string        $page_path Page path
- * @param string        $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
- * @param string|array  $post_type Optional. Post type; default is 'page'.
- * @return WP_Post|null WP_Post on success or null on failure
- * @link https://docs.wpvip.com/technical-references/caching/uncached-functions/ Uncached Functions
- */
-function wpcom_vip_get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
-	global $wp_version;
-	if ( version_compare( $wp_version, '6.1', '<' ) ) {
-		_deprecated_function( __FUNCTION__, '6.1', 'get_page_by_path' );
-	}
-
- 	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
-	$cache_key = md5( $page_path . serialize( $post_type ) );
-	$page_id   = wp_cache_get( $cache_key, 'wpcom_vip_get_page_by_path' );
-
-	if ( false === $page_id ) {
-		$page    = get_page_by_path( $page_path, $output, $post_type );
-		$page_id = $page ? $page->ID : 0;
-		if ( 0 === $page_id ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_mt_rand, WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
-			wp_cache_set( $cache_key, $page_id, 'wpcom_vip_get_page_by_path', ( 1 * HOUR_IN_SECONDS + mt_rand( 0, HOUR_IN_SECONDS ) ) ); // We only store the ID to keep our footprint small
-		} else {
-			wp_cache_set( $cache_key, $page_id, 'wpcom_vip_get_page_by_path', 0 ); // We only store the ID to keep our footprint small
-		}
-	}
-
-	if ( $page_id ) {
-		return get_post( $page_id, $output );
-	}
-
-	return null;
 }
 
 /**

--- a/vip-helpers/vip-deprecated.php
+++ b/vip-helpers/vip-deprecated.php
@@ -1308,23 +1308,70 @@ function wpcom_vip_disable_instapost() {
 	_deprecated_function( __FUNCTION__, '2.0.0' );
 }
 
-if ( ! function_exists( 'wpcom_vip_term_exists' ) ) {
-	/**
-	 * `term_exists()` now uses `get_terms()` and is cached.
-	 *
-	 * @deprecated Since WP 6.0
-	 *
-	 * @param int|string $term The term to check can be id, slug or name.
-	 * @param string     $taxonomy The taxonomy name to use
-	 * @param int        $parent Optional. ID of parent term under which to confine the exists search.
-	 * @return mixed Returns null if the term does not exist. Returns the term ID
-	 *               if no taxonomy is specified and the term ID exists. Returns
-	 *               an array of the term ID and the term taxonomy ID the taxonomy
-	 *               is specified and the pairing exists.
-	 */
-	function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
-		_deprecated_function( __FUNCTION__, '6.0', 'term_exists' );
+/**
+ * `get_page_by_path()` is now cached and no longer calls direct SQL.
+ * 
+ * @deprecated Since WP 6.1
+ * 
+ * @param string        $page_path Page path
+ * @param string        $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
+ * @param string|array  $post_type Optional. Post type; default is 'page'.
+ * @return WP_Post|null WP_Post on success or null on failure
+ */
+function wpcom_vip_get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
+	_deprecated_function( __FUNCTION__, '6.1', 'get_page_by_path' );
 
-		return term_exists( $term, $taxonomy, $parent ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.term_exists_term_exists
+	return get_page_by_path( $page_path, $output, $post_type ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
+}
+
+/**
+ * `get_page_by_title()` is deprecated in favour of WP_Query.
+ * 
+ * @deprecated Since WP 6.2
+ * 
+ * @param string $page_title Page title
+ * @param string $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
+ * @param string $post_type Optional. Post type; default is 'page'.
+ * @return WP_Post|null WP_Post on success or null on failure
+ */
+function wpcom_vip_get_page_by_title( $title, $output = OBJECT, $post_type = 'page' ) {
+	_deprecated_function( __FUNCTION__, '6.2', 'WP_Query' );
+
+	$query   = new WP_Query(
+		array(
+			'title'          => $title,
+			'post_type'      => $post_type,
+			'posts_per_page' => 1,
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+			'no_found_rows'  => true,
+			'fields'         => 'ids',
+		),
+	);
+	$page_id = ! empty( $query->posts ) ? $query->posts[0] : 0;
+
+	if ( $page_id ) {
+		return get_post( $page_id, $output );
 	}
+
+	return null;
+}
+
+/**
+ * `term_exists()` now uses `get_terms()` and is cached.
+ *
+ * @deprecated Since WP 6.0
+ *
+ * @param int|string $term The term to check can be id, slug or name.
+ * @param string     $taxonomy The taxonomy name to use
+ * @param int        $parent Optional. ID of parent term under which to confine the exists search.
+ * @return mixed Returns null if the term does not exist. Returns the term ID
+ *               if no taxonomy is specified and the term ID exists. Returns
+ *               an array of the term ID and the term taxonomy ID the taxonomy
+ *               is specified and the pairing exists.
+ */
+function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
+	_deprecated_function( __FUNCTION__, '6.0', 'term_exists' );
+
+	return term_exists( $term, $taxonomy, $parent ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.term_exists_term_exists
 }


### PR DESCRIPTION
## Description
Given that [we no longer recommend the VIP-equivalent on our docs,](https://docs.wpvip.com/technical-references/caching/uncached-functions/#h-previously-uncached-wordpress-core-functions) it's time to deprecate them since Core has added caching to these functions since 6.0+.

Since VIP only supports versions 1 version back and WP 6.4 is coming up, we should reflect that in our codebase.

## Changelog Description

### Functions Deprecated: wpcom_vip_get_page_by_path(), wpcom_vip_term_exists() and wpcom_vip_get_page_by_title()

`wpcom_vip_get_page_by_path()`, `wpcom_vip_term_exists()` and `wpcom_vip_get_page_by_title()` are now deprecated since WordPress core has added caching to these functions.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
