### PR TITLE
Private sites: Disable Jetpack AI

### DIFF
--- a/security/class-private-sites.php
+++ b/security/class-private-sites.php
@@ -61,6 +61,8 @@ class Private_Sites {
 
 		$this->disable_core_feeds();
 		$this->block_unnecessary_access();
+
+		add_filter( 'jetpack_ai_enabled', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
## Description
With latest JP, AI gutenberg extension can be disabled per https://github.com/Automattic/jetpack/pull/33618. Let's disable it for private sites by default

## Changelog Description

### Class Updated: Private Sites

Jetpack AI will be disabled for private sites running JP 12.8+

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
