### PR TITLE
Remove `WPCOM_VIP_QUERY_LOG`

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -132,35 +132,6 @@ function _vip_filter_rest_url_for_ssl( $url ) {
 	return $url;
 }
 
-
-function wpcom_vip_query_log() {
-	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	$request_uri = $_SERVER['REQUEST_URI'] ?? '';
-	if ( '/cache-healthcheck?' === $request_uri ) {
-		return;
-	}
-
-	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-	$action      = $_REQUEST['action'] ?? 'N/A';
-	$num_queries = count( $GLOBALS['wpdb']->queries );
-	// phpcs:ignore WordPress.PHP.DevelopmentFunctions
-	error_log( 'WPCOM VIP Query Log for ' . $request_uri . '  (action: ' . $action . ') ' . $num_queries . 'q: ' . PHP_EOL . print_r( $GLOBALS['wpdb']->queries, true ) );
-}
-
-/**
- * Think carefully before enabling this on a production site. Then
- * if you still want to do it, think again, and talk it over with
- * someone else.
- */
-if ( defined( 'WPCOM_VIP_QUERY_LOG' ) && WPCOM_VIP_QUERY_LOG ) {
-	if ( ! defined( 'SAVEQUERIES' ) || ! SAVEQUERIES ) {
-		define( 'SAVEQUERIES', true );
-	}
-	// For hyperdb, which doesn't use SAVEQUERIES
-	$GLOBALS['wpdb']->save_queries = SAVEQUERIES;
-	add_action( 'shutdown', 'wpcom_vip_query_log' );
-}
-
 /**
  * Improve perfomance of the `_WP_Editors::wp_link_query` method
  *


### PR DESCRIPTION
## Description
It's not currently being used and it seems that this can be potentially expensive, so I think we should just remove it.

## Changelog Description

### Constant Deprecated: WPCOM_VIP_QUERY_LOG

Removes `WPCOM_VIP_QUERY_LOG` constant

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
