### PR TITLE
Fix strlen of null values in autoloaded options

### DIFF
--- a/qm-plugins/qm-alloptions/class-qm-collector-alloptions.php
+++ b/qm-plugins/qm-alloptions/class-qm-collector-alloptions.php
@@ -24,7 +24,7 @@ class QM_Collector_AllOptions extends QM_Collector {
 		$options    = [];
 
 		foreach ( $alloptions as $name => $val ) {
-			$size        = mb_strlen( $val );
+			$size        = is_null( $val ) ? 0 : mb_strlen( $val );
 			$total_size += $size;
 
 			$option = new stdClass();


### PR DESCRIPTION
Fixes #4995

## Description

Since PHP 8.1, passing null to `mb_strlen()` is deprecated, so check if null before.

## Changelog Description

Fix bug when using `mb_strlen()` on `null` value in the Autoloaded Options panel of QM

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Object cache may convert a null value to an empty string causing natural occurrences to be intermittent. A straightforward way to reproduce the circumstance is to manually append a null value option:

```
add_filter( 'alloptions', function( $a ) { 
    $a['nulloption'] = null;
    return $a; 
} );
ini_set('display_errors', 1 );
error_reporting( E_ALL );
```