### PR TITLE
fix(files): account for instantiation of `WP_Filesystem_VIP` without arguments

### DIFF
--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -25,6 +25,10 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 		$this->method = 'vip';
 		$this->errors = new WP_Error();
 
+		if ( ! is_array( $dependencies ) || 2 !== count( $dependencies ) ) {
+			$dependencies = request_filesystem_credentials( site_url() );
+		}
+
 		list( $filesystem_uploads, $filesystem_direct ) = $dependencies;
 
 		$this->uploads = $filesystem_uploads;


### PR DESCRIPTION
## Description

See CANTINA-997.

When `WP_Filesystem()` is invoked without arguments, it instantiates `WP_Filesystem_VIP` without passing arguments it expects. As a result, the reference to `WP_Filesystem_Direct` becomes `null`, and all FS operations fail.

## Changelog Description

### Plugin Updated: VIP File Service

Fix a bug during the instantiation of `WP_Filesystem_VIP` without arguments.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See CANTINA-997.
