### PR TITLE
test: fix E2E tests

### DIFF
--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -48,6 +48,9 @@ const selectors = {
     desktopEditorSidebarButton: 'button[aria-label="Block editor sidebar"]:visible',
     desktopDashboardLink: 'a[aria-description="Returns to the dashboard"]:visible',
     mobileDashboardLink: 'a[aria-current="page"]:visible',
+
+    // Choose a pattern
+    choosePatternCloseButton: '.components-modal__screen-overlay .components-modal__header button',
 };
 
 export class EditorPage {
@@ -76,6 +79,22 @@ export class EditorPage {
         }
 
         const closeButton = this.page.locator( selectors.welcomeTourCloseButton );
+        return closeButton.click( {
+            delay: 20,
+        } );
+    }
+
+    async dismissPatternSelector(): Promise<void> {
+        try {
+            await this.page.waitForSelector( selectors.choosePatternCloseButton, {
+                state: 'visible',
+                timeout: 5000,
+            } );
+        } catch ( err ) {
+            return;
+        }
+
+        const closeButton = this.page.locator( selectors.choosePatternCloseButton );
         return closeButton.click( {
             delay: 20,
         } );

--- a/__tests__/e2e/specs/page__publish.spec.ts
+++ b/__tests__/e2e/specs/page__publish.spec.ts
@@ -34,6 +34,7 @@ test( 'publish a Page', async ( { page } ) => {
 
     await test.step( 'Write Page', async () => {
         editorPage = new EditorPage( page );
+        await editorPage.dismissPatternSelector();
         await editorPage.enterTitle( titleText );
         await editorPage.enterText( bodyText );
         await editorPage.addImage( 'test_media/image_01.jpg' );


### PR DESCRIPTION
This PR‌ fixes E2E tests. WP 6.4 introduced a "Choose a pattern" modal that interferes with the "Publish page" test.
