### PR TITLE
Set JP default version to the 12.7 release

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -34,7 +34,7 @@ function vip_default_jetpack_version() {
 		return '12.5';
 	} else {
 		// WordPress 6.2 and newer.
-		return '12.7.1';
+		return '12.7';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '12.7.1';
+		$latest = '12.7';
 
 		$versions_map = [
 			// WordPress version => Jetpack version


### PR DESCRIPTION
Need to return the latest major/minor release without the point/fix. Those are kept unspecified, as it expects the plugin folder to be `jetpack-12.7`.