### PR TITLE
Query monitor tweaks: Implement a new Header outputter for PHP Errors. 

### DIFF
--- a/qm-plugins/qm-limited-header-php-errors/output/headers/php-errors.php
+++ b/qm-plugins/qm-limited-header-php-errors/output/headers/php-errors.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * PHP error output for HTTP headers.
+ *
+ * @package query-monitor
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class QM_Output_Headers_Limited_PHP_Errors extends QM_Output_Headers {
+
+	/**
+	 * Collector instance.
+	 *
+	 * @var QM_Collector_PHP_Errors Collector.
+	 */
+	protected $collector;
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function get_output() {
+		/** @var QM_Data_PHP_Errors $data */
+		$data    = $this->collector->get_data();
+		$headers = array();
+
+		if ( empty( $data->errors ) ) {
+			return array();
+		}
+
+		$count = 0;
+
+		foreach ( $data->errors as $type => $errors ) {
+
+			foreach ( $errors as $error_key => $error ) {
+
+				// phpcs:ignore Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound
+				$count++;
+
+				$stack = array();
+
+				if ( ! empty( $error['filtered_trace'] ) ) {
+					$stack = array_column( $error['filtered_trace'], 'display' );
+				}
+
+				$output_error = array(
+					'key'       => $error_key,
+					'type'      => $error['type'],
+					'message'   => $error['message'],
+					'file'      => QM_Util::standard_dir( $error['file'], '' ),
+					'line'      => $error['line'],
+					'stack'     => $stack,
+					'component' => $error['component']->name,
+				);
+
+				$key             = sprintf( 'error-%d', $count );
+				$headers[ $key ] = json_encode( $output_error ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+
+			}
+		}
+
+		// VIP: hack to avoid failed requests due to headers being too large
+		// these are subject to change at any time
+		// All of the values are padded to make sure failsafe is triggered earlier
+		$max_header_length       = 11 * 1024;  // padded
+		$max_total_header_length = 31 * 1024;  // padded
+		$max_total_headers       = 100;        // padded
+
+		$current_headers_length = strlen( join( "\n", headers_list() ) );
+		$current_headers_count  = count( headers_list() );
+
+		// Any single header too long, truncate it
+		foreach ( $headers as $key => $value ) {
+			if ( strlen( $value ) + strlen( $key ) > $max_header_length ) {
+				$headers[ $key ] = substr( $value, 0, $max_header_length );
+			}
+		}
+
+		// Too many headers, slice the array
+		if ( $current_headers_count + $count > $max_total_headers ) {
+			$headers = array_slice( $headers, 0, $max_total_headers - $current_headers_count );
+		}
+
+		// Wholesale remove QM error headers if we're still over the limit
+		$max_qm_headers_length = $max_total_header_length - $current_headers_length;
+		if ( strlen( join( "\n", $headers ) ) > $max_qm_headers_length ) {
+			$headers = [ 'errors-truncated' => 'Too many errors, check your Application performance monitor for details.' ];
+		}
+		// End VIP Hack
+
+		return array_merge(
+			array(
+				'error-count' => $count,
+			),
+			$headers
+		);
+	}
+}
+
+/**
+ * @param array<string, QM_Output> $output
+ * @param QM_Collectors $collectors
+ * @return array<string, QM_Output>
+ * phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed,Universal.Files.SeparateFunctionsFromOO.Mixed
+ */
+function vip_register_qm_output_headers_php_errors( array $output, QM_Collectors $collectors ) {
+	$collector = QM_Collectors::get( 'php_errors' );
+	if ( $collector ) {
+		$output['php_errors'] = new QM_Output_Headers_Limited_PHP_Errors( $collector );
+	}
+	return $output;
+}
+
+add_filter( 'qm/outputter/headers', 'vip_register_qm_output_headers_php_errors', 111, 2 );

--- a/qm-plugins/qm-limited-header-php-errors/output/headers/php-errors.php
+++ b/qm-plugins/qm-limited-header-php-errors/output/headers/php-errors.php
@@ -66,9 +66,9 @@ class QM_Output_Headers_Limited_PHP_Errors extends QM_Output_Headers {
 		// VIP: hack to avoid failed requests due to headers being too large
 		// these are subject to change at any time
 		// All of the values are padded to make sure failsafe is triggered earlier
-		$max_header_length       = 11 * 1024;  // padded
-		$max_total_header_length = 31 * 1024;  // padded
-		$max_total_headers       = 100;        // padded
+		$max_header_length       = 10 * 1024;  // padded
+		$max_total_header_length = 30 * 1024;  // padded
+		$max_total_headers       = 50;        // padded
 
 		$current_headers_length = strlen( join( "\n", headers_list() ) );
 		$current_headers_count  = count( headers_list() );

--- a/query-monitor.php
+++ b/query-monitor.php
@@ -107,6 +107,10 @@ function wpcom_vip_qm_require() {
 	if ( file_exists( __DIR__ . '/qm-plugins/qm-db-connections/qm-db-connections.php' ) ) {
 		require_once __DIR__ . '/qm-plugins/qm-db-connections/qm-db-connections.php';
 	}
+
+	if ( file_exists( __DIR__ . '/qm-plugins/qm-limited-header-php-errors/output/headers/php-errors.php' ) ) {
+		require_once __DIR__ . '/qm-plugins/qm-limited-header-php-errors/output/headers/php-errors.php';
+	}
 }
 add_action( 'plugins_loaded', 'wpcom_vip_qm_require', 1 );
 


### PR DESCRIPTION
The main purpose of it is to reduce the chances of requests breaking due to too many errors presented as headers for REST and redirect contexts.


## Description

The main purpose of it is to reduce the chances of requests breaking due to too many errors presented as headers for REST and redirect contexts. There are several constraints that may get violated:

1. Single header length
2. Total headers length
3. Total headers number

This PR tries to address each of those cases.

1. It will truncate the value 
2. It will remove all errors while preserving error count and adding a message to check APM
3. Will slice the headers to only lnculde what's allowed

## Changelog Description

### Plugin Updated:  Query Monitor

In certain scenarios too many errors in Query Monitor output may have resulted in broken request. This change adds safety limits around that functionality to minimize the chances. 


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Apply the PR 
2. Add the following snippet in your codebase:
 
```php
add_action( 'init', function() {
  for( $i = 0; $i < 255; $i++ ) {
    trigger_error('test error message' . $i . str_repeat( '1', 12 * 1024 ), E_USER_WARNING );
  }
} );
```
3. Verify the errors are truncated.
4. Modify the above snippet to match all conditions and verify everything is handled appropriately.