### PR TITLE
Parsely: Fix config values of Site Details Sync

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -292,6 +292,7 @@ class Site_Details_Index {
 
 	/**
 	 * Gather all the information about Parse.ly.
+	 *
 	 * @return array Parse.ly plugin info.
 	 */
 	public function get_parsely_info() {

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -2,10 +2,12 @@
 
 namespace Automattic\VIP\WP_Parsely_Integration;
 
-use Automattic\Test\Constant_Mocker;
+use Automattic\VIP\Integrations\Integration;
+use Automattic\VIP\Integrations\ParselyIntegration;
 use Parsely\UI\Row_Actions;
 use WP_UnitTestCase;
 
+use function Automattic\Test\Utils\get_class_property_as_public;
 use function Automattic\Test\Utils\get_parsely_test_mode;
 use function Automattic\Test\Utils\is_parsely_disabled;
 
@@ -292,11 +294,11 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 			'tracked_post_types'           => array(
 				array(
 					'name'       => 'post',
-					'track_type' => 'do-not-track',
+					'track_type' => 'post',
 				),
 				array(
 					'name'       => 'page',
-					'track_type' => 'do-not-track',
+					'track_type' => 'non-post',
 				),
 				array(
 					'name'       => 'attachment',
@@ -350,6 +352,57 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 
 		// Reset settings.
 		update_option( 'parsely', $current_settings );
+	}
+
+	/**
+	 * Verify Parse.ly data is correctly setting when the plugin is in Managed Mode.
+	 *
+	 * @return void
+	 */
+	public function test_parsely_configs_for_managed_mode() {
+		maybe_load_plugin();
+
+		if ( is_parsely_disabled() ) {
+			$this->assertNull( Parsely_Loader_Info::get_configs() );
+			return;
+		}
+
+		// Arrange.
+		$parsely_integration = new ParselyIntegration( 'parsely' );
+		get_class_property_as_public( Integration::class, 'options' )->setValue( $parsely_integration, [
+			'config' => [
+				'site_id'    => 'site_id_value',
+				'api_secret' => 'api_secret_value',
+			],
+		] );
+		$parsely_integration->configure();
+
+		// Act.
+		$configs = Parsely_Loader_Info::get_configs();
+
+		// Assert.
+		$this->assertEquals( $configs, array(
+			'is_pinned_version'            => has_filter( 'wpvip_parsely_version' ),
+			'site_id'                      => 'site_id_value',
+			'have_api_secret'              => true,
+			'is_javascript_disabled'       => false,
+			'is_autotracking_disabled'     => false,
+			'should_track_logged_in_users' => false,
+			'tracked_post_types'           => array(
+				array(
+					'name'       => 'post',
+					'track_type' => 'post',
+				),
+				array(
+					'name'       => 'page',
+					'track_type' => 'non-post',
+				),
+				array(
+					'name'       => 'attachment',
+					'track_type' => 'do-not-track',
+				),
+			),
+		) );
 	}
 
 	public function test_alter_option_use_repeated_metas() {

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -293,6 +293,8 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 			return;
 		}
 
+		\Parsely\parsely_initialize_plugin();
+
 		$this->assertEquals( Parsely_Loader_Info::get_configs(), array(
 			'is_pinned_version'            => has_filter( 'wpvip_parsely_version' ),
 			'site_id'                      => '',
@@ -325,6 +327,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 			return;
 		}
 
+		\Parsely\parsely_initialize_plugin();
 		$current_settings = get_option( 'parsely' ) ?: [];
 		update_option( 'parsely', array_merge( $current_settings, array(
 			'apikey'                    => 'example.com',
@@ -387,6 +390,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		$parsely_integration->configure();
 
 		// Act.
+		\Parsely\parsely_initialize_plugin();
 		$configs = Parsely_Loader_Info::get_configs();
 
 		// Assert.

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -17,6 +17,15 @@ function test_version() {
 }
 
 /**
+ * Checks if the version of the Parse.ly is latest or not.
+ *
+ * @return boolean
+ */
+function is_latest_version() {
+	return test_version() === SUPPORTED_VERSIONS[0];
+}
+
+/**
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
@@ -290,7 +299,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 			'have_api_secret'              => false,
 			'is_javascript_disabled'       => false,
 			'is_autotracking_disabled'     => false,
-			'should_track_logged_in_users' => false,
+			'should_track_logged_in_users' => is_latest_version() ? false : true,
 			'tracked_post_types'           => array(
 				array(
 					'name'       => 'post',
@@ -383,11 +392,11 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		// Assert.
 		$this->assertEquals( $configs, array(
 			'is_pinned_version'            => has_filter( 'wpvip_parsely_version' ),
-			'site_id'                      => 'site_id_value',
-			'have_api_secret'              => true,
+			'site_id'                      => is_latest_version() ? 'site_id_value' : '',
+			'have_api_secret'              => is_latest_version() ? true : false,
 			'is_javascript_disabled'       => false,
 			'is_autotracking_disabled'     => false,
-			'should_track_logged_in_users' => false,
+			'should_track_logged_in_users' => is_latest_version() ? false : true,
 			'tracked_post_types'           => array(
 				array(
 					'name'       => 'post',

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -17,6 +17,8 @@
 
 namespace Automattic\VIP\WP_Parsely_Integration;
 
+use Parsely\Parsely;
+
 /**
  * The default version is the first entry in the SUPPORTED_VERSIONS list.
  */
@@ -60,13 +62,6 @@ final class Parsely_Loader_Info {
 	 * @var string
 	 */
 	private static string $version;
-
-	/**
-	 * Options of the plugin.
-	 *
-	 * @var array
-	 */
-	private static array $parsely_options;
 
 	/**
 	 * Check if the plugin is active.
@@ -144,7 +139,7 @@ final class Parsely_Loader_Info {
 		}
 
 		$configs = array();
-		$options = self::get_parsely_options() ?: [];
+		$options = self::get_parsely_options();
 
 		$configs['is_pinned_version']            = has_filter( 'wpvip_parsely_version' );
 		$configs['site_id']                      = $options['apikey'] ?? '';
@@ -179,11 +174,16 @@ final class Parsely_Loader_Info {
 	 * Get Parse.ly options.
 	 */
 	public static function get_parsely_options(): array {
-		if ( ! isset( self::$parsely_options ) ) {
-			self::$parsely_options = get_option( 'parsely', [] );
-		}
+		$parsely = new Parsely();
 
-		return is_array( self::$parsely_options ) ? self::$parsely_options : [];
+		/**
+		 * Parse.ly options.
+		 *
+		 * @var array
+		 */
+		$parsely_options = $parsely->get_options();
+
+		return $parsely_options;
 	}
 }
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -17,8 +17,6 @@
 
 namespace Automattic\VIP\WP_Parsely_Integration;
 
-use Parsely\Parsely;
-
 /**
  * The default version is the first entry in the SUPPORTED_VERSIONS list.
  */
@@ -178,15 +176,17 @@ final class Parsely_Loader_Info {
 			return array();
 		}
 
-		$parsely = new Parsely();
-
 		/**
 		 * Parse.ly options.
 		 *
 		 * @var array
 		 */
-		$parsely_options = $parsely->get_options();
+		$parsely_options = array();
 
+		if ( isset( $GLOBALS['parsely'] ) && is_a( $GLOBALS['parsely'], 'Parsely\Parsely' ) ) {
+			$parsely_options = $GLOBALS['parsely']->get_options();
+		}
+		
 		return $parsely_options;
 	}
 }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -174,6 +174,10 @@ final class Parsely_Loader_Info {
 	 * Get Parse.ly options.
 	 */
 	public static function get_parsely_options(): array {
+		if ( ! self::is_active() ) {
+			return array();
+		}
+
 		$parsely = new Parsely();
 
 		/**


### PR DESCRIPTION
## Description

If the plugin is managed via Platform then Site Details Service was not receiving correct values because `wp_parsely_credentials` filter was not executing, this has been fixed now.

## Changelog Description

Parsely: Fix config values of SIte Details Sync (if the plugin is managed via Platform)

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [n/a] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. There is no visible effect of this change so kindly verify through unit tests.
