### PR TITLE
CI: Remove PHP 7.4 and 8.0 from matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,45 +27,19 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # Jetpack, Single-Site, PHP 7.4
-          - { wp: 5.9.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
-          - { wp: 6.0.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
-          - { wp: 6.1.x,   ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
-          - { wp: latest,  ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
-          - { wp: nightly, ms: 'no',  jp: 'yes', php: '7.4', phpunit: 7 }
-        # Jetpack, Multi-Site, PHP 7.4
-          - { wp: latest,  ms: 'yes', jp: 'yes', php: '7.4', phpunit: 7 }
-          - { wp: nightly, ms: 'yes', jp: 'yes', php: '7.4', phpunit: 7 }
-        # No Jetpack, WP latest, PHP 7.4
-          - { wp: latest,  ms: 'no',  jp: 'no',  php: '7.4', phpunit: 7 }
-          - { wp: latest,  ms: 'yes', jp: 'no',  php: '7.4', phpunit: 7 }
-        # PHP 8.0, Jetpack
-          - { wp: 6.0.x,   ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.0.x,   ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.1.x,   ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.1.x,   ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.2.x,   ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.2.x,   ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.3.x,   ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.3.x,   ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.0', phpunit: '', coverage: 'yes' }
-          - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.0', phpunit: '', coverage: 'yes' }
-          - { wp: nightly, ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: nightly, ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-        # No Jetpack, WP latest, PHP 8.0
-          - { wp: latest,  ms: 'no',  jp: 'no',  php: '8.0', phpunit: '' }
-          - { wp: latest,  ms: 'yes', jp: 'no',  php: '8.0', phpunit: '' }
         # PHP 8.1, Jetpack
-          - { wp: 6.0.x,   ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.0.x,   ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.1.x,   ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.1.x,   ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.2.x,   ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.2.x,   ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.3.x,   ms: 'no',  jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: 6.3.x,   ms: 'yes', jp: 'yes', php: '8.0', phpunit: '' }
-          - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
-          - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.0.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.0.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.1.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.1.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.2.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.2.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.3.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.3.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.1', phpunit: '', coverage: 'yes' }
+          - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.1', phpunit: '', coverage: 'yes' }
+          - { wp: nightly, ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: nightly, ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
         # No Jetpack, WP latest, PHP 8.1
           - { wp: latest,  ms: 'no',  jp: 'no',  php: '8.1', phpunit: '' }
           - { wp: latest,  ms: 'yes', jp: 'no',  php: '8.1', phpunit: '' }


### PR DESCRIPTION
## Description
Now that they are deprecated on VIP.
