### PR TITLE
CANTINA-1000: Prevent impact of filtered formatted ES args when `wp vip-search health validate-counts` runs

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -181,6 +181,11 @@ class Health {
 				// Since the user indexable is global, we want to include ALL in count.
 				unset( $query->query_vars['blog_id'] );
 			}
+
+			// An improperly formatted ES args filter can break the `wp vip-search health validate-counts` CLI.
+			remove_all_filters( 'ep_formatted_args' );
+			remove_all_filters( 'ep_post_formatted_args' );
+
 			$formatted_args = $indexable->format_args( $query->query_vars, $query );
 
 			// Get exact total count since Elasticsearch default stops at 10,000.


### PR DESCRIPTION
## Description
Since `wp vip-search health validate-counts` ultimately calls `$indexable->format_args()` which applies the `ep_formatted_args` filter, it can return the incorrect results for counting ES entities if it's filtered improperly.

Example #1:
```
add_filter('ep_formatted_args', function ($formatted_args, $args, $wp_query) {
    $formatted_args['test'] = 1.2;

    return $formatted_args;
}, 25, 3);
```
There's no ES `test` parameter, so this breaks the ES query and results in the below when we run `wp vip-search health validate-counts`:
```
Warning: Error while validating count: failure querying ES. #vip-search
Warning: Error while validating count: failure querying ES. #vip-search
```

Example #2:
```
add_filter('ep_formatted_args', function ($formatted_args, $args, $wp_query) {
    $formatted_args['min_score'] = 3;

    return $formatted_args;
}, 25, 3);
```
Since we're using a high minimum scoring of `3` and there may be no documents are scoring above `3` with the way ES uses the TF/IDF scoring model, it returns 0 results, which is not what we want if we just want to validate the general ES document counts. This would be the result when we run `wp vip-search health validate-counts`:
```
🟧 skipping, because there are no documents in ES when counting entity: post, type: post, index_version: 1
🟧 skipping, because there are no documents in ES when counting entity: post, type: page, index_version: 1
```
## Changelog Description

### Plugin Updated: Enterprise Search
 Prevent impact of filtered formatted ES args when `wp vip-search health validate-counts` runs

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Try out both scenarios mentioned in the description and ensure that they return the expected results when running `wp vip-search health validate-counts`