### PR TITLE
`wpcom_vip_add_role()`: set `$capabilities` as empty array if not array

### DIFF
--- a/vip-helpers/vip-roles.php
+++ b/vip-helpers/vip-roles.php
@@ -30,6 +30,10 @@ function wpcom_vip_get_role_caps( $role ) {
  * @param array $capabilities Key/value array of capabilities for the role
  */
 function wpcom_vip_add_role( $role, $name, $capabilities ) {
+	if ( ! is_array( $capabilities ) ) {
+		$capabilities = array();
+	}
+	
 	if ( array_is_list( $capabilities ) && ! array_filter( $capabilities, 'is_bool' ) ) {
 		$capabilities = array_flip( $capabilities );
 		$capabilities = array_map( '__return_true', $capabilities );


### PR DESCRIPTION
## Description
Seeing the error in logs:
```
Uncaught TypeError: array_is_list(): Argument #1 ($array) must be of type array, null given
```

## Changelog Description

### Function Updated: wpcom_vip_add_role

Set `$capabilities` as empty array if not array type

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
