### PR TITLE
Set Jetpack 12.9 as default for WP 6.3+

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.8
+ * Version: 12.9
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,9 +32,12 @@ function vip_default_jetpack_version() {
 	} elseif ( version_compare( $wp_version, '6.2', '<' ) ) {
 		// WordPress 6.1.x
 		return '12.5';
-	} else {
-		// WordPress 6.2 and newer.
+	} elseif ( version_compare( $wp_version, '6.3', '<' ) ) {
+		// WordPress 6.2.x.
 		return '12.8';
+	} else {
+		// WordPress 6.3 and newer.
+		return '12.9';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '12.8';
+		$latest = '12.9';
 
 		$versions_map = [
 			// WordPress version => Jetpack version
@@ -16,7 +16,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 			'5.9.5' => '11.4',
 			'6.0'   => '12.0',
 			'6.1'   => '12.5',
-			'6.2'   => $latest,
+			'6.2'   => '12.8',
 			'6.3'   => $latest,
 			'6.3.1' => $latest,
 		];


### PR DESCRIPTION
## Description
All WP sites running 6.3 and above will be updated to Jetpack 12.9 as their default if not pinned

## Changelog Description

### Plugin Updated: Jetpack 12.9

We upgraded Jetpack 12.8 to 12.9 on all unpinned WP 6.3+ sites

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
