### PR TITLE
Deprecate `wpcom_vip_term_exists()`

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -3,7 +3,6 @@
  * This file contains a bunch of helper functions that handle add caching to core WordPress functions.
  */
 
-// phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.term_exists_term_exists
 // phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
 // phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_title_get_page_by_title
 // phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
@@ -76,67 +75,6 @@ function wp_flush_get_term_by_cache( $term_id, $taxonomy ) {
 	foreach ( array( 'name', 'slug' ) as $field ) {
 		$cache_key   = $field . '|' . $taxonomy . '|' . md5( $term->$field );
 		$cache_group = 'get_term_by';
-		wp_cache_delete( $cache_key, $cache_group );
-	}
-}
-
-/**
- * Cached version of term_exists()
- *
- * Term exists calls can pile up on a single pageload.
- * This function adds a layer of caching to prevent lots of queries.
- *
- * @param int|string $term The term to check can be id, slug or name.
- * @param string     $taxonomy The taxonomy name to use
- * @param int        $parent Optional. ID of parent term under which to confine the exists search.
- * @return mixed Returns null if the term does not exist. Returns the term ID
- *               if no taxonomy is specified and the term ID exists. Returns
- *               an array of the term ID and the term taxonomy ID the taxonomy
- *               is specified and the pairing exists.
- */
-
-function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
-	global $wp_version;
-	if ( version_compare( $wp_version, '6.0', '<' ) ) {
-		_deprecated_function( __FUNCTION__, '6.0', 'term_exists' );
-	}
-
-	// If $parent is not null, let's skip the cache.
-	if ( null !== $parent ) {
-		return term_exists( $term, $taxonomy, $parent );
-	}
-
-	if ( ! empty( $taxonomy ) ) {
-		$cache_key = $term . '|' . $taxonomy;
-	} else {
-		$cache_key = $term;
-	}
-
-	$cache_value = wp_cache_get( $cache_key, 'term_exists' );
-
-	// term_exists frequently returns null, but (happily) never false
-	if ( false === $cache_value ) {
-		$term_exists = term_exists( $term, $taxonomy );
-		wp_cache_set( $cache_key, $term_exists, 'term_exists', 3 * HOUR_IN_SECONDS );
-	} else {
-		$term_exists = $cache_value;
-	}
-
-	if ( is_wp_error( $term_exists ) ) {
-		$term_exists = null;
-	}
-
-	return $term_exists;
-}
-
-/**
- * Properly clear wpcom_vip_term_exists() cache when a term is updated
- */
-add_action( 'delete_term', 'wp_flush_term_exists', 10, 4 );
-function wp_flush_term_exists( $term, $tt_id, $taxonomy, $deleted_term ) {
-	foreach ( array( 'term_id', 'name', 'slug' ) as $field ) {
-		$cache_key   = $deleted_term->$field . '|' . $taxonomy;
-		$cache_group = 'term_exists';
 		wp_cache_delete( $cache_key, $cache_group );
 	}
 }

--- a/vip-helpers/vip-deprecated.php
+++ b/vip-helpers/vip-deprecated.php
@@ -1307,3 +1307,22 @@ function wpcom_vip_load_geolocation_styles_only_when_needed() {
 function wpcom_vip_disable_instapost() {
 	_deprecated_function( __FUNCTION__, '2.0.0' );
 }
+
+/**
+ * `term_exists()` now uses `get_terms()` and is cached.
+ *
+ * @deprecated Since WP 6.0
+ *
+ * @param int|string $term The term to check can be id, slug or name.
+ * @param string     $taxonomy The taxonomy name to use
+ * @param int        $parent Optional. ID of parent term under which to confine the exists search.
+ * @return mixed Returns null if the term does not exist. Returns the term ID
+ *               if no taxonomy is specified and the term ID exists. Returns
+ *               an array of the term ID and the term taxonomy ID the taxonomy
+ *               is specified and the pairing exists.
+ */
+function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
+	_deprecated_function( __FUNCTION__, '6.0', 'term_exists' );
+
+	return term_exists( $term, $taxonomy, $parent ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.term_exists_term_exists
+}

--- a/vip-helpers/vip-deprecated.php
+++ b/vip-helpers/vip-deprecated.php
@@ -1308,21 +1308,23 @@ function wpcom_vip_disable_instapost() {
 	_deprecated_function( __FUNCTION__, '2.0.0' );
 }
 
-/**
- * `term_exists()` now uses `get_terms()` and is cached.
- *
- * @deprecated Since WP 6.0
- *
- * @param int|string $term The term to check can be id, slug or name.
- * @param string     $taxonomy The taxonomy name to use
- * @param int        $parent Optional. ID of parent term under which to confine the exists search.
- * @return mixed Returns null if the term does not exist. Returns the term ID
- *               if no taxonomy is specified and the term ID exists. Returns
- *               an array of the term ID and the term taxonomy ID the taxonomy
- *               is specified and the pairing exists.
- */
-function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
-	_deprecated_function( __FUNCTION__, '6.0', 'term_exists' );
+if ( ! function_exists( 'wpcom_vip_term_exists' ) ) {
+	/**
+	 * `term_exists()` now uses `get_terms()` and is cached.
+	 *
+	 * @deprecated Since WP 6.0
+	 *
+	 * @param int|string $term The term to check can be id, slug or name.
+	 * @param string     $taxonomy The taxonomy name to use
+	 * @param int        $parent Optional. ID of parent term under which to confine the exists search.
+	 * @return mixed Returns null if the term does not exist. Returns the term ID
+	 *               if no taxonomy is specified and the term ID exists. Returns
+	 *               an array of the term ID and the term taxonomy ID the taxonomy
+	 *               is specified and the pairing exists.
+	 */
+	function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
+		_deprecated_function( __FUNCTION__, '6.0', 'term_exists' );
 
-	return term_exists( $term, $taxonomy, $parent ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.term_exists_term_exists
+		return term_exists( $term, $taxonomy, $parent ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.term_exists_term_exists
+	}
 }


### PR DESCRIPTION
## Description
Going to break https://github.com/Automattic/vip-go-mu-plugins/pull/4983 up. Let's start with `wpcom_vip_term_exists()` because 99.9% is on WP 6.0+

## Changelog Description

### Function Updated: wpcom_vip_term_exists

Deprecate `wpcom_vip_term_exists()` because WP 6.0 now has caching in `term_exists()`. Please use core function instead.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
