### PR TITLE
(CANTINA-1006) Search: For CLI commands, use composition instead of inheritance

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -675,7 +675,8 @@ class Search {
 			WP_CLI::add_command( 'vip-search queue', __NAMESPACE__ . '\Commands\QueueCommand' );
 			WP_CLI::add_command( 'vip-search index-versions', __NAMESPACE__ . '\Commands\VersionCommand' );
 			WP_CLI::add_command( 'vip-search documents', __NAMESPACE__ . '\Commands\DocumentCommand' );
-			WP_CLI::add_command( 'vip-search', __NAMESPACE__ . '\Commands\CoreCommand' );
+			$vip_search_core_command = new \Automattic\VIP\Search\Commands\CoreCommand( new \ElasticPress\Command() );
+			WP_CLI::add_command( 'vip-search', $vip_search_core_command );
 		}
 	}
 

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -388,6 +388,9 @@ class CoreCommand {
 	 * Throw error when delete-index command is attempted to be used.
 	 *
 	 * @subcommand delete-index
+	 * 
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function delete_index( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		WP_CLI::error( 'Please use index versioning to manage your indices: https://docs.wpvip.com/how-tos/vip-search/version-with-enterprise-search/' );
@@ -401,7 +404,7 @@ class CoreCommand {
 	 * @param array $assoc_args arguments that were passed to the caller command.
 	 * @return void
 	 */
-	public static function confirm_destructive_operation( $assoc_args ) {
+	public static function confirm_destructive_operation( array $assoc_args ) {
 		if ( isset( $assoc_args['skip-confirm'] ) && $assoc_args['skip-confirm'] ) {
 			return;
 		}

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -613,9 +613,12 @@ class CoreCommand {
 	}
 
 	/**
-	 * Returns a JSON array with the results of the last index (if present) or an empty array.
+	 * Returns a JSON array with the results of the last CLI index (if present) or an empty array.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [--clear]
+	 * : Clear the `ep_last_cli_index` option.
 	 *
 	 * [--pretty]
 	 * : Use this flag to render a pretty-printed version of the JSON response.
@@ -625,7 +628,7 @@ class CoreCommand {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_last_index( $args, $assoc_args ) {
-		$this->ep_command->get_last_sync( $args, $assoc_args );
+		$this->ep_command->get_last_cli_index( $args, $assoc_args );
 	}
 
 	/**

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -225,9 +225,6 @@ class CoreCommand {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function index( $args, $assoc_args ) {
-		if ( isset( $assoc_args['setup'] ) && $assoc_args['setup'] ) {
-			self::confirm_destructive_operation( $assoc_args );
-		}
 		$this->verify_arguments_compatibility( $assoc_args );
 
 		$using_versions = $assoc_args['using-versions'] ?? false;
@@ -298,6 +295,10 @@ class CoreCommand {
 
 			WP_CLI::line( WP_CLI::colorize( '%CRun took: ' . ( round( microtime( true ) - $start, 3 ) ) . '%n' ) );
 		} else {
+			if ( isset( $assoc_args['setup'] ) && $assoc_args['setup'] ) {
+				self::confirm_destructive_operation( $assoc_args );
+			}
+			
 			// Unset our arguments since they don't exist in ElasticPress and causes
 			// an error for indexing operations exclusively for some reason.
 			unset( $assoc_args['version'] );

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -14,8 +14,8 @@ use ElasticPress\Elasticsearch;
 class CoreCommand {
 	private $ep_command;
 
-	public function __construct() {
-		$this->ep_command = new \ElasticPress\Command();
+	public function __construct( \ElasticPress\Command $ep_command ) {
+		$this->ep_command = $ep_command;
 	}
 
 	private function verify_arguments_compatibility( $assoc_args ) {
@@ -389,7 +389,7 @@ class CoreCommand {
 	 *
 	 * @subcommand delete-index
 	 */
-	public function delete_index() {
+	public function delete_index( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		WP_CLI::error( 'Please use index versioning to manage your indices: https://docs.wpvip.com/how-tos/vip-search/version-with-enterprise-search/' );
 	}
 
@@ -401,7 +401,7 @@ class CoreCommand {
 	 * @param array $assoc_args arguments that were passed to the caller command.
 	 * @return void
 	 */
-	public static function confirm_destructive_operation( array $assoc_args ) {
+	public static function confirm_destructive_operation( $assoc_args ) {
 		if ( isset( $assoc_args['skip-confirm'] ) && $assoc_args['skip-confirm'] ) {
 			return;
 		}
@@ -414,8 +414,7 @@ class CoreCommand {
 	 *
 	 * @subcommand get-indexes
 	 */
-	public function get_indexes() {
-
+	public function get_indexes( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$indexes = $this->list_indexes();
 
 		if ( is_wp_error( $indexes ) ) {
@@ -433,7 +432,7 @@ class CoreCommand {
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
-	public function get_mapping( $args, $assoc_args ) {
+	public function get_mapping( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$index_names = (array) ( isset( $assoc_args['index-name'] ) ? $assoc_args['index-name'] : $this->list_indexes() );
 
 		$path = join( ',', $index_names ) . '/_mapping';
@@ -506,7 +505,7 @@ class CoreCommand {
 	 *
 	 * @subcommand get-last-indexed-post-id
 	 */
-	public function get_last_indexed_post_id() {
+	public function get_last_indexed_post_id( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$search = \Automattic\VIP\Search\Search::instance();
 
 		$last_id = get_option( $search::LAST_INDEXED_POST_ID_OPTION );
@@ -522,11 +521,8 @@ class CoreCommand {
 	 * Clean the ep_feature_settings individual blog option if it exists for sites with EP_IS_NETWORK.
 	 *
 	 * @subcommand clean-ep-feature-settings
-	 *
-	 * @param array $args Positional CLI args.
-	 * @param array $assoc_args Associative CLI args.
 	 */
-	public function clean_ep_feature_settings() {
+	public function clean_ep_feature_settings( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( is_multisite() && defined( 'EP_IS_NETWORK' ) && true === constant( 'EP_IS_NETWORK' ) ) {
 			$delete_option = delete_option( 'ep_feature_settings' );
 			if ( $delete_option ) {
@@ -640,7 +636,7 @@ class CoreCommand {
 	 *
 	 * @subcommand get-algorithm-version
 	 */
-	public function get_algorithm_version() {
+	public function get_algorithm_version( $args, $assoc_args ) {  // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$version = apply_filters( 'ep_search_algorithm_version', get_option( 'ep_search_algorithm_version', '3.5' ) );
 		WP_CLI::line( $version );
 	}
@@ -650,7 +646,7 @@ class CoreCommand {
 	 * 
 	 * @subcommand stats
 	 */
-	public function get_stats() {
+	public function get_stats( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$this->ep_command->stats();
 	}
 }

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -289,7 +289,9 @@ class CoreCommand {
 				switch_to_blog( (int) $blog_id );
 				$assoc_args['url'] = home_url();
 				WP_CLI::line( "* Indexing blog {$blog_id}: {$assoc_args['url']}" );
-				$this->ep_command->index( $args, $assoc_args );
+				WP_CLI::runcommand( 'vip-search index ' . Utils\assoc_args_to_str( $assoc_args ), [
+					'exit_error' => false,
+				] );
 				Utils\wp_clear_object_cache();
 				restore_current_blog();
 			}
@@ -317,7 +319,8 @@ class CoreCommand {
 				]
 			);
 
-			$this->ep_command->index( $args, $assoc_args );
+			array_unshift( $args, 'elasticpress', 'index' );
+			WP_CLI::run_command( $args, $assoc_args );
 		}
 
 		if ( $using_versions ) {
@@ -533,5 +536,117 @@ class CoreCommand {
 		} else {
 			WP_CLI::error( 'Not a multisite or EP_IS_NETWORK is not enabled!' );
 		}
+	}
+
+	/**
+	 * Stop the current indexing operation.
+	 *
+	 * @subcommand stop-indexing
+	 * 
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function stop_indexing( $args, $assoc_args ) {
+		$this->ep_command->stop_indexing( $args, $assoc_args );
+	}
+
+	/**
+	 * List features (either active or all).
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--all]
+	 * : Show all registered features
+	 *
+	 * @subcommand list-features
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function list_features( $args, $assoc_args ) {
+		$this->ep_command->list_features( $args, $assoc_args );
+	}
+
+	/**
+	 * Recreates the alias index which points to every index in the network.
+	 *
+	 * Map network alias to every index in the network for every non-global indexable
+	 *
+	 * @subcommand recreate-network-alias
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function recreate_network_alias( $args, $assoc_args ) {
+		$this->ep_command->recreate_network_alias( $args, $assoc_args );
+	}
+
+	/**
+	 * Clear a sync/index process.
+	 *
+	 * If an index was stopped prematurely and won't start again, this will clear this cached data such that a new index can start.
+	 *
+	 * @subcommand clear-index
+	 * @alias delete-transient
+	 */
+	public function clear_index( $args, $assoc_args ) {
+		$this->ep_command->clear_index( $args, $assoc_args );
+	}
+
+	/**
+	 * Returns the status of an ongoing index operation in JSON array.
+	 *
+	 * Returns the status of an ongoing index operation in JSON array with the following fields:
+	 * indexing | boolean | True if index operation is ongoing or false
+	 * items_indexed | integer | Total number of items indexed
+	 * total_items | integer | Total number of items indexed or -1 if not yet determined
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--pretty]
+	 * : Use this flag to render a pretty-printed version of the JSON response.
+	 *
+	 * @subcommand get-indexing-status
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get_indexing_status( $args, $assoc_args ) {
+		$this->ep_command->get_indexing_status( $args, $assoc_args );
+	}
+
+	/**
+	 * Returns a JSON array with the results of the last index (if present) or an empty array.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--pretty]
+	 * : Use this flag to render a pretty-printed version of the JSON response.
+	 *
+	 * @subcommand get-last-index
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get_last_index( $args, $assoc_args ) {
+		$this->ep_command->get_last_sync( $args, $assoc_args );
+	}
+
+	/**
+	 * Get the algorithm version.
+	 *
+	 * Get the value of the `ep_search_algorithm_version` option, or
+	 * `default` if empty.
+	 *
+	 * @subcommand get-algorithm-version
+	 */
+	public function get_algorithm_version() {
+		$version = apply_filters( 'ep_search_algorithm_version', get_option( 'ep_search_algorithm_version', '3.5' ) );
+		WP_CLI::line( $version );
+	}
+
+	/**
+	 * Get stats on the current index.
+	 * 
+	 * @subcommand stats
+	 */
+	public function get_stats() {
+		$this->ep_command->stats();
 	}
 }

--- a/tests/search/e2e/integration/wp-cli.spec.js
+++ b/tests/search/e2e/integration/wp-cli.spec.js
@@ -126,14 +126,14 @@ describe('WP-CLI Commands', () => {
 			);
 	});
 
-	it('Can return a string indicating with the appropriate fields if user runs wp vip-search get-last-cli-index command', () => {
+	it('Can return a string indicating with the appropriate fields if user runs wp vip-search get-last-index command', () => {
 		cy.wpCli('wp vip-search index');
 
-		cy.wpCli('wp vip-search get-last-cli-index')
+		cy.wpCli('wp vip-search get-last-index')
 			.its('stdout')
 			.should('contain', '"total":');
 
-		cy.wpCli('wp vip-search get-last-cli-index --clear')
+		cy.wpCli('wp vip-search get-last-index --clear')
 			.its('stdout')
 			.should('contain', '[]');
 	});

--- a/tests/search/e2e/integration/wp-cli.spec.js
+++ b/tests/search/e2e/integration/wp-cli.spec.js
@@ -176,32 +176,8 @@ describe('WP-CLI Commands', () => {
 		});
 	});
 
-	it('Can set the algorithm version', () => {
-		cy.wpCli('wp vip-search set-algorithm-version --default')
-			.its('stdout')
-			.should('contain', 'Done');
-
-		cy.wpCli('wp vip-search get-algorithm-version')
-			.its('stdout')
-			.should('contain', 'default');
-
-		cy.wpCli('wp vip-search set-algorithm-version --version=1.0.0')
-			.its('stdout')
-			.should('contain', 'Done');
-
-		cy.wpCli('wp vip-search get-algorithm-version').its('stdout').should('contain', '1.0.0');
-
-		cy.wpCli('wp vip-search set-algorithm-version', true)
-			.its('stderr')
-			.should('contain', 'This command expects a version number or the --default flag');
-	});
-
 	it('Can get the mapping information', () => {
 		cy.wpCli('wp vip-search get-mapping').its('stdout').should('contain', 'mapping_version');
-	});
-
-	it('Can get the cluster indexes information', () => {
-		cy.wpCli('wp vip-search get-cluster-indexes').its('stdout').should('contain', 'health');
 	});
 
 	it('Can get the indexes names', () => {


### PR DESCRIPTION
## Description
On a maintenance aspect, it makes sense to use composition instead of inheriting all of the commands into `vip-search` & overriding the ones we don't need (as they will still appear in the list when we do `wp vip-search`). 

This should not change anything functionally, except for:
- the subcommand, `wp vip-search get-algorithm-version`, which will return the actual number rather than `default` as a value
- for multi-sites using `--network-mode` and `--setup`, fixes a minor bug where it prompts via `confirm_destructive_operation()` twice (once before the command is run at all, and then, again for each subsite) to only prompt once per each subsite.

## Changelog Description

### Plugin Updated: Enterprise Search

Remove inheritance from ElasticPress commands and fix CLI command `get-algorithm-version` to return a numeric value.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Test all commands listed below and ensure they work the same as before:
```
─$ vip dev-env --slug es-ms-site exec -- wp vip-search
Running validation steps...
✓ Check for Docker installation
✓ Check for docker-compose installation
✓ Check Docker connectivity
✓ Check DNS resolution
usage: wp vip-search activate-feature <feature-slug>
   or: wp vip-search clean-ep-feature-settings
   or: wp vip-search clear-index
   or: wp vip-search deactivate-feature <feature-slug>
   or: wp vip-search delete-index
   or: wp vip-search documents <command>
   or: wp vip-search get-algorithm-version
   or: wp vip-search get-index-settings <type> [--version] [--format=<string>]
   or: wp vip-search get-indexes
   or: wp vip-search get-indexing-status [--pretty]
   or: wp vip-search get-last-index [--pretty]
   or: wp vip-search get-last-indexed-post-id
   or: wp vip-search get-mapping
   or: wp vip-search health <command>
   or: wp vip-search index [--setup] [--network-wide] [--blog-ids] [--per-page] [--nobulk] [--show-errors] [--offset] [--upper-limit-object-id] [--lower-limit-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--version] [--skip-confirm] [--using-versions]
   or: wp vip-search index-versions <command>
   or: wp vip-search list-features [--all]
   or: wp vip-search put-mapping [--network-wide] [--indexables] [--ep-host] [--ep-prefix] [--skip-confirm]
   or: wp vip-search queue <command>
   or: wp vip-search recreate-network-alias
   or: wp vip-search stop-indexing

See 'wp help vip-search <command>' for more information on a specific command.
```