### PR TITLE
CANTINA-995: Disable crawling for VIP convenience domains

### DIFF
--- a/001-core/privacy.php
+++ b/001-core/privacy.php
@@ -457,3 +457,22 @@ function delete_old_export_files() {
 		}
 	}
 }
+
+/**
+ * Disable crawling for go-vip.co and go-vip.net domains.
+ * 
+ * @param string $output The robots.txt content.
+ * @return string The modified robots.txt content.
+ */
+function vip_convenience_domain_robots_txt( $output ) {
+	$host = strtolower( $_SERVER['HTTP_HOST'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	if ( false !== strpos( $host, '.go-vip.co' ) || false !== strpos( $host, '.go-vip.net' ) ) {
+		$output  = "# Crawling is blocked for go-vip.co and go-vip.net domains\n";
+		$output .= "User-agent: *\n";
+		$output .= "Disallow: /\n";
+	}
+
+	return $output;
+}
+// phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.robots_txt
+add_filter( 'robots_txt', __NAMESPACE__ . '\vip_convenience_domain_robots_txt' );


### PR DESCRIPTION
## Description
Should be no change functionally since we are moving this logic into MU-plugins.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Pull the latest version of `vip-cli` to incorporate [this nginx update change](https://github.com/Automattic/vip-cli/pull/1623) and then, link it
2) To test with dev-env, change the line `if ( false !== strpos( $host, '.go-vip.co' ) || false !== strpos( $host, '.go-vip.net' ) ) {` to `if ( false !== strpos( $host, '.vip-dev.lndo.site' ) || false !== strpos( $host, '.go-vip.net' ) ) {`
