### PR TITLE
BB8-10943: Update the 2FA messaging generic for different scenarios

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -248,7 +248,7 @@ function wpcom_vip_two_factor_admin_notice() {
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#ffb900;"></div>
 			<div>
 				<p style="font-weight:bold; font-size:16px;">
-					Your account requires <a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/">two-factor authentication</a> to be enabled.
+					Your account requires <a href="https://docs.wpvip.com/security/two-factor-authentication/">two-factor authentication</a> to be enabled.
 				</p>
 
 				<p>For the safety and security of this site, your account access has been downgraded. Please enable two-factor authentication to restore your access.</p>

--- a/two-factor.php
+++ b/two-factor.php
@@ -248,7 +248,7 @@ function wpcom_vip_two_factor_admin_notice() {
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#ffb900;"></div>
 			<div>
 				<p style="font-weight:bold; font-size:16px;">
-					Access requires your account to have <a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/">Two-factor authentication</a> enabled.
+					Your account requires <a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/">two-factor authentication</a> to be enabled.
 				</p>
 
 				<p>For the safety and security of this site, your account access has been downgraded. Please enable two-factor authentication to restore your access.</p>

--- a/two-factor.php
+++ b/two-factor.php
@@ -255,7 +255,7 @@ function wpcom_vip_two_factor_admin_notice() {
 
 				<p>
 					<a href="<?php echo esc_url( admin_url( 'profile.php#two-factor-options' ) ); ?>" class="button button-primary">
-						Enable Two-factor authentication
+						Enable Two-factor Authentication
 					</a>
 
 					<a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/" class="button" target="_blank">Learn More</a>

--- a/two-factor.php
+++ b/two-factor.php
@@ -248,14 +248,14 @@ function wpcom_vip_two_factor_admin_notice() {
 			<div class="dashicons dashicons-warning" style="display:flex;float:left;margin-right:2rem;font-size:38px;align-items:center;margin-left:-20px;color:#ffb900;"></div>
 			<div>
 				<p style="font-weight:bold; font-size:16px;">
-					<a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/">Two Factor Authentication</a> is required to edit content on this site.
+					Access requires your account to have <a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/">Two-factor authentication</a> enabled.
 				</p>
 
-				<p>For the safety and security of this site, your account access has been downgraded. Please enable two-factor authentication to restore your access.</p>
+				<p>For the safety and security of this site, your account access has been downgraded. Please enable Two-factor authentication to restore your access.</p>
 
 				<p>
 					<a href="<?php echo esc_url( admin_url( 'profile.php#two-factor-options' ) ); ?>" class="button button-primary">
-						Enable Two-factor Authentication
+						Enable Two-factor authentication
 					</a>
 
 					<a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/" class="button" target="_blank">Learn More</a>

--- a/two-factor.php
+++ b/two-factor.php
@@ -251,7 +251,7 @@ function wpcom_vip_two_factor_admin_notice() {
 					Access requires your account to have <a href="https://wpvip.com/documentation/vip-go/two-factor-authentication-on-vip-go/">Two-factor authentication</a> enabled.
 				</p>
 
-				<p>For the safety and security of this site, your account access has been downgraded. Please enable Two-factor authentication to restore your access.</p>
+				<p>For the safety and security of this site, your account access has been downgraded. Please enable two-factor authentication to restore your access.</p>
 
 				<p>
 					<a href="<?php echo esc_url( admin_url( 'profile.php#two-factor-options' ) ); ?>" class="button button-primary">


### PR DESCRIPTION
## Description

If a customer [enforced 2fa for all roles](https://docs.wpvip.com/security/two-factor-authentication/#h-enforce-two-factor-authentication-for-all-users), like subscriber, the 2FA admin notice banner we present to these lower cap users can be confusing/misleading.

This PR tries updating the message to keep it generic for different scenarios.