### PR TITLE
FORNO-1751: Update mu-plugins to use new smtp

### DIFF
--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -75,6 +75,31 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 		$this->assertMatchesRegularExpression( '/X-Automattic-Tracking: 1:\d+:.+:\d+:\d+:\d+(\\r\\n|\\r|\\n)/', $header );
 	}
 
+	public function test__vip_smtp_enabled() {
+		$GLOBALS['all_smtp_servers'] = [ 'server1', 'server2' ];
+		Constant_Mocker::define( 'VIP_SMTP_ENABLED', true );
+		Constant_Mocker::define( 'VIP_SMTP_USERNAME', 'username' );
+		Constant_Mocker::define( 'VIP_SMTP_PASSWORD', 'password' );
+
+		wp_mail( 'test@example.com', 'Test', 'Test' );
+		$mailer = tests_retrieve_phpmailer_instance();
+		// Verify that the SMTP settings are set
+		self::assertEquals( true, $mailer->SMTPAuth );
+		self::assertEquals( 'username', $mailer->Username );
+		self::assertEquals( 'password', $mailer->Password );
+	}
+
+	public function test__vip_smtp_disabled() {
+		$GLOBALS['all_smtp_servers'] = [ 'server1', 'server2' ];
+		Constant_Mocker::define( 'VIP_SMTP_ENABLED', false );
+
+		wp_mail( 'test@example.com', 'Test', 'Test' );
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// Verify that the SMTP Auth settings are not set
+		self::assertEquals( false, $mailer->SMTPAuth );
+	}
+
 	public function test_load_VIP_PHPMailer() {
 		$this->assertTrue( class_exists( '\Automattic\VIP\Mail\VIP_PHPMailer', false ) );
 	}
@@ -150,7 +175,7 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 			},
 			E_ALL
 		);
-		
+
 		add_filter( 'vip_block_wp_mail', '__return_true' );
 
 		$this->expectException( \Exception::class );

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -121,7 +121,8 @@ final class VIP_SMTP {
 		$phpmailer->isSMTP();
 		$phpmailer->Host = current( $all_smtp_servers );
 
-		if ( defined( 'VIP_SMTP_USERNAME' ) && defined( 'VIP_SMTP_PASSWORD' ) ) {
+		if ( defined( 'VIP_SMTP_ENABLED' ) && true === constant( 'VIP_SMTP_ENABLED'  ) && defined( 'VIP_SMTP_USERNAME' ) && defined( 'VIP_SMTP_PASSWORD' )) {
+			$phpmailer->SMTPAuth = true;
 			$phpmailer->Username = VIP_SMTP_USERNAME;
 			$phpmailer->Password = VIP_SMTP_PASSWORD;
 		}

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -89,7 +89,7 @@ final class VIP_SMTP {
 	}
 
 	/**
-	 * @param PHPMailer $phpmailer 
+	 * @param PHPMailer $phpmailer
 	 */
 	public function phpmailer_init( &$phpmailer ): void {
 		if ( defined( 'VIP_BLOCK_WP_MAIL' ) && true === constant( 'VIP_BLOCK_WP_MAIL' ) ) { // Constant will take precedence over filter
@@ -120,6 +120,11 @@ final class VIP_SMTP {
 
 		$phpmailer->isSMTP();
 		$phpmailer->Host = current( $all_smtp_servers );
+
+		if ( defined( 'VIP_SMTP_USERNAME' ) && defined( 'VIP_SMTP_PASSWORD' ) ) {
+			$phpmailer->Username = VIP_SMTP_USERNAME;
+			$phpmailer->Password = VIP_SMTP_PASSWORD;
+		}
 
 		$tracking_header = $this->get_tracking_header( WPCOM_VIP_MAIL_TRACKING_KEY );
 		if ( false !== $tracking_header ) {

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -121,7 +121,7 @@ final class VIP_SMTP {
 		$phpmailer->isSMTP();
 		$phpmailer->Host = current( $all_smtp_servers );
 
-		if ( defined( 'VIP_SMTP_ENABLED' ) && true === constant( 'VIP_SMTP_ENABLED'  ) && defined( 'VIP_SMTP_USERNAME' ) && defined( 'VIP_SMTP_PASSWORD' )) {
+		if ( defined( 'VIP_SMTP_ENABLED' ) && true === constant( 'VIP_SMTP_ENABLED' ) && defined( 'VIP_SMTP_USERNAME' ) && defined( 'VIP_SMTP_PASSWORD' ) ) {
 			$phpmailer->SMTPAuth = true;
 			$phpmailer->Username = VIP_SMTP_USERNAME;
 			$phpmailer->Password = VIP_SMTP_PASSWORD;

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -123,8 +123,8 @@ final class VIP_SMTP {
 
 		if ( defined( 'VIP_SMTP_ENABLED' ) && true === constant( 'VIP_SMTP_ENABLED' ) && defined( 'VIP_SMTP_USERNAME' ) && defined( 'VIP_SMTP_PASSWORD' ) ) {
 			$phpmailer->SMTPAuth = true;
-			$phpmailer->Username = VIP_SMTP_USERNAME;
-			$phpmailer->Password = VIP_SMTP_PASSWORD;
+			$phpmailer->Username = constant( 'VIP_SMTP_USERNAME' );
+			$phpmailer->Password = constant( 'VIP_SMTP_PASSWORD' );
 		}
 
 		$tracking_header = $this->get_tracking_header( WPCOM_VIP_MAIL_TRACKING_KEY );


### PR DESCRIPTION
##  Description

This PR tries to enable auth for migrating to new SMTP server. It's behind the flag `VIP_SMTP_ENABLED` so the changes won't be effective until that config is enabled.