### PR TITLE
Fix `Caught Error: Class "Two_Factor_Core" not found in /var/www/wp-content/mu-plugins/prometheus-collectors/class-user-stats-collector.php:71`

### DIFF
--- a/prometheus-collectors/class-user-stats-collector.php
+++ b/prometheus-collectors/class-user-stats-collector.php
@@ -137,7 +137,7 @@ class User_Stats_Collector implements CollectorInterface {
 	 * @return bool True if the user is using 2FA, false otherwise.
 	 */
 	public function is_user_using_two_factor( $user_id ) {
-		return Two_Factor_Core::is_user_using_two_factor( $user_id );
+		return class_exists( 'Two_Factor_Core' ) && Two_Factor_Core::is_user_using_two_factor( $user_id );
 	}
 
 	/**
@@ -147,6 +147,10 @@ class User_Stats_Collector implements CollectorInterface {
 	 * @return array The users with 2FA meta.
 	 */
 	public function get_2fa_users() {
+		if ( ! class_exists( 'Two_Factor_Core' ) ) {
+			return [];
+		}
+
 		$users = get_users( [
 			'count_total' => false,
 			'number'      => -1,

--- a/prometheus-collectors/class-user-stats-collector.php
+++ b/prometheus-collectors/class-user-stats-collector.php
@@ -51,6 +51,10 @@ class User_Stats_Collector implements CollectorInterface {
 			return;
 		}
 
+		if ( ! class_exists( 'Two_Factor_Core' ) ) {
+			return;
+		}
+
 		// Since we bunch everything together under a single label this logic wouldn't make any sense.
 		if ( is_multisite() && wp_count_sites()['all'] > Plugin::MAX_NETWORK_SITES ) {
 			return;


### PR DESCRIPTION
## Description
Fix `Caught Error: Class "Two_Factor_Core" not found in /var/www/wp-content/mu-plugins/prometheus-collectors/class-user-stats-collector.php:71` occurring on batch pods

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
