### PR TITLE
test(e2e): fix Unexpected use of page.waitForSelector()

### DIFF
--- a/__tests__/e2e/lib/pages/media-upload-page.ts
+++ b/__tests__/e2e/lib/pages/media-upload-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 const selectors = {
 	selectFilesButton: '#plupload-browse-button',
@@ -13,19 +10,19 @@ export class MediaUploadPage {
 	readonly page: Page;
 
 	/**
-     * Constructs an instance of the component.
-     *
-     * @param { Page } page The underlying page
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param { Page } page The underlying page
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 	}
 
 	/**
-     * Upload File
-     *
-     * @param { string } mediaFile Media file name
-     */
+	 * Upload File
+	 *
+	 * @param { string } mediaFile Media file name
+	 */
 	async uploadFile( mediaFile: string ): Promise<void> {
 		const [ fileChooser ] = await Promise.all( [
 			// It is important to call waitForEvent before click to set up waiting.
@@ -37,12 +34,11 @@ export class MediaUploadPage {
 	}
 
 	/**
-     * Get Meduia URL
-     *
-     * @return { Promise<string | null> } Url of uploaded media
-     */
+	 * Get Media URL
+	 *
+	 * @return { Promise<string | null> } Url of uploaded media
+	 */
 	async getMediaUrl(): Promise<string | null> {
-		await this.page.waitForSelector( selectors.attachedMediaDetails );
 		return this.page.locator( selectors.copyURLButton ).getAttribute( 'data-clipboard-text' );
 	}
 }

--- a/__tests__/e2e/lib/pages/page-list-page.ts
+++ b/__tests__/e2e/lib/pages/page-list-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 const selectors = {
 	pageLink: ( pageID: string ) => `#post-${ pageID } a.row-title`,
@@ -11,26 +8,26 @@ export class PageListPage {
 	readonly page: Page;
 
 	/**
-     *  Constructs an instance of the component.
-     *
-     * @param { Page } page The underlying page
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param { Page } page The underlying page
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 	}
 
 	/**
-     * Navigate to Page List page
-     */
+	 * Navigate to Page List page
+	 */
 	visit(): Promise<unknown> {
 		return this.page.goto( '/wp-admin/edit.php?post_type=page' );
 	}
 
 	/**
-     * Edit Page by ID
-     *
-     * @param { string } pageID ID of the page to be edited
-     */
+	 * Edit Page by ID
+	 *
+	 * @param { string } pageID ID of the page to be edited
+	 */
 	editPageByID( pageID: string ): Promise<void> {
 		return this.page.click( selectors.pageLink( pageID ) );
 	}

--- a/__tests__/e2e/lib/pages/post-list-page.ts
+++ b/__tests__/e2e/lib/pages/post-list-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 const selectors = {
 	postLink: ( postID: string ) => `#post-${ postID } a.row-title`,
@@ -11,26 +8,26 @@ export class PostListPage {
 	readonly page: Page;
 
 	/**
-     *  Constructs an instance of the component.
-     *
-     * @param { Page } page The underlying page
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param { Page } page The underlying page
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 	}
 
 	/**
-     * Navigate to Post List page
-     */
+	 * Navigate to Post List page
+	 */
 	visit(): Promise<unknown> {
 		return this.page.goto( '/wp-admin/edit.php' );
 	}
 
 	/**
-     * Edit Post by ID
-     *
-     * @param {string} postID ID of the post to be edited
-     */
+	 * Edit Post by ID
+	 *
+	 * @param {string} postID ID of the post to be edited
+	 */
 	editPostByID( postID: string ): Promise<void> {
 		return this.page.click( selectors.postLink( postID ) );
 	}

--- a/__tests__/e2e/lib/pages/published-page-page.ts
+++ b/__tests__/e2e/lib/pages/published-page-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from 'playwright';
+import type { Page } from 'playwright';
 
 const selectors = {
 	entryTitle: '.wp-block-post-title',
@@ -16,25 +13,24 @@ export class PublishedPagePage {
 	private page: Page;
 
 	/**
-     * Constructs an instance of the component.
-     *
-     * @param {Page} page The underlying page.
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 	}
 
 	/**
-     * Validates that the provided text can be found in the page.
-     *
-     * @param {string} text Text to search for in the page
-     */
+	 * Validates that the provided text can be found in the page.
+	 *
+	 * @param {string} text Text to search for in the page
+	 */
 	async validateTextInPost( text: string ): Promise<void> {
 		// If text isn't found the first time, reload and check again up to 2 more times.
 		let postTry = 0;
 		/* eslint-disable no-await-in-loop */
 		while ( postTry < 3 ) {
-			await this.page.waitForSelector( selectors.entryTitle );
 			if ( await this.page.locator( selectors.pageText( text ) ).first().isVisible() ) {
 				break;
 			} else {
@@ -46,10 +42,10 @@ export class PublishedPagePage {
 	}
 
 	/**
-     * Returns boolean of whether or not image was found in page
-     *
-     * @return {Promise<boolean>} True if image is found, otherwise false
-     */
+	 * Returns boolean of whether or not image was found in page
+	 *
+	 * @return {Promise<boolean>} True if image is found, otherwise false
+	 */
 	isImageDisplayed(): Promise<boolean> {
 		return this.page.isVisible( selectors.pageImage );
 	}

--- a/__tests__/e2e/lib/pages/published-post-page.ts
+++ b/__tests__/e2e/lib/pages/published-post-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from 'playwright';
+import type { Page } from 'playwright';
 
 const selectors = {
 	entryTitle: '.wp-block-post-title',
@@ -16,25 +13,24 @@ export class PublishedPostPage {
 	private page: Page;
 
 	/**
-     * Constructs an instance of the component.
-     *
-     * @param {Page} page The underlying page.
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 	}
 
 	/**
-     * Validates that the provided text can be found in the post page.
-     *
-     * @param {string} text Text to search for in post page
-     */
+	 * Validates that the provided text can be found in the post page.
+	 *
+	 * @param {string} text Text to search for in post page
+	 */
 	async validateTextInPost( text: string ): Promise<void> {
 		// If text isn't found the first time, reload and check again up to 2 more times.
 		let pageTry = 0;
 		/* eslint-disable no-await-in-loop */
 		while ( pageTry < 3 ) {
-			await this.page.waitForSelector( selectors.entryTitle );
 			if ( await this.page.locator( selectors.postText( text ) ).first().isVisible() ) {
 				break;
 			} else {
@@ -46,10 +42,10 @@ export class PublishedPostPage {
 	}
 
 	/**
-     * Returns boolean of whether or not image was found in post
-     *
-     * @return {Promise<boolean>} True if image is found, otherwise false
-     */
+	 * Returns boolean of whether or not image was found in post
+	 *
+	 * @return {Promise<boolean>} True if image is found, otherwise false
+	 */
 	isImageDisplayed(): Promise<boolean> {
 		return this.page.isVisible( selectors.postImage );
 	}

--- a/__tests__/e2e/lib/pages/search-page.ts
+++ b/__tests__/e2e/lib/pages/search-page.ts
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
-/**
- * Internal dependencies
- */
 import { getClassList } from '../playwright-helpers';
 
 const selectors = {
 	devToolsMenu: () => '#wp-admin-bar-vip-search-dev-tools',
-	devToolsPortal: () => '#search-dev-tools-portal',
 	devToolsContainer: () => '#search-dev-tools-portal > .search-dev-tools__overlay',
 	devToolsClose: () => '.search-dev-tools__overlay__close',
 	queryCount: () => 'h2[class^="vip-h2 query_count"]',
@@ -23,8 +16,7 @@ const selectors = {
 	queryColumn: () => 'div[class^="query_src__"]',
 	sourceQuery: () => 'textarea',
 	queryActionsButton: () => 'div[class^="query_actions"] > button',
-	queryResult: () => 'div[class^="query_result__"] > pre > code',
-	queryResultText: ( text: string ) => `#search-dev-tools-portal div[class^="query_result__"] > pre:has-text(${ text })`,
+	queryResult: () => 'div[class^="query_result__"]',
 };
 
 export class SearchPage {
@@ -32,83 +24,90 @@ export class SearchPage {
 	private readonly devToolsMenuLocator: Locator;
 	private readonly devToolsContainerLocator: Locator;
 	private readonly devToolsCloseButtonLocator: Locator;
+	private readonly queryCountLocator: Locator;
+	private readonly resultCountLocator: Locator;
 	private readonly queryWrapLocator: Locator;
+	private readonly queryHandleLocator: Locator;
 	private readonly queryExtrasLocator: Locator;
 	private readonly queryExtrasExpandLocator: Locator;
 	private readonly queryExtrasListLocator: Locator;
 	private readonly queryColumnLocator: Locator;
 	private readonly sourceQueryLocator: Locator;
 	private readonly queryActionsLocator: Locator;
+	private readonly queryResultLocator: Locator;
 
 	/**
-     * Constructs an instance of the component.
-     *
-     * @param {Page} page The underlying page
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 		this.devToolsMenuLocator = page.locator( selectors.devToolsMenu() );
 		this.devToolsContainerLocator = page.locator( selectors.devToolsContainer() );
 		this.devToolsCloseButtonLocator = this.devToolsContainerLocator.locator( selectors.devToolsClose() );
+		this.queryCountLocator = this.devToolsContainerLocator.locator( selectors.queryCount() );
+		this.resultCountLocator = this.devToolsContainerLocator.locator( selectors.resultCount() );
 		this.queryWrapLocator = this.devToolsContainerLocator.locator( selectors.queryWrap() );
+		this.queryHandleLocator = this.queryWrapLocator.locator( selectors.queryHandle() );
 		this.queryExtrasLocator = this.queryWrapLocator.locator( selectors.queryExtras() );
 		this.queryExtrasExpandLocator = this.queryExtrasLocator.locator( selectors.queryExtrasExpand() );
 		this.queryExtrasListLocator = this.queryExtrasLocator.locator( selectors.queryExtrasList() );
 		this.queryColumnLocator = this.queryWrapLocator.locator( selectors.queryColumn() );
 		this.sourceQueryLocator = this.queryColumnLocator.locator( selectors.sourceQuery() );
 		this.queryActionsLocator = this.queryColumnLocator.locator( selectors.queryActionsButton() );
+		this.queryResultLocator = this.devToolsContainerLocator.locator( selectors.queryResult() );
 	}
 
 	/**
-     * Perform a search.
-     *
-     * @param {string} searchTerm Search term
-     * @return {Promise<*>} Resolves after DOMContentLoaded event fires
-     */
+	 * Perform a search.
+	 *
+	 * @param {string} searchTerm Search term
+	 * @return {Promise<*>} Resolves after DOMContentLoaded event fires
+	 */
 	visit( searchTerm: string ): Promise<unknown> {
 		return this.page.goto( `/?s=${ encodeURIComponent( searchTerm ) }`, { waitUntil: 'domcontentloaded' } );
 	}
 
 	/**
-     * Opens the Search DevTools panel
-     *
-     * @return {Promise<*>} Resolves when Search DevTools panel is visible
-     */
+	 * Opens the Search DevTools panel
+	 *
+	 * @return {Promise<*>} Resolves when Search DevTools panel is visible
+	 */
 	async openSearchDevTools(): Promise<unknown> {
-		await this.devToolsMenuLocator.waitFor( { state: 'visible' } );
 		await this.devToolsMenuLocator.click();
-		return this.devToolsContainerLocator.waitFor( { state: 'visible' } );
+		return expect( this.devToolsContainerLocator ).toBeVisible();
 	}
 
 	/**
-     * Returns the number of queries run by the page.
-     *
-     * @return {Promise<number>} Resolves with the number of queries or -1 if the number is unavailable
-     */
+	 * Returns the number of queries run by the page.
+	 *
+	 * @return {Promise<number>} Resolves with the number of queries or -1 if the number is unavailable
+	 */
 	async getNumberOfQueries(): Promise<number> {
-		const text = ( await this.devToolsContainerLocator.locator( selectors.queryCount() ).innerText() ).trim();
+		const text = ( await this.queryCountLocator.innerText() ).trim();
 		const matches = /^(\d+)/.exec( text );
 		return matches ? Number( matches[ 1 ] ) : -1;
 	}
 
 	/**
-     * Returns the number of results (should match the number of queries).
-     *
-     * @return {Promise<number>} Resolves with the number of results or -1 if the number is unavailable
-     */
+	 * Returns the number of results (should match the number of queries).
+	 *
+	 * @return {Promise<number>} Resolves with the number of results or -1 if the number is unavailable
+	 */
 	async getNumberOfFirstResults(): Promise<number> {
-		const text = ( await this.devToolsContainerLocator.locator( selectors.resultCount() ).first().innerText() ).trim();
+		const text = ( await this.resultCountLocator.first().innerText() ).trim();
 		const matches = /^(\d+)/.exec( text );
 		return matches ? Number( matches[ 1 ] ) : -1;
 	}
 
 	/**
-     * Expands search results panel.
-     *
-     * @return {Promise<boolean>} Whether the panel has been shown
-     */
+	 * Expands search results panel.
+	 *
+	 * @return {Promise<boolean>} Whether the panel has been shown
+	 */
 	async expandFirstResults(): Promise<boolean> {
-		const queryHandleLocator = this.queryWrapLocator.locator( selectors.queryHandle() ).first();
+		const queryHandleLocator = this.queryHandleLocator.first();
 
 		let classes = await getClassList( this.queryWrapLocator );
 		const isCollapsed = classes.some( ( className ) => className.startsWith( 'query_collapsed' ) );
@@ -123,60 +122,60 @@ export class SearchPage {
 	}
 
 	/**
-     * Get the list of WP_Query parameters.
-     *
-     * @return {Promise<string>} Parameters as a string
-     */
+	 * Get the list of WP_Query parameters.
+	 *
+	 * @return {Promise<string>} Parameters as a string
+	 */
 	getWPQuery(): Promise<string> {
 		return this.getQueryExtrasHelper( 0 );
 	}
 
 	/**
-     * Returns the backtrace for the query.
-     *
-     * @return {Promise<string>} Backtrace as a string
-     */
+	 * Returns the backtrace for the query.
+	 *
+	 * @return {Promise<string>} Backtrace as a string
+	 */
 	getTrace(): Promise<string> {
 		return this.getQueryExtrasHelper( 1 );
 	}
 
 	/**
-     * Returns the query.
-     *
-     * @return {Promise<string>} Query
-     */
+	 * Returns the query.
+	 *
+	 * @return {Promise<string>} Query
+	 */
 	getQuery(): Promise<string> {
 		return this.sourceQueryLocator.inputValue();
 	}
 
 	/**
-     * Updates the query box with a new query.
-     *
-     * @param {string} newQuery New Query
-     * @return {Promise<*>} Resolves on success
-     */
+	 * Updates the query box with a new query.
+	 *
+	 * @param {string} newQuery New Query
+	 * @return {Promise<*>} Resolves on success
+	 */
 	editQuery( newQuery: string ): Promise<unknown> {
 		return this.sourceQueryLocator.fill( newQuery );
 	}
 
 	/**
-     * Resets the query to the original value.
-     *
-     * @return {Promise<string>} Original query
-     */
+	 * Resets the query to the original value.
+	 *
+	 * @return {Promise<string>} Original query
+	 */
 	async resetQuery(): Promise<string> {
 		await this.queryActionsLocator.nth( 1 ).click();
 		return this.getQuery();
 	}
 
 	/**
-     * Runs the query and returns the results as JSON
-     *
-     * @return {Promise<*>} Result of the query
-     */
+	 * Runs the query and returns the results as JSON
+	 *
+	 * @return {Promise<*>} Result of the query
+	 */
 	async runQuery(): Promise<unknown> {
 		const [ response ] = await Promise.all( [
-			this.page.waitForResponse( ( resp ) => /\/wp-json\/vip\/v1\/search\/dev-tools$/.test( resp.url() ) && resp.request().method() === 'POST' && resp.status() === 200 ),
+			this.page.waitForResponse( ( resp ) => resp.url().endsWith( '/wp-json/vip/v1/search/dev-tools' ) && resp.request().method() === 'POST' && resp.status() === 200 ),
 			this.queryActionsLocator.first().click(),
 		] );
 
@@ -184,37 +183,36 @@ export class SearchPage {
 	}
 
 	/**
-     * Waits until the query response contains the specific substring.
-     *
-     * @param {string} substring Substring to check
-     * @return {Promise<*>} Resolves on success
-     */
+	 * Waits until the query response contains the specific substring.
+	 *
+	 * @param {string} substring Substring to check
+	 * @return {Promise<*>} Resolves on success
+	 */
 	ensureQueryResponse( substring: string ): Promise<unknown> {
-		return this.page.waitForSelector( selectors.queryResultText( substring ) );
+		return expect( this.queryResultLocator.getByText( substring ) ).toBeVisible();
 	}
 
 	/**
-     * Closes the DevTools panel
-     *
-     * @return {Promise<*>} Resolves on success
-     */
-	async closeSearchDevTools(): Promise<unknown> {
-		await this.devToolsCloseButtonLocator.waitFor( { state: 'visible' } );
+	 * Closes the DevTools panel
+	 *
+	 * @return {Promise<*>} Resolves on success
+	 */
+	closeSearchDevTools(): Promise<unknown> {
 		return this.devToolsCloseButtonLocator.click();
 	}
 
 	/**
-     * Gets the data from the specific block in the Query Extra section.
-     *
-     * @param {number} index Number of the block, zero-based
-     * @return {Promise<string>} Resolves with the block data
-     */
+	 * Gets the data from the specific block in the Query Extra section.
+	 *
+	 * @param {number} index Number of the block, zero-based
+	 * @return {Promise<string>} Resolves with the block data
+	 */
 	private async getQueryExtrasHelper( index: number ): Promise<string> {
 		await this.queryExtrasExpandLocator.nth( index ).click();
-		await this.queryExtrasListLocator.nth( index ).waitFor( { state: 'visible' } );
+		await expect( this.queryExtrasListLocator.nth( index ) ).toBeVisible();
 		const result = await this.queryExtrasListLocator.nth( index ).innerText();
 		await this.queryExtrasExpandLocator.nth( index ).click();
-		await this.queryExtrasListLocator.nth( index ).waitFor( { state: 'hidden' } );
+		await expect( this.queryExtrasListLocator.nth( index ) ).toBeHidden();
 		return result;
 	}
 }

--- a/__tests__/e2e/lib/pages/settings-writing-page.ts
+++ b/__tests__/e2e/lib/pages/settings-writing-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 const selectors = {
 	classicEditorBlock: '#classic-editor-block',
@@ -13,34 +10,34 @@ export class SettingsWritingPage {
 	readonly page: Page;
 
 	/**
-     * Constructs an instance of the component.
-     *
-     * @param { Page } page The underlying page
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param { Page } page The underlying page
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 	}
 
 	/**
-     * Navigate to Writing Settings page
-     */
+	 * Navigate to Writing Settings page
+	 */
 	visit(): Promise<unknown> {
 		return this.page.goto( '/wp-admin/options-writing.php' );
 	}
 
 	/**
-     * Checks to see if Classic Editor Settings are available
-     *
-     * @return { Promise<boolean> } Whether classic editor settings are visible
-     */
-	async hasClassicEditor(): Promise<boolean> {
+	 * Checks to see if Classic Editor Settings are available
+	 *
+	 * @return { Promise<boolean> } Whether classic editor settings are visible
+	 */
+	hasClassicEditor(): Promise<boolean> {
 		const editorSettings = this.page.locator( selectors.classicEditorBlock );
-		return await editorSettings.isVisible();
+		return editorSettings.isVisible();
 	}
 
 	/**
-     * Select settings to allow either block or classic editor
-     */
+	 * Select settings to allow either block or classic editor
+	 */
 	async allowBothEditors(): Promise<void> {
 		await this.page.click( selectors.classicEditorBlock );
 		await this.page.click( selectors.classicEditorAllow );

--- a/__tests__/e2e/lib/pages/wp-admin-page.ts
+++ b/__tests__/e2e/lib/pages/wp-admin-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Locator, Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 const selectors = {
 	adminBar: '#wpadminbar',
@@ -12,18 +9,18 @@ export class WPAdminPage {
 	readonly adminBar: Locator;
 
 	/**
-     * Constructs an instance of the component.
-     *
-     * @param { Page } page The underlying page
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param { Page } page The underlying page
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 		this.adminBar = page.locator( selectors.adminBar );
 	}
 
 	/**
-     * Navigate to WP Admin
-     */
+	 * Navigate to WP Admin
+	 */
 	visit(): Promise<unknown> {
 		return this.page.goto( '/wp-admin' );
 	}

--- a/__tests__/e2e/lib/pages/wp-classic-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-classic-editor-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 const selectors = {
 	editorTitle: '#title',

--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 const selectors = {
 	// Editor
@@ -68,36 +65,22 @@ export class EditorPage {
 	/**
 	 * Dismisses the Welcome Tour (card) if it is present.
 	 */
-	async dismissWelcomeTour(): Promise<void> {
-		try {
-			await this.page.waitForSelector( selectors.welcomeTourCloseButton, {
-				state: 'visible',
-				timeout: 5000,
-			} );
-		} catch {
-			return;
-		}
-
-		const closeButton = this.page.locator( selectors.welcomeTourCloseButton );
-		return closeButton.click( {
-			delay: 20,
-		} );
+	dismissWelcomeTour(): Promise<void> {
+		return this.clickButtonIfExists( this.page.locator( selectors.welcomeTourCloseButton ) );
 	}
 
-	async dismissPatternSelector(): Promise<void> {
+	dismissPatternSelector(): Promise<void> {
+		return this.clickButtonIfExists( this.page.locator( selectors.choosePatternCloseButton ) );
+	}
+
+	private async clickButtonIfExists( locator: Locator ): Promise<void> {
 		try {
-			await this.page.waitForSelector( selectors.choosePatternCloseButton, {
-				state: 'visible',
-				timeout: 5000,
-			} );
+			await locator.waitFor( { state: 'visible', timeout: 5000 } );
 		} catch {
 			return;
 		}
 
-		const closeButton = this.page.locator( selectors.choosePatternCloseButton );
-		return closeButton.click( {
-			delay: 20,
-		} );
+		return locator.click( { delay: 20 } );
 	}
 
 	/**
@@ -185,7 +168,7 @@ export class EditorPage {
 			this.page.click( selectors.uploadImageButton ),
 		] );
 		await fileChooser.setFiles( fileName );
-		await this.page.waitForSelector( selectors.spinner, { state: 'detached' } );
+		await this.page.locator( selectors.spinner ).waitFor( { state: 'detached' } );
 	}
 
 	/**
@@ -197,8 +180,7 @@ export class EditorPage {
 	async publish( { visit = false }: { visit?: boolean } = {} ): Promise<string> {
 		await this.page.click( selectors.publishButton( selectors.postToolbar ) );
 		await this.page.click( selectors.publishButton( selectors.publishPanel ) );
-		const viewPublishedArticleButton = await this.page.waitForSelector( selectors.viewButton );
-		const publishedURL = ( await viewPublishedArticleButton.getAttribute( 'href' ) )!;
+		const publishedURL = ( await this.page.locator( selectors.viewButton ).getAttribute( 'href' ) )!;
 
 		if ( visit ) {
 			await this.visitPublishedPost( publishedURL );

--- a/__tests__/e2e/lib/pages/wp-login-page.ts
+++ b/__tests__/e2e/lib/pages/wp-login-page.ts
@@ -1,7 +1,4 @@
-/**
- * External dependencies
- */
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 const selectors = {
 	userField: '#user_login',
@@ -13,28 +10,28 @@ export class LoginPage {
 	private page: Page;
 
 	/**
-     *  Constructs an instance of the component.
-     *
-     * @param { Page } page The underlying page
-     */
+	 * Constructs an instance of the component.
+	 *
+	 * @param { Page } page The underlying page
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 	}
 
 	/**
-     * Navigate to login page
-     *
-     */
+	 * Navigate to login page
+	 *
+	 */
 	visit(): Promise<unknown> {
 		return this.page.goto( '/wp-login.php' );
 	}
 
 	/**
-     * Logs in to account with specified username and password
-     *
-     * @param {string} username Username to login as
-     * @param {string} password Password for account
-     */
+	 * Logs in to account with specified username and password
+	 *
+	 * @param {string} username Username to login as
+	 * @param {string} password Password for account
+	 */
 	async login( username: string, password: string ): Promise<unknown> {
 		await this.page.fill( selectors.userField, username );
 		await this.page.fill( selectors.passwordField, password );

--- a/__tests__/e2e/specs/searchdevtools.spec.ts
+++ b/__tests__/e2e/specs/searchdevtools.spec.ts
@@ -36,7 +36,7 @@ test( 'Search Dev Tools', async ( { page } ) => {
 			} ),
 		} );
 
-		return searchPage.ensureQueryResponse( '"world"' );
+		return searchPage.ensureQueryResponse( 'world' );
 	} );
 	await test.step( 'Close DevTools', () => searchPage.closeSearchDevTools() );
 } );


### PR DESCRIPTION
This PR fixes the "Unexpected use of page.waitForSelector()" issue (Playwright waits for the selector anyway, and `waitForSelector()` is often meaningless) and fixes mixed indentation in some files.