### PR TITLE
Add and set wp-parsely 3.13 as the default version

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -21,6 +21,7 @@ namespace Automattic\VIP\WP_Parsely_Integration;
  * The default version is the first entry in the SUPPORTED_VERSIONS list.
  */
 const SUPPORTED_VERSIONS = [
+	'3.13',
 	'3.12',
 	'3.11',
 	'3.10',
@@ -187,7 +188,7 @@ final class Parsely_Loader_Info {
 		if ( isset( $GLOBALS['parsely'] ) && is_a( $GLOBALS['parsely'], 'Parsely\Parsely' ) ) {
 			$parsely_options = $GLOBALS['parsely']->get_options();
 		}
-		
+
 		return $parsely_options;
 	}
 }


### PR DESCRIPTION
## Description
This PR adds and sets wp-parsely 3.13 as the default version in vip-go-mu-plugins. Any users who are not pinned to a specific wp-parsely version will automatically be upgraded to 3.13.x when this PR takes effect.

## Changelog Description

### wp-parsely default version was upgraded to 3.13

Changed the default version of wp-parsely from 3.12 to 3.13.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test
1. Checkout the PR.
2. Enable wp-parsely:
```
add_filter( 'wpvip_parsely_load_mu', '__return_true' );
```
3. In wp-admin, go the plugin's settings (Settings -> Parse.ly). On the top of the page, you should be seeing the new default version number (3.13.x).