### PR TITLE
Handle Jetpack connection timeouts

### DIFF
--- a/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-controls.php
@@ -83,6 +83,10 @@ class Controls {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			if ( 'http_request_failed' === $response->get_error_code() && str_contains( $response->get_error_message(), 'Operation timed out' ) ) {
+				return new WP_Error( 'jp-cxn-pilot-test-timeout', sprintf( 'Failed to test connection (#%s: %s)', $response->get_error_code(), $response->get_error_message() ) );
+			}
+
 			return new WP_Error( 'jp-cxn-pilot-test-fail', sprintf( 'Failed to test connection (#%s: %s)', $response->get_error_code(), $response->get_error_message() ) );
 		}
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-pilot.php
@@ -288,6 +288,11 @@ class Connection_Pilot {
 					$this->send_alert( 'Jetpack cannot currently be connected on this site due to the environment. JP may be in development mode.', $error );
 					return false;
 
+				// If the site is timing out, then attempting to reconnect right now could mess up an otherwise valid connection.
+				case 'jp-cxn-pilot-test-timeout':
+					$this->send_alert( 'Jetpack cannot currently be connected due to site availability issues (request timeout)', $error );
+					return false;
+
 				// It is connected but not under the right account.
 				case 'jp-cxn-pilot-not-vip-owned':
 					$this->send_alert( 'Jetpack is connected to a non-VIP account.', $error );
@@ -359,7 +364,7 @@ class Connection_Pilot {
 			return $message;
 		}
 
-		$errors_to_ignore = [ 'jp-cxn-pilot-not-vip-owned', 'jp-cxn-pilot-development-mode', 'jp-cxn-pilot-domain-changed' ];
+		$errors_to_ignore = [ 'jp-cxn-pilot-not-vip-owned', 'jp-cxn-pilot-development-mode', 'jp-cxn-pilot-domain-changed', 'jp-cxn-pilot-akismet-connection-failed' ];
 		if ( is_wp_error( $wp_error ) && in_array( $wp_error->get_error_code(), $errors_to_ignore, true ) ) {
 			return $message;
 		}


### PR DESCRIPTION
When testing if Jetpack has an active connection, it's important we don't try to "fix" the connection if the site is currently unreachable due to an http timeout.

Can replicate availability issues via:

```
add_action( 'init', function() {
	if ( 'enabled' !== get_option( 'vip_jetpack_timeout_test', false ) ) {
		return;
	}

	if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) && $_SERVER['HTTP_USER_AGENT'] === 'Jetpack by WordPress.com' ) {
		// Cause a timeout when WPcom tries to reach out to the site.
		sleep( 11 );
	}
} );
```

Before this patch, the connection pilot thinks the connection is broken and goes about trying to fix the connection. But with timeout errors occurring, attempting to fix at that moment is more likely to break a valid connection than it is to create/fix the connection.