### PR TITLE
Two Factor: Update two-factor-user-options- filter name for 0.7.0+

### DIFF
--- a/wpcom-vip-two-factor/sms-provider.php
+++ b/wpcom-vip-two-factor/sms-provider.php
@@ -28,7 +28,7 @@ class Two_Factor_SMS extends Two_Factor_Provider {
 	}
 
 	protected function __construct() {
-		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
+		add_action( 'two_factor_user_options_' . __CLASS__, array( $this, 'user_options' ) );
 		add_action( 'personal_options_update', array( $this, 'user_options_update' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'user_options_update' ) );
 		parent::__construct();


### PR DESCRIPTION
## Description
In the release of Two Factor 0.7.0 `two-factor-user-options-` was renamed to `two_factor_user_options_` This PR replaces the deprecated function with that new function name.

See: [upstream PR #363](https://github.com/WordPress/two-factor/pull/363)

Without this PR the deprecated function if fired, creating the following notice on our platform:

```
PHP message: PHP Deprecated: Hook two-factor-user-options-Two_Factor_SMS is deprecated since version 0.7.0! Use two_factor_user_options_Two_Factor_SMS instead. in /var/www/wp-includes/functions.php on line 6031
```

Deprecation notice found in the source code at: https://github.com/WordPress/two-factor/blob/0.8.2/class-two-factor-core.php#L1462-L1472

## Changelog Description

### Update wpcom-vip-two-factor remove deprecated filter

This change replaces `two-factor-user-options-` with `two_factor_user_options_` in VIP's SMS two factor provider as the former was deprecated in 0.7.0 of the upstream Two Factor Plugin. 
 
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
Example:

1. Check out PR.
1. Go to `wp-admin` > `Profile`
1. Check the logs for the deprecation notice. 

