### PR TITLE
Filter the font directory to work with the VIP Filesystem

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -468,13 +468,7 @@ class VIP_Filesystem {
 	 * Changes the Font Library directory to work with the VIP Filesystem.
 	 */
 	public function filter_wp_font_dir( $defaults ) {
-		// Without removing the filter, there will be an infinite loop, because
-		// calling wp_upload_dir will trigger upload_dir, which includes wp_get_font_dir
-		// in the context of uploading fonts. That ultimately calls this function
-		// again through the font_dir filter.
-		remove_filter( 'upload_dir', 'wp_get_font_dir' );
 		$upload_dir = wp_upload_dir();
-		add_filter( 'upload_dir', 'wp_get_font_dir' );
 	
 		$defaults['basedir'] = $upload_dir['basedir'] . '/fonts';
 		$defaults['baseurl'] = $upload_dir['baseurl'] . '/fonts';

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -4,7 +4,6 @@ namespace Automattic\VIP\Files;
 
 use Automattic\Test\Constant_Mocker;
 use ErrorException;
-use Parsely\RemoteAPI\Base_Endpoint_Remote;
 use WP_Error;
 use WP_Filesystem_Base;
 use WP_Filesystem_Direct;
@@ -394,10 +393,8 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 			$this->assertEquals( true, true );
 			return;
 		}
-		// Simulate filter behavior which happens during upload:
-		add_filter( 'upload_dir', '\wp_get_font_dir' );
+
 		$font_dir = \wp_get_font_dir();
-		remove_filter( 'upload_dir', '\zwp_get_font_dir' );
 
 		$this->assertEquals( $font_dir, [
 			'path'    => 'vip://wp-contentt/uploads/fonts',

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -29,8 +29,8 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 
 	public static function configure_constant_mocker(): void {
 		Constant_Mocker::clear();
-		define( 'LOCAL_UPLOADS', '/wp/uploads' );
-		define( 'WP_CONTENT_DIR', '/wp/wordpress/wp-content' );
+		define( 'LOCAL_UPLOADS', '/tmp/uploads' );
+		define( 'WP_CONTENT_DIR', '/tmp/wordpress/wp-content' );
 	}
 
 	public function setUp(): void {
@@ -397,8 +397,8 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		$font_dir = \wp_get_font_dir();
 
 		$this->assertEquals( $font_dir, [
-			'path'    => 'vip://wp-contentt/uploads/fonts',
-			'basedir' => 'vip://wp-contentt/uploads/fonts',
+			'path'    => 'vip://wp-content/uploads/fonts',
+			'basedir' => 'vip://wp-content/uploads/fonts',
 			'url'     => 'http://example.org/wp-content/uploads/fonts',
 			'baseurl' => 'http://example.org/wp-content/uploads/fonts',
 			'subdir'  => '',

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -390,7 +390,7 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 	public function test_wp_font_dir() {
 		// Only available in WP 6.5 and newer:
 		if ( ! function_exists( '\wp_get_font_dir' ) ) {
-			$this->assertEquals( true, true );
+			$this->markTestSkipped( 'test_wp_font_dir does not need to run for WP < 6.5.' );
 			return;
 		}
 

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Files;
 
 use Automattic\Test\Constant_Mocker;
 use ErrorException;
+use Parsely\RemoteAPI\Base_Endpoint_Remote;
 use WP_Error;
 use WP_Filesystem_Base;
 use WP_Filesystem_Direct;
@@ -385,5 +386,26 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 			[ constant( 'WP_CONTENT_DIR' ) . '/plugins/test.txt', 'direct' ],
 			[ constant( 'WP_CONTENT_DIR' ) . '/languages/test.txt', 'direct' ],
 		];
+	}
+
+	public function test_wp_font_dir() {
+		// Only available in WP 6.5 and newer:
+		if ( ! function_exists( '\wp_get_font_dir' ) ) {
+			$this->assertEquals( true, true );
+			return;
+		}
+		// Simulate filter behavior which happens during upload:
+		add_filter( 'upload_dir', '\wp_get_font_dir' );
+		$font_dir = \wp_get_font_dir();
+		remove_filter( 'upload_dir', '\zwp_get_font_dir' );
+
+		$this->assertEquals( $font_dir, [
+			'path'    => 'vip://wp-contentt/uploads/fonts',
+			'basedir' => 'vip://wp-contentt/uploads/fonts',
+			'url'     => 'http://example.org/wp-content/uploads/fonts',
+			'baseurl' => 'http://example.org/wp-content/uploads/fonts',
+			'subdir'  => '',
+			'error'   => false,
+		] );
 	}
 }


### PR DESCRIPTION
## Description
WordPress 6.5 [introduces the Font Library](https://make.wordpress.org/test/2023/10/03/help-test-the-font-library/), which allows customers to upload custom fonts and use them with global styles.

We need to use the new `font_dir` filter to ensure this will work in the VIP FS, since the default font dir is not writable on our platform.

This ultimately changes the font dir and URL to:

Normal/root site:
- `vip://wp-content/uploads/fonts`
- `https://$site_url/wp-content/uploads/fonts`

Network site:
- `vip://wp-content/uploads/sites/$network_site_id/fonts`
- `https://$site_url/$network_site_path/wp-content/uploads/sites/$network_site_id/fonts`

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->

### Use a custom font directory for the new Font Library
WordPress 6.5 [introduces the Font Library](https://make.wordpress.org/test/2023/10/03/help-test-the-font-library/), which allows you to upload and manage your own font files from the site editor. We have used the new `font_dir` filter to set the font upload directory to `wp-content/uploads/fonts` to get this feature working with the VIP Filesystem.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Sandbox a VIP site and copy these changes to mu-plugins on that site.
2. From the site editor, choose the global styles sidebar, and then typography.
3. Click the settings icon.
4. Upload a font that you don't have installed on your computer.
5. Use the font for, say, site headings in global styles.
6. Reload the editor, and the new font should display there.
7. View the frontend of the site and the new font should display there.

This recording shows the process:

https://github.com/Automattic/vip-go-mu-plugins/assets/6265975/54cad5ef-e199-4d35-af26-c6847369a556

