### PR TITLE
Disable auto-resend with fallback email

### DIFF
--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -143,7 +143,7 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 		do_action( 'wp_mail_failed', new \WP_Error( 'wp_mail_failed', 'SMTP Error: The following recipients failed: test@test.com: : Sender address rejected: not owned by user user-123', $mail_data ) );
 		$mailer = tests_retrieve_phpmailer_instance();
 
-		// mail failure is ignored, hence none of these happened.
+		// mail failure is ignored, hence none of these values gets assigned.
 		$this->assertEquals( '', $mailer->Body );
 		$this->assertEquals( '', $mailer->Subject );
 		$this->assertEquals( '', $mailer->From );

--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -142,9 +142,11 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 
 		do_action( 'wp_mail_failed', new \WP_Error( 'wp_mail_failed', 'SMTP Error: The following recipients failed: test@test.com: : Sender address rejected: not owned by user user-123', $mail_data ) );
 		$mailer = tests_retrieve_phpmailer_instance();
-		$this->assertEquals( $mail_data['message'], $mailer->Body );
-		$this->assertEquals( $mail_data['subject'], $mailer->Subject );
-		$this->assertEquals( 'test@example.com', $mailer->From );
+
+		// mail failure is ignored, hence none of these happened.
+		$this->assertEquals( '', $mailer->Body );
+		$this->assertEquals( '', $mailer->Subject );
+		$this->assertEquals( '', $mailer->From );
 	}
 
 	public function test_load_VIP_PHPMailer() {

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -85,7 +85,9 @@ final class VIP_SMTP {
 
 		if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
 			add_filter( 'wp_mail_from', array( $this, 'filter_wp_mail_from' ), 1 );
-			add_action( 'wp_mail_failed', array( $this, 'handle_wp_mail_failures' ), PHP_INT_MAX );
+			if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+				add_action( 'wp_mail_failed', array( $this, 'handle_wp_mail_failures' ), PHP_INT_MAX );
+			}
 		}
 	}
 

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -85,9 +85,7 @@ final class VIP_SMTP {
 
 		if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
 			add_filter( 'wp_mail_from', array( $this, 'filter_wp_mail_from' ), 1 );
-			if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-				add_action( 'wp_mail_failed', array( $this, 'handle_wp_mail_failures' ), PHP_INT_MAX );
-			}
+			add_action( 'wp_mail_failed', array( $this, 'handle_wp_mail_failures' ), PHP_INT_MAX );
 		}
 	}
 
@@ -149,7 +147,8 @@ final class VIP_SMTP {
 	 * @param WP_Error $error The WP_Error object passed by reference
 	 */
 	public function handle_wp_mail_failures( $error ) {
-		if ( defined( 'VIP_SMTP_ENABLED' ) && true === constant( 'VIP_SMTP_ENABLED' ) && isset( $error->error_data['wp_mail_failed'] ) && isset( $error->error_data['wp_mail_failed']['phpmailer_exception_code'] ) && isset( $error->errors['wp_mail_failed'] ) ) {
+		$is_production = defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === constant( 'VIP_GO_APP_ENVIRONMENT' );
+		if ( $is_production && defined( 'VIP_SMTP_ENABLED' ) && true === constant( 'VIP_SMTP_ENABLED' ) && isset( $error->error_data['wp_mail_failed'] ) && isset( $error->error_data['wp_mail_failed']['phpmailer_exception_code'] ) && isset( $error->errors['wp_mail_failed'] ) ) {
 			$error_data = $error->error_data['wp_mail_failed'];
 
 			// The phpmailer exception code for Sender Address rejection is 1 and we also are validating the message is matching to the one that's expected + avoid re-sending the email from  @wpvip.com address that was rejected to avoid infinite loop


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

### BEFORE YOU PROCEED!!

If you’re editing a feature without changing the spirit of the implementation, fixing bugs, or performing upgrades, then please proceed!

If you’re adding a feature or changing the spirit of an existing implementation, please create a proposal in Cantina P2 using the MU Plugins Proposal Block Pattern. Please mention the [CODEOWNERS](.github/CODEOWNERS) of this repository and relevant stakeholders in your proposal :). Please be aware that any unplanned work may take some time to get reviewed. Thank you 🙇‍♀️🙇!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description

This PR disables auto email resend if the `From:` field contains a domain that the current credentials are not allowed to use. Failures will instead go through.
<!--

-->

## Changelog Description

### Email Deliverability Changes

We've disabled auto email resend from our `donotreply@wpvip.com` if we detect that the `From:` field contains a domain that the current SMTP credentials are not allowed to use.

<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->

TODO