### PR TITLE
Instead of adding user to superadmins option, filter

### DIFF
--- a/tests/vip-support/test-user-proxied.php
+++ b/tests/vip-support/test-user-proxied.php
@@ -7,6 +7,7 @@
 namespace Automattic\VIP\Support_User\Tests;
 
 use Automattic\Test\Constant_Mocker;
+use Automattic\VIP\Support_User\Role;
 use Automattic\VIP\Support_User\User;
 use WP_UnitTestCase;
 
@@ -16,14 +17,26 @@ use WP_UnitTestCase;
  * @preserveGlobalState disabled
  */
 class VIPSupportUserProxiedTest extends WP_UnitTestCase {
+
+	private $original_current_user_id;
+
 	public function setUp(): void {
 		parent::setUp();
 
-		// @phpcs:ignore
-		define( 'A8C_PROXIED_REQUEST', true );
+		if ( ! defined( 'A8C_PROXIED_REQUEST' ) ) { // phpcs:ignore WordPressVIPMinimum.Constants.RestrictedConstants.UsingRestrictedConstant
+			define( 'A8C_PROXIED_REQUEST', true ); // phpcs:ignore WordPressVIPMinimum.Constants.RestrictedConstants.DefiningRestrictedConstant
+		}
+
+		$this->original_current_user_id = get_current_user_id();
 	}
 
 	public function test__superadmin_filter(): void {
+		if ( ! defined( 'A8C_PROXIED_REQUEST' ) && false === A8C_PROXIED_REQUEST ) { // phpcs:ignore WordPressVIPMinimum.Constants.RestrictedConstants.UsingRestrictedConstant
+			$this->markTestIncomplete( 'is_proxied_automattician() needs to be made Constant_Mocker friendly and overridden' );
+		}
+
+		// Wire up the hooks
+		Role::init()->maybe_upgrade_version();
 
 		// Ensure a regular user is not filtered to be a superadmin
 		$regular_user_id = $this->factory()->user->create( [
@@ -32,23 +45,37 @@ class VIPSupportUserProxiedTest extends WP_UnitTestCase {
 			'display_name' => 'Regular User',
 		] );
 
-		$this->assertFalse( is_super_admin( $regular_user_id ) );
+		wp_set_current_user( $regular_user_id );
+
+		$this->assertNotContains( 'regular-user', get_super_admins() );
 
 		// Ensure a VIP Support user is not filtered to be a superadmin until they are verified and proxied
 		$vip_user_id = $this->factory()->user->create( [
 			'user_email'   => 'regular-user@automattic.com',
 			'user_login'   => 'vip_regular_user',
 			'display_name' => 'Regular A11n User',
-			'role'         => 'vip_support',
 		] );
 
-		$this->assertFalse( is_super_admin( $vip_user_id ) );
+		wp_set_current_user( $vip_user_id );
+		wp_get_current_user()->set_role( Role::VIP_SUPPORT_ROLE );
+
+		$this->assertNotContains( 'vip_regular_user', get_super_admins() );
 
 		// Ensure a verified + proxied user is filtered to be a superadmin
 		$instance = User::init();
 
 		$instance->mark_user_email_verified( $vip_user_id, 'regular-user@automattic.com' );
 
-		$this->assertTrue( is_super_admin( $vip_user_id ) );
+		wp_set_current_user( $vip_user_id );
+
+		$this->assertContains( 'vip_regular_user', get_super_admins() );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		wp_set_current_user( $this->original_current_user_id );
+
+		Constant_Mocker::clear();
 	}
 }

--- a/tests/vip-support/test-user-proxied.php
+++ b/tests/vip-support/test-user-proxied.php
@@ -35,7 +35,7 @@ class VIPSupportUserProxiedTest extends WP_UnitTestCase {
 	}
 
 	public function test__superadmin_filter(): void {
-		if ( ! defined( 'A8C_PROXIED_REQUEST' ) && false === A8C_PROXIED_REQUEST ) { // phpcs:ignore WordPressVIPMinimum.Constants.RestrictedConstants.UsingRestrictedConstant
+		if ( defined( 'A8C_PROXIED_REQUEST' ) && false === A8C_PROXIED_REQUEST ) { // phpcs:ignore WordPressVIPMinimum.Constants.RestrictedConstants.UsingRestrictedConstant
 			$this->markTestIncomplete( 'is_proxied_automattician() needs to be made Constant_Mocker friendly and overridden' );
 		}
 

--- a/tests/vip-support/test-user-proxied.php
+++ b/tests/vip-support/test-user-proxied.php
@@ -65,6 +65,7 @@ class VIPSupportUserProxiedTest extends WP_UnitTestCase {
 		wp_set_current_user( $vip_user_id );
 		wp_get_current_user()->set_role( Role::VIP_SUPPORT_ROLE );
 
+		$this->assertFalse( is_proxied_automattician( $vip_user_id ) );
 		$this->assertNotContains( 'vip_regular_user', get_super_admins() );
 
 		// Ensure a verified + proxied user is filtered to be a superadmin
@@ -72,6 +73,7 @@ class VIPSupportUserProxiedTest extends WP_UnitTestCase {
 
 		$instance->mark_user_email_verified( $vip_user_id, 'regular-user@automattic.com' );
 
+		$this->assertTrue( is_proxied_automattician( $vip_user_id ) );
 		$this->assertContains( 'vip_regular_user', get_super_admins() );
 	}
 }

--- a/tests/vip-support/test-user-proxied.php
+++ b/tests/vip-support/test-user-proxied.php
@@ -13,8 +13,6 @@ use WP_UnitTestCase;
 
 /**
  * @group vip_support_user
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
  */
 class VIPSupportUserProxiedTest extends WP_UnitTestCase {
 

--- a/tests/vip-support/test-user-proxied.php
+++ b/tests/vip-support/test-user-proxied.php
@@ -72,8 +72,6 @@ class VIPSupportUserProxiedTest extends WP_UnitTestCase {
 
 		$instance->mark_user_email_verified( $vip_user_id, 'regular-user@automattic.com' );
 
-		wp_set_current_user( $vip_user_id );
-
 		$this->assertContains( 'vip_regular_user', get_super_admins() );
 	}
 }

--- a/tests/vip-support/test-user-proxied.php
+++ b/tests/vip-support/test-user-proxied.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Test support user
+ */
+
+namespace Automattic\VIP\Support_User\Tests;
+
+use Automattic\Test\Constant_Mocker;
+use Automattic\VIP\Support_User\User;
+use WP_UnitTestCase;
+
+/**
+ * @group vip_support_user
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class VIPSupportUserProxiedTest extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+
+		// @phpcs:ignore
+		define( 'A8C_PROXIED_REQUEST', true );
+	}
+
+	public function test__superadmin_filter(): void {
+
+		// Ensure a regular user is not filtered to be a superadmin
+		$regular_user_id = $this->factory()->user->create( [
+			'user_email'   => 'regular-user@somedomain.com',
+			'user_login'   => 'regular-user',
+			'display_name' => 'Regular User',
+		] );
+
+		$this->assertFalse( is_super_admin( $regular_user_id ) );
+
+		// Ensure a VIP Support user is not filtered to be a superadmin until they are verified and proxied
+		$vip_user_id = $this->factory()->user->create( [
+			'user_email'   => 'regular-user@automattic.com',
+			'user_login'   => 'vip_regular_user',
+			'display_name' => 'Regular A11n User',
+			'role'         => 'vip_support',
+		] );
+
+		$this->assertFalse( is_super_admin( $vip_user_id ) );
+
+		// Ensure a verified + proxied user is filtered to be a superadmin
+		$instance = User::init();
+
+		$instance->mark_user_email_verified( $vip_user_id, 'regular-user@automattic.com' );
+
+		$this->assertTrue( is_super_admin( $vip_user_id ) );
+	}
+}

--- a/tests/vip-support/test-user-proxied.php
+++ b/tests/vip-support/test-user-proxied.php
@@ -30,6 +30,12 @@ class VIPSupportUserProxiedTest extends WP_UnitTestCase {
 		$this->original_current_user_id = get_current_user_id();
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		wp_set_current_user( $this->original_current_user_id );
+	}
+
 	public function test__superadmin_filter(): void {
 		if ( ! defined( 'A8C_PROXIED_REQUEST' ) && false === A8C_PROXIED_REQUEST ) { // phpcs:ignore WordPressVIPMinimum.Constants.RestrictedConstants.UsingRestrictedConstant
 			$this->markTestIncomplete( 'is_proxied_automattician() needs to be made Constant_Mocker friendly and overridden' );
@@ -69,13 +75,5 @@ class VIPSupportUserProxiedTest extends WP_UnitTestCase {
 		wp_set_current_user( $vip_user_id );
 
 		$this->assertContains( 'vip_regular_user', get_super_admins() );
-	}
-
-	public function tearDown(): void {
-		parent::tearDown();
-
-		wp_set_current_user( $this->original_current_user_id );
-
-		Constant_Mocker::clear();
 	}
 }

--- a/tests/vip-support/test-user.php
+++ b/tests/vip-support/test-user.php
@@ -217,4 +217,24 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 
 		$this->assertFalse( $removed_user_obj, 'User was not deleted' );
 	}
+
+	public function test__superadmin_filter(): void {
+		// Ensure a regular user is not filtered to be a superadmin
+		$regular_user_id = $this->factory()->user->create( [
+			'user_email'   => 'regular-user@somedomain.com',
+			'user_login'   => 'regular-user',
+			'display_name' => 'Regular User',
+		] );
+
+		$this->assertFalse( is_super_admin( $regular_user_id ) );
+
+		// Ensure a regular user is not filtered to be a superadmin, without being verified + proxied
+		$vip_user_id = $this->factory()->user->create( [
+			'user_email'   => 'regular-user@automattic.com',
+			'user_login'   => 'vip_regular_user',
+			'display_name' => 'Regular A11n User',
+		] );
+
+		$this->assertFalse( is_super_admin( $vip_user_id ) );
+	}
 }

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1472,10 +1472,11 @@ function is_automattician( $user_id = false ) {
  *
  * @see is_automattician
  *
+ * @param int $user_id A WP User id
  * @return bool True, if the current request is made via the Automattic proxy
  */
-function is_proxied_automattician() {
-	return is_proxied_request() && is_automattician();
+function is_proxied_automattician( $user_id = false ) {
+	return is_proxied_request() && is_automattician( $user_id );
 }
 
 /**
@@ -1485,7 +1486,9 @@ function is_proxied_automattician() {
  */
 function is_proxied_request() {
 	// phpcs:disable WordPressVIPMinimum.Constants.RestrictedConstants.UsingRestrictedConstant
-	return defined( 'A8C_PROXIED_REQUEST' ) && true === A8C_PROXIED_REQUEST;
+	if ( defined( 'A8C_PROXIED_REQUEST' ) && true === constant( 'A8C_PROXIED_REQUEST' ) ) {
+		return true;
+	}
 }
 
 /**

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1486,9 +1486,7 @@ function is_proxied_automattician( $user_id = false ) {
  */
 function is_proxied_request() {
 	// phpcs:disable WordPressVIPMinimum.Constants.RestrictedConstants.UsingRestrictedConstant
-	if ( defined( 'A8C_PROXIED_REQUEST' ) && true === constant( 'A8C_PROXIED_REQUEST' ) ) {
-		return true;
-	}
+	return defined( 'A8C_PROXIED_REQUEST' ) && true === constant( 'A8C_PROXIED_REQUEST' );
 }
 
 /**

--- a/vip-support/class-vip-support-cli.php
+++ b/vip-support/class-vip-support-cli.php
@@ -123,11 +123,6 @@ class Command extends WP_CLI_Command {
 			\WP_CLI::error( "Could not find a user with ID $user_id" );
 		}
 
-		// If this is a multisite, commence super powers!
-		if ( is_multisite() ) {
-			grant_super_admin( $user->ID );
-		}
-
 		User::init()->mark_user_email_verified( $user->ID, $user->user_email );
 
 		// Print a success message

--- a/vip-support/class-vip-support-role.php
+++ b/vip-support/class-vip-support-role.php
@@ -71,6 +71,7 @@ class Role {
 		}
 		add_filter( 'editable_roles', array( $this, 'filter_editable_roles' ) );
 		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), PHP_INT_MAX, 4 );
+		add_filter( 'site_option_site_admins', array( $this, 'filter_site_option_site_admins' ), PHP_INT_MAX );
 	}
 
 	// HOOKS
@@ -107,6 +108,16 @@ class Role {
 			}
 		}
 		return $user_caps;
+	}
+
+	public function filter_site_option_site_admins( array $site_admins ) {
+		$user = wp_get_current_user();
+
+		if ( in_array( self::VIP_SUPPORT_ROLE, $user->roles ) && is_proxied_automattician() ) {
+			$site_admins[] = $user->user_login;
+		}
+		
+		return $site_admins;
 	}
 
 	/**

--- a/vip-support/class-vip-support-role.php
+++ b/vip-support/class-vip-support-role.php
@@ -110,7 +110,7 @@ class Role {
 		return $user_caps;
 	}
 
-	public function filter_site_option_site_admins( array $site_admins ) {
+	public function filter_site_option_site_admins( $site_admins ) {
 		$user = wp_get_current_user();
 
 		if ( in_array( self::VIP_SUPPORT_ROLE, $user->roles ) && is_proxied_automattician() ) {

--- a/vip-support/class-vip-support-user.php
+++ b/vip-support/class-vip-support-user.php
@@ -641,38 +641,12 @@ class User {
 		if ( ! is_multisite() ) {
 			return;
 		}
-		// If the user:
-		// * Is an inactive support user
-		// * Is a super admin
-		// …revoke their powers
-		if ( self::user_has_vip_support_role( $user->ID, false ) && is_super_admin( $user->ID ) ) {
+
+		// Revoke superadmin if the support user is inactive.
+		$has_inactive_vip_support_role = self::user_has_vip_support_role( $user->ID, false );
+		if ( $has_inactive_vip_support_role && is_super_admin( $user->ID ) ) {
 			require_once ABSPATH . '/wp-admin/includes/ms.php';
 			revoke_super_admin( $user->ID );
-			return;
-		}
-		if ( ! self::user_has_vip_support_role( $user->ID ) ) {
-			// If the user is a super admin, but has been demoted to
-			// the inactive VIP Support role, we should remove
-			// their super powers
-			if ( is_super_admin( $user->ID ) && self::user_has_vip_support_role( $user->ID, false ) ) {
-				// This user is NOT VIP Support, remove
-				// their powers forthwith
-				require_once ABSPATH . '/wp-admin/includes/ms.php';
-				revoke_super_admin( $user->ID );
-			}
-			return;
-		}
-		if ( ! $this->user_has_verified_email( $user->ID ) ) {
-			return;
-		}
-		if ( is_super_admin( $user->ID ) ) {
-			return;
-		}
-		if ( ! is_super_admin( $user->ID ) ) {
-			// This user is VIP Support, verified, let's give them
-			// great power and responsibility
-			require_once ABSPATH . '/wp-admin/includes/ms.php';
-			grant_super_admin( $user->ID );
 		}
 	}
 
@@ -946,10 +920,6 @@ class User {
 		}
 
 		$user->set_role( Role::VIP_SUPPORT_ROLE );
-		if ( is_multisite() ) {
-			require_once ABSPATH . '/wp-admin/includes/ms.php';
-			grant_super_admin( $user_id );
-		}
 		update_user_meta( $user->ID, $GLOBALS['wpdb']->get_blog_prefix() . 'user_level', 10 );
 
 		return true;
@@ -1029,11 +999,6 @@ class User {
 		$user->set_role( Role::VIP_SUPPORT_ROLE );
 
 		update_user_meta( $user_id, self::VIP_SUPPORT_USER_META_KEY, time() );
-
-		// If this is a multisite, commence super powers!
-		if ( is_multisite() ) {
-			grant_super_admin( $user->ID );
-		}
 
 		return $user_id;
 	}

--- a/vip-support/class-vip-support-user.php
+++ b/vip-support/class-vip-support-user.php
@@ -871,6 +871,7 @@ class User {
 		if ( ! $verification_data ) {
 			$verification_data = array(
 				'touch' => time(), // GPL timestamp
+				'email' => null,
 			);
 			$generate_new_code = true;
 		}


### PR DESCRIPTION
## Description

It's easier to control which support users are super admins with a filter, rather than updating the site_admins option via grant_super_admin()

## Changelog Description

### Update: Improve how VIP Support Users are created

Tweak to VIP's internal support system to make management easier.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- n/a This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- n/a This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

