### PR TITLE
Prevent saving unnecessary Jetpack post_by_email_address* DB options

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -436,3 +436,22 @@ function vip_filter_jetpack_offline_mode_on_site_launch( $offline_mode ) {
 }
 
 add_filter( 'jetpack_offline_mode', 'vip_filter_jetpack_offline_mode_on_site_launch', PHP_INT_MAX, 1 );
+
+/**
+ * Prevent admin/support users from spawning (usleless, autoloaded) NULL value post_by_email_address* options.
+ * Addresses https://github.com/Automattic/jetpack/issues/35636
+ */
+
+function cleaner_jp_pbe_options()
+{
+    add_filter('pre_update_option_post_by_email_address' . get_current_user_id(), 'no_null_post_by_email_address_options', 10, 3);
+}
+
+function no_null_post_by_email_address_options($value, $old_value, $option)
+{
+    if ($value === 'NULL') {
+        return $old_value;
+    } else {
+        return $value;
+    }
+}

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -438,7 +438,8 @@ function vip_filter_jetpack_offline_mode_on_site_launch( $offline_mode ) {
 add_filter( 'jetpack_offline_mode', 'vip_filter_jetpack_offline_mode_on_site_launch', PHP_INT_MAX, 1 );
 
 /**
- * Prevent admin/support users from spawning (usleless, autoloaded) NULL value post_by_email_address* options.
+ * Prevent admin/support users from spawning (useless, autoloaded) NULL value post_by_email_address* options.
+ * Returns old_value instead of NULL, which in this context is no option at all.
  * Addresses https://github.com/Automattic/jetpack/issues/35636
  */
 


### PR DESCRIPTION

## Description
This addresses the main symptom (autoloaded `post_by_email_address*` options being created per-user) of JP issue https://github.com/Automattic/jetpack/issues/35636

## Changelog Description
`cleaner_jp_pbe_options` uses `pre_update_option_post_by_email_address*` (where * is the current user ID) to prevent creation of unused NULL `post_by_email_address*` options (by returning the old_value in place of NULL, which in this case is no option at all).

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ 👍 ] This change works and has been tested locally (or has an appropriate fallback).
- [ 👍 ] This change works and has been tested on a Go sandbox 
- [ 👍 ] Also tested live in a VIP test env (with this function in a standalone mu-plugin)
- [ n/a ] This change has relevant unit tests (if applicable).
- [ n/a ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ n/a ] This change has relevant documentation additions / updates (if applicable).
- [ 👍 ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ n/a ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Login and visit the JP setting page in wp-admin, which without this filter would spawn a post_by_email_address option
3. Do `wp option list --search="post_by_email*" --fields=option_name,option_value,autoload`
4. Verify that no new `post_by_email_address` option has been created for your logged-in user ID
5. To verify that non-NULL post_by_email_address* options aren't filtered, add this quick snippet to a sandbox and redo steps 2 & 3:
```
function create_post_by_email_option()
{
    $current_user_id = get_current_user_id();
    $option_name = 'post_by_email_address' . $current_user_id;
    update_option($option_name, 'NOTNULL');
}

add_action('admin_init', 'create_post_by_email_option');
```