### PR TITLE
Update Akismet to 5.3.1

### DIFF
--- a/akismet/.htaccess
+++ b/akismet/.htaccess
@@ -23,7 +23,7 @@
 </FilesMatch>
 
 # Akismet images
-<FilesMatch "^(logo-(a|full)-2x\.png|akismet-refresh-logo\.svg|akismet-refresh-logo@2x\.png|arrow-left\.svg)$">
+<FilesMatch "^(logo-(a|full)-2x\.png|akismet-refresh-logo\.svg|akismet-refresh-logo@2x\.png|arrow-left\.svg|icon-external\.svg)$">
 	<IfModule !mod_authz_core.c>
 		Allow from all
 	</IfModule>

--- a/akismet/_inc/akismet-admin.css
+++ b/akismet/_inc/akismet-admin.css
@@ -174,7 +174,25 @@
 }
 
 .akismet-card-actions {
+	display: flex;
+	justify-content: flex-end;
 	padding: 1em;
+}
+
+.akismet-card-actions__secondary-action {
+	align-self: center;
+	margin-right: auto;
+}
+
+.akismet-card-actions__secondary-action a[target="_blank"]::after {
+	background: url('img/icon-external.svg') no-repeat;
+	background-size: contain;
+	content: "";
+	display: inline-block;
+	height: 16px;
+	margin-left: 5px;
+	vertical-align: middle;
+	width: 16px;
 }
 
 .akismet-settings__row label {

--- a/akismet/_inc/akismet-frontend.js
+++ b/akismet/_inc/akismet-frontend.js
@@ -80,52 +80,68 @@
 
 				var input_fields = {
 					// When did the user begin entering any input?
-					'ak_bib': input_begin,
+					'bib': input_begin,
 
 					// When was the form submitted?
-					'ak_bfs': Date.now(),
+					'bfs': Date.now(),
 
 					// How many keypresses did they make?
-					'ak_bkpc': keypresses.length,
+					'bkpc': keypresses.length,
 
 					// How quickly did they press a sample of keys, and how long between them?
-					'ak_bkp': ak_bkp,
+					'bkp': ak_bkp,
 
 					// How quickly did they click the mouse, and how long between clicks?
-					'ak_bmc': ak_bmc,
+					'bmc': ak_bmc,
 
 					// How many mouseclicks did they make?
-					'ak_bmcc': mouseclicks.length,
+					'bmcc': mouseclicks.length,
 
 					// When did they press modifier keys (like Shift or Capslock)?
-					'ak_bmk': modifierKeys.join( ';' ),
+					'bmk': modifierKeys.join( ';' ),
 
 					// When did they correct themselves? e.g., press Backspace, or use the arrow keys to move the cursor back
-					'ak_bck': correctionKeys.join( ';' ),
+					'bck': correctionKeys.join( ';' ),
 
 					// How many times did they move the mouse?
-					'ak_bmmc': mousemoves.length,
+					'bmmc': mousemoves.length,
 
 					// How many times did they move around using a touchscreen?
-					'ak_btmc': touchmoveCount,
+					'btmc': touchmoveCount,
 
 					// How many times did they scroll?
-					'ak_bsc': scrollCount,
+					'bsc': scrollCount,
 
 					// How quickly did they perform touch events, and how long between them?
-					'ak_bte': ak_bte,
+					'bte': ak_bte,
 
 					// How many touch events were there?
-					'ak_btec' : touchEvents.length,
+					'btec' : touchEvents.length,
 
 					// How quickly did they move the mouse, and how long between moves?
-					'ak_bmm' : ak_bmm
+					'bmm' : ak_bmm
 				};
+
+				var akismet_field_prefix = 'ak_';
+
+				if ( this.getElementsByClassName ) {
+					// Check to see if we've used an alternate field name prefix. We store this as an attribute of the container around some of the Akismet fields.
+					var possible_akismet_containers = this.getElementsByClassName( 'akismet-fields-container' );
+
+					for ( var containerIndex = 0; containerIndex < possible_akismet_containers.length; containerIndex++ ) {
+						var container = possible_akismet_containers.item( containerIndex );
+
+						if ( container.getAttribute( 'data-prefix' ) ) {
+							akismet_field_prefix = container.getAttribute( 'data-prefix' );
+							break;
+						}
+					}
+				}
 
 				for ( var field_name in input_fields ) {
 					var field = document.createElement( 'input' );
 					field.setAttribute( 'type', 'hidden' );
-					field.setAttribute( 'name', field_name );
+					field.setAttribute( 'name', akismet_field_prefix + field_name );
 					field.setAttribute( 'value', input_fields[ field_name ] );
 					this.appendChild( field );
 				}

--- a/akismet/_inc/img/icon-external.svg
+++ b/akismet/_inc/img/icon-external.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="#357b49" d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z"></path></svg>

--- a/akismet/_inc/rtl/akismet-admin-rtl.css
+++ b/akismet/_inc/rtl/akismet-admin-rtl.css
@@ -1,4 +1,4 @@
-/* This file was automatically generated on Aug 25 2023 04:22:56 */
+/* This file was automatically generated on Nov 20 2023 03:10:42 */
 
 #akismet-plugin-container {
 	background-color: var(--akismet-color-light-grey);
@@ -176,7 +176,25 @@
 }
 
 .akismet-card-actions {
+	display: flex;
+	justify-content: flex-end;
 	padding: 1em;
+}
+
+.akismet-card-actions__secondary-action {
+	align-self: center;
+	margin-left: auto;
+}
+
+.akismet-card-actions__secondary-action a[target="_blank"]::after {
+	background: url('../img/icon-external.svg') no-repeat;
+	background-size: contain;
+	content: "";
+	display: inline-block;
+	height: 16px;
+	margin-right: 5px;
+	vertical-align: middle;
+	width: 16px;
 }
 
 .akismet-settings__row label {

--- a/akismet/akismet.php
+++ b/akismet/akismet.php
@@ -6,7 +6,7 @@
 Plugin Name: Akismet Anti-spam: Spam Protection
 Plugin URI: https://akismet.com/
 Description: Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. Akismet Anti-spam keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.
-Version: 5.3
+Version: 5.3.1
 Requires at least: 5.8
 Requires PHP: 5.6.20
 Author: Automattic - Anti-spam Team
@@ -39,7 +39,7 @@ if ( !function_exists( 'add_action' ) ) {
 	exit;
 }
 
-define( 'AKISMET_VERSION', '5.3' );
+define( 'AKISMET_VERSION', '5.3.1' );
 define( 'AKISMET__MINIMUM_WP_VERSION', '5.8' );
 define( 'AKISMET__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'AKISMET_DELETE_LIMIT', 10000 );

--- a/akismet/class.akismet-admin.php
+++ b/akismet/class.akismet-admin.php
@@ -135,20 +135,20 @@ class Akismet_Admin {
 			'plugins.php',
 		) ) ) ) {
 			$akismet_css_path = is_rtl() ? '_inc/rtl/akismet-rtl.css' : '_inc/akismet.css';
-			wp_register_style( 'akismet', plugin_dir_url( __FILE__ ) . $akismet_css_path, array(), filemtime( dirname( __FILE__ ) . '/' . $akismet_css_path ) );
+			wp_register_style( 'akismet', plugin_dir_url( __FILE__ ) . $akismet_css_path, array(), self::get_asset_file_version( $akismet_css_path ) );
 			wp_enqueue_style( 'akismet' );
 
-			wp_register_style( 'akismet-font-inter', plugin_dir_url( __FILE__ ) . '_inc/fonts/inter.css', array(), filemtime( dirname( __FILE__ ) . '/_inc/fonts/inter.css' ) );
+			wp_register_style( 'akismet-font-inter', plugin_dir_url( __FILE__ ) . '_inc/fonts/inter.css', array(), self::get_asset_file_version( '_inc/fonts/inter.css' ) );
 			wp_enqueue_style( 'akismet-font-inter' );
 
 			$akismet_admin_css_path = is_rtl() ? '_inc/rtl/akismet-admin-rtl.css' : '_inc/akismet-admin.css';
-			wp_register_style( 'akismet-admin', plugin_dir_url( __FILE__ ) . $akismet_admin_css_path, array(), filemtime( dirname( __FILE__ ) . '/' . $akismet_admin_css_path ) );
+			wp_register_style( 'akismet-admin', plugin_dir_url( __FILE__ ) . $akismet_admin_css_path, array(), self::get_asset_file_version( $akismet_admin_css_path ) );
 			wp_enqueue_style( 'akismet-admin' );
 
-			wp_register_script( 'akismet.js', plugin_dir_url( __FILE__ ) . '_inc/akismet.js', array( 'jquery' ), AKISMET_VERSION );
+			wp_register_script( 'akismet.js', plugin_dir_url( __FILE__ ) . '_inc/akismet.js', array( 'jquery' ), self::get_asset_file_version( '_inc/akismet.js' ) );
 			wp_enqueue_script( 'akismet.js' );
 
-			wp_register_script( 'akismet-admin.js', plugin_dir_url( __FILE__ ) . '_inc/akismet-admin.js', array(), filemtime( dirname( __FILE__ ) . '/_inc/akismet-admin.js' ) );
+			wp_register_script( 'akismet-admin.js', plugin_dir_url( __FILE__ ) . '_inc/akismet-admin.js', array(), self::get_asset_file_version( '/_inc/akismet-admin.js' ) );
 			wp_enqueue_script( 'akismet-admin.js' );
 
 			$inline_js = array(
@@ -555,7 +555,7 @@ class Akismet_Admin {
 		}
 
 		// add a History item to the hover links, just after Edit
-		if ( $akismet_result ) {
+		if ( $akismet_result && is_array( $a ) ) {
 			$b = array();
 			foreach ( $a as $k => $item ) {
 				$b[ $k ] = $item;
@@ -852,7 +852,14 @@ class Akismet_Admin {
 	public static function get_akismet_user( $api_key ) {
 		$akismet_user = false;
 
-		$subscription_verification = Akismet::http_post( Akismet::build_query( array( 'key' => $api_key, 'blog' => get_option( 'home' ) ) ), 'get-subscription' );
+		$request_args = array(
+			'key' => $api_key,
+			'blog' => get_option( 'home' ),
+		);
+
+		$request_args = apply_filters( 'akismet_request_args', $request_args, 'get-subscription' );
+
+		$subscription_verification = Akismet::http_post( Akismet::build_query( $request_args ), 'get-subscription' );
 
 		if ( ! empty( $subscription_verification[1] ) ) {
 			if ( 'invalid' !== $subscription_verification[1] ) {
@@ -867,7 +874,15 @@ class Akismet_Admin {
 		$stat_totals = array();
 
 		foreach( array( '6-months', 'all' ) as $interval ) {
-			$response = Akismet::http_post( Akismet::build_query( array( 'blog' => get_option( 'home' ), 'key' => $api_key, 'from' => $interval ) ), 'get-stats' );
+			$request_args = array(
+				'blog' => get_option( 'home' ),
+				'key' => $api_key,
+				'from' => $interval,
+			);
+
+			$request_args = apply_filters( 'akismet_request_args', $request_args, 'get-stats' );
+
+			$response = Akismet::http_post( Akismet::build_query( $request_args ), 'get-stats' );
 
 			if ( ! empty( $response[1] ) ) {
 				$stat_totals[$interval] = json_decode( $response[1] );
@@ -878,11 +893,18 @@ class Akismet_Admin {
 	}
 
 	public static function verify_wpcom_key( $api_key, $user_id, $extra = array() ) {
-		$akismet_account = Akismet::http_post( Akismet::build_query( array_merge( array(
-			'user_id'          => $user_id,
-			'api_key'          => $api_key,
-			'get_account_type' => 'true'
-		), $extra ) ), 'verify-wpcom-key' );
+		$request_args = array_merge(
+			array(
+				'user_id' => $user_id,
+				'api_key' => $api_key,
+				'get_account_type' => 'true',
+			),
+			$extra
+		);
+
+		$request_args = apply_filters( 'akismet_request_args', $request_args, 'verify-wpcom-key' );
+
+		$akismet_account = Akismet::http_post( Akismet::build_query( $request_args ), 'verify-wpcom-key' );
 
 		if ( ! empty( $akismet_account[1] ) )
 			$akismet_account = json_decode( $akismet_account[1] );
@@ -1331,5 +1353,25 @@ class Akismet_Admin {
 	 */
 	public static function get_notice_kses_allowed_elements() {
 		return self::$allowed;
+	}
+
+	/**
+	 * Return a version to append to the URL of an asset file (e.g. CSS and images).
+	 *
+	 * @param string $relative_path Relative path to asset file
+	 * @return string
+	 */
+	public static function get_asset_file_version( $relative_path ) {
+
+		$full_path = AKISMET__PLUGIN_DIR . $relative_path;
+
+		// If the AKISMET_VERSION contains a lower-case letter, it's a development version (e.g. 5.3.1a2).
+		// Use the file modified time in development.
+		if ( preg_match( '/[a-z]/', AKISMET_VERSION ) && file_exists( $full_path ) ) {
+			return filemtime( $full_path );
+		}
+
+		// Otherwise, use the AKISMET_VERSION.
+		return AKISMET_VERSION;
 	}
 }

--- a/akismet/class.akismet-cli.php
+++ b/akismet/class.akismet-cli.php
@@ -146,15 +146,16 @@ class Akismet_CLI extends WP_CLI_Command {
 				break;
 		}
  
-		$response = Akismet::http_post(
-			Akismet::build_query( array(
-				'blog' => get_option( 'home' ),
-				'key'  => $api_key,
-				'from' => $interval,
-			) ),
-			'get-stats'
+		$request_args = array(
+			'blog' => get_option( 'home' ),
+			'key'  => $api_key,
+			'from' => $interval,
 		);
  
+		$request_args = apply_filters( 'akismet_request_args', $request_args, 'get-stats' );
+
+		$response = Akismet::http_post( Akismet::build_query( $request_args ), 'get-stats' );
+
 		if ( empty( $response[1] ) ) {
 			WP_CLI::error( __( 'Currently unable to fetch stats. Please try again.', 'akismet' ) );
 		}

--- a/akismet/class.akismet-rest-api.php
+++ b/akismet/class.akismet-rest-api.php
@@ -264,7 +264,15 @@ class Akismet_REST_API {
 
 		$stat_totals = array();
 
-		$response = Akismet::http_post( Akismet::build_query( array( 'blog' => get_option( 'home' ), 'key' => $api_key, 'from' => $interval ) ), 'get-stats' );
+		$request_args = array(
+			'blog' => get_option( 'home' ),
+			'key' => $api_key,
+			'from' => $interval,
+		);
+
+		$request_args = apply_filters( 'akismet_request_args', $request_args, 'get-stats' );
+
+		$response = Akismet::http_post( Akismet::build_query( $request_args ), 'get-stats' );
 
 		if ( ! empty( $response[1] ) ) {
 			$stat_totals[$interval] = json_decode( $response[1] );
@@ -318,15 +326,14 @@ class Akismet_REST_API {
 	}
 
 	private static function key_is_valid( $key ) {
-		$response = Akismet::http_post(
-			Akismet::build_query(
-				array(
-					'key' => $key,
-					'blog' => get_option( 'home' )
-				)
-			),
-			'verify-key'
+		$request_args = array(
+			'key' => $key,
+			'blog' => get_option( 'home' ),
 		);
+
+		$request_args = apply_filters( 'akismet_request_args', $request_args, 'verify-key' );
+
+		$response = Akismet::http_post( Akismet::build_query( $request_args ), 'verify-key' );
 
 		if ( $response[1] == 'valid' ) {
 			return true;

--- a/akismet/readme.txt
+++ b/akismet/readme.txt
@@ -3,7 +3,7 @@ Contributors: matt, ryan, andy, mdawaffe, tellyworth, josephscott, lessbloat, eo
 Tags: comments, spam, antispam, anti-spam, contact form, anti spam, comment moderation, comment spam, contact form spam, spam comments
 Requires at least: 5.8
 Tested up to: 6.4
-Stable tag: 5.3
+Stable tag: 5.3.1
 License: GPLv2 or later
 
 The best anti-spam protection to block spam comments and spam in a contact form. The most trusted antispam solution for WordPress and WooCommerce.
@@ -31,6 +31,15 @@ Upload the Akismet plugin to your blog, activate it, and then enter your Akismet
 1, 2, 3: You're done!
 
 == Changelog ==
+
+= 5.3.1 =
+*Release Date - 17 January 2024*
+
+* Make the plugin more resilient when asset files are missing (as seen in WordPress Playground).
+* Add a link to the 'Account overview' page on akismet.com.
+* Fix a minor error that occurs when another plugin removes all comment actions from the dashboard.
+* Add the akismet_request_args filter to allow request args in Akismet API requests to be filtered.
+* Fix a bug that causes some contact forms to include unnecessary data in the comment_content parameter.
 
 = 5.3 =
 *Release Date - 14 September 2023*

--- a/akismet/views/config.php
+++ b/akismet/views/config.php
@@ -2,7 +2,11 @@
 
 //phpcs:disable VariableAnalysis
 // There are "undefined" variables here because they're defined in the code that includes this file as a template.
-
+$kses_allow_link_href = array(
+	'a' => array(
+		'href' => true,
+	),
+);
 ?>
 <div id="akismet-plugin-container">
 	<div class="akismet-masthead">
@@ -37,7 +41,7 @@
 				<div class="akismet-new-snapshot">
 					<?php /* name attribute on iframe is used as a cache-buster here to force Firefox to load the new style charts: https://bugzilla.mozilla.org/show_bug.cgi?id=356558 */ ?>
 					<div class="akismet-new-snapshot__chart">
-						<iframe id="stats-iframe" allowtransparency="true" scrolling="no" frameborder="0" style="width: 100%; height: 220px; overflow: hidden;" src="<?php echo esc_url( sprintf( 'https://tools.akismet.com/1.0/snapshot.php?blog=%s&token=%s&height=200&locale=%s&is_redecorated=1', urlencode( get_option( 'home' ) ), urlencode( Akismet::get_access_token() ), get_locale() ) ); ?>" name="<?php echo esc_attr( 'snapshot-' . filemtime( __FILE__ ) ); ?>" title="<?php echo esc_attr__( 'Akismet stats' ); ?>"></iframe>
+						<iframe id="stats-iframe" allowtransparency="true" scrolling="no" frameborder="0" style="width: 100%; height: 220px; overflow: hidden;" src="<?php echo esc_url( sprintf( 'https://tools.akismet.com/1.0/snapshot.php?blog=%s&token=%s&height=200&locale=%s&is_redecorated=1', rawurlencode( get_option( 'home' ) ), rawurlencode( Akismet::get_access_token() ), get_locale() ) ); ?>" name="<?php echo esc_attr( 'snapshot-' . filemtime( __FILE__ ) ); ?>" title="<?php echo esc_attr__( 'Akismet stats' ); ?>"></iframe>
 					</div>
 					<ul class="akismet-new-snapshot__list">
 						<li class="akismet-new-snapshot__item">
@@ -78,13 +82,13 @@
 			<div class="akismet-card">
 				<div class="akismet-section-header">
 					<h2 class="akismet-section-header__label">
-						<span><?php esc_html_e( 'Settings' , 'akismet'); ?></span>
+						<span><?php esc_html_e( 'Settings', 'akismet' ); ?></span>
 					</h2>
 				</div>
 
 				<div class="inside">
 					<form action="<?php echo esc_url( Akismet_Admin::get_page_url() ); ?>" autocomplete="off" method="POST" id="akismet-settings-form">
-						
+
 						<div class="akismet-settings">
 							<?php if ( ! Akismet::predefined_api_key() ) : ?>
 								<div class="akismet-settings__row">
@@ -92,27 +96,30 @@
 										<label class="akismet-settings__row-label" for="key"><?php esc_html_e( 'API key', 'akismet' ); ?></label>
 									</h3>
 									<div class="akismet-settings__row-input">
-										<span class="api-key"><input id="key" name="key" type="text" size="15" value="<?php echo esc_attr( get_option('wordpress_api_key') ); ?>" class="<?php echo esc_attr( 'regular-text code ' . $akismet_user->status ); ?>"></span>
+										<span class="api-key"><input id="key" name="key" type="text" size="15" value="<?php echo esc_attr( get_option( 'wordpress_api_key' ) ); ?>" class="<?php echo esc_attr( 'regular-text code ' . $akismet_user->status ); ?>"></span>
 									</div>
 								</div>
 							<?php endif; ?>
-							
-							<?php if ( isset( $_GET['ssl_status'] ) ) : ?>
+
+							<?php
+							//phpcs:ignore WordPress.Security.NonceVerification.Recommended
+							if ( isset( $_GET['ssl_status'] ) ) :
+								?>
 								<div class="akismet-settings__row">
 									<div class="akismet-settings__row-text">
 										<h3 class="akismet-settings__row-title"><?php esc_html_e( 'SSL status', 'akismet' ); ?></h3>
 										<div class="akismet-settings__row-description">
 											<?php if ( ! wp_http_supports( array( 'ssl' ) ) ) : ?>
-												<strong><?php esc_html_e( 'Disabled.', 'akismet' ); ?></strong> 
+												<strong><?php esc_html_e( 'Disabled.', 'akismet' ); ?></strong>
 												<?php esc_html_e( 'Your Web server cannot make SSL requests; contact your Web host and ask them to add support for SSL requests.', 'akismet' ); ?>
 											<?php else : ?>
 												<?php $ssl_disabled = get_option( 'akismet_ssl_disabled' ); ?>
 
 												<?php if ( $ssl_disabled ) : ?>
-													<strong><?php esc_html_e( 'Temporarily disabled.', 'akismet' ); ?></strong> 
+													<strong><?php esc_html_e( 'Temporarily disabled.', 'akismet' ); ?></strong>
 													<?php esc_html_e( 'Akismet encountered a problem with a previous SSL request and disabled it temporarily. It will begin using SSL for requests again shortly.', 'akismet' ); ?>
 												<?php else : ?>
-													<strong><?php esc_html_e( 'Enabled.', 'akismet' ); ?></strong> 
+													<strong><?php esc_html_e( 'Enabled.', 'akismet' ); ?></strong>
 													<?php esc_html_e( 'All systems functional.', 'akismet' ); ?>
 												<?php endif; ?>
 											<?php endif; ?>
@@ -120,7 +127,7 @@
 									</div>
 								</div>
 							<?php endif; ?>
-							
+
 							<div class="akismet-settings__row">
 								<div class="akismet-settings__row-text">
 									<h3 class="akismet-settings__row-title"><?php esc_html_e( 'Comments', 'akismet' ); ?></h3>
@@ -143,7 +150,7 @@
 									</label>
 								</div>
 							</div>
-							
+
 							<div class="akismet-settings__row is-radio">
 								<div class="akismet-settings__row-text">
 									<h3 class="akismet-settings__row-title"><?php esc_html_e( 'Spam filtering', 'akismet' ); ?></h3>
@@ -155,7 +162,7 @@
 										</legend>
 										<div>
 											<label class="akismet-settings__row-input-label" for="akismet_strictness_1">
-												<input type="radio" name="akismet_strictness" id="akismet_strictness_1" value="1" <?php checked( '1', get_option( 'akismet_strictness' ) ); ?> /> 
+												<input type="radio" name="akismet_strictness" id="akismet_strictness_1" value="1" <?php checked( '1', get_option( 'akismet_strictness' ) ); ?> />
 												<span class="akismet-settings__row-label-text">
 													<?php esc_html_e( 'Silently discard the worst and most pervasive spam so I never see it.', 'akismet' ); ?>
 												</span>
@@ -163,34 +170,39 @@
 										</div>
 										<div>
 											<label class="akismet-settings__row-input-label" for="akismet_strictness_0">
-												<input type="radio" name="akismet_strictness" id="akismet_strictness_0" value="0" <?php checked( '0', get_option( 'akismet_strictness' ) ); ?> /> 
+												<input type="radio" name="akismet_strictness" id="akismet_strictness_0" value="0" <?php checked( '0', get_option( 'akismet_strictness' ) ); ?> />
 												<span class="akismet-settings__row-label-text">
 													<?php esc_html_e( 'Always put spam in the Spam folder for review.', 'akismet' ); ?>
 												</span>
 											</label>
 										</div>
 									</fieldset>
-									
+
 									<div class="akismet-settings__row-note">
 										<strong><?php esc_html_e( 'Note:', 'akismet' ); ?></strong>
 										<?php
 										$delete_interval = max( 1, intval( apply_filters( 'akismet_delete_comment_interval', 15 ) ) );
 
+										$spam_folder_link = sprintf(
+											'<a href="%s">%s</a>',
+											esc_url( admin_url( 'edit-comments.php?comment_status=spam' ) ),
+											esc_html__( 'spam folder', 'akismet' )
+										);
+
+										// The _n() needs to be on one line so the i18n tooling can extract the translator comment.
+										/* translators: %1$s: spam folder link, %2$d: delete interval in days */
+										$delete_message = _n( 'Spam in the %1$s older than %2$d day is deleted automatically.', 'Spam in the %1$s older than %2$d days is deleted automatically.', $delete_interval, 'akismet' );
+
 										printf(
-											_n(
-												'Spam in the <a href="%1$s">spam folder</a> older than 1 day is deleted automatically.',
-												'Spam in the <a href="%1$s">spam folder</a> older than %2$d days is deleted automatically.',
-												$delete_interval,
-												'akismet'
-											),
-											admin_url( 'edit-comments.php?comment_status=spam' ),
-											$delete_interval
+											wp_kses( $delete_message, $kses_allow_link_href ),
+											wp_kses( $spam_folder_link, $kses_allow_link_href ),
+											esc_html( $delete_interval )
 										);
 										?>
 									</div>
 								</div>
 							</div>
-								
+
 							<div class="akismet-settings__row is-radio">
 								<div class="akismet-settings__row-text">
 									<h3 class="akismet-settings__row-title"><?php esc_html_e( 'Privacy', 'akismet' ); ?></h3>
@@ -210,35 +222,34 @@
 										</div>
 										<div>
 											<label class="akismet-settings__row-input-label" for="akismet_comment_form_privacy_notice_hide">
-												<input type="radio" name="akismet_comment_form_privacy_notice" id="akismet_comment_form_privacy_notice_hide" value="hide" <?php echo in_array( get_option( 'akismet_comment_form_privacy_notice' ), array( 'display', 'hide' ) ) ? checked( 'hide', get_option( 'akismet_comment_form_privacy_notice' ), false ) : 'checked="checked"'; ?> /> 
+												<input type="radio" name="akismet_comment_form_privacy_notice" id="akismet_comment_form_privacy_notice_hide" value="hide" <?php echo in_array( get_option( 'akismet_comment_form_privacy_notice' ), array( 'display', 'hide' ), true ) ? checked( 'hide', get_option( 'akismet_comment_form_privacy_notice' ), false ) : 'checked="checked"'; ?> />
 												<span class="akismet-settings__row-label-text">
 													<?php esc_html_e( 'Do not display privacy notice.', 'akismet' ); ?>
 												</span>
 											</label>
 										</div>
 									</fieldset>
-									
+
 									<div class="akismet-settings__row-note">
 										<?php esc_html_e( 'To help your site with transparency under privacy laws like the GDPR, Akismet can display a notice to your users under your comment forms.', 'akismet' ); ?>
 									</div>
 								</div>
 							</div>
 						</div>
-						
+
 						<div class="akismet-card-actions">
 							<?php if ( ! Akismet::predefined_api_key() ) : ?>
-								<div id="delete-action">
+								<div id="delete-action" class="akismet-card-actions__secondary-action">
 									<a class="submitdelete deletion" href="<?php echo esc_url( Akismet_Admin::get_page_url( 'delete_key' ) ); ?>"><?php esc_html_e( 'Disconnect this account', 'akismet' ); ?></a>
 								</div>
 							<?php endif; ?>
-							
+
 							<?php wp_nonce_field( Akismet_Admin::NONCE ); ?>
-							
+
 							<div id="publishing-action">
 								<input type="hidden" name="action" value="enter-key">
 								<input type="submit" name="submit" id="submit" class="akismet-button akismet-could-be-primary" value="<?php esc_attr_e( 'Save changes', 'akismet' ); ?>">
 							</div>
-							<div class="clear"></div>
 						</div>
 					</form>
 				</div>
@@ -248,7 +259,7 @@
 				<div class="akismet-card">
 					<div class="akismet-section-header">
 						<h2 class="akismet-section-header__label">
-							<span><?php esc_html_e( 'Account' , 'akismet'); ?></span>
+							<span><?php esc_html_e( 'Account', 'akismet' ); ?></span>
 						</h2>
 					</div>
 
@@ -265,13 +276,13 @@
 									<th scope="row"><?php esc_html_e( 'Status', 'akismet' ); ?></th>
 									<td>
 										<?php
-										if ( 'cancelled' == $akismet_user->status ) :
+										if ( 'cancelled' === $akismet_user->status ) :
 											esc_html_e( 'Cancelled', 'akismet' );
-										elseif ( 'suspended' == $akismet_user->status ) :
+										elseif ( 'suspended' === $akismet_user->status ) :
 											esc_html_e( 'Suspended', 'akismet' );
-										elseif ( 'missing' == $akismet_user->status ) :
+										elseif ( 'missing' === $akismet_user->status ) :
 											esc_html_e( 'Missing', 'akismet' );
-										elseif ( 'no-sub' == $akismet_user->status ) :
+										elseif ( 'no-sub' === $akismet_user->status ) :
 											esc_html_e( 'No subscription found', 'akismet' );
 										else :
 											esc_html_e( 'Active', 'akismet' );
@@ -290,14 +301,26 @@
 							</tbody>
 						</table>
 						<div class="akismet-card-actions">
+							<?php if ( $akismet_user->status === 'active' ) : ?>
+								<div class="akismet-card-actions__secondary-action">
+									<a href="https://akismet.com/account" target="_blank" rel="noopener noreferrer" aria-label="Account overview on akismet.com (opens in a new window)"><?php esc_html_e( 'Account overview', 'akismet' ); ?></a>
+								</div>
+							<?php endif; ?>
 							<div id="publishing-action">
-								<?php Akismet::view( 'get', array( 'text' => ( $akismet_user->account_type == 'free-api-key' && $akismet_user->status == 'active' ? __( 'Upgrade' , 'akismet') : __( 'Change' , 'akismet') ), 'redirect' => 'upgrade' ) ); ?>
+								<?php
+								Akismet::view(
+									'get',
+									array(
+										'text'     => ( $akismet_user->account_type === 'free-api-key' && $akismet_user->status === 'active' ? __( 'Upgrade', 'akismet' ) : __( 'Change', 'akismet' ) ),
+										'redirect' => 'upgrade',
+									)
+								);
+								?>
 							</div>
-							<div class="clear"></div>
 						</div>
 					</div>
 				</div>
 			<?php endif; ?>
-		<?php endif;?>
+		<?php endif; ?>
 	</div>
 </div>

--- a/akismet/views/notice.php
+++ b/akismet/views/notice.php
@@ -178,7 +178,7 @@ $kses_allow_strong = array( 'strong' => true );
 	}
 	?>
 	<div class="akismet-alert is-good">
-		<p><?php esc_html_e( 'Akismet is now protecting your site from spam. Happy blogging!', 'akismet' ); ?></p>
+		<p><?php esc_html_e( 'Akismet is now protecting your site from spam.', 'akismet' ); ?></p>
 		<?php if ( $check_pending_link ) : ?>
 			<p>
 				<?php


### PR DESCRIPTION
## Description
Bumps Akismet from 5.3 to 5.3.1 released back in January.

## Changelog Description

### Plugin Updated: Akismet to 5.3.1

We upgraded Akismet 5.3 to Akismet 5.3.1. 

This version contains the following changes: 

* Make the plugin more resilient when asset files are missing (as seen in WordPress Playground).
* Add a link to the 'Account overview' page on akismet.com.
* Fix a minor error that occurs when another plugin removes all comment actions from the dashboard.
* Add the akismet_request_args filter to allow request args in Akismet API requests to be filtered.
* Fix a bug that causes some contact forms to include unnecessary data in the comment_content parameter.
*  
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Ensure that Akismet version in WP-Admin (and `wp plugin list`) is showing 5.3.1.
1. Click around and ensure no unexpected behavior occurs and scripts are loaded on the front end.

