### PR TITLE
Removes extraneous text from command description.

### DIFF
--- a/vip-support/class-vip-support-cli.php
+++ b/vip-support/class-vip-support-cli.php
@@ -8,8 +8,7 @@ namespace Automattic\VIP\Support_User;
 use WP_CLI_Command;
 
 /**
- * Implements a WP CLI command that converts guid users to meta users
- * Class command
+ * Implements a WP CLI command that converts guid users to meta users.
  *
  * @package a8c\vip_support
  */


### PR DESCRIPTION
## Description

When describing the `vipsupport` command with `wp help vipsupport`, an out-of-place text would appear after the command description:

```
NAME

  wp vipsupport

DESCRIPTION

  Implements a WP CLI command that converts guid users to meta users

SYNOPSIS

  wp vipsupport <command>

SUBCOMMANDS

  create-user      Creates a user in the VIP Support role, already verified,
  remove-user      Removes a user in the VIP Support role.
  reset-roles      Reset / re-add VIP Support related roles.
  verify           Marks the user with the provided ID as having a verified email.

  Class command <---
```

## Changelog Description

### Removed extraneous text from `vipsupport` command description

When running `wp help vipsupport`, an out-of-place text would appear after the command description: `Class command`.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Run the following command on any site with the mu-plugins: `wp help vipsupport`
1. Verify that the `Class command` text is displayed
1. Checkout this PR
1. Run the command again
1. Verify that the extraneous text is no longer there

