### PR TITLE
BB8-11121: Prevent enabling debug mode on local env for logged out users

### DIFF
--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -40,9 +40,19 @@ function is_debug_mode_enabled() {
 	$is_nocache = isset( $_COOKIE['vip-go-cb'] ) && '1' === $_COOKIE['vip-go-cb'];  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	$is_debug   = isset( $_COOKIE['a8c-debug'] ) && '1' === $_COOKIE['a8c-debug'];  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	$is_proxied = \is_proxied_request();
+	$is_local   = function_exists( 'is_local_env' ) && \is_local_env();
 
 	if ( $is_nocache && $is_debug && $is_proxied ) {
 		return true;
+	}
+
+	if ( $is_local ) {
+		if ( ! function_exists( 'is_user_logged_in' ) ) {
+			require_once ABSPATH . WPINC . '/pluggable.php';
+		}
+		if ( is_user_logged_in() ) {
+			return true;
+		}
 	}
 
 	return false;

--- a/000-debug/debug-mode.php
+++ b/000-debug/debug-mode.php
@@ -40,9 +40,8 @@ function is_debug_mode_enabled() {
 	$is_nocache = isset( $_COOKIE['vip-go-cb'] ) && '1' === $_COOKIE['vip-go-cb'];  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	$is_debug   = isset( $_COOKIE['a8c-debug'] ) && '1' === $_COOKIE['a8c-debug'];  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	$is_proxied = \is_proxied_request();
-	$is_local   = function_exists( 'is_local_env' ) && \is_local_env();
 
-	if ( ( $is_nocache && $is_debug && $is_proxied ) || $is_local ) {
+	if ( $is_nocache && $is_debug && $is_proxied ) {
 		return true;
 	}
 


### PR DESCRIPTION
## Description

We are updating the code to prevent debug mode from enabling automatically on local env for logged out users.


## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
