### PR TITLE
Increase dependabot interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - directory: /
     package-ecosystem: github-actions
     schedule:
-      interval: daily
+      interval: weekly
     labels:
       - '[Status] Needs Review'
       - '[Status] No files to Deploy'
@@ -13,7 +13,7 @@ updates:
   - directory: /.github/actions/prepare-source
     package-ecosystem: github-actions
     schedule:
-      interval: daily
+      interval: weekly
     labels:
       - '[Status] Needs Review'
       - '[Status] No files to Deploy'
@@ -22,7 +22,7 @@ updates:
   - directory: /.github/actions/run-wp-tests
     package-ecosystem: github-actions
     schedule:
-      interval: daily
+      interval: weekly
     labels:
       - '[Status] Needs Review'
       - '[Status] No files to Deploy'
@@ -31,7 +31,7 @@ updates:
   - directory: /
     package-ecosystem: npm
     schedule:
-      interval: daily
+      interval: weekly
     versioning-strategy: increase-if-necessary
     ignore:
       - dependency-name: "cypress"
@@ -42,7 +42,7 @@ updates:
   - directory: /__tests__/e2e/
     package-ecosystem: npm
     schedule:
-      interval: daily
+      interval: weekly
     versioning-strategy: increase-if-necessary
     labels:
       - '[Status] Needs Review'
@@ -51,7 +51,7 @@ updates:
   - directory: /search/search-dev-tools/
     package-ecosystem: npm
     schedule:
-      interval: daily
+      interval: weekly
     versioning-strategy: increase-if-necessary
     labels:
       - '[Status] Needs Review'
@@ -59,7 +59,7 @@ updates:
   - directory: /
     package-ecosystem: composer
     schedule:
-      interval: daily
+      interval: weekly
     versioning-strategy: increase-if-necessary
     labels:
       - '[Status] Needs Review'


### PR DESCRIPTION
## Description

Daily is a bit much.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Merge and enjoy the daily silence.