### PR TITLE
Jetpack: Revert to 13.1 for WP 6.3

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -34,8 +34,11 @@ function vip_default_jetpack_version() {
 	} elseif ( version_compare( $wp_version, '6.3', '<' ) ) {
 		// WordPress 6.2.x.
 		return '12.8';
+	} elseif ( version_compare( $wp_version, '6.4', '<' ) ) { 
+		// WordPress 6.3.x
+		return '13.1';
 	} else {
-		// WordPress 6.3 and newer.
+		// WordPress 6.4 and newer.
 		return '13.2';
 	}
 }

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -17,7 +17,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 			'6.0'   => '12.0',
 			'6.1'   => '12.5',
 			'6.2'   => '12.8',
-			'6.3'   => $latest,
+			'6.3'   => '13.1',
 			'6.4'   => $latest,
 		];
 


### PR DESCRIPTION
## Description
Revert WordPress 6.3 sites to Jetpack 13.1

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
