### PR TITLE
[BB8-11132] Fix issue with user-index-validation command getting killed for large datasets

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -229,7 +229,8 @@ class Health {
 		$index_version = $search->versioning->get_current_version_number( $users );
 
 		$query_args = [
-			'order' => 'asc',
+			'order'  => 'asc',
+			'number' => 1,
 		];
 
 		$result = ( new self( $search ) )->validate_index_entity_count( $query_args, $users );


### PR DESCRIPTION
## Description

Validating user count in the es-index is getting killed if there are a large number of users. One workaround is to force the query to fetch only one entry per page, as done here with the [posts](https://github.com/Automattic/vip-go-mu-plugins/blob/5241ac59dd8c826848f5614f73761e806567c954/search/includes/classes/class-health.php#L293-L295):

To do that, we are setting  number=1 param to the user-count query arg.

## Changelog Description

### Plugin Updated: Enterprise Search
Fixes `wp vip-search health validate-users-count` getting killed for large user dataset.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
