### PR TITLE
ci: fix Dependency Review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
             github.com:443
 


### PR DESCRIPTION
The recent version of the `dependency-review-action` needs access to `api.deps.dev:443`.
