### PR TITLE
ci: use exact versions of actions

### DIFF
--- a/.github/actions/prepare-source/action.yml
+++ b/.github/actions/prepare-source/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Check out mu-plugins-ext
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.2
       with:
         repository: 'Automattic/vip-go-mu-plugins-ext'
         path: 'vip-go-mu-plugins-ext'

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request to build Docker image
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.0.1
         with:
           github-token: ${{ secrets.WPCOM_VIP_BOT_TOKEN }}
           script: |

--- a/.github/workflows/changelog-summary-prod.yml
+++ b/.github/workflows/changelog-summary-prod.yml
@@ -20,7 +20,7 @@ jobs:
       id: ${{ steps.id-generator.outputs.id }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@v2.7.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@v4.1.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v3.24.9
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v3.24.9

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -42,14 +42,14 @@ jobs:
           echo "PHP_FPM_GID=$(id -g)" >> "${GITHUB_ENV}"
 
       - name: Checkout WordPress
-        uses: actions/checkout@v4.1.2 # v4.0.0
+        uses: actions/checkout@v4.1.2
         with:
           repository: wordpress/wordpress-develop
           path: wordpress
           ref: ${{ steps.version.outputs.latest }}
 
       - name: Check out source code
-        uses: actions/checkout@v4.1.2 # v4.0.0
+        uses: actions/checkout@v4.1.2
         with:
           submodules: recursive
           path: wordpress/src/wp-content/mu-plugins
@@ -60,7 +60,7 @@ jobs:
           echo "GITHUB_EVENT_NAME=pull_request" >> "wordpress/.env"
 
       - name: Set up Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@v4.0.2
         with:
           node-version-file: 'wordpress/.nvmrc'
           cache: npm
@@ -80,9 +80,9 @@ jobs:
         run: composer install -n
         working-directory: wordpress
 
-      - name: Downgrade PHPUnit
-        run: composer require --dev -n phpunit/phpunit:9.6.12
-        working-directory: wordpress
+      # - name: Downgrade PHPUnit
+      #   run: composer require --dev -n phpunit/phpunit:^9
+      #   working-directory: wordpress
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     name: Review Dependencies
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@v2.7.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -24,4 +24,4 @@ jobs:
         uses: actions/checkout@v4.1.2
 
       - name: Review dependencies
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v4.2.3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@v2.7.0
         with:
           egress-policy: audit
 


### PR DESCRIPTION
This is to avoid situations like #5365, when a workflow suddenly fails because one of the actions it depends upon has changed.
