### PR TITLE
Increase upload_size_limit to 5GB

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -73,9 +73,9 @@ class A8C_Files {
 
 	public function __construct() {
 
-		// Upload size limit is 1GB
+		// Upload size limit is 5GB
 		add_filter( 'upload_size_limit', function () {
-			return 1073741824; // 2^30
+			return 5368709120; // 2^30 * 5
 		});
 
 		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER ) {


### PR DESCRIPTION
## Description

A minor tweak to make `5GB` the default `upload_size_limit` instead of `1GB`. This is a more reasonable modern limit.

## Changelog Description

### Update default upload size limit

We updated the default `upload_size_limit` from 1 GB to 5 GB.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.