### PR TITLE
Ensure that required data is defined before using it for $request_url_for_logging in Search class

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1188,8 +1188,8 @@ class Search {
 			return;
 		}
 
-		if ( ! $is_cli ) {
-			global $wp;
+		global $wp;
+		if ( ! $is_cli && isset( $wp->query_vars ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 			$request_url_for_logging = esc_url_raw( add_query_arg( $wp->query_vars, home_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
 		}


### PR DESCRIPTION
## Description

Fixes #5390.

## Changelog Description

### Bugfix: prevent PHP warnings when composing `$request_url_for_logging` in `Search` class.

Ensure that variables referenced are actually defined when building the `$request_url_for_logging` for logging.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR, start the wp-env development environment for this repository which has `VIP_ENABLE_VIP_SEARCH` enabled.
1. Configure the `VIP_ELASTICSEARCH_ENDPOINTS` constant to point to _an invalid_ hostname in the project `vip-config.php`.
1. Visit any WP admin section to trigger `Automattic\VIP\Search::load_dependencies()` which in turn calls `ElasticPress::register_indexable_posts()` in either `search/elasticpress/elasticpress.php` or `search/elasticpress-next/elasticpress.php`.
1. Confirm that `url` is set to a valid URL of the current request in https://github.com/Automattic/vip-go-mu-plugins/blob/d0a3d7d5b6236d6f93bc0cda9b6534da52fd80c4/search/includes/classes/class-search.php#L1208