### PR TITLE
Remove font filter, as it is no longer needed

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -100,7 +100,6 @@ class VIP_Filesystem {
 		add_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20 );
 		add_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ], 10, 2 );
 		add_filter( 'wp_read_image_metadata', [ $this, 'filter_wp_read_image_metadata' ], 10, 2 );
-		add_filter( 'font_dir', [ $this, 'filter_wp_font_dir' ], 10, 1 );
 
 		/**
 		 * The core's function recurse_dirsize would call to opendir() which is not supported by the
@@ -125,7 +124,6 @@ class VIP_Filesystem {
 		remove_filter( 'get_attached_file', [ $this, 'filter_get_attached_file' ], 20 );
 		remove_filter( 'wp_generate_attachment_metadata', [ $this, 'filter_wp_generate_attachment_metadata' ] );
 		remove_filter( 'wp_read_image_metadata', [ $this, 'filter_wp_read_image_metadata' ], 10, 2 );
-		remove_filter( 'font_dir', [ $this, 'filter_wp_font_dir' ], 10, 1 );
 		remove_filter( 'pre_recurse_dirsize', '__return_zero' );
 	}
 
@@ -462,19 +460,5 @@ class VIP_Filesystem {
 		unlink( $temp_file );
 
 		return $meta;
-	}
-
-	/**
-	 * Changes the Font Library directory to work with the VIP Filesystem.
-	 */
-	public function filter_wp_font_dir( $defaults ) {
-		$upload_dir = wp_upload_dir();
-	
-		$defaults['basedir'] = $upload_dir['basedir'] . '/fonts';
-		$defaults['baseurl'] = $upload_dir['baseurl'] . '/fonts';
-		$defaults['path']    = $defaults['basedir'];
-		$defaults['url']     = $defaults['baseurl'];
-	
-		return $defaults;
 	}
 }

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -29,8 +29,8 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 
 	public static function configure_constant_mocker(): void {
 		Constant_Mocker::clear();
-		define( 'LOCAL_UPLOADS', '/tmp/uploads' );
-		define( 'WP_CONTENT_DIR', '/tmp/wordpress/wp-content' );
+		define( 'LOCAL_UPLOADS', '/wp/uploads' );
+		define( 'WP_CONTENT_DIR', '/wp/wordpress/wp-content' );
 	}
 
 	public function setUp(): void {
@@ -385,24 +385,5 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 			[ constant( 'WP_CONTENT_DIR' ) . '/plugins/test.txt', 'direct' ],
 			[ constant( 'WP_CONTENT_DIR' ) . '/languages/test.txt', 'direct' ],
 		];
-	}
-
-	public function test_wp_font_dir() {
-		// Only available in WP 6.5 and newer:
-		if ( ! function_exists( '\wp_get_font_dir' ) ) {
-			$this->markTestSkipped( 'test_wp_font_dir does not need to run for WP < 6.5.' );
-			return;
-		}
-
-		$font_dir = \wp_get_font_dir();
-
-		$this->assertEquals( $font_dir, [
-			'path'    => 'vip://wp-content/uploads/fonts',
-			'basedir' => 'vip://wp-content/uploads/fonts',
-			'url'     => 'http://example.org/wp-content/uploads/fonts',
-			'baseurl' => 'http://example.org/wp-content/uploads/fonts',
-			'subdir'  => '',
-			'error'   => false,
-		] );
 	}
 }


### PR DESCRIPTION
This reverts the font filter we added to prep for 6.5. Changes have been made in 6.5 which removes the need for this filter.