### PR TITLE
Update Block Data API to v1.2

### DIFF
--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -20,7 +20,7 @@ class BlockDataApiIntegration extends Integration {
 	 *
 	 * @var string
 	 */
-	protected string $version = '1.1';
+	protected string $version = '1.2';
 
 	/**
 	 * Returns `true` if `Block Data API` is already available e.g. via customer code. We will use


### PR DESCRIPTION
## Description

Update mu-plugins to use the latest version of the Block Data API (`v1.2`). This update [was already available in vip-go-mu-plugins-ext](https://github.com/Automattic/vip-go-mu-plugins-ext/tree/trunk/vip-integrations) since February, but was not being included in the integration.

This is especially important because [the most recent `v1.2.1` Block Data API](https://github.com/Automattic/vip-block-data-api/releases/tag/1.2.1) update adds `rich-text` attribute support which rolled out with WordPress 6.5.

## Changelog Description

### Plugin Updated: Block Data API

We upgraded the Block Data API integration to version `1.2.1`, which supports WordPress 6.5 `rich-text` attribute parsing.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

This is a straightforward change, and the existance of the `1.2` folder [can be verified in -ext already](https://github.com/Automattic/vip-go-mu-plugins-ext/tree/trunk/vip-integrations).

See [**Steps to Test** on this prior PR](https://github.com/Automattic/vip-go-mu-plugins/pull/5099) for the more involved steps for testing an `-ext` update in general.
