### PR TITLE
Update WordPress Importer plugin to include post_type in the query for existing post

### DIFF
--- a/wordpress-importer/class-wp-import.php
+++ b/wordpress-importer/class-wp-import.php
@@ -656,7 +656,7 @@ class WP_Import extends WP_Importer {
 
 			$post_type_object = get_post_type_object( $post['post_type'] );
 
-			$post_exists = post_exists( $post['post_title'], '', $post['post_date'] );
+			$post_exists = post_exists( $post['post_title'], '', $post['post_date'], $post['post_type'] );
 
 			/**
 			* Filter ID of the existing post corresponding to post currently importing.


### PR DESCRIPTION
## Description

The post import process uses [post_exists](https://developer.wordpress.org/reference/functions/post_exists/) function to check whether each of the importing posts already exists. The query utilises the title and date parameters for this search, which will run through all the posts to try and find a match.  

In cases where we have a large number of posts this process times out and the import fails. 

Passing the **post_type** to **post_exists** function allows us to use the **type_status_date** key, which significantly drops the number of rows examined and the overall query time in certain instances, depending on how many posts of that post_type we have.


## Changelog Description

Update to WordPress Importer plugin to improve the post_exists query time during post import process.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
