### PR TITLE
fix(optionsapi): make `pre_wp_load_alloptions_protections()` compatible with WP 6.6

### DIFF
--- a/001-core/options-api.php
+++ b/001-core/options-api.php
@@ -39,8 +39,14 @@ function pre_wp_load_alloptions_protections( $pre_loaded_alloptions, $force_cach
 	}
 
 	// 3) Otherwise query the DB for fresh results.
+	if ( function_exists( 'wp_autoload_values_to_autoload' ) ) {
+		$values = wp_autoload_values_to_autoload();
+	} else {
+		$values = [ 'yes' ];
+	}
+
 	$suppress      = $wpdb->suppress_errors();
-	$alloptions_db = $wpdb->get_results( "SELECT option_name, option_value FROM $wpdb->options WHERE autoload = 'yes'" );
+	$alloptions_db = $wpdb->get_results( "SELECT option_name, option_value FROM $wpdb->options WHERE autoload IN ( '" . implode( "', '", $values ) . "' )" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	$wpdb->suppress_errors( $suppress );
 
 	$alloptions = [];


### PR DESCRIPTION
## Description

Fixes: #5414 

WordPress 6.6 introduces several types of option autoloading variants; this PR adds support for them.

## Changelog Description

### Plugin Updated: Options API

Compatibility with WordPress 6.6.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

CI should pass (WP Core Tests may still fail; this is addressed in #5413).
