### PR TITLE
fix(optionsapi): escape SQL parameters

### DIFF
--- a/001-core/options-api.php
+++ b/001-core/options-api.php
@@ -45,8 +45,10 @@ function pre_wp_load_alloptions_protections( $pre_loaded_alloptions, $force_cach
 		$values = [ 'yes' ];
 	}
 
+	/** @var string[] $values */
+
 	$suppress      = $wpdb->suppress_errors();
-	$alloptions_db = $wpdb->get_results( "SELECT option_name, option_value FROM $wpdb->options WHERE autoload IN ( '" . implode( "', '", $values ) . "' )" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	$alloptions_db = $wpdb->get_results( "SELECT option_name, option_value FROM $wpdb->options WHERE autoload IN ( '" . implode( "', '", esc_sql( $values ) ) . "' )" );
 	$wpdb->suppress_errors( $suppress );
 
 	$alloptions = [];


### PR DESCRIPTION
## Description

Run `esc_sql()` on the array returned by `wp_autoload_values_to_autoload()`.

While this isn't strictly necessary now because `wp_autoload_values_to_autoload()` returns a predefined set of values, and it is impossible to add new values to that set, this makes the code safer in case the situation changes later.

Related: #5415

## Changelog Description

### Plugin Updated: Options API

Harden `pre_wp_load_alloptions_protections()` function.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

CI should pass.
