### PR TITLE
test: refactor tests for integrations

### DIFF
--- a/tests/integrations/test-integration-vip-config.php
+++ b/tests/integrations/test-integration-vip-config.php
@@ -340,20 +340,18 @@ class VIP_Integration_Vip_Config_Test extends WP_UnitTestCase {
 	 *
 	 * @param array|null|string $vip_config
 	 *
-	 * @return MockObject
+	 * @return MockObject&IntegrationVipConfig
 	 */
 	private function get_mock( $vip_config ) {
 		/**
 		 * Config Mock.
 		 *
-		 * @var MockObject
+		 * @var MockObject&IntegrationVipConfig
 		 */
 		$mock = $this->getMockBuilder( IntegrationVipConfig::class )
-								->disableOriginalConstructor()
-								->setMethods( [
-									'get_vip_config_from_file',
-								] )
-								->getMock();
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_vip_config_from_file' ] )
+			->getMock();
 
 		$mock->method( 'get_vip_config_from_file' )->willReturn( $vip_config );
 		$mock->__construct( 'slug' );

--- a/tests/integrations/test-integration.php
+++ b/tests/integrations/test-integration.php
@@ -79,7 +79,7 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 		 *
 		 * @var MockObject|FakeIntegration
 		 */
-		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'is_loaded' ] )->getMock();
+		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->onlyMethods( [ 'is_loaded' ] )->getMock();
 		$integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( true );
 
 		$integration_mock->activate();
@@ -113,7 +113,7 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 		 *
 		 * @var IntegrationVipConfig|MockObject
 		 */
-		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->setMethods( [ 'get_vip_config_from_file' ] )->getMock();
+		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->onlyMethods( [ 'get_vip_config_from_file' ] )->getMock();
 		$config_mock->method( 'get_vip_config_from_file' )->willReturn( [
 			'network_sites' => [
 				get_current_blog_id() => [
@@ -131,7 +131,7 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 
 		// By default return config passed via activate().
 		$this->assertEquals( array( 'activate_config' ), $integration->get_config() );
-		
+
 		// If blog is switched then return config of current network site.
 		switch_to_blog( $blog_2_id );
 		$this->assertEquals( array( 'network_site_2_config' ), $integration->get_config() );

--- a/tests/integrations/test-integrations.php
+++ b/tests/integrations/test-integrations.php
@@ -44,7 +44,7 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 	}
 
 	public function test__integrations_are_activating_based_on_given_vip_config(): void {
-		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->setMethods( [ 'is_active_via_vip', 'get_site_config' ] )->getMock();
+		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->onlyMethods( [ 'is_active_via_vip', 'get_site_config' ] )->getMock();
 		$config_mock->expects( $this->exactly( 2 ) )->method( 'is_active_via_vip' )->willReturnOnConsecutiveCalls( true, false );
 		$config_mock->expects( $this->exactly( 1 ) )->method( 'get_site_config' )->willReturnOnConsecutiveCalls( [ 'config_key_1' => 'vip_value' ] );
 
@@ -53,7 +53,7 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 		 *
 		 * @var MockObject|Integrations
 		 */
-		$mock = $this->getMockBuilder( Integrations::class )->setMethods( [ 'get_integration_vip_config' ] )->getMock();
+		$mock = $this->getMockBuilder( Integrations::class )->onlyMethods( [ 'get_integration_vip_config' ] )->getMock();
 		$mock->expects( $this->any() )->method( 'get_integration_vip_config' )->willReturn( $config_mock );
 
 		$integration_1 = new FakeIntegration( 'fake-1' );
@@ -78,21 +78,21 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 	}
 
 	public function test__expected_methods_are_getting_called_when_the_integration_is_activated_via_vip_config(): void {
-		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->setMethods( [ 'is_active_via_vip' ] )->getMock();
+		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->onlyMethods( [ 'is_active_via_vip' ] )->getMock();
 		$config_mock->expects( $this->once() )->method( 'is_active_via_vip' )->willReturn( true );
 		/**
 		 * Integrations mock.
 		 *
 		 * @var MockObject|Integrations
 		 */
-		$integrations_mock = $this->getMockBuilder( Integrations::class )->setMethods( [ 'get_integration_vip_config' ] )->getMock();
+		$integrations_mock = $this->getMockBuilder( Integrations::class )->onlyMethods( [ 'get_integration_vip_config' ] )->getMock();
 		$integrations_mock->expects( $this->once() )->method( 'get_integration_vip_config' )->willReturn( $config_mock );
 		/**
 		 * Integration mock.
 		 *
 		 * @var MockObject|FakeIntegration
 		 */
-		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->setMethods( [ 'configure', 'set_vip_config' ] )->getMock();
+		$integration_mock = $this->getMockBuilder( FakeIntegration::class )->setConstructorArgs( [ 'fake' ] )->onlyMethods( [ 'configure', 'set_vip_config' ] )->getMock();
 		$integration_mock->expects( $this->once() )->method( 'configure' );
 		$integration_mock->expects( $this->once() )->method( 'set_vip_config' );
 

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -30,7 +30,7 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		 *
 		 * @var MockObject|ParselyIntegration
 		 */
-		$parsely_integration_mock = $this->getMockBuilder( ParselyIntegration::class )->setConstructorArgs( [ 'parsely' ] )->setMethods( [ 'is_loaded' ] )->getMock();
+		$parsely_integration_mock = $this->getMockBuilder( ParselyIntegration::class )->setConstructorArgs( [ 'parsely' ] )->onlyMethods( [ 'is_loaded' ] )->getMock();
 		$parsely_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( true );
 		$preload_state = defined( 'VIP_PARSELY_ENABLED' );
 
@@ -45,13 +45,13 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		 *
 		 * @var MockObject|ParselyIntegration
 		 */
-		$parsely_integration_mock = $this->getMockBuilder( ParselyIntegration::class )->setConstructorArgs( [ 'parsely' ] )->setMethods( [ 'is_loaded' ] )->getMock();
+		$parsely_integration_mock = $this->getMockBuilder( ParselyIntegration::class )->setConstructorArgs( [ 'parsely' ] )->onlyMethods( [ 'is_loaded' ] )->getMock();
 		$parsely_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( false );
 		$existing_value = defined( 'VIP_PARSELY_ENABLED' ) ? VIP_PARSELY_ENABLED : null;
 
 		$parsely_integration_mock->load();
 
-		if ( is_null( $existing_value ) || true == $existing_value ) {
+		if ( is_null( $existing_value ) || $existing_value ) {
 			$this->assertTrue( VIP_PARSELY_ENABLED );
 		} else {
 			$this->assertFalse( defined( 'VIP_PARSELY_ENABLED' ) );

--- a/tests/test-vip-integrations.php
+++ b/tests/test-vip-integrations.php
@@ -15,7 +15,7 @@ use function Automattic\Test\Utils\get_class_property_as_public;
 
 class VIP_Integrations_Plugin_Test extends WP_UnitTestCase {
 	public function test_activate_function_is_calling_the_activate_method_from_integrations_class(): void {
-		$integrations_mock = $this->getMockBuilder( Integrations::class )->setMethods( [ 'activate' ] )->getMock();
+		$integrations_mock = $this->getMockBuilder( Integrations::class )->onlyMethods( [ 'activate' ] )->getMock();
 		$integrations_mock->expects( $this->once() )->method( 'activate' )->with( $this->equalTo( 'test-slug' ), $this->equalTo( [ 'test-key' => 'test-value' ] ) );
 
 		$this->set_integrations( $integrations_mock );
@@ -46,7 +46,7 @@ class VIP_Integrations_Plugin_Test extends WP_UnitTestCase {
 	/**
 	 * Set integrations mock.
 	 *
-	 * @param MockObject $mock
+	 * @param MockObject&Integrations $mock
 	 */
 	private function set_integrations( $mock ): void {
 		$instance = IntegrationsSingleton::instance();


### PR DESCRIPTION
This PR updates unit tests for integrations by refactoring calls to deprecated PHPUnit methods.
