### PR TITLE
test: do not use deprecated `setMethods()`

### DIFF
--- a/tests/admin-notice/conditions/test-class-capability-condition.php
+++ b/tests/admin-notice/conditions/test-class-capability-condition.php
@@ -13,15 +13,11 @@ class Capability_Condition_Test extends TestCase {
 
 	public function setUp(): void {
 		self::$mock_global_functions = $this->getMockBuilder( self::class )
-			->setMethods( [ 'mock_current_user_can' ] )
+			->addMethods( [ 'mock_current_user_can' ] )
 			->getMock();
 	}
 
-	public function mock_current_user_can( string $capability, ...$args ) {
-	}
-
 	public function evaluate_data() {
-
 		return [
 			[ [ true ], true ],
 			[ [ true, true ], true ],
@@ -36,7 +32,6 @@ class Capability_Condition_Test extends TestCase {
 	 * @dataProvider evaluate_data
 	 */
 	public function test__evaluate( $has_capabilities, $expected_result ) {
-
 		self::$mock_global_functions->method( 'mock_current_user_can' )
 			->will( $this->onConsecutiveCalls( ...$has_capabilities ) );
 
@@ -45,7 +40,6 @@ class Capability_Condition_Test extends TestCase {
 		$this->assertEquals( $expected_result, $condition->evaluate() );
 	}
 }
-
 
 /**
  * Overwriting global function so that no real remote request is called

--- a/tests/admin-notice/test-class-admin-notice-controller.php
+++ b/tests/admin-notice/test-class-admin-notice-controller.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\VIP\Admin_Notice;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../admin-notice/class-admin-notice-controller.php';
@@ -13,19 +14,11 @@ class Admin_Notice_Controller_Test extends TestCase {
 
 	public function setUp(): void {
 		self::$mock_global_functions = $this->getMockBuilder( self::class )
-			->setMethods( [ 'add_user_meta', 'get_user_meta', 'delete_user_meta' ] )
+			->addMethods( [ 'add_user_meta', 'get_user_meta', 'delete_user_meta' ] )
 			->getMock();
 	}
 
-	public function add_user_meta( int $user_id, string $meta_key, $meta_value, bool $unique = false ) {
-	}
-	public function get_user_meta( int $user_id, string $key = '', bool $single = false ) {
-	}
-	public function delete_user_meta( int $user_id, string $meta_key, $meta_value ) {
-	}
-
 	public function mayby_clean_stale_dismissed_notices_data() {
-
 		return [
 			[ 101, true ],
 			[ -1, false ],
@@ -38,8 +31,9 @@ class Admin_Notice_Controller_Test extends TestCase {
 	public function test__mayby_clean_stale_dismissed_notices( $limit_value, $expect_called ) {
 		Admin_Notice_Controller::$stale_dismiss_cleanup_value = $limit_value;
 
+		/** @var MockObject&Admin_Notice_Controller */
 		$partially_mocked_controller = $this->getMockBuilder( Admin_Notice_Controller::class )
-			->setMethods( [ 'clean_stale_dismissed_notices' ] )
+			->onlyMethods( [ 'clean_stale_dismissed_notices' ] )
 			->getMock();
 
 		$partially_mocked_controller->expects( $expect_called ? $this->once() : $this->never() )
@@ -49,7 +43,6 @@ class Admin_Notice_Controller_Test extends TestCase {
 	}
 
 	public function clean_stale_dismissed_notices_data() {
-
 		return [
 			[ [], [ 'a' ], [] ],
 			[ [ 'a' ], [ 'a' ], [] ],
@@ -84,9 +77,11 @@ class Admin_Notice_Controller_Test extends TestCase {
 function add_user_meta( int $user_id, string $meta_key, $meta_value, bool $unique = false ) {
 	return is_null( Admin_Notice_Controller_Test::$mock_global_functions ) ? null : Admin_Notice_Controller_Test::$mock_global_functions->add_user_meta( $user_id, $meta_key, $meta_value, $unique );
 }
+
 function get_user_meta( int $user_id, string $key = '', bool $single = false ) {
 	return is_null( Admin_Notice_Controller_Test::$mock_global_functions ) ? null : Admin_Notice_Controller_Test::$mock_global_functions->get_user_meta( $user_id, $key, $single );
 }
+
 function delete_user_meta( int $user_id, string $meta_key, $meta_value ) {
 	return is_null( Admin_Notice_Controller_Test::$mock_global_functions ) ? null : Admin_Notice_Controller_Test::$mock_global_functions->delete_user_meta( $user_id, $meta_key, $meta_value );
 }

--- a/tests/files/test-vip-filesystem.php
+++ b/tests/files/test-vip-filesystem.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Files;
 
 use Automattic\Test\Constant_Mocker;
 use ErrorException;
+use PHPUnit\Framework\MockObject\MockObject;
 use WP_Error;
 use WP_Filesystem_Base;
 use WP_Filesystem_Direct;
@@ -50,7 +51,7 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		set_error_handler( static function ( int $errno, string $errstr ) {
 			if ( $errno & error_reporting() ) {
 				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI
-				throw new ErrorException( $errstr, $errno );
+				throw new ErrorException( $errstr, $errno ); // NOSONAR
 			}
 
 			return false;
@@ -265,14 +266,15 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		];
 		$basepath = $this->get_upload_path();
 
+		/** @var MockObject&VIP_Filesystem */
 		$stub = $this->getMockBuilder( VIP_Filesystem::class )
-				->setMethods( [ 'validate_file_name' ] )
-				->getMock();
+			->onlyMethods( [ 'validate_file_name' ] )
+			->getMock();
 
 		$stub->expects( $this->once() )
-				->method( 'validate_file_name' )
-				->with( $basepath . '/' . $file['name'] )
-				->will( $this->returnValue( $file['name'] ) );
+			->method( 'validate_file_name' )
+			->with( $basepath . '/' . $file['name'] )
+			->will( $this->returnValue( $file['name'] ) );
 
 		$actual = $stub->filter_validate_file( $file );
 
@@ -287,8 +289,9 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		$unique_file_name = 'testfile_8hj30h.txt';
 		$basepath         = $this->get_upload_path();
 
+		/** @var MockObject&VIP_Filesystem */
 		$stub = $this->getMockBuilder( VIP_Filesystem::class )
-			->setMethods( [ 'validate_file_name' ] )
+			->onlyMethods( [ 'validate_file_name' ] )
 			->getMock();
 
 		$stub->expects( $this->once() )
@@ -308,14 +311,15 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		];
 		$basepath = $this->get_upload_path();
 
+		/** @var MockObject&VIP_Filesystem */
 		$stub = $this->getMockBuilder( VIP_Filesystem::class )
-				->setMethods( [ 'validate_file_name' ] )
-				->getMock();
+			->onlyMethods( [ 'validate_file_name' ] )
+			->getMock();
 
 		$stub->expects( $this->once() )
-				->method( 'validate_file_name' )
-				->with( $basepath . '/' . $file['name'] )
-				->will( $this->returnValue( $file['name'] ) );
+			->method( 'validate_file_name' )
+			->with( $basepath . '/' . $file['name'] )
+			->will( $this->returnValue( $file['name'] ) );
 
 		$actual = $stub->filter_validate_file( $file );
 
@@ -332,14 +336,15 @@ class VIP_Filesystem_Test extends WP_UnitTestCase {
 		];
 		$basepath = $this->get_upload_path();
 
+		/** @var MockObject&VIP_Filesystem */
 		$stub = $this->getMockBuilder( VIP_Filesystem::class )
-				->setMethods( [ 'validate_file_name' ] )
-				->getMock();
+			->onlyMethods( [ 'validate_file_name' ] )
+			->getMock();
 
 		$stub->expects( $this->once() )
-				->method( 'validate_file_name' )
-				->with( $basepath . '/' . $file['name'] )
-				->will( $this->returnValue( new WP_Error( 'invalid-file-type', 'Failed to generate new unique file name `testfile.exe` (response code: 400)' ) ) );
+			->method( 'validate_file_name' )
+			->with( $basepath . '/' . $file['name'] )
+			->will( $this->returnValue( new WP_Error( 'invalid-file-type', 'Failed to generate new unique file name `testfile.exe` (response code: 400)' ) ) );
 
 		$actual = $stub->filter_validate_file( $file );
 

--- a/tests/performance/test-class-mime-types-caching.php
+++ b/tests/performance/test-class-mime-types-caching.php
@@ -219,13 +219,8 @@ class Mime_Types_Caching_Test extends WP_UnitTestCase {
 
 		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- Mock $wpdb.
 		$mock_builder = $this->getMockBuilder( \wpdb::class )
-							->setConstructorArgs( array( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) );
-
-		if ( method_exists( $mock_builder, 'onlyMethods' ) ) {
-			$mock_builder = $mock_builder->onlyMethods( array( 'get_var' ) );
-		} else {
-			$mock_builder = $mock_builder->setMethods( array( 'get_var' ) );
-		}
+			->setConstructorArgs( array( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) )
+			->onlyMethods( array( 'get_var' ) );
 
 		$wpdb = $mock_builder->getMock();
 		$wpdb->method( 'get_var' )->willReturn( null );


### PR DESCRIPTION
This PR refactors various files to eliminate the deprecated `setMethods()` method.

In this PR, I grouped all files that are small enough for a separate pull request/
