### PR TITLE
test: fix a warning in `test_move_with_no_filesystem()` for WP 6.1

### DIFF
--- a/tests/files/test-wp-filesystem-vip.php
+++ b/tests/files/test-wp-filesystem-vip.php
@@ -372,7 +372,16 @@ class WP_Filesystem_VIP_Test extends WP_UnitTestCase {
 			$source = $tmp . 'source.txt';
 			$dest   = $tmp . 'dest.txt';
 
-			$actual = $wp_filesystem->move( $source, $dest );
+			// See https://github.com/Automattic/vip-go-mu-plugins/issues/5445
+			// WP 6.1.4 does not check whether the file exists and spits a warning.
+			$original = error_reporting();
+			error_reporting( $original & ~E_WARNING );
+			try {
+				$actual = $wp_filesystem->move( $source, $dest );
+			} finally {
+				error_reporting( $original );
+			}
+
 			self::assertFalse( $actual );
 		} finally {
 			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
Fixes: #5445 
