### PR TITLE
Add Jetpack 13.3 as default

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.2.1
+ * Version: 13.3.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -36,7 +36,7 @@ function vip_default_jetpack_version() {
 		return '12.8';
 	} else {
 		// WordPress 6.3 and newer.
-		return '13.2';
+		return '13.3';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '13.2';
+		$latest = '13.3';
 
 		$versions_map = [
 			// WordPress version => Jetpack version


### PR DESCRIPTION
## Description
Update the default Jetpack version to the latest (13.3.1)

## Changelog Description

### Plugin Updated: Jetpack 13.3.1

We upgraded Jetpack 13.2 to 13.3

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
