### PR TITLE
Fix changelog generator so that all PR commits are checked

### DIFF
--- a/ci/changelog-summary.php
+++ b/ci/changelog-summary.php
@@ -329,7 +329,7 @@ function get_changelog_tags( $pr ) {
  * @return array $pr_ids The IDs pulled from the commits
  */
 function get_pr_ids_from_commits( $commit_url ) {
-    $commits = curl_get( $commit_url );
+    $commits = curl_get_all( $commit_url );
     $pr_ids = [];
 
     foreach( $commits as $commit ) {
@@ -360,7 +360,7 @@ function curl_get( $url ) {
     curl_setopt( $ch, CURLOPT_HEADER, 0 );
     curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
     // curl_setopt( $ch, CURLOPT_VERBOSE, true );
-    if ( GITHUB_TOKEN ) {
+    if ( defined( 'GITHUB_TOKEN' ) && GITHUB_TOKEN ) {
         array_push( $headers, 'Authorization:token ' . GITHUB_TOKEN );
     }
     curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
@@ -373,6 +373,22 @@ function curl_get( $url ) {
     curl_close( $ch );
 
     return json_decode( $data, true );
+}
+
+/**
+ * Wrapper which paginates the GitHub request to fetch everything. Useful when
+ * the endpoint doesn't include pagination information.
+ *
+ * @param string $url URL to get
+ * @return array $data The array with all the data
+ */
+function curl_get_all( $url ) {
+	$all_data = [];
+    $pagination_url = $url . '?per_page=50&page=';
+	for ( $page = 1; ! empty( $data = curl_get( $pagination_url . $page ) ); $page++ ) {
+		$all_data = array_merge( $all_data, $data );
+	}
+	return $all_data;
 }
 
 /**


### PR DESCRIPTION
## Description
When working through a recent mu-plugins release, a changelog was not generated for production. After some digging, I realized the script was only fetching 30 of the many PRs associated, and so some PRs/commits were not being checked for chaneglogs. (So if the first 30 commits had no changelog entry, no post would be generated.)

Thankfully, this endpoint can be paginated with `page` and `per_page`, so we simply request with page++ until the page is empty. At that point, we have all the commits for the request.

## Steps to Test
First, create a `test.php` file, and copy both the `curl_get_all` and `curl_get` functions from this branch into that file. Then, add this test code:

```php
$commit_url = 'https://api.github.com/repos/Automattic/vip-go-mu-plugins/pulls/5472/commits';

$some_data = curl_get($commit_url);
print_r($some_data[0]);
echo( "\nPartial commits count: " . count( $some_data ) );

$all_data = curl_get_all( $commit_url );
print_r($all_data[0]);
echo( "\nAll commits count: " . count( $all_data ) );
```

You can compare the two commits to see that they are the same, and verify that more commits are requested using the new approach.