### PR TITLE
fix: check-before-use in `vip_reset_local_object_cache()`

### DIFF
--- a/vip-helpers/vip-caching.php
+++ b/vip-helpers/vip-caching.php
@@ -636,9 +636,17 @@ function vip_reset_local_object_cache() {
 		return;
 	}
 
-	$wp_object_cache->group_ops      = array();
-	$wp_object_cache->memcache_debug = array();
-	$wp_object_cache->cache          = array();
+	$properties = [
+		'group_ops',
+		'memcache_debug',
+		'cache',
+	];
+
+	foreach ( $properties as $property ) {
+		if ( property_exists( $wp_object_cache, $property ) ) {
+			$wp_object_cache->$property = [];
+		}
+	}
 
 	if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
 		$wp_object_cache->__remoteset(); // important


### PR DESCRIPTION
## Description

This PR adds a check to `vip_reset_local_object_cache()` to ensure the property exists before setting it. This fix addresses the deprecation of dynamic properties in PHP 8.2.

Fixes: #5404

## Changelog Description

### Plugin Updated: VIP Init

Fix `vip_reset_local_object_cache()` to address the deprecation of dynamic properties in PHP 8.2.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See #5404 
