### PR TITLE
Add log suppression to VIP_Request_Block

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -17,6 +17,13 @@
  */
 class VIP_Request_Block {
 	/**
+	 * Suppress logging of blocked requests to reduce log noise.
+	 *
+	 * @var bool
+	 */
+	public static $suppressLog = false;
+
+	/**
 	 * Block a specific IP based either on true-client-ip, falling back to x-forwarded-for
 	 *
 	 * 🛑 BE CAREFUL: blocking a reverse proxy IP instead of the client's IP will result in legitimate traffic being blocked!!!
@@ -137,8 +144,11 @@ class VIP_Request_Block {
 			header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
 			header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
+			if ( ! self::$suppressLog ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
+			}
+
 			exit;
 		}
 

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -166,7 +166,25 @@ class VIP_Request_Block {
 	 * @param bool $should_log whether to log blocked requests.
 	 * @return void
 	 */
-	public static function should_log( bool $should_log = true ) {
+	public static function toggle_logging( bool $should_log = true ) {
 		static::$should_log = $should_log;
+	}
+
+	/**
+	 * Enable logging of blocked requests.
+	 *
+	 * @return void
+	 */
+	public static function enable_logging() {
+		static::toggle_logging( true );
+	}
+
+	/**
+	 * Disable logging of blocked requests.
+	 *
+	 * @return void
+	 */
+	public static function disable_logging() {
+		static::toggle_logging( false );
 	}
 }

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -146,7 +146,7 @@ class VIP_Request_Block {
 
 			if ( static::$should_log ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				self::log( $criteria, $value );
+				static::log( $criteria, $value );
 			}
 
 			exit;

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -21,7 +21,7 @@ class VIP_Request_Block {
 	 *
 	 * @var bool
 	 */
-	public static $suppressLog = false;
+	public static $suppress_log = false;
 
 	/**
 	 * Block a specific IP based either on true-client-ip, falling back to x-forwarded-for
@@ -144,7 +144,7 @@ class VIP_Request_Block {
 			header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
 			header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 
-			if ( ! self::$suppressLog ) {
+			if ( ! static::$suppress_log ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
 			}

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -146,12 +146,17 @@ class VIP_Request_Block {
 
 			if ( ! static::$suppress_log ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
+				log( $criteria, $value );
 			}
 
 			exit;
 		}
 
 		return true;
+	}
+
+	public static function log( string $criteria, string $value ): void {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
 	}
 }

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -17,11 +17,11 @@
  */
 class VIP_Request_Block {
 	/**
-	 * Suppress logging of blocked requests to reduce log noise.
+	 * Controls logging of blocked requests (may be too noisy for some environments).
 	 *
 	 * @var bool
 	 */
-	public static $suppress_log = false;
+	protected static $should_log = true;
 
 	/**
 	 * Block a specific IP based either on true-client-ip, falling back to x-forwarded-for
@@ -144,9 +144,9 @@ class VIP_Request_Block {
 			header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
 			header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 
-			if ( ! static::$suppress_log ) {
+			if ( static::$should_log ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				log( $criteria, $value );
+				self::log( $criteria, $value );
 			}
 
 			exit;
@@ -158,5 +158,15 @@ class VIP_Request_Block {
 	public static function log( string $criteria, string $value ): void {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( sprintf( 'VIP Request Block: request was blocked based on "%s" with value of "%s"', $criteria, $value ) );
+	}
+
+	/**
+	 * Control logging of blocked requests.
+	 *
+	 * @param bool $should_log whether to log blocked requests.
+	 * @return void
+	 */
+	public static function should_log( bool $should_log = true ) {
+		static::$should_log = $should_log;
 	}
 }

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -49,7 +49,6 @@ class Wp_Cli_Db {
 			'query',
 			'prefix',
 			'columns',
-			'size',
 			'tables',
 		];
 

--- a/lib/helpers/wp-cli-db/class-wp-cli-db.php
+++ b/lib/helpers/wp-cli-db/class-wp-cli-db.php
@@ -49,6 +49,7 @@ class Wp_Cli_Db {
 			'query',
 			'prefix',
 			'columns',
+			'size',
 			'tables',
 		];
 

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -9,7 +9,7 @@ class LogTrackingRequestBlock extends VIP_Request_Block {
 	public static $log_called = false;
 
 	public static function log( string $criteria, string $value ): void {
-			self::$log_called = true;
+		self::$log_called = true;
 	}
 }
 
@@ -69,23 +69,23 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 	}
 
 	public function test__error_log_when_suppress_false(): void {
-		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 8.8.8.8';
+		$_SERVER['HTTP_TRUE_CLIENT_IP'] = '1.1.1.1';
 
 		LogTrackingRequestBlock::$suppress_log = false;
 		LogTrackingRequestBlock::$log_called   = false;
 
-		$actual = LogTrackingRequestBlock::ip( '1.1.1.1' );
+		LogTrackingRequestBlock::ip( '1.1.1.1' );
 
 		self::assertTrue( LogTrackingRequestBlock::$log_called );
 	}
 
 	public function test__no_error_log_when_suppress_true(): void {
-		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.1.1.1, 8.8.8.8';
+		$_SERVER['HTTP_TRUE_CLIENT_IP'] = '1.1.1.1';
 		
 		LogTrackingRequestBlock::$suppress_log = true;
 		LogTrackingRequestBlock::$log_called   = false;
 
-		$actual = LogTrackingRequestBlock::ip( '1.1.1.1' );
+		LogTrackingRequestBlock::ip( '1.1.1.1' );
 
 		self::assertFalse( LogTrackingRequestBlock::$log_called );
 	}

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -15,7 +15,7 @@ class LogTrackingRequestBlock extends VIP_Request_Block {
 	public static function block_and_log( string $value, string $criteria ) {
 		if ( static::$should_log ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			self::log( $criteria, $value );
+			static::log( $criteria, $value );
 		}
 	}
 }

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -85,7 +85,7 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 	public function test__no_error_log_when_suppressed(): void {
 		$_SERVER['HTTP_TRUE_CLIENT_IP'] = '1.1.1.1';
 
-		LogTrackingRequestBlock::should_log( false );
+		LogTrackingRequestBlock::toggle_logging( false );
 		LogTrackingRequestBlock::ip( '1.1.1.1' );
 
 		self::assertFalse( LogTrackingRequestBlock::$log_called );
@@ -94,7 +94,7 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 	public function test__error_log_when_not_suppressed(): void {
 		$_SERVER['HTTP_TRUE_CLIENT_IP'] = '1.1.1.1';
 
-		LogTrackingRequestBlock::should_log( true );
+		LogTrackingRequestBlock::toggle_logging( true );
 		LogTrackingRequestBlock::ip( '1.1.1.1' );
 
 		self::assertTrue( LogTrackingRequestBlock::$log_called );


### PR DESCRIPTION
## Description

This PR introduces a new method that allows suppression of the logs. In case it's too noisy a new helper can be used in vip-config.php

```php
/* vip-config.php */
// Supress the logs
VIP_Request_Block::should_log( false );

// Resume the logs
VIP_Request_Block::should_log( true );
```

## Changelog Description

### VIP_Request_Block Log Output Control

Added an option to suppress logging for requests blocked by `VIP_Request_Block`:

```php
/* In vip-config.php */

// Supress the logs
VIP_Request_Block::should_log( false );

// Resume the logs
VIP_Request_Block::should_log( true );
```


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Check out the PR
2. Spin up a dev environment
3. Add `VIP_Request_Block::should_log( false );` to `vip-config.php`
4. Add a block for a local request (I used user-agent, but there's probably a simpler option)
5. Make a request, verify it was blocked, then verify no log entry for the block
6. Remove the `VIP_Request_Block::should_log( false );` line, repeat step 5, verify the block was logged.