### PR TITLE
Jetpack loader: prefer Jetpack loaded from customer-code

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -9,7 +9,7 @@
  * License: GPL2+
  * Text Domain: jetpack
  * Requires at least: 5.7
- * Requires PHP: 5.6
+ * Requires PHP: 8.0
  *
  * @package automattic/jetpack
  */
@@ -528,11 +528,9 @@ function vip_jetpack_load() {
 		return;
 	}
 
-	$jetpack_to_test = array();
-
-	if ( defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && WPCOM_VIP_JETPACK_LOCAL ) {
-		$jetpack_to_test[] = 'local';
-	}
+	$jetpack_to_test = [
+		'local',
+	];
 
 	if ( defined( 'VIP_JETPACK_PINNED_VERSION' ) ) {
 		$jetpack_to_test[] = VIP_JETPACK_PINNED_VERSION;


### PR DESCRIPTION
## Description

Previously we required the constant named `WPCOM_VIP_JETPACK_LOCAL` to signal the want to load from `client-mu-plugins`. Within the current implementation it's an extra step - because we iterate over the list of fallbacks until we find a Jetpack to load.

## Changelog Description

### Plugin Updated: Jetpack Loader

You don't need to set `WPCOM_VIP_JETPACK_LOCAL` constant in order to load Jetpack from `client-mu-plugins`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
