### PR TITLE
fix: `count_users()` returns an array

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1707,7 +1707,7 @@ class Search {
 	public function filter__ep_user_mapping( $mapping ) {
 		$users_count = count_users();
 
-		if ( isset( $users_count->total_users ) && ( $users_count->total_users > self::USER_SHARD_THRESHOLD ) ) {
+		if ( isset( $users_count['total_users'] ) && ( $users_count['total_users'] > self::USER_SHARD_THRESHOLD ) ) {
 			$mapping['settings']['index.number_of_shards'] = 4;
 		}
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -387,13 +387,10 @@ class Search_Test extends WP_UnitTestCase {
 		Features::factory()->setup_features();
 
 		// Simulate a large site
-		$return_big_count = function () {
-			$counts              = new stdClass();
-			$counts->avail_roles = 100;
-			$counts->total_users = 3000000;
-
-			return $counts;
-		};
+		$return_big_count = fn () => [
+			'avail_roles' => 100,
+			'total_users' => 3000000,
+		];
 
 		add_filter( 'pre_count_users', $return_big_count );
 
@@ -405,8 +402,6 @@ class Search_Test extends WP_UnitTestCase {
 			$settings = $mapping['settings'];
 		}
 		$this->assertEquals( 4, $settings['index.number_of_shards'] );
-
-		remove_filter( 'pre_count_users', $return_big_count );
 	}
 
 	public function test__vip_search_filter_ep_default_index_number_of_replicas() {


### PR DESCRIPTION
## Description

In WordPress, `count_users()` returns an array. The code incorrectly assumed the return value to be an object and, as a result, our `ep_user_mapping` filter did not work as expected. 

## Changelog Description

### Plugin Updated: VIP Enterprise Search

Fixed a bug when setting the number of shards in the index settings for the `user` indexable.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

N/A