### PR TITLE
CI: Preserve the .git folder when running --delete-excluded

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Synchronize files
         run: |
-          rsync --delete -a "${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/" "${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/"* "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/" --exclude-from="${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/.dockerignore" --exclude-from="${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/.dockerignore" --exclude="jetpack-*/"
+          rsync --delete --delete-excluded -a "${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/" "${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/"* "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/" --exclude-from="${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/.dockerignore" --exclude-from="${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/.dockerignore" --exclude="/jetpack-*/"
 
       - name: Clean up
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,8 +49,9 @@ jobs:
 
       - name: Synchronize files
         run: |
+          mv .git .git.bak
           rsync --delete --delete-excluded -a "${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/" "${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/"* "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/" --exclude-from="${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/.dockerignore" --exclude-from="${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/.dockerignore" --exclude="/jetpack-*/"
-
+          mv .git.bak .git
       - name: Clean up
         run: |
           TARGET="${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Synchronize files
         run: |
-          mv .git .git.bak
+          mv "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/.git" "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/.git.bak"
           rsync --delete --delete-excluded -a "${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/" "${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/"* "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/" --exclude-from="${GITHUB_WORKSPACE}/${SOURCE_REPO_PATH}/.dockerignore" --exclude-from="${GITHUB_WORKSPACE}/${EXT_REPO_PATH}/.dockerignore" --exclude="/jetpack-*/"
-          mv .git.bak .git
+          mv "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/.git.bak" "${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}/.git"
       - name: Clean up
         run: |
           TARGET="${GITHUB_WORKSPACE}/${TARGET_REPO_PATH}"


### PR DESCRIPTION
Previous PR got a bit overzealous with `--delete-excluded`, We need to preserve it. 
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
