### PR TITLE
Integrations: Add Enterprise Search

### DIFF
--- a/integrations/enterprise-search.php
+++ b/integrations/enterprise-search.php
@@ -33,4 +33,32 @@ class EnterpriseSearchIntegration extends Integration {
 
 		require_once __DIR__ . '/../search/search.php';
 	}
+
+	/**
+	 * Configure `Enterprise Search` for VIP Platform.
+	 */
+	public function configure(): void {
+		if ( $this->is_es_credentials_set() ) {
+			return;
+		}
+
+		add_action( 'vip_search_loaded', array( $this, 'vip_set_es_credentials' ) );
+	}
+
+	/**
+	 * Set the Elasticsearch credentials.
+	 */
+	public function vip_set_es_credentials(): void {
+		$config = $this->get_config();
+		if ( isset( $config['username'] ) && isset( $config['password'] ) ) {
+			define( 'VIP_ELASTICSEARCH_USERNAME', $config['username'] );
+			define( 'VIP_ELASTICSEARCH_PASSWORD', $config['password'] );
+		}
+	}
+
+	private function is_es_credentials_set(): bool {
+		$username_defined = defined( 'VIP_ELASTICSEARCH_USERNAME' ) && constant( 'VIP_ELASTICSEARCH_USERNAME' );
+		$password_defined = defined( 'VIP_ELASTICSEARCH_PASSWORD' ) && constant( 'VIP_ELASTICSEARCH_PASSWORD' );
+		return $username_defined && $password_defined;
+	}
 }

--- a/integrations/enterprise-search.php
+++ b/integrations/enterprise-search.php
@@ -16,7 +16,7 @@ class EnterpriseSearchIntegration extends Integration {
 	 * this function to prevent loading of integration again from platform side.
 	 */
 	public function is_loaded(): bool {
-		return class_exists( '\Automattic\VIP\Search\Search' );
+		return class_exists( \Automattic\VIP\Search\Search::class );
 	}
 
 	/**

--- a/integrations/enterprise-search.php
+++ b/integrations/enterprise-search.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Integration: Enterprise Search.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+/**
+ * Loads Enterprise Search VIP Integration.
+ *
+ * @private
+ */
+class EnterpriseSearchIntegration extends Integration {
+	/**
+	 * Returns `true` if Enterprise Search is already available e.g. customer code. We will use
+	 * this function to prevent loading of integration again from platform side.
+	 */
+	public function is_loaded(): bool {
+		return class_exists( '\Automattic\VIP\Search\Search' );
+	}
+
+	/**
+	 * Loads the plugin.
+	 *
+	 * @private
+	 */
+	public function load(): void {
+		// Return if the integration is already loaded.
+		//
+		// In activate() method we do make sure to not activate the integration if its already loaded
+		// but still adding it here as a safety measure i.e. if load() is called directly.
+		if ( $this->is_loaded() ) {
+			return;
+		}
+
+		require_once __DIR__ . '/../search/search.php';
+	}
+}

--- a/integrations/enterprise-search.php
+++ b/integrations/enterprise-search.php
@@ -11,6 +11,14 @@ namespace Automattic\VIP\Integrations;
  * Loads Enterprise Search VIP Integration.
  */
 class EnterpriseSearchIntegration extends Integration {
+
+	/**
+	 * The version of Enterprise Search to load.
+	 *
+	 * @var string
+	 */
+	protected string $version = '1.0';
+
 	/**
 	 * Returns `true` if Enterprise Search is already available e.g. customer code. We will use
 	 * this function to prevent loading of integration again from platform side.
@@ -31,7 +39,14 @@ class EnterpriseSearchIntegration extends Integration {
 			return;
 		}
 
-		require_once __DIR__ . '/../search/search.php';
+		// Load the version of the plugin that should be set to the latest version, otherwise if it's not found, fallback to the one in MU.
+		$load_path    = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/vip-enterprise-search-' . $this->version . '/src/search.php';
+		$use_versions = false; // Remove this once we are ready to use the versioned plugin.
+		if ( $use_versions && file_exists( $load_path ) ) {
+			require_once $load_path;
+		} else {
+			require_once __DIR__ . '/../search/search.php';
+		}
 	}
 
 	/**

--- a/integrations/enterprise-search.php
+++ b/integrations/enterprise-search.php
@@ -9,8 +9,6 @@ namespace Automattic\VIP\Integrations;
 
 /**
  * Loads Enterprise Search VIP Integration.
- *
- * @private
  */
 class EnterpriseSearchIntegration extends Integration {
 	/**
@@ -23,8 +21,6 @@ class EnterpriseSearchIntegration extends Integration {
 
 	/**
 	 * Loads the plugin.
-	 *
-	 * @private
 	 */
 	public function load(): void {
 		// Return if the integration is already loaded.

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -135,12 +135,14 @@ class IntegrationVipConfig {
 	 * Get site config.
 	 *
 	 * @return array
-	 *
-	 * @private
 	 */
 	public function get_site_config() {
 		if ( is_multisite() ) {
 			$config = $this->get_value_from_config( 'network_sites', 'config' );
+			// If network site config is not found then fallback to env config if it exists
+			if ( empty( $config ) && true === $this->get_value_from_config( 'env', 'cascadeConfig' ) ) {
+				$config = $this->get_value_from_config( 'env', 'config' );
+			}
 		} else {
 			$config = $this->get_value_from_config( 'env', 'config' );
 		}

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -140,7 +140,7 @@ class IntegrationVipConfig {
 		if ( is_multisite() ) {
 			$config = $this->get_value_from_config( 'network_sites', 'config' );
 			// If network site config is not found then fallback to env config if it exists
-			if ( empty( $config ) && true === $this->get_value_from_config( 'env', 'cascadeConfig' ) ) {
+			if ( empty( $config ) && true === $this->get_value_from_config( 'env', 'cascade_config' ) ) {
 				$config = $this->get_value_from_config( 'env', 'config' );
 			}
 		} else {

--- a/tests/integrations/test-enterprise-search.php
+++ b/tests/integrations/test-enterprise-search.php
@@ -55,4 +55,23 @@ class VIP_EnterpriseSearch_Integration_Test extends WP_UnitTestCase {
 			$this->assertTrue( class_exists( '\Automattic\VIP\Search\Search' ) );
 		}
 	}
+
+	public function test__configure_action(): void {
+		$credentials    = [
+			'username' => 'test-username',
+			'password' => 'foo-bar',
+		];
+		$es_integration = new EnterpriseSearchIntegration( $this->slug );
+		$es_integration->configure();
+
+		get_class_property_as_public( Integration::class, 'options' )->setValue( $es_integration, [
+			'config' => $credentials,
+		] );
+
+		do_action( 'vip_search_loaded' );
+
+		$this->assertEquals( 10, has_action( 'vip_search_loaded', [ $es_integration, 'vip_set_es_credentials' ] ) );
+		$this->assertEquals( constant( 'VIP_ELASTICSEARCH_USERNAME' ), $credentials['username'] );
+		$this->assertEquals( constant( 'VIP_ELASTICSEARCH_PASSWORD' ), $credentials['password'] );
+	}
 }

--- a/tests/integrations/test-enterprise-search.php
+++ b/tests/integrations/test-enterprise-search.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Test: Enterprise Search Integration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_UnitTestCase;
+
+use function Automattic\Test\Utils\get_class_property_as_public;
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+class VIP_EnterpriseSearch_Integration_Test extends WP_UnitTestCase {
+	private string $slug = 'enterprise-search';
+
+	public function test_is_loaded_returns_true_if_es_exist(): void {
+		require_once __DIR__ . '/../../search/search.php';
+
+		$es_integration = new EnterpriseSearchIntegration( $this->slug );
+		$this->assertTrue( $es_integration->is_loaded() );
+	}
+
+	public function test__load_call_returns_without_requiring_class_if_es_is_already_loaded(): void {
+		/**
+		 * Integration mock.
+		 *
+		 * @var MockObject|EnterpriseSearchIntegration
+		 */
+		$es_integration_mock = $this->getMockBuilder( EnterpriseSearchIntegration::class )->setConstructorArgs( [ 'enterprise-search' ] )->onlyMethods( [ 'is_loaded' ] )->getMock();
+		$es_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( true );
+		$preload_state = class_exists( '\Automattic\VIP\Search\Search' );
+
+		$es_integration_mock->load();
+
+		$this->assertEquals( $preload_state, class_exists( '\Automattic\VIP\Search\Search' ) );
+	}
+
+	public function test__load_call_if_class_not_exist(): void {
+		/**
+		 * Integration mock.
+		 *
+		 * @var MockObject|EnterpriseSearchIntegration
+		 */
+		$es_integration_mock = $this->getMockBuilder( EnterpriseSearchIntegration::class )->setConstructorArgs( [ 'enterprise-search' ] )->onlyMethods( [ 'is_loaded' ] )->getMock();
+		$es_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( false );
+		$existing_value = class_exists( '\Automattic\VIP\Search\Search' );
+
+		$es_integration_mock->load();
+
+		if ( ! $existing_value ) {
+			$this->assertTrue( class_exists( '\Automattic\VIP\Search\Search' ) );
+		}
+	}
+}

--- a/tests/integrations/test-integration-vip-config.php
+++ b/tests/integrations/test-integration-vip-config.php
@@ -231,6 +231,28 @@ class VIP_Integration_Vip_Config_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test__get_site_config_with_cascading_config(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Only valid for multisite.' );
+		}
+
+		$this->do_test_get_site_config(
+			[
+				'env'           => [
+					'status'        => Env_Integration_Status::ENABLED,
+					'config'        => array( 'env-config' ),
+					'cascadeConfig' => true,
+				],
+				'network_sites' => [
+					'1' => [
+						'status' => Env_Integration_Status::ENABLED,
+					],
+				],
+			],
+			array( 'env-config' ),
+		);
+	}
+
 	/**
 	 * Helper function for testing `get_site_config`.
 	 *

--- a/tests/integrations/test-integration-vip-config.php
+++ b/tests/integrations/test-integration-vip-config.php
@@ -239,9 +239,9 @@ class VIP_Integration_Vip_Config_Test extends WP_UnitTestCase {
 		$this->do_test_get_site_config(
 			[
 				'env'           => [
-					'status'        => Env_Integration_Status::ENABLED,
-					'config'        => array( 'env-config' ),
-					'cascadeConfig' => true,
+					'status'         => Env_Integration_Status::ENABLED,
+					'config'         => array( 'env-config' ),
+					'cascade_config' => true,
 				],
 				'network_sites' => [
 					'1' => [

--- a/tests/integrations/test-parsely.php
+++ b/tests/integrations/test-parsely.php
@@ -9,6 +9,7 @@ namespace Automattic\VIP\Integrations;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
+use Automattic\Test\Constant_Mocker;
 
 use function Automattic\Test\Utils\get_class_property_as_public;
 
@@ -32,11 +33,11 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		 */
 		$parsely_integration_mock = $this->getMockBuilder( ParselyIntegration::class )->setConstructorArgs( [ 'parsely' ] )->onlyMethods( [ 'is_loaded' ] )->getMock();
 		$parsely_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( true );
-		$preload_state = defined( 'VIP_PARSELY_ENABLED' );
+		$preload_state = Constant_Mocker::defined( 'VIP_PARSELY_ENABLED' );
 
 		$parsely_integration_mock->load();
 
-		$this->assertEquals( $preload_state, defined( 'VIP_PARSELY_ENABLED' ) );
+		$this->assertEquals( $preload_state, Constant_Mocker::defined( 'VIP_PARSELY_ENABLED' ) );
 	}
 
 	public function test__load_call_is_setting_the_enabled_constant_if_no_constant_is_defined(): void {
@@ -47,14 +48,14 @@ class VIP_Parsely_Integration_Test extends WP_UnitTestCase {
 		 */
 		$parsely_integration_mock = $this->getMockBuilder( ParselyIntegration::class )->setConstructorArgs( [ 'parsely' ] )->onlyMethods( [ 'is_loaded' ] )->getMock();
 		$parsely_integration_mock->expects( $this->once() )->method( 'is_loaded' )->willReturn( false );
-		$existing_value = defined( 'VIP_PARSELY_ENABLED' ) ? VIP_PARSELY_ENABLED : null;
+		$existing_value = Constant_Mocker::defined( 'VIP_PARSELY_ENABLED' ) ? Constant_Mocker::constant( 'VIP_PARSELY_ENABLED' ) : null;
 
 		$parsely_integration_mock->load();
 
 		if ( is_null( $existing_value ) || $existing_value ) {
-			$this->assertTrue( VIP_PARSELY_ENABLED );
+			$this->assertTrue( Constant_Mocker::constant( 'VIP_PARSELY_ENABLED' ) );
 		} else {
-			$this->assertFalse( defined( 'VIP_PARSELY_ENABLED' ) );
+			$this->assertFalse( Constant_Mocker::defined( 'VIP_PARSELY_ENABLED' ) );
 		}
 	}
 

--- a/tests/mock-constants.php
+++ b/tests/mock-constants.php
@@ -232,3 +232,19 @@ namespace Automattic\VIP\Mail {
 		return Constant_Mocker::constant( $constant );
 	}
 }
+
+namespace Automattic\VIP\Integrations {
+	use Automattic\Test\Constant_Mocker;
+
+	function define( $constant, $value ) {
+		return Constant_Mocker::define( $constant, $value );
+	}
+
+	function defined( $constant ) {
+		return Constant_Mocker::defined( $constant );
+	}
+
+	function constant( $constant ) {
+		return Constant_Mocker::constant( $constant );
+	}
+}

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -22,11 +22,13 @@ require_once __DIR__ . '/integrations/integration-vip-config.php';
 require_once __DIR__ . '/integrations/block-data-api.php';
 require_once __DIR__ . '/integrations/parsely.php';
 require_once __DIR__ . '/integrations/vip-governance.php';
+require_once __DIR__ . '/integrations/enterprise-search.php';
 
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
 IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
+IntegrationsSingleton::instance()->register( new EnterpriseSearchIntegration( 'enterprise-search' ) );
 // @codeCoverageIgnoreEnd
 
 /**


### PR DESCRIPTION
## Description
This PR does two things:
- Adds ES as an integration
- Adds cascadingConfig ability to configs on multisites

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1) Using dev-env, create a multisite
2) Create another subsite to be site ID 2
3) Inside the PHP container, create `/wp/config/integrations-config/enterprise-search-config.php` (you will probably need to create the `integrations-config` folder) with contents:
```
<?php

return array(
  'env' => array(
  	'status' => 'disabled',
  	'config' => array (
  		'username' => 'test-username',
  		'password' => 'test-password',
  	),
	'cascade_config' => true,
  ),
  'network_sites' => array (
  	'1' => array (
  		'status' => 'enabled',
  		'config' => array (
  		)
  	),
  )
);
```
3) Verify integration being enabled on site 1, but not on 2 with the existence of CLI command `vip dev-env exec -- wp --url=<siteUrl> vip-search`