### PR TITLE
Add the ability to define a custom VIP integrations config directory

### DIFF
--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -78,7 +78,9 @@ class IntegrationVipConfig {
 	 * @return null|mixed
 	 */
 	protected function get_vip_config_from_file( string $slug ) {
-		$config_file_directory = ABSPATH . 'config/integrations-config';
+		$config_file_directory = defined( 'WPVIP_INTEGRATIONS_CONFIG_DIR' )
+			? constant( 'WPVIP_INTEGRATIONS_CONFIG_DIR' )
+			: ABSPATH . 'config/integrations-config';
 		$config_file_name      = $slug . '-config.php';
 		$config_file_path      = $config_file_directory . '/' . $config_file_name;
 


### PR DESCRIPTION
## Description

This PR adds the ability to define a custom directory for the VIP integrations config dir by setting a `WPVIP_INTEGRATIONS_CONFIG_DIR` constant.

## Changelog Description
<!--
A description of the context of the change for a changelog. It should have a title, examples (if applicable), and why the change was made.

**Please keep the changelog title format same as in example below (### <Title>), as this is later used to generate the changelog entry title.**

Example for a plugin upgrade:

### Plugin Updated: Jetpack 9.2.1

We upgraded Jetpack 9.2 to Jetpack 9.2.1.

Not a lot of significant changes in this patch release, just bugfixes and compatibility improvements.
-->
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
