### PR TITLE
CI: set minimum Parse.ly version to 3.5

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -54,7 +54,7 @@ runs:
       run: |
         if [ "${{ inputs.coverage }}" = "yes" ] && [ -n "${{ inputs.coverage-file }}" ]; then
           echo "coverage=pcov" >> $GITHUB_OUTPUT
-          echo 'ini=apc.enable_cli=1, pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|advanced-post-cache|akismet|cron-control|debug-bar|debug-bar-cron|drop-ins|http-concat|lightweight-term-count-update|query-monitor|(search/(elasticpress|debug-bar-elasticpress|es-wp-query))|shared-plugins|rewrite-rules-inspector|vaultpress|wordpress-importer)/~"' >> $GITHUB_OUTPUT
+          echo 'ini=apc.enable_cli=1, pcov.directory=., pcov.exclude="~/(vendor|tests|node_modules|jetpack[^/]*|wp-parsely[^/]+|advanced-post-cache|akismet|cron-control|drop-ins|http-concat|lightweight-term-count-update|query-monitor|(search/(elasticpress|debug-bar-elasticpress|es-wp-query))|shared-plugins|rewrite-rules-inspector|vaultpress|wordpress-importer)/~"' >> $GITHUB_OUTPUT
         else
           echo "coverage=none" >> $GITHUB_OUTPUT
           echo "ini=apc.enable_cli=1, opcache.enable_cli=1" >> $GITHUB_OUTPUT

--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -89,7 +89,7 @@ runs:
       run: echo "WP_MULTISITE=1" >> $GITHUB_ENV
       if: inputs.multisite == 'yes'
 
-    - name: Disable JetPack
+    - name: Disable Jetpack
       shell: bash
       run: echo "VIP_JETPACK_SKIP_LOAD=1" >> $GITHUB_ENV
       if: inputs.jetpack == 'no'

--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -23,20 +23,20 @@ jobs:
       matrix:
         config:
           # Oldest version of the parsely plugin
-          - { wp: latest, parsely: '3.1', mode: 'filter_enabled', php: '8.0' }
-          - { wp: latest, parsely: '3.1', mode: 'filter_disabled', php: '8.0' }
-          - { wp: latest, parsely: '3.1', mode: 'option_enabled', php: '8.0' }
-          - { wp: latest, parsely: '3.1', mode: 'option_disabled', php: '8.0' }
-          - { wp: latest, parsely: '3.1', mode: 'filter_and_option_enabled', php: '8.0' }
-          - { wp: latest, parsely: '3.1', mode: 'filter_and_option_disabled', php: '8.0' }
+          - { wp: latest, parsely: '3.5', mode: 'filter_enabled', php: '8.1' }
+          - { wp: latest, parsely: '3.5', mode: 'filter_disabled', php: '8.1' }
+          - { wp: latest, parsely: '3.5', mode: 'option_enabled', php: '8.1' }
+          - { wp: latest, parsely: '3.5', mode: 'option_disabled', php: '8.1' }
+          - { wp: latest, parsely: '3.5', mode: 'filter_and_option_enabled', php: '8.1' }
+          - { wp: latest, parsely: '3.5', mode: 'filter_and_option_disabled', php: '8.1' }
 
           # Latest version of the parsely plugin
-          - { wp: latest, mode: 'filter_enabled', php: '8.0' }
-          - { wp: latest, mode: 'filter_disabled', php: '8.0' }
-          - { wp: latest, mode: 'option_enabled', php: '8.0' }
-          - { wp: latest, mode: 'option_disabled', php: '8.0' }
-          - { wp: latest, mode: 'filter_and_option_enabled', php: '8.0' }
-          - { wp: latest, mode: 'filter_and_option_disabled', php: '8.0' }
+          - { wp: latest, mode: 'filter_enabled', php: '8.1' }
+          - { wp: latest, mode: 'filter_disabled', php: '8.1' }
+          - { wp: latest, mode: 'option_enabled', php: '8.1' }
+          - { wp: latest, mode: 'option_disabled', php: '8.1' }
+          - { wp: latest, mode: 'filter_and_option_enabled', php: '8.1' }
+          - { wp: latest, mode: 'filter_and_option_disabled', php: '8.1' }
     services:
       mysql:
         image: mysql:8


### PR DESCRIPTION
## Description

After cleaning up https://github.com/Automattic/vip-go-mu-plugins-ext the minimum Parse.ly version became 3.5 so we should use that.

Additionally bump Parse.ly's PHP version to 8.1

Also fixes some typos and removes a couple of other folders from coverage action.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
