### PR TITLE
Group package updates in the same namespace together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,4 +75,4 @@ groups:
     applies-to: version-updates
     patterns:
     - "eslint"
-    - "babel-*"
+    - "eslint-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,17 @@ updates:
     labels:
       - '[Status] Needs Review'
       - '[Status] No files to Deploy'
+    groups:
+      babel:
+        applies-to: version-updates
+        patterns:
+        - "@babel*"
+        - "babel-*"
+      eslint:
+        applies-to: version-updates
+        patterns:
+        - "eslint"
+        - "eslint-*"
 
   - directory: /__tests__/e2e/
     package-ecosystem: npm
@@ -55,6 +66,17 @@ updates:
     versioning-strategy: increase-if-necessary
     labels:
       - '[Status] Needs Review'
+    groups:
+      babel:
+        applies-to: version-updates
+        patterns:
+        - "@babel*"
+        - "babel-*"
+      eslint:
+        applies-to: version-updates
+        patterns:
+        - "eslint"
+        - "eslint-*"
 
   - directory: /
     package-ecosystem: composer
@@ -63,16 +85,3 @@ updates:
     versioning-strategy: increase-if-necessary
     labels:
       - '[Status] Needs Review'
-
-# Group certain dependencies, which should normally be updated altogether:
-groups:
-  babel:
-    applies-to: version-updates
-    patterns:
-    - "@babel*"
-    - "babel-*"
-  eslint:
-    applies-to: version-updates
-    patterns:
-    - "eslint"
-    - "eslint-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,14 +65,14 @@ updates:
       - '[Status] Needs Review'
 
 # Group certain dependencies together, which should normally be updated altogether:
-  - groups:
-    babel:
-      applies-to: version-updates
-      patterns:
-      - "@babel*"
-      - "babel-*"
-    eslint:
-      applies-to: version-updates
-      patterns:
-      - "eslint"
-      - "babel-*"
+groups:
+  babel:
+    applies-to: version-updates
+    patterns:
+    - "@babel*"
+    - "babel-*"
+  eslint:
+    applies-to: version-updates
+    patterns:
+    - "eslint"
+    - "babel-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,16 @@ updates:
     versioning-strategy: increase-if-necessary
     labels:
       - '[Status] Needs Review'
+
+# Group certain dependencies together, which should normally be updated altogether:
+  - groups:
+    babel:
+      applies-to: version-updates
+      patterns:
+      - "@babel*"
+      - "babel-*"
+    eslint:
+      applies-to: version-updates
+      patterns:
+      - "eslint"
+      - "babel-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,7 @@ updates:
     labels:
       - '[Status] Needs Review'
 
-# Group certain dependencies together, which should normally be updated altogether:
+# Group certain dependencies, which should normally be updated altogether:
 groups:
   babel:
     applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,11 @@ updates:
         patterns:
         - "eslint"
         - "eslint-*"
+      react:
+        applies-to: version-updates
+        patterns:
+        - "react"
+        - "react-dom"
 
   - directory: /__tests__/e2e/
     package-ecosystem: npm


### PR DESCRIPTION
Many projects in the JS ecosystem split functionality into multiple smaller packages so you can include functionality as needed. It makes a lot of sense to update these as a group (e.g., to update every `babel` related package in one PR): 

1. Fewer PRs to review, test, and manage reduces developer workload
2. Often, these updates _must_ be merged at the same time. For example, when we update to Babel 8, we will need to update most of the babel packages to version 8 simultaneously for compatibility.
3. Extra packages are updated in the package-lock anyways. For example, when updating one babel plugin (https://github.com/Automattic/vip-go-mu-plugins/pull/5518/files#diff-6019080c74c204b559b8222a95184785c8920b70c325e5d9d68f95ac4e3c9475L172), a number of other babel packages are updated simultaneously in the package-lock. This happens because the package we're updating has an updated dependency on these other babel packages, and our semver allows for them to be updated. As a result, other update PRs can easily get stale.

edit: looks like this will be easier to implement after https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/