### PR TITLE
fix(files-acl): more thorough filename sanitization

### DIFF
--- a/files/acl/pre-wp-utils.php
+++ b/files/acl/pre-wp-utils.php
@@ -66,6 +66,13 @@ function validate_path( $file_path ) {
 		return false;
 	}
 
+	$decoded = urldecode( $file_path );
+	if ( false !== strpos( $decoded, './' ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		trigger_error( sprintf( 'VIP Files ACL failed due to a possible path traversal attack (for %s)', htmlspecialchars( $file_path ) ), E_USER_WARNING );
+		return false;
+	}
+
 	return true;
 }
 
@@ -79,7 +86,9 @@ function validate_path( $file_path ) {
  * @return array $file_paths Indexed array with two entries: 0 is the path before `/wp-content/uploads/` and 1 is the path + file after.
  */
 function sanitize_and_split_path( $file_path ) {
-	list( $pre_wpcontent_path, $post_wpcontent_path ) = explode( '/wp-content/uploads/', $file_path, 2 );
+	$decoded    = urldecode( $file_path );
+	$compressed = preg_replace( '!/{2,}!', '/', $decoded );
+	list( $pre_wpcontent_path, $post_wpcontent_path ) = explode( '/wp-content/uploads/', $compressed, 2 );
 
 	return [
 		$pre_wpcontent_path,

--- a/files/acl/pre-wp-utils.php
+++ b/files/acl/pre-wp-utils.php
@@ -73,6 +73,13 @@ function validate_path( $file_path ) {
 		return false;
 	}
 
+	// Trailing whitespace (like %0A) in the filename. This won't work on our prod servers but will work in dev env.
+	if ( strlen( rtrim( $decoded ) ) !== strlen( $decoded ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		trigger_error( sprintf( 'VIP Files ACL failed due to a possible attack (for %s)', htmlspecialchars( $file_path ) ), E_USER_WARNING );
+		return false;
+	}
+
 	return true;
 }
 

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -83,39 +83,49 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 
 	public function get_data__validate_path__invalid() {
 		return [
-			'null-uri'                     => [
+			'null-uri'                       => [
 				null,
 				'VIP Files ACL failed due to empty path',
 			],
 
-			'empty-uri'                    => [
+			'empty-uri'                      => [
 				'',
 				'VIP Files ACL failed due to empty path',
 			],
 
-			'path-no-wp-content'           => [
+			'path-no-wp-content'             => [
 				'/a/path/to/a/file.jpg',
 				'VIP Files ACL failed due to invalid path (for /a/path/to/a/file.jpg)',
 			],
 
-			'relative-url-with-wp-content' => [
+			'relative-url-with-wp-content'   => [
 				'en/wp-content/uploads/file.png',
 				'VIP Files ACL failed due to relative path (for en/wp-content/uploads/file.png)',
 			],
 
-			'path-traversal-dot'           => [
+			'path-traversal-dot'             => [
 				'/wp-content/uploads/./file.jpg',
 				'VIP Files ACL failed due to a possible path traversal attack (for /wp-content/uploads/./file.jpg)',
 			],
 
-			'path-traversal'               => [
+			'path-traversal'                 => [
 				'/wp-content/uploads/../file.jpg',
 				'VIP Files ACL failed due to a possible path traversal attack (for /wp-content/uploads/../file.jpg)',
 			],
 
-			'trailing-whitespace'          => [
+			'path-traversal-urlencoded'      => [
+				'/wp-content/uploads/..%2Ffile.jpg',
+				'VIP Files ACL failed due to a possible path traversal attack (for /wp-content/uploads/..%2Ffile.jpg)',
+			],
+
+			'trailing-whitespace'            => [
 				'/wp-content/uploads/file.jpg ',
 				'VIP Files ACL failed due to a possible attack (for /wp-content/uploads/file.jpg )',
+			],
+
+			'trailing-whitespace-urlencoded' => [
+				'/wp-content/uploads/file.jpg%0a',
+				'VIP Files ACL failed due to a possible attack (for /wp-content/uploads/file.jpg%0a)',
 			],
 		];
 	}
@@ -218,6 +228,14 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 				[
 					'',
 					'path/to/wp-content/uploads/otters.png',
+				],
+			],
+
+			'urlencoded'                     => [
+				'/wp-content/uploads/%6B%69%74%74%65%6e%73%2egif',
+				[
+					'',
+					'kittens.gif',
 				],
 			],
 

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -102,6 +102,21 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 				'en/wp-content/uploads/file.png',
 				'VIP Files ACL failed due to relative path (for en/wp-content/uploads/file.png)',
 			],
+
+			'path-traversal-dot'           => [
+				'/wp-content/uploads/./file.jpg',
+				'VIP Files ACL failed due to a possible path traversal attack (for /wp-content/uploads/./file.jpg)',
+			],
+
+			'path-traversal'               => [
+				'/wp-content/uploads/../file.jpg',
+				'VIP Files ACL failed due to a possible path traversal attack (for /wp-content/uploads/../file.jpg)',
+			],
+
+			'trailing-whitespace'          => [
+				'/wp-content/uploads/file.jpg ',
+				'VIP Files ACL failed due to a possible attack (for /wp-content/uploads/file.jpg )',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Description

Improve (or introduce) filename sanitization in the ACL validation:
- URL decode the file name
- disallow `./` patterns (this also prevents path traversal attacks: `./` matches `../` as well);
- disallow trailing whitespace (this only affects dev env);
- compress multiple slashes.

## Changelog Description

### Fixed
- Filename sanitization during ACL validation in VIP Restricted Files plugin

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See BB8-11310 for details.