### PR TITLE
Jetpack: Update default to 13.4 from 13.3

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3.1
+ * Version: 13.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack

--- a/jetpack.php
+++ b/jetpack.php
@@ -39,7 +39,7 @@ function vip_default_jetpack_version() {
 		return '13.1';
 	} else {
 		// WordPress 6.4 and newer.
-		return '13.3';
+		return '13.4';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '13.3';
+		$latest = '13.4';
 
 		$versions_map = [
 			// WordPress version => Jetpack version


### PR DESCRIPTION
## Description
Default Jetpack version is now 13.4

## Changelog Description

### Changed
- Jetpack default version is now 13.4

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->