### PR TITLE
feat(vary-cache): allow for customizing cookie path and domain

### DIFF
--- a/cache/class-vary-cache.php
+++ b/cache/class-vary-cache.php
@@ -613,9 +613,11 @@ class Vary_Cache {
 	 * @param string $value Cookie Value.
 	 */
 	private static function set_cookie( $name, $value ) {
-		$expiry = time() + self::$cookie_expiry;
+		$expiry        = time() + self::$cookie_expiry;
+		$cookie_path   = (string) apply_filters( 'vip_vary_cache_cookie_path', COOKIEPATH );
+		$cookie_domain = (string) apply_filters( 'vip_vary_cache_cookie_domain', COOKIE_DOMAIN );
 		// Need to use setrawcookie() here to prevent PHP from URLEncoding the base-64 terminator (==) on encrypted payloads
-		setrawcookie( $name, $value, $expiry, COOKIEPATH, COOKIE_DOMAIN );
+		setrawcookie( $name, $value, $expiry, $cookie_path, $cookie_domain );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fixes: #5531 

## Changelog Description

### Added

It is now possible to customize the cookie path and domain for the cookies set by the Vary Cache plugin. To achieve that, we introduced two new filters: `vip_vary_cache_cookie_path` and `vip_vary_cache_cookie_domain`.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See #5531.
