### PR TITLE
Removed submodule shared-plugins/jetpack-force-2fa

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "http-concat"]
 	path = http-concat
 	url = https://github.com/Automattic/nginx-http-concat.git
-[submodule "shared-plugins/jetpack-force-2fa"]
-	path = shared-plugins/jetpack-force-2fa
-	url = https://github.com/Automattic/jetpack-force-2fa.git
 [submodule "lightweight-term-count-update"]
 	path = lightweight-term-count-update
 	url = https://github.com/Automattic/lightweight-term-count-update

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1261,7 +1261,6 @@ function wpcom_vip_can_use_shared_plugin( $plugin ) {
 	// Array of shared plugins we are not deprecating
 	$protected_shared_plugins = array(
 		'two-factor',
-		'jetpack-force-2fa',
 	);
 
 	if ( ! defined( 'WPCOM_VIP_DISABLE_SHARED_PLUGINS' ) ) {


### PR DESCRIPTION
## Description
This removes the jetpack-force-2fa plugin from shared-plugins folder now that it is built into Jetpack 12.7+: https://github.com/Automattic/jetpack/blob/ad49374b17a8801f0faa493bfd5ee8e79acd5df7/projects/packages/connection/src/sso/class-sso.php#L69-L91


## Changelog Description

### Removed
- Remove jetpack-force-2fa plugin from shared-plugins folder, as it is included now in SSO module for Jetpack 12.7+. Use `add_filter( 'jetpack_force_2fa', '__return_true' );` to enable.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->