### PR TITLE
Force secure_logged_in_cookie to always be true

### DIFF
--- a/security.php
+++ b/security.php
@@ -397,3 +397,13 @@ function vip_send_wplogin_header( $user ) {
 	return $user;
 }
 add_filter( 'determine_current_user', 'vip_send_wplogin_header', 10000 );
+
+/**
+ * Force secure_logged_in_cookie to be always secure no matter what.
+ * 
+ * @return true Always return true to force secure_logged_in_cookie to be secure.
+ */
+function vip_force_secure_logged_in_cookie() {
+	return true;
+}
+add_filter( 'secure_logged_in_cookie', 'vip_force_secure_logged_in_cookie' );

--- a/security.php
+++ b/security.php
@@ -399,11 +399,16 @@ function vip_send_wplogin_header( $user ) {
 add_filter( 'determine_current_user', 'vip_send_wplogin_header', 10000 );
 
 /**
- * Force secure_logged_in_cookie to be always secure no matter what.
+ * Force secure_logged_in_cookie to be always secure on VIP environments.
  * 
- * @return true Always return true to force secure_logged_in_cookie to be secure.
+ * @param bool $secure_logged_in_cookie Whether the logged in cookie should only be sent over HTTPS.
+ * @return bool Return true on VIP environments, otherwise return the original value.
  */
-function vip_force_secure_logged_in_cookie() {
-	return true;
+function vip_force_secure_logged_in_cookie( $secure_logged_in_cookie ) {
+	if ( Context::is_vip_env() && ! is_local_env() ) {
+		return true;
+	}
+
+	return $secure_logged_in_cookie;
 }
 add_filter( 'secure_logged_in_cookie', 'vip_force_secure_logged_in_cookie' );


### PR DESCRIPTION
## Description
Forces `secure_logged_in_cookie` to be always `true`

## Changelog Description

### Changed
- Force `secure_logged_in_cookie` to always return true

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->