### PR TITLE
CI: Update e2e tests to run on PHP 8.2

### DIFF
--- a/__tests__/e2e/bin/setup-env.sh
+++ b/__tests__/e2e/bin/setup-env.sh
@@ -26,7 +26,7 @@ fi
 vip dev-env destroy --slug=e2e-test-site || true
 
 # Create and run test site
-vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --mailpit false --wordpress=trunk --multisite=false --app-code="${clientCodePath}" --php 8.0 --xdebug false --phpmyadmin false --elasticsearch true < /dev/null
+vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --mailpit false --wordpress=trunk --multisite=false --app-code="${clientCodePath}" --php 8.2 --xdebug false --phpmyadmin false --elasticsearch true < /dev/null
 vip dev-env start --slug e2e-test-site --skip-wp-versions-check
 vip dev-env shell --root --slug e2e-test-site -- chown -R www-data:www-data /wp
 vip dev-env exec --slug e2e-test-site --quiet -- wp plugin install --activate classic-editor


### PR DESCRIPTION
## Description
Currently b0rked because:
```
Error:  Unknown or unsupported PHP version: 8.0.
Debug:  VIP-CLI v3.3.0, Node v20.14.0, linux 6.5.0-1021-azure x64
```
