### PR TITLE
Run unit tests under x86 platform with docker

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -115,6 +115,7 @@ docker run \
     ${interactive} \
     --rm \
     --network "${NETWORK_NAME}" \
+    --platform linux/x86_64 \
     -e WP_VERSION \
     -e WP_MULTISITE \
     -e PHP_VERSION \


### PR DESCRIPTION
## Description
When running unit tests locally on M* mac chips, myself and a few others have seen errors like this:

```sh
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```

This causes several tests to fail, if the test suite runs at all. This is fixed by adjusting the docker run command to use `--platform linux/x86_64`.

Since at least @mehmoodak and @sanmai have also run into this problem (and it's occurring for me again too), it's worth adjusting this in the test script.

## Steps to Test
Run `./bin/test.sh` locally.