### PR TITLE
FS: Fix image request being broken up by file name

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -174,7 +174,7 @@ class VIP_Filesystem {
 	 * @param  string[]  An array of data for a single file.
 	 */
 	public function filter_validate_file( $file ) {
-		$file_name   = $file['name'];
+		$file_name   = rawurlencode( $file['name'] );
 		$upload_path = trailingslashit( $this->get_upload_path() );
 		$file_path   = $upload_path . $file_name;
 


### PR DESCRIPTION
## Description
We should encode the filename before sending it to the Files Service to ensure the request goes through to the FS. For example, `#1-test.jpg` gets broken up due to the anchor.

## Changelog Description

### Fixed
- Filenames with special characters no longer throw an error and are now are being sent to the Files Service

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Try uploading image called `1#-.jpeg` and see that it throws an error.