### PR TITLE
revert: run unit tests under x86 platform with docker

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -115,7 +115,6 @@ docker run \
     ${interactive} \
     --rm \
     --network "${NETWORK_NAME}" \
-    --platform linux/x86_64 \
     -e WP_VERSION \
     -e WP_MULTISITE \
     -e PHP_VERSION \


### PR DESCRIPTION
Reverts Automattic/vip-go-mu-plugins#5647.

The root cause was fixed in Automattic/vip-container-images#781
