### PR TITLE
fix(vip-helpers): add checks to `is_automattician()`

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1443,6 +1443,16 @@ function is_automattician( $user_id = false ) {
 	if ( $user_id ) {
 		$user = new WP_User( $user_id );
 	} else {
+		if ( ! function_exists( 'wp_get_current_user' ) ) {
+			_doing_it_wrong( __FUNCTION__, 'This function should not be called without $user_id before the `plugins_loaded` hook.', null );
+			return false;
+		}
+
+		if ( ! did_action( 'init' ) && ! has_filter( 'determine_current_user' ) ) {
+			_doing_it_wrong( __FUNCTION__, 'This function should not be called without $user_id before the `init` hook without a filter for the `determine_current_user` hook.', null );
+			return false;
+		}
+
 		$user = wp_get_current_user();
 	}
 


### PR DESCRIPTION
## Description

This PR adds a couple of checks to `is_automattician()` to make sure is is called from the right place:
* `_doing_it_wrong()` when `wp_get_current_user()` is not available and `$user_id` is not provided. This happens when the function is called before the `plugins_loaded` event fires and results in a fatal error;
* `_doing_it_wrong()` when `$user_id` is not provided, filters for `determine_current_user` are not set, and the function is called before `init` fires. WordPress sets the current user before it fires `init`; if there are no handlers for `determine_current_user` are set, the current user will be `null`.

Ref: 188391-z

## Changelog Description

### Added

- checks to `is_automattician()` to prevent fatal errors and ensure that it is called when the current user is known.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See 188391-z. In a Dev Env, if a function is called from the wrong place, a deprecation warning should be shown.
