### PR TITLE
Use post ID instead of object

### DIFF
--- a/files/acl/restrict-unpublished-files.php
+++ b/files/acl/restrict-unpublished-files.php
@@ -44,7 +44,7 @@ function check_file_visibility( $file_visibility, $file_path ) {
 			return FILE_IS_PUBLIC;
 		}
 
-		$user_has_edit_access = current_user_can( 'edit_post', $parent_post );
+		$user_has_edit_access = current_user_can( 'edit_post', $parent_post->ID );
 
 		if ( $user_has_edit_access ) {
 			return FILE_IS_PRIVATE_AND_ALLOWED;


### PR DESCRIPTION
More aligned with Core usage, and better compatibility with other plugins.

While using an object does work on its own, plugins that interact may expect only an ID as in other calls in WP Core. 

If the parent post ID doesn't exist, `get_post()` safely returns null.

```
wp> $p = get_post( 99999999889 );
=> NULL
wp> $p->ID
=> NULL
wp> current_user_can( 'edit_post', $p->ID )
=> bool(false)
```

## Changelog Description

Use ID over object in `current_user_can()`

### Changed
- Use ID over object in `current_user_can()`


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->