### PR TITLE
Remove Admin Notice displayed for WP 5.9 since VIP no longer supports it

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -26,24 +26,3 @@ add_action(
 		do_action( 'vip_admin_notice_init', $admin_notice_controller );
 	}
 );
-
-// Old WP version w/o pinned Jetpack version
-add_action(
-	'vip_admin_notice_init',
-	function ( $admin_notice_controller ) {
-		global $wp_version;
-		$message = "We've noticed that you are running WordPress {$wp_version}, which is an outdated version. This prevents you from running the latest version of Jetpack, as the current version of Jetpack only supports 5.9 and up. Please upgrade to the most recent WordPress version to use the latest features of Jetpack.";
-
-		$admin_notice_controller->add(
-			new Admin_Notice(
-				$message,
-				[
-					new Expression_Condition( version_compare( $wp_version, '5.9', '<' ) ),
-					new Expression_Condition( ! defined( 'VIP_JETPACK_PINNED_VERSION' ) ),
-				],
-				'old-wp-versions',
-				'error'
-			)
-		);
-	}
-);


### PR DESCRIPTION
## Description
We no longer support WP 5.9, so we can remove the admin notice displayed for the Jetpack and WP incompatibility.

Eventually, we can probably deprecate `admin-notice` in its entirety with WP 6.4 introducing `wp_admin_notice()`.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->