### PR TITLE
Fixes `log2logstash` debugging on local dev-envs

### DIFF
--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -565,11 +565,6 @@ class Logger {
 	 * @param array $entry Data.
 	 */
 	public static function wp_debug_log( array $entry ): void {
-		if ( defined( 'VIP_GO_ENV' ) && constant( 'VIP_GO_ENV' ) !== 'local' ) {
-			// Don't run this on VIP Go
-			return;
-		}
-
 		$log_path = WP_CONTENT_DIR . '/debug.log';
 		$log_path = is_string( WP_DEBUG_LOG ) && WP_DEBUG_LOG ? WP_DEBUG_LOG : $log_path;
 

--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -524,7 +524,7 @@ class Logger {
 
 		// Process all entries.
 		foreach ( static::$entries as $entry ) {
-			if ( ! defined( 'VIP_GO_ENV' ) || ! VIP_GO_ENV ) {
+			if ( ! defined( 'VIP_GO_ENV' ) || constant( 'VIP_GO_ENV' ) === 'local' ) {
 				static::maybe_wp_debug_log_entries( $entry );
 				continue; // Bypassing logstash log writing below in this case.
 			}
@@ -565,7 +565,7 @@ class Logger {
 	 * @param array $entry Data.
 	 */
 	public static function wp_debug_log( array $entry ): void {
-		if ( defined( 'VIP_GO_ENV' ) && VIP_GO_ENV ) {
+		if ( defined( 'VIP_GO_ENV' ) && constant( 'VIP_GO_ENV' ) !== 'local' ) {
 			// Don't run this on VIP Go
 			return;
 		}

--- a/logstash/class-logger.php
+++ b/logstash/class-logger.php
@@ -524,7 +524,7 @@ class Logger {
 
 		// Process all entries.
 		foreach ( static::$entries as $entry ) {
-			if ( ! defined( 'VIP_GO_ENV' ) || constant( 'VIP_GO_ENV' ) === 'local' ) {
+			if ( ! defined( 'VIP_GO_ENV' ) || ! VIP_GO_ENV || constant( 'VIP_GO_ENV' ) === 'local' ) {
 				static::maybe_wp_debug_log_entries( $entry );
 				continue; // Bypassing logstash log writing below in this case.
 			}


### PR DESCRIPTION
## Description

I noticed calls to `Logger::log2logstash` didn't output to either `stdout` or `debug.log` on local `vip dev-env`s . Some checks were not accounting for the case where `VIP_GO_ENV` is set to `local` - which is the case on the local dev-env.

## Changelog Description

### Fixed
- Fixed debug logs with `Logger::log2logstash` on local dev envs.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Create a dev-env with `vip dev-env create` that points to your local mu-plugins folder.
1. Add a call to 

```php
Logger::log2logstash( [
	'severity' => 'error',
	'feature'  => 'test',
	'message'  => 'Test message'
] );
```

somewhere on your php files

4. Check that logs are written to `/tmp/debug.log` on your dev-env container.