### PR TITLE
Adds support for the TWILIO_MESSAGING_SERVICE_SID when sending SMS

### DIFF
--- a/lib/sms.php
+++ b/lib/sms.php
@@ -43,10 +43,18 @@ function send_sms( $to, $message ) {
 			}
 
 			$body = array(
-				'From' => SMS_FROM_NUMBER,
 				'To'   => $to_number,
 				'Body' => $message_split,
 			);
+			/**
+			 * If defined, we want to use the MessagingServiceSid to leverage all the automatic logic of the messaging service to route the SMS from the right "From" number.
+			 * For example in some countries, the "From" number should be a local number to the recipient or an alphanumeric sender ID.
+			 */
+			if ( defined( 'TWILIO_MESSAGING_SERVICE_SID' ) ) {
+				$body['MessagingServiceSid'] = TWILIO_MESSAGING_SERVICE_SID;
+			} else {
+				$body['From'] = SMS_FROM_NUMBER;
+			}
 
 			$result = send_single_sms_via_rest( $body );
 			if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
## Description

This PR adds support for the `MessagingServiceSid` parameter in Twilio Calls. This is an alternative approach to sending SMS where all the logic around the sender is located in Twilio, to benefit from their knowledge about if/when to use an alphanumeric ID instead of a number.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [X] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- In a local test site, using this change, define the variable `define( 'TWILIO_MESSAGING_SERVICE_SID', '<redacted>' );` with the correct `MessagingServiceId` from Twilio.
- Log in, and go into your user profile and setup SMS as a 2FA.
- The SMS should arrive.
- Confirm, from the [Twilio Messaging logs](https://console.twilio.com/us1/monitor/logs/sms), that the message has been sent and that the "Service" column is now set.