### PR TITLE
Add basic Prometheus / metrics docs

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -1,0 +1,29 @@
+# Prometheus Metrics
+
+MU-Plugins supports collecting and shipping internal metrics to Prometheus. 
+
+This system is intended for use by WPVIP to monitor the operation of sites and is not suitable for customer use.
+
+## Stats Endpoint
+
+Prometheus metrics are exposed at `/.vip-prom-metrics`.
+
+## Collectors
+
+Stat collection is implemented as Collectors (see the `prometheus-collectors` directory). Each Collector implements `CollectorInterface` and is responsible for collecting the relevant metrics.
+
+For real-time metrics, like recording specific actions, implement a method in the Collector that is called directly or via WP-hook.
+
+For "aggregated" metrics collected on an interval (like post counts), implement `collect_metrics()`, which will be run on cron.
+
+### Registering Collectors
+
+Collectors must be registered via the `vip_prometheus_collectors` hook:
+
+```
+add_filter( 'vip_prometheus_collectors', function ( $collectors ) {
+	$collectors['my_collector_name'] = new Collector();
+
+	return $collectors;
+} );
+```


### PR DESCRIPTION
## Description

Adds a README w/ basic docs for the Prometheus stats system.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- n/a This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- n/a This change works and has been tested on a sandbox.
- n/a This change has relevant unit tests (if applicable).
- n/a This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- n/a I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- n/a VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Docs-only change