### PR TITLE
test: update E2E tests for WP 6.6.1

### DIFF
--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -156,7 +156,7 @@ export class EditorPage {
 			await this.page.click( selectors.blockAppender );
 		} else {
 			await this.page.click( selectors.editorTitleContainer );
-			await this.page.click( selectors.blockInserter );
+			await this.page.getByLabel( 'Toggle block inserter' ).click();
 		}
 		await this.page.click( selectors.imageBlocks );
 


### PR DESCRIPTION
WP 6.6 now hides the inline Block inserter by default; we now use the global Block inserter from the toolbar.
