### PR TITLE
fix: do not load ES when WP is being installed

### DIFF
--- a/search/search.php
+++ b/search/search.php
@@ -26,7 +26,7 @@ if ( defined( 'VIP_ELASTICSEARCH_DISABLED' ) && true === constant( 'VIP_ELASTICS
 require_once __DIR__ . '/includes/functions/utils.php';
 require_once __DIR__ . '/includes/classes/class-search.php';
 
-if ( \Automattic\VIP\Search\Search::are_es_constants_defined() ) {
+if ( \Automattic\VIP\Search\Search::are_es_constants_defined() && ! wp_installing() ) {
 	$search_plugin = \Automattic\VIP\Search\Search::instance();
 
 	require_once __DIR__ . '/search-dev-tools/search-dev-tools.php';


### PR DESCRIPTION
## Description

In Dev Env, when Elasticsearch is enabled for a multisite installation, the setup script generates a lot of PHP errors, like

```
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('ep_feature_requirement_statuses', 'a:9:{s:6:\"search\";i:0;s:11:\"woocommerce\";i:2;s:6:\"facets\";i:0;s:13:\"related_posts\";i:0;s:14:\"searchordering\";i:2;s:17:\"protected_content\";i:1;s:8:\"comments\";i:1;s:5:\"users\";i:1;s:5:\"terms\";i:1;}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('ep_feature_settings', 'a:1:{s:6:\"search\";a:7:{s:16:\"decaying_enabled\";s:1:\"1\";s:20:\"synonyms_editor_mode\";s:6:\"simple\";s:17:\"highlight_enabled\";s:1:\"0\";s:17:\"highlight_excerpt\";s:1:\"0\";s:13:\"highlight_tag\";s:4:\"mark\";s:6:\"active\";b:1;s:14:\"force_inactive\";b:0;}}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('ep_feature_settings', 'a:1:{s:6:\"facets\";a:3:{s:10:\"match_type\";s:3:\"all\";s:6:\"active\";b:1;s:14:\"force_inactive\";b:0;}}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('ep_feature_settings', 'a:1:{s:13:\"related_posts\";a:2:{s:6:\"active\";b:1;s:14:\"force_inactive\";b:0;}}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query SELECT autoload FROM wp_options WHERE option_name = 'elasticpress_synonyms_post_id' made by delete_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_id FROM wp_sitemeta WHERE meta_key = 'elasticpress_synonyms_post_id' AND site_id = 1 made by delete_network_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('cron', 'a:2:{i:1721819320;a:1:{s:24:\"vip_search_queue_sweeper\";a:1:{s:32:\"40cd750bba9870f18aada2478b24840a\";a:3:{s:8:\"schedule\";s:33:\"vip_search_queue_sweeper_interval\";s:4:\"args\";a:0:{}s:8:\"interval\";i:60;}}}s:7:\"version\";i:2;}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:40 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('cron', 'a:2:{i:1722424120;a:1:{s:29:\"vip_search_versioning_cleanup\";a:1:{s:32:\"40cd750bba9870f18aada2478b24840a\";a:3:{s:8:\"schedule\";s:6:\"weekly\";s:4:\"args\";a:0:{}s:8:\"interval\";i:604800;}}}s:7:\"version\";i:2;}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
No installation found, installing WordPress...
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('ep_feature_requirement_statuses', 'a:9:{s:6:\"search\";i:0;s:11:\"woocommerce\";i:2;s:6:\"facets\";i:0;s:13:\"related_posts\";i:0;s:14:\"searchordering\";i:2;s:17:\"protected_content\";i:1;s:8:\"comments\";i:1;s:5:\"users\";i:1;s:5:\"terms\";i:1;}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('ep_feature_settings', 'a:1:{s:6:\"search\";a:7:{s:16:\"decaying_enabled\";s:1:\"1\";s:20:\"synonyms_editor_mode\";s:6:\"simple\";s:17:\"highlight_enabled\";s:1:\"0\";s:17:\"highlight_excerpt\";s:1:\"0\";s:13:\"highlight_tag\";s:4:\"mark\";s:6:\"active\";b:1;s:14:\"force_inactive\";b:0;}}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('ep_feature_settings', 'a:1:{s:6:\"facets\";a:3:{s:10:\"match_type\";s:3:\"all\";s:6:\"active\";b:1;s:14:\"force_inactive\";b:0;}}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('ep_feature_settings', 'a:1:{s:13:\"related_posts\";a:2:{s:6:\"active\";b:1;s:14:\"force_inactive\";b:0;}}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'ep_feature_settings' AND site_id = 1 made by get_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query SELECT autoload FROM wp_options WHERE option_name = 'elasticpress_synonyms_post_id' made by delete_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_sitemeta' doesn't exist for query SELECT meta_id FROM wp_sitemeta WHERE meta_key = 'elasticpress_synonyms_post_id' AND site_id = 1 made by delete_network_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('cron', 'a:2:{i:1721819321;a:1:{s:24:\"vip_search_queue_sweeper\";a:1:{s:32:\"40cd750bba9870f18aada2478b24840a\";a:3:{s:8:\"schedule\";s:33:\"vip_search_queue_sweeper_interval\";s:4:\"args\";a:0:{}s:8:\"interval\";i:60;}}}s:7:\"version\";i:2;}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
[24-Jul-2024 11:08:41 UTC] WordPress database error Table 'wordpress.wp_options' doesn't exist for query INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('cron', 'a:2:{i:1722164921;a:1:{s:29:\"vip_search_versioning_cleanup\";a:1:{s:32:\"40cd750bba9870f18aada2478b24840a\";a:3:{s:8:\"schedule\";s:6:\"weekly\";s:4:\"args\";a:0:{}s:8:\"interval\";i:604800;}}}s:7:\"version\";i:2;}', 'auto') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option
```

This PR makes sure that ES is disabled while WordPress is being installed.

See: BB8-11580

## Changelog Description

### Fixed
- Elasticsearch Integration is disabled while WordPress is installed to prevent local development environment errors.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

```sh
# Adjust paths as necessary; make sure ES constants are on in the skeleton
vip dev-env create -e -m -u $(pwd) -a $(pwd)/../vip-go-skeleton < /dev/null
vip dev-env start
```

Without this fix, there will be errors when WP gets installed; with this fix, there won't be errors.
