### PR TITLE
fix(security): user enumeration when resetting password

### DIFF
--- a/__tests__/e2e/lib/global-setup.ts
+++ b/__tests__/e2e/lib/global-setup.ts
@@ -25,6 +25,9 @@ async function globalSetup( config: FullConfig ) {
 	page.setDefaultNavigationTimeout( timeout );
 	await context.tracing.start( { name: 'global-setup', screenshots: true, snapshots: true } );
 
+	process.env.E2E_USER = user;
+	process.env.E2E_PASSWORD = pass;
+
 	try {
 		// Log in to wp-admin
 		await goToPage( page, baseURL! + '/wp-login.php' );

--- a/__tests__/e2e/lib/pages/lost-password-page.ts
+++ b/__tests__/e2e/lib/pages/lost-password-page.ts
@@ -23,11 +23,8 @@ export class LostPasswordPage {
 
 	public async resetPassword( login: string ): Promise<Response> {
 		await this.loginField.fill( login );
-		const [ response ] = await Promise.all( [
-			this.page.waitForResponse( ( resp ) => resp.url().includes( '/wp-login.php' ) && resp.request().method() === 'GET' ),
-			this.getPasswordButton.click(),
-		] );
-
-		return response;
+		const responsePromise = this.page.waitForResponse( ( resp ) => resp.url().includes( '/wp-login.php' ) && resp.request().method() === 'GET' );
+		await this.getPasswordButton.click();
+		return responsePromise;
 	}
 }

--- a/__tests__/e2e/lib/pages/lost-password-page.ts
+++ b/__tests__/e2e/lib/pages/lost-password-page.ts
@@ -1,0 +1,33 @@
+import type { Locator, Page, Response } from '@playwright/test';
+
+export class LostPasswordPage {
+	public readonly loginField: Locator;
+	public readonly getPasswordButton: Locator;
+	public readonly loginErrorBlock: Locator;
+	public readonly loginLink: Locator;
+	public readonly registerLink: Locator;
+	public readonly backToBlogLink: Locator;
+
+	public constructor( private readonly page: Page ) {
+		this.loginField = page.locator( 'input#user_login' );
+		this.getPasswordButton = page.locator( 'input#wp-submit' );
+		this.loginErrorBlock = page.locator( 'div#login_error' );
+		this.loginLink = page.locator( '#nav a[href$="wp-login.php"]' );
+		this.registerLink = page.locator( '#nav a[href*="wp-login.php?action=register"]' );
+		this.backToBlogLink = page.locator( '#backtoblog a' );
+	}
+
+	public visit(): Promise<Response> {
+		return this.page.goto( './wp-login.php?action=lostpassword' ) as Promise<Response>;
+	}
+
+	public async resetPassword( login: string ): Promise<Response> {
+		await this.loginField.fill( login );
+		const [ response ] = await Promise.all( [
+			this.page.waitForResponse( ( resp ) => resp.url().includes( '/wp-login.php' ) && resp.request().method() === 'GET' ),
+			this.getPasswordButton.click(),
+		] );
+
+		return response;
+	}
+}

--- a/__tests__/e2e/lib/pages/wp-login-page.ts
+++ b/__tests__/e2e/lib/pages/wp-login-page.ts
@@ -4,6 +4,7 @@ const selectors = {
 	userField: '#user_login',
 	passwordField: '#user_pass',
 	submitButton: '#wp-submit',
+	lostPasswordLink: '#nav a[href*="wp-login.php?action=lostpassword"]',
 };
 
 export class LoginPage {
@@ -20,7 +21,6 @@ export class LoginPage {
 
 	/**
 	 * Navigate to login page
-	 *
 	 */
 	public visit(): Promise<unknown> {
 		return this.page.goto( '/wp-login.php' );
@@ -36,5 +36,12 @@ export class LoginPage {
 		await this.page.fill( selectors.userField, username );
 		await this.page.fill( selectors.passwordField, password );
 		return Promise.all( [ this.page.waitForURL( '**/wp-admin/**' ), this.page.click( selectors.submitButton ) ] );
+	}
+
+	public lostPassword(): Promise<unknown> {
+		return Promise.all( [
+			this.page.waitForURL( /\/wp-login\.php\?action=lostpassword/ ),
+			this.page.locator( selectors.lostPasswordLink ).click(),
+		] );
 	}
 }

--- a/__tests__/e2e/specs/security.spec.ts
+++ b/__tests__/e2e/specs/security.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+
+import { LostPasswordPage } from '../lib/pages/lost-password-page';
+import { LoginPage } from '../lib/pages/wp-login-page';
+
+test.describe( 'Security', () => {
+	test.beforeEach( async ( { page, context } ) => {
+		await context.clearCookies();
+		await page.goto( '/wp-login.php' );
+	} );
+
+	test( 'Reset password for existing user', async ( { page } ) => {
+		const loginPage = new LoginPage( page );
+		await loginPage.lostPassword();
+
+		const lostPasswordPage = new LostPasswordPage( page );
+		const response = await lostPasswordPage.resetPassword( process.env.E2E_USER! );
+
+		expect( response.status() ).toBe( 200 );
+		expect( response.url() ).toContain( '/wp-login.php?checkemail=confirm' );
+	} );
+
+	test( 'Reset password for existing non-existing user', async ( { page } ) => {
+		const loginPage = new LoginPage( page );
+		await loginPage.lostPassword();
+
+		const lostPasswordPage = new LostPasswordPage( page );
+		const response = await lostPasswordPage.resetPassword( 'this-user-does-not-exist' );
+
+		expect( response.status() ).toBe( 200 );
+		expect( response.url() ).toContain( '/wp-login.php?checkemail=confirm' );
+	} );
+} );

--- a/security/login-error.php
+++ b/security/login-error.php
@@ -41,7 +41,7 @@ function use_ambiguous_login_error( $error ): string {
 add_filter( 'login_errors', __NAMESPACE__ . '\use_ambiguous_login_error', 99, 1 );
 
 function use_ambiguous_password_reset_confirmation( $errors ) {
-	if ( is_wp_error( $errors ) && $errors->has_errors() && ! headers_sent() ) {
+	if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] && is_wp_error( $errors ) && $errors->has_errors() && ! headers_sent() ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$redirect_to = ! empty( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : 'wp-login.php?checkemail=confirm';
 		wp_safe_redirect( $redirect_to );
@@ -49,9 +49,7 @@ function use_ambiguous_password_reset_confirmation( $errors ) {
 	}
 }
 
-if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
-	add_action( 'lost_password', __NAMESPACE__ . '\\use_ambiguous_password_reset_confirmation', 0 );
-}
+add_action( 'lost_password', __NAMESPACE__ . '\\use_ambiguous_password_reset_confirmation', 0 );
 
 /**
  * Use a message that does not reveal the type of login error in an attempted brute-force on forget password.

--- a/security/login-error.php
+++ b/security/login-error.php
@@ -19,14 +19,6 @@ function use_ambiguous_login_error( $error ): string {
 		return (string) $error;
 	}
 
-	// For lostpassword action, use different message.
-	if ( isset( $_GET['action'] ) && 'lostpassword' === $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		return esc_html__(
-			'If there is an account associated with the username/email address, you will receive an email with a link to reset your password.',
-			'vip'
-		);
-	}
-
 	$err_codes = $errors->get_error_codes();
 
 	$err_types = [
@@ -38,7 +30,7 @@ function use_ambiguous_login_error( $error ): string {
 
 	foreach ( $err_types as $err ) {
 		if ( in_array( $err, $err_codes, true ) ) {
-			$error = '<strong>' . esc_html__( 'Error', 'vip' ) . '</strong>: ' . 
+			$error = '<strong>' . esc_html__( 'Error', 'vip' ) . '</strong>: ' .
 			esc_html__( 'The username/email address or password is incorrect. Please try again.', 'vip' );
 			break;
 		}
@@ -47,6 +39,19 @@ function use_ambiguous_login_error( $error ): string {
 	return (string) $error;
 }
 add_filter( 'login_errors', __NAMESPACE__ . '\use_ambiguous_login_error', 99, 1 );
+
+function use_ambiguous_password_reset_confirmation( $errors ) {
+	if ( is_wp_error( $errors ) && $errors->has_errors() && ! headers_sent() ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$redirect_to = ! empty( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : 'wp-login.php?checkemail=confirm';
+		wp_safe_redirect( $redirect_to );
+		exit();
+	}
+}
+
+if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+	add_action( 'lost_password', __NAMESPACE__ . '\\use_ambiguous_password_reset_confirmation', 0 );
+}
 
 /**
  * Use a message that does not reveal the type of login error in an attempted brute-force on forget password.


### PR DESCRIPTION
## Description

It is still possible to enumerate users when resetting the password by looking at the target URL: when the attempt is unsuccessful, we stay on the original page, while for successful attempts, we are redirected to `wp-login.php?checkemail=confirm`.

This PR modifies this behavior by always redirecting to the `wp-login.php?checkemail=confirm` page (or the URL specified in the `redirect_to` request parameter).

## Changelog Description

### Fixed
- possibility to enumerate users by abusing the reset password functionality

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Try resetting the password for an existing and non-existing user with and without this patch and compare the results.
