### PR TITLE
test(e2e): add generic checks

### DIFF
--- a/__tests__/e2e/lib/pages/published-page-page.ts
+++ b/__tests__/e2e/lib/pages/published-page-page.ts
@@ -1,4 +1,4 @@
-import type { Page } from 'playwright';
+import type { Page } from '@playwright/test';
 
 const selectors = {
 	entryTitle: '.wp-block-post-title',

--- a/__tests__/e2e/lib/pages/published-post-page.ts
+++ b/__tests__/e2e/lib/pages/published-post-page.ts
@@ -1,4 +1,4 @@
-import type { Page } from 'playwright';
+import type { Page } from '@playwright/test';
 
 const selectors = {
 	entryTitle: '.wp-block-post-title',

--- a/__tests__/e2e/lib/playwright-helpers.ts
+++ b/__tests__/e2e/lib/playwright-helpers.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Locator, Page } from 'playwright';
+import type { Locator, Page } from '@playwright/test';
 
 /**
  * Returns the list of classes for the given element as a string list.

--- a/__tests__/e2e/package-lock.json
+++ b/__tests__/e2e/package-lock.json
@@ -16,7 +16,6 @@
         "eslint": "^8.51.0",
         "eslint-plugin-deprecation": "^3.0.0",
         "eslint-plugin-playwright": "^1.0.1",
-        "playwright": "^1.39.0",
         "typescript": "^5.2.2"
       }
     },

--- a/__tests__/e2e/package.json
+++ b/__tests__/e2e/package.json
@@ -19,7 +19,6 @@
     "eslint": "^8.51.0",
     "eslint-plugin-deprecation": "^3.0.0",
     "eslint-plugin-playwright": "^1.0.1",
-    "playwright": "^1.39.0",
     "typescript": "^5.2.2"
   }
 }

--- a/__tests__/e2e/specs/generic.spec.ts
+++ b/__tests__/e2e/specs/generic.spec.ts
@@ -9,4 +9,32 @@ test.describe( 'Generic Checks', () => {
 		const html = await page.content();
 		expect( html ).toContain( '</html>' );
 	} );
+
+	test( 'REST API smoke test', async ( { request } ) => {
+		const response = await request.get( './wp-json/' );
+		expect( response.status() ).toBe( 200 );
+		const data: unknown = await response.json();
+		expect( typeof data ).toBe( 'object' );
+		expect.soft( data ).toHaveProperty( 'name' );
+		expect.soft( data ).toHaveProperty( 'description' );
+		expect.soft( data ).toHaveProperty( 'url' );
+		expect.soft( data ).toHaveProperty( 'routes' );
+	} );
+
+	test( 'XML RPC smoke test', async ( { request } ) => {
+		const xmlPayload = '<?xml version="1.0"?><methodCall><methodName>demo.sayHello</methodName><params/></methodCall>';
+
+		const response = await request.post( './xmlrpc.php', {
+			headers: {
+				'Content-Type': 'text/xml',
+			},
+			data: xmlPayload,
+		} );
+
+		expect( response.status() ).toBe( 200 );
+		const responseText = await response.text();
+		expect( responseText ).toContain( '<methodResponse>' );
+		expect( responseText ).not.toContain( '<fault>' );
+		expect( responseText ).toContain( '<string>Hello!</string>' );
+	} );
 } );

--- a/__tests__/e2e/specs/generic.spec.ts
+++ b/__tests__/e2e/specs/generic.spec.ts
@@ -1,0 +1,12 @@
+import { type Response, expect, test } from '@playwright/test';
+
+test.describe( 'Generic Checks', () => {
+	test( 'Page contains closing html tag and no wp_die() message', async ( { page, baseURL } ) => {
+		expect( baseURL ).toBeDefined();
+		const response = await page.goto( baseURL! ) as Response;
+		expect.soft( response.status() ).toBeLessThan( 500 );
+		await expect( page.locator( '.wp-die-message' ) ).toHaveCount( 0 );
+		const html = await page.content();
+		expect( html ).toContain( '</html>' );
+	} );
+} );


### PR DESCRIPTION
This PR adds generic checks to our E2E test suite. So far, there are only three checks, but suggestions are welcome:
* check that the home page contains the closing `</html>` tag, no `wp_die()` message, and its response code is less than 500. This check ensures that our code does not accidentally break the frontend;
* check that the REST API works, responds with 200 OK, and provides a valid JSON that contains some expected fields;
* check that XML RPC works, responds with 200 OK, and responds to the `demo.sayHello` RPC call.
