### PR TITLE
Update Block Data API to 1.3

### DIFF
--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -20,7 +20,7 @@ class BlockDataApiIntegration extends Integration {
 	 *
 	 * @var string
 	 */
-	protected string $version = '1.2';
+	protected string $version = '1.3';
 
 	/**
 	 * Returns `true` if `Block Data API` is already available e.g. via customer code. We will use


### PR DESCRIPTION
## Description

Update mu-plugins to use the latest version of the Block Data API (`1.3`). This update [has been pulled into vip-go-mu-plugins-ext](https://github.com/Automattic/vip-go-mu-plugins-ext/tree/trunk/vip-integrations/vip-block-data-api-1.3) already.

## Changelog Description

### Plugin Updated: Block Data API

We upgraded the Block Data API integration to version `1.3.0`, which improves GraphQL data representation and adds a new `blocksDataV2` property. [See the full release here](https://github.com/Automattic/vip-block-data-api/releases/tag/1.3.0).

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

This is a straightforward change, and the existence of the `1.3` folder [can be verified in -ext already](https://github.com/Automattic/vip-go-mu-plugins-ext/tree/trunk/vip-integrations).

See [**Steps to Test** on a prior PR](https://github.com/Automattic/vip-go-mu-plugins/pull/5099) for the more involved steps for testing an `-ext` update in general.
