### PR TITLE
BB8-11643: Fix WP-Admin Contact Support Form

### DIFF
--- a/vip-dashboard/vip-dashboard.php
+++ b/vip-dashboard/vip-dashboard.php
@@ -12,6 +12,8 @@
  * Domain Path: /languages/
 */
 
+const VIP_SUPPORT_EMAIL = 'support@wpvip.com';
+
 /**
  * Boot the new VIP Dashboard
  *
@@ -97,7 +99,6 @@ function vip_contact_form_handler() {
 		die();
 	}
 
-	$vipsupportemailaddy  = 'vip-support@wordpress.com';
 	$cc_headers_to_kayako = '';
 
 	$current_user = wp_get_current_user();
@@ -177,16 +178,18 @@ function vip_contact_form_handler() {
 
 	// Filter from name/email. NOTE - not un-hooking the filter because we die() immediately after wp_mail()
 	add_filter( 'wp_mail_from', function () use ( $email ) {
-		return $email;
+		return VIP_SUPPORT_EMAIL;
 	}, PHP_INT_MAX );
 
 	add_filter( 'wp_mail_from_name', function () use ( $name ) {
 		return $name;
 	}, PHP_INT_MAX );
 
-	$headers = "From: \"$name\" <$email>\r\n";
+	$headers  = "From: \"$name\" <" . VIP_SUPPORT_EMAIL . ">\r\n";
+	$headers .= "Reply-To: $email\r\n"; // Add the Reply-To header so ZD can map correct email
+
 	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-	if ( wp_mail( $vipsupportemailaddy, $subject, $content, $headers . $cc_headers_to_kayako ) ) {
+	if ( wp_mail( VIP_SUPPORT_EMAIL, $subject, $content, $headers . $cc_headers_to_kayako ) ) {
 		$return = array(
 			'status'  => 'success',
 			'message' => __( 'Your support request is on its way, we will be in touch soon.', 'vip-dashboard' ),
@@ -247,7 +250,7 @@ function vip_echo_mailto_vip_hosting( $linktext = 'Send an email to VIP Hosting.
 	$url = add_query_arg( array(
 		'subject' => rawurlencode( __( 'Descriptive subject please', 'vip-dashboard' ) ),
 		'body'    => rawurlencode( $email ),
-	), 'mailto:vip-support@wordpress.com' );
+	), 'mailto:' . VIP_SUPPORT_EMAIL );
 
 	$html = '<a href="' . esc_url( $url ) . '">' . esc_html( $linktext ) . '</a>';
 


### PR DESCRIPTION
## Description
Fix being able to use the WP-Admin Contact Support form again from an outside domain

## Changelog Description

### Fixed
- Fixed being able to use the wp-admin support form from an outside domain

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->