### PR TITLE
ACL: Default to restricting all on non-prod if ACL is enabled but no options are set

### DIFF
--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -20,6 +20,7 @@ function maybe_load_restrictions() {
 	$is_files_acl_enabled            = defined( 'VIP_FILES_ACL_ENABLED' ) && true === constant( 'VIP_FILES_ACL_ENABLED' );
 	$is_restrict_all_enabled         = get_option_as_bool( 'vip_files_acl_restrict_all_enabled' );
 	$is_restrict_unpublished_enabled = get_option_as_bool( 'vip_files_acl_restrict_unpublished_enabled' );
+	$no_option_set                   = get_option( 'vip_files_acl_restrict_all_enabled', null ) === null && get_option( 'vip_files_acl_restrict_unpublished_enabled', null ) === null;
 
 	if ( ! $is_files_acl_enabled ) {
 		// Throw warning if restrictions are enabled but ACL constant is not set.
@@ -32,16 +33,16 @@ function maybe_load_restrictions() {
 		return;
 	}
 
-	if ( $is_restrict_all_enabled ) {
-		require_once __DIR__ . '/restrict-all-files.php';
-
-		add_filter( 'vip_files_acl_file_visibility', __NAMESPACE__ . '\Restrict_All_Files\check_file_visibility', 10, 2 );
-	} elseif ( $is_restrict_unpublished_enabled ) {
+	if ( $is_restrict_unpublished_enabled ) {
 		require_once __DIR__ . '/restrict-unpublished-files.php';
 
 		add_filter( 'vip_files_acl_file_visibility', __NAMESPACE__ . '\Restrict_Unpublished_Files\check_file_visibility', 10, 2 );
 		// Purge attachments for posts for better cacheability
 		add_filter( 'wpcom_vip_cache_purge_urls', __NAMESPACE__ . '\Restrict_Unpublished_Files\purge_attachments_for_post', 10, 2 );
+	} elseif ( $is_restrict_all_enabled || ( $no_option_set && ( defined( 'VIP_GO_ENV' ) && constant( 'VIP_GO_ENV' ) !== 'production' ) ) ) {
+		require_once __DIR__ . '/restrict-all-files.php';
+
+		add_filter( 'vip_files_acl_file_visibility', __NAMESPACE__ . '\Restrict_All_Files\check_file_visibility', 10, 2 );
 	}
 }
 

--- a/tests/files/acl/test-acl.php
+++ b/tests/files/acl/test-acl.php
@@ -111,9 +111,9 @@ class VIP_Files_Acl_Test extends WP_UnitTestCase {
 	}
 
 	public function test__get_option_as_bool__option_not_exists() {
-		$actual_value = get_option_as_bool( 'my_test_get_option_as_bool_option_not_exists' );
+		$actual_value = get_option_as_bool_if_exists( 'my_test_get_option_as_bool_option_not_exists' );
 
-		$this->assertEquals( false, $actual_value );
+		$this->assertEquals( null, $actual_value );
 	}
 
 	public function data_provider__get_option_as_bool__option_exists() {
@@ -166,7 +166,7 @@ class VIP_Files_Acl_Test extends WP_UnitTestCase {
 	public function test__get_option_as_bool__option_exists( $option_value, $expected_value ) {
 		update_option( 'my_test_get_option_as_bool_option', $option_value );
 
-		$actual_value = get_option_as_bool( 'my_test_get_option_as_bool_option' );
+		$actual_value = get_option_as_bool_if_exists( 'my_test_get_option_as_bool_option' );
 
 		$this->assertEquals( $expected_value, $actual_value );
 	}


### PR DESCRIPTION
## Description
If ACL is enabled but no options are explicitly set, we should default non-prods to use `vip_files_acl_restrict_all_enabled`. 

## Changelog Description

### Changed
- Non-prods: If ACL is enabled but no options are explicitly set, we should default to using `vip_files_acl_restrict_all_enabled`. 


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->