### PR TITLE
Add medium_large size to the image_downsize filter

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -263,6 +263,9 @@ class A8C_Files {
 				$_max_w = 300;
 				$_max_h = 300;
 			}
+		} elseif ( 'medium_large' == $size ) {
+			$_max_w = get_option( 'medium_large_size_w' );
+			$_max_h = get_option( 'medium_large_size_h' );
 		} elseif ( 'large' == $size ) {
 			$_max_w = get_option( 'large_size_w' );
 			$_max_h = get_option( 'large_size_h' );


### PR DESCRIPTION
## Description

We currently filter image_downsize using most of the default reserved image sizes but still need to include medium_large. This means that anyone using medium_large as an image size gets the wrong height and width returned.

## Changelog Description


### Fixed
- Fixed image_downsize filer to be aware of the reserved size medium_large 


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [X] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- Check the image size returned for a media image of medium_large size
```
wp> wp_get_attachment_image(23,'medium_large','')
=> phar:///usr/local/bin/wp/vendor/wp-cli/shell-command/src/WP_CLI/Shell/REPL.php:52:
string(1023) "<img width="750" height="1125" src="http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?w=750" class="attachment-medium_large size-medium_large" alt="" decoding="async" loading="lazy" srcset="http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg 1728w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=200,300 200w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=768,1152 768w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=683,1024 683w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=1024,1536 1024w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=1365,2048 1365w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=1568,2352 1568w" sizes="(max-width: 750px) 100vw, 750px" style="width:100%;height:150%;max-width:1728px;" />"
```

-Checkout the changed a8c-files.php and retest the image size and you should get the correct default width for medium_large of 768px

```
wp_get_attachment_image(23,'medium_large','')
=> phar:///usr/local/bin/wp/vendor/wp-cli/shell-command/src/WP_CLI/Shell/REPL.php:52:
string(1023) "<img width="768" height="1152" src="http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?w=768" class="attachment-medium_large size-medium_large" alt="" decoding="async" loading="lazy" srcset="http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg 1728w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=200,300 200w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=768,1152 768w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=683,1024 683w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=1024,1536 1024w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=1365,2048 1365w, http://anigel-testsite.go-vip.net/wp-content/uploads/2024/08/Wiki_Test_Image.jpg?resize=1568,2352 1568w" sizes="(max-width: 768px) 100vw, 768px" style="width:100%;height:150%;max-width:1728px;" />"
```