### PR TITLE
Search e2e: (woo) wait for tasks bar to show up before proceeding with rest of tests

### DIFF
--- a/tests/search/e2e/integration/features/woocommerce.spec.js
+++ b/tests/search/e2e/integration/features/woocommerce.spec.js
@@ -69,8 +69,14 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 		it('Can not display other users orders on the My Account Order page', () => {
 			// enable payment gateway.
 			cy.visitAdminPage('admin.php?page=wc-settings&tab=checkout&section=cod');
+			cy.get('.woocommerce-layout__header-tasks-reminder-bar', { timeout: 10000 })
+  			.should('be.visible');
+
 			cy.get('#woocommerce_cod_enabled').check({waitForAnimations: false});
-			cy.get('.is-primary.woocommerce-save-button').click();
+			cy.get(
+				`.button-primary.woocommerce-save-button,
+				.components-button.is-primary.woocommerce-save-button`,
+			).click();
 
 			cy.logout();
 


### PR DESCRIPTION
## Description
Fix search e2e tests for Woo. It needs to wait for the modal to load before attempting anything:
<img width="1323" alt="Screenshot 2024-08-19 at 12 16 47 PM" src="https://github.com/user-attachments/assets/09a531d4-4070-495f-8e6f-637dae7ac67c">

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->