### PR TITLE
Jetpack: Set 13.7 as default (for WP 6.5+)

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.6
+ * Version: 13.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -39,7 +39,7 @@ function vip_default_jetpack_version() {
 		return '13.1';
 	} else {
 		// WordPress 6.4 and newer.
-		return '13.6';
+		return '13.7';
 	}
 }
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -37,8 +37,11 @@ function vip_default_jetpack_version() {
 	} elseif ( version_compare( $wp_version, '6.4', '<' ) ) { 
 		// WordPress 6.3.x
 		return '13.1';
+	} elseif ( version_compare( $wp_version, '6.5', '<' ) ) {
+		// WordPress 6.4.x
+		return '13.6';
 	} else {
-		// WordPress 6.4 and newer.
+		// WordPress 6.5 and newer.
 		return '13.7';
 	}
 }

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '13.6';
+		$latest = '13.7';
 
 		$versions_map = [
 			// WordPress version => Jetpack version

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -18,7 +18,8 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 			'6.1'   => '12.5',
 			'6.2'   => '12.8',
 			'6.3'   => '13.1',
-			'6.4'   => $latest,
+			'6.4'   => '13.6',
+			'6.5'   => $latest,
 		];
 
 		foreach ( $versions_map as $wordpress_version => $jetpack_version ) {


### PR DESCRIPTION
## Description
Set Jetpack 13.7 as default

## Changelog Description

### Changed
- Jetpack 13.7 is now the default version for WP 6.5+

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->