### PR TITLE
Update Link to Docs for Jetpack Content Distribution Settings

### DIFF
--- a/blogpublic-notice.php
+++ b/blogpublic-notice.php
@@ -23,7 +23,7 @@ function notice() {
 
 	printf(
 		'<div id="blogpublic-notice" class="notice notice-warning is-dismissible"><p>Your site may be discoverable. You can change this by <a href="%s">disabling content distribution</a>.</p></div>',
-		'https://docs.wpvip.com/technical-references/restricting-site-access/controlling-content-distribution-via-jetpack/#h-disabling-content-distribution',
+		'https://docs.wpvip.com/wordpress-on-vip/jetpack/content-distribution/#h-disabling-content-distribution',
 	);
 	add_action( 'admin_footer', __NAMESPACE__ . '\dismiss_handler' );
 }


### PR DESCRIPTION
## Description
The Jetpack Content Distribution page has been moved on the WPVIP Docs site, this PR updates the URL to point the correct page.

## Changelog Description

### Updated
- Update link to Jetpack Content Distribution Documentation when a non-production site may be public.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Merge the PR, and then set `add_filter( 'option_blog_public', '__return_true' );` to true. 
Click the link to ensure it goes to the correct page and not a 400

![Screenshot 2024-08-21 at 12 42 26](https://github.com/user-attachments/assets/6ebd0488-9a45-461a-90e9-722aad3163da)


