### PR TITLE
Allow Overwriting SMTP Host in VIP Mail

### DIFF
--- a/tests/test-vip-mail.php
+++ b/tests/test-vip-mail.php
@@ -150,6 +150,40 @@ class VIP_Mail_Test extends \WP_UnitTestCase {
 		self::assertEquals( $expected, $mailer->Host );
 	}
 
+	public function test_smtp_servers_not_overwritten_when_not_present_in_host_overwrite_allow_list(): void {
+		Constant_Mocker::define( 'VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST', 'server1,not-preset-server,server2' );
+
+		$GLOBALS['all_smtp_servers'] = [ 'server1', 'server2' ];
+
+		$expected = 'preset-server';
+
+		add_action( 'phpmailer_init', function ( PHPMailer &$phpmailer ) use ( $expected ) {
+			$phpmailer->isSMTP();
+			$phpmailer->Host = $expected;
+		} );
+
+		wp_mail( 'test@example.com', 'Test', 'Test' );
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		self::assertEquals( $expected, $mailer->Host );
+	}
+
+	public function test_smtp_servers_are_overwritten_when_present_in_host_overwrite_allow_list(): void {
+		Constant_Mocker::define( 'VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST', 'server1,overwritable-host,server2' );
+
+		$GLOBALS['all_smtp_servers'] = [ 'new-host' ];
+
+		add_action( 'phpmailer_init', function ( PHPMailer &$phpmailer ) {
+			$phpmailer->isSMTP();
+			$phpmailer->Host = 'overwritable-host';
+		} );
+
+		wp_mail( 'test@example.com', 'Test', 'Test' );
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		self::assertEquals( 'new-host', $mailer->Host );
+	}
+
 	/**
 	 * @ticket GH-3638
 	 */

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -103,7 +103,7 @@ final class VIP_SMTP {
 		}
 
 		$host_overwrite_allow_list = defined( 'VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST' )
-			? explode( ',', constant( 'VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST' ) )
+			? array_map( 'trim', explode( ',', constant( 'VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST' ) ) )
 			: [];
 
 		if ( 'smtp' === $phpmailer->Mailer && ! in_array( $phpmailer->Host, $host_overwrite_allow_list, true ) ) {

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -106,7 +106,7 @@ final class VIP_SMTP {
 			? explode( ',', constant( 'VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST' ) )
 			: [];
 
-		if ( 'smtp' === $phpmailer->Mailer && ! in_array( $phpmailer->Host, $host_overwrite_allow_list ) ) {
+		if ( 'smtp' === $phpmailer->Mailer && ! in_array( $phpmailer->Host, $host_overwrite_allow_list, true ) ) {
 			return;
 		}
 

--- a/vip-mail.php
+++ b/vip-mail.php
@@ -102,7 +102,11 @@ final class VIP_SMTP {
 			return;
 		}
 
-		if ( 'smtp' === $phpmailer->Mailer ) {
+		$host_overwrite_allow_list = defined( 'VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST' )
+			? explode( ',', constant( 'VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST' ) )
+			: [];
+
+		if ( 'smtp' === $phpmailer->Mailer && ! in_array( $phpmailer->Host, $host_overwrite_allow_list ) ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description

This PR introduces a new feature in the VIP Mail plugin that allows for the SMTP host to be overwritten. This is particularly useful in cases where the default SMTP host needs to be changed for specific mailing requirements.

The changes include:

1. A new constant `VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST` has been defined. This constant holds a comma-separated list of hosts that are allowed to overwrite the default SMTP host.

2. In the `phpmailer_init` method of the `VIP_SMTP` class, we check if the `VIP_SMTP_HOST_OVERWRITE_ALLOW_LIST` constant is defined. If it is, we explode it into an array of allowed hosts.

3. We then check if the `Mailer` property of the `phpmailer` object is set to 'smtp' and if the `Host` property of the `phpmailer` object is not in the array of allowed hosts. If both conditions are met, we return early from the method, effectively preventing the host from being overwritten.

This feature provides more flexibility in configuring the SMTP settings for the VIP Mail plugin. It allows developers to specify a list of hosts that can overwrite the default SMTP host, thereby catering to a wider range of mailing requirements.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->