### PR TITLE
Remove the deprecated `SERVICES_API_URL` and `SERVICES_AUTH_TOKEN` constants

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -349,24 +349,14 @@ class Site_Details_Index {
 	 * and sends it to the site details service
 	 */
 	public function put_site_details() {
-		$site_details      = $this->get_site_details();
-		$url               = null;
-		$token             = null;
-		$new_service_url   = null;
-		$new_service_token = null;
+		$site_details = $this->get_site_details();
+		$url          = null;
+		$token        = null;
 
 		if ( defined( 'VIP_SERVICES_AUTH_TOKENS' ) && ! empty( VIP_SERVICES_AUTH_TOKENS ) ) {
 			$auth_token_details = json_decode( base64_decode( VIP_SERVICES_AUTH_TOKENS ), true );
-			$new_service_url    = $auth_token_details['site']['vip-site-details']['url'] ?? null;
-			$new_service_token  = $auth_token_details['site']['vip-site-details']['token'] ?? null;
-		}
-
-		if ( $new_service_url && $new_service_token ) {
-			$url   = rtrim( $new_service_url, '/' ) . '/sites';
-			$token = $new_service_token;
-		} elseif ( defined( 'SERVICES_API_URL' ) && defined( 'SERVICES_AUTH_TOKEN' ) && ! empty( SERVICES_AUTH_TOKEN ) ) {
-			$url   = rtrim( SERVICES_API_URL, '/' ) . '/site-details/sites';
-			$token = SERVICES_AUTH_TOKEN;
+			$url                = $auth_token_details['site']['vip-site-details']['url'] ?? null;
+			$token              = $auth_token_details['site']['vip-site-details']['token'] ?? null;
 		}
 
 		if ( $url && $token ) {
@@ -379,7 +369,7 @@ class Site_Details_Index {
 				),
 			);
 
-			vip_safe_wp_remote_request( $url, false, 3, 5, 10, $args );
+			vip_safe_wp_remote_request( rtrim( $url, '/' ) . '/sites', false, 3, 5, 10, $args );
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR tries to remove 2 constants as part of code cleanup for the `SERVICES_AUTH_TOKEN` and `SERVICES_API_URL` ENV variables. The site-details related token is used from the `VIP_SERVICES_AUTH_TOKENS` variable.