### PR TITLE
Enterprise Search CLI: In `wp vip-search health validate-contents`, if `protected_content` feature is not enabled, do not mark as missing

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -632,14 +632,16 @@ class Health {
 		$mode    = $options['mode'] ?? null;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$rows = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_type, post_status FROM $wpdb->posts WHERE ID >= %d AND ID < %d", $start_post_id, $next_batch_post_id ) );
+		$rows = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_type, post_status, post_password FROM $wpdb->posts WHERE ID >= %d AND ID < %d", $start_post_id, $next_batch_post_id ) );
 
-		$post_types    = $indexable->get_indexable_post_types();
-		$post_statuses = $indexable->get_indexable_post_status();
+		$post_types                = $indexable->get_indexable_post_types();
+		$post_statuses             = $indexable->get_indexable_post_status();
+		$protected_content         = \ElasticPress\Features::factory()->get_registered_feature( 'protected_content' );
+		$protected_content_enabled = $protected_content ? $protected_content->is_active() : false;
 
 		// First we need to see identify which posts are actually expected in the index, by checking the same filters that
 		// are used in ElasticPress\Indexable\Post\SyncManager::action_sync_on_update()
-		$expected_post_rows = self::filter_expected_post_rows( $rows, $post_types, $post_statuses );
+		$expected_post_rows = self::filter_expected_post_rows( $rows, $post_types, $post_statuses, $protected_content_enabled );
 
 		$document_ids = self::get_document_ids_for_batch( $start_post_id, $next_batch_post_id - 1 );
 
@@ -756,13 +758,17 @@ class Health {
 		return $diffs;
 	}
 
-	public static function filter_expected_post_rows( $rows, $post_types, $post_statuses ) {
-		$filtered = array_filter( $rows, function ( $row ) use ( $post_types, $post_statuses ) {
+	public static function filter_expected_post_rows( $rows, $post_types, $post_statuses, $protected_content_enabled ) {
+		$filtered = array_filter( $rows, function ( $row ) use ( $post_types, $post_statuses, $protected_content_enabled ) {
 			if ( ! in_array( $row->post_type, $post_types, true ) ) {
 				return false;
 			}
 
 			if ( ! in_array( $row->post_status, $post_statuses, true ) ) {
+				return false;
+			}
+
+			if ( ! $protected_content_enabled && '' !== $row->post_password ) {
 				return false;
 			}
 

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -641,7 +641,7 @@ class Health {
 
 		// First we need to see identify which posts are actually expected in the index, by checking the same filters that
 		// are used in ElasticPress\Indexable\Post\SyncManager::action_sync_on_update()
-		$expected_post_rows = self::filter_expected_post_rows( $rows, $post_types, $post_statuses, $protected_content_enabled );
+		$expected_post_rows = static::filter_expected_post_rows( $rows, $post_types, $post_statuses, $protected_content_enabled );
 
 		$document_ids = self::get_document_ids_for_batch( $start_post_id, $next_batch_post_id - 1 );
 
@@ -759,12 +759,8 @@ class Health {
 	}
 
 	public static function filter_expected_post_rows( $rows, $post_types, $post_statuses, $protected_content_enabled ) {
-		$filtered = array_filter( $rows, function ( $row ) use ( $post_types, $post_statuses, $protected_content_enabled ) {
-			if ( ! in_array( $row->post_type, $post_types, true ) ) {
-				return false;
-			}
-
-			if ( ! in_array( $row->post_status, $post_statuses, true ) ) {
+		return array_filter( $rows, function ( $row ) use ( $post_types, $post_statuses, $protected_content_enabled ) {
+			if ( ! in_array( $row->post_type, $post_types, true ) || ! in_array( $row->post_status, $post_statuses, true ) ) {
 				return false;
 			}
 
@@ -776,8 +772,6 @@ class Health {
 
 			return ! $skipped;
 		} );
-
-		return $filtered;
 	}
 
 	public static function simplified_diff_document_and_prepared_document( $document, $prepared_document ) {

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -85,49 +85,95 @@ class Health_Test extends WP_UnitTestCase {
 		$rows = array(
 			// Indexed
 			(object) array(
-				'ID'          => 1,
-				'post_type'   => 'post',
-				'post_status' => 'publish',
+				'ID'            => 1,
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
+				'post_password' => '',
 			),
 
 			// Filtered out by ep_post_sync_kill
 			(object) array(
-				'ID'          => 2,
-				'post_type'   => 'post',
-				'post_status' => 'publish',
+				'ID'            => 2,
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
+				'post_password' => '',
 			),
 
 			// Un-indexed post_type
 			(object) array(
-				'ID'          => 3,
-				'post_type'   => 'unindexed',
-				'post_status' => 'publish',
+				'ID'            => 3,
+				'post_type'     => 'unindexed',
+				'post_status'   => 'publish',
+				'post_password' => '',
 			),
 
 			// Un-indexed post_status
 			(object) array(
-				'ID'          => 4,
-				'post_type'   => 'post',
-				'post_status' => 'unindexed',
+				'ID'            => 4,
+				'post_type'     => 'post',
+				'post_status'   => 'unindexed',
+				'post_password' => '',
 			),
 
 			// Indexed
 			(object) array(
-				'ID'          => 5,
-				'post_type'   => 'post',
-				'post_status' => 'publish',
+				'ID'            => 5,
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
+				'post_password' => '',
+			),
+
+			// Protected post
+			(object) array(
+				'ID'            => 6,
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
+				'post_password' => 'test',
 			),
 		);
 
-		$indexed_post_types    = array( 'post' );
-		$indexed_post_statuses = array( 'publish' );
+		$indexed_post_types        = array( 'post' );
+		$indexed_post_statuses     = array( 'publish' );
+		$protected_content_enabled = false;
 
-		$filtered = Health::filter_expected_post_rows( $rows, $indexed_post_types, $indexed_post_statuses );
+		$filtered = Health::filter_expected_post_rows( $rows, $indexed_post_types, $indexed_post_statuses, $protected_content_enabled );
 
 		// Grab just the IDs to make validation simpler
 		$filtered_ids = array_values( wp_list_pluck( $filtered, 'ID' ) );
 
 		$expected_ids = array( 1, 5 );
+
+		$this->assertEquals( $expected_ids, $filtered_ids );
+	}
+
+	public function test_filter_expected_post_rows__protected_content() {
+		$rows = array(
+			(object) array(
+				'ID'            => 1,
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
+				'post_password' => '',
+			),
+
+			// Protected post
+			(object) array(
+				'ID'            => 6,
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
+				'post_password' => 'test',
+			),
+		);
+
+		$indexed_post_types        = array( 'post' );
+		$indexed_post_statuses     = array( 'publish' );
+		$protected_content_enabled = true;
+
+		$filtered = Health::filter_expected_post_rows( $rows, $indexed_post_types, $indexed_post_statuses, $protected_content_enabled );
+
+		// Grab just the IDs to make validation simpler
+		$filtered_ids = array_values( wp_list_pluck( $filtered, 'ID' ) );
+
+		$expected_ids = array( 1, 6 );
 
 		$this->assertEquals( $expected_ids, $filtered_ids );
 	}


### PR DESCRIPTION
## Description
It looks like if we do `wp vip-search health validate-contents` without `protected_content`, but have password-protected posts, it will end up indexing them to ES when we run the `validate-contents` CLI command. This is because it marks that post as missing since it doesn't get filtered in `filter_expected_post_rows()`, which only filters for the indexable post_status and post_types. We should use the SQL query to grab the `post_password` from the DB and then, compare that against if `protected_content` feature is not enabled AND if the post has a password.
## Changelog Description

### Fixed
- Enterprise Search: CLI command `wp vip-search health validate-contents`, if `protected_content` feature is not enabled, do not mark as missing


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
If testing w/ dev-env, it might be easier to replace `\Automattic\VIP\Search\Search::instance()->queue->queue_object( $id, $type, [ 'priority' => $priority ] );` with `\ElasticPress\Indexables::factory()->get( $type )->index( $id, false );`

1) Do not enable `protected_content` feature
2) Create a passworded post
3) Do `wp vip-search health validate-contents` 
4) Check the index if the passworded post ID was indexed via `wp vip-search documents get post <postId>`

Enable protected_content and run the `validate-contents` feature and ensure that it marks it as missing. 