### PR TITLE
Simplify Parse.ly loader

### DIFF
--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -25,18 +25,10 @@ jobs:
           # Oldest version of the parsely plugin
           - { wp: latest, parsely: '3.5', mode: 'filter_enabled', php: '8.1' }
           - { wp: latest, parsely: '3.5', mode: 'filter_disabled', php: '8.1' }
-          - { wp: latest, parsely: '3.5', mode: 'option_enabled', php: '8.1' }
-          - { wp: latest, parsely: '3.5', mode: 'option_disabled', php: '8.1' }
-          - { wp: latest, parsely: '3.5', mode: 'filter_and_option_enabled', php: '8.1' }
-          - { wp: latest, parsely: '3.5', mode: 'filter_and_option_disabled', php: '8.1' }
 
           # Latest version of the parsely plugin
           - { wp: latest, mode: 'filter_enabled', php: '8.1' }
           - { wp: latest, mode: 'filter_disabled', php: '8.1' }
-          - { wp: latest, mode: 'option_enabled', php: '8.1' }
-          - { wp: latest, mode: 'option_disabled', php: '8.1' }
-          - { wp: latest, mode: 'filter_and_option_enabled', php: '8.1' }
-          - { wp: latest, mode: 'filter_and_option_disabled', php: '8.1' }
     services:
       mysql:
         image: mysql:8

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -220,51 +220,12 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertFalse( get_option( '_wpvip_parsely_mu' ) );
 				break;
-			case 'option_enabled':
-				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
-				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
-				break;
-			case 'option_disabled':
-				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
-				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
-				break;
-			case 'filter_and_option_enabled':
-				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
-				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
-				break;
-			case 'filter_and_option_disabled':
-				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
-				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
-				break;
 			default:
 				$this->fail( 'Invalid test mode specified: ' . self::$test_mode );
 		}
 
 		$this->assertFalse( Parsely_Loader_Info::is_active() );
 		$this->assertEquals( Parsely_Integration_Type::DISABLED_CONSTANT, Parsely_Loader_Info::get_integration_type() );
-	}
-
-	public function test_parsely_ui_hooks() {
-		maybe_load_plugin();
-
-		$this->assertFalse( has_action( 'option_parsely', __NAMESPACE__ . '\alter_option_use_repeated_metas' ) );
-
-		if ( is_parsely_disabled() ) {
-			return;
-		}
-
-		\Parsely\parsely_initialize_plugin();
-		maybe_disable_some_features();
-
-		$repeated_metas_expected = 'option_enabled' === self::$test_mode ? 10 : false;
-		$this->assertSame( $repeated_metas_expected, has_action( 'option_parsely', __NAMESPACE__ . '\alter_option_use_repeated_metas' ) );
-
-		$row_actions = new Row_Actions( $GLOBALS['parsely'] );
-		$row_actions->run();
-
-		$row_actions_expected = in_array( self::$test_mode, [ 'filter_enabled', 'filter_and_option_enabled' ] ) ? 10 : false;
-		$this->assertSame( $row_actions_expected, has_filter( 'page_row_actions', array( $row_actions, 'row_actions_add_parsely_link' ) ) );
-		$this->assertSame( $row_actions_expected, has_filter( 'post_row_actions', array( $row_actions, 'row_actions_add_parsely_link' ) ) );
 	}
 
 	public function test_default_parsely_configs() {

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -139,24 +139,6 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 				);
 				$this->assertEquals( Parsely_Integration_Type::DISABLED_MUPLUGINS_FILTER, Parsely_Loader_Info::get_integration_type() );
 				break;
-			case 'option_enabled':
-				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
-				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );
-				$this->assertTrue(
-					Parsely_Loader_Info::is_active(),
-					'Expecting wp-parsely plugin to be enabled by the option.'
-				);
-				$this->assertEquals( Parsely_Integration_Type::ENABLED_MUPLUGINS_SILENT_OPTION, Parsely_Loader_Info::get_integration_type() );
-				break;
-			case 'option_disabled':
-				$this->assertFalse( has_filter( 'wpvip_parsely_load_mu' ) );
-				$this->assertSame( '0', get_option( '_wpvip_parsely_mu' ) );
-				$this->assertFalse(
-					Parsely_Loader_Info::is_active(),
-					'Expecting wp-parsely plugin to be disabled by the option.'
-				);
-				$this->assertEquals( Parsely_Integration_Type::DISABLED_MUPLUGINS_SILENT_OPTION, Parsely_Loader_Info::get_integration_type() );
-				break;
 			case 'filter_and_option_enabled':
 				$this->assertTrue( has_filter( 'wpvip_parsely_load_mu' ) );
 				$this->assertSame( '1', get_option( '_wpvip_parsely_mu' ) );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -281,22 +281,19 @@ function maybe_load_plugin() {
 		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::ENABLED_CONSTANT );
 	}
 
-	$option_load_status   = get_option( '_wpvip_parsely_mu', null );
 	$filtered_load_status = apply_filters( 'wpvip_parsely_load_mu', null );
 
 	// If plugin isn't enabled via constant then check for filter and option status.
 	if ( true !== $parsely_enabled_constant ) {
-		$should_load            = true === $filtered_load_status || '1' === $option_load_status;
-		$should_prevent_loading = false === $filtered_load_status || '0' === $option_load_status;
+		$should_load            = true === $filtered_load_status;
+		$should_prevent_loading = false === $filtered_load_status;
 
 		// No integration: The site has not enabled parsely.
 		if ( ! $should_load || $should_prevent_loading ) {
 			Parsely_Loader_Info::set_active( false );
 
-			if ( false === $filtered_load_status ) {
+			if ( $should_prevent_loading ) {
 				Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_MUPLUGINS_FILTER );
-			} elseif ( '0' === $option_load_status ) {
-				Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_MUPLUGINS_SILENT_OPTION );
 			}
 
 			return;
@@ -350,12 +347,7 @@ function maybe_load_plugin() {
 
 	// If plugin isn't enabled via constant then set filter or option integration_type.
 	if ( true !== $parsely_enabled_constant ) {
-		$integration_type = Parsely_Integration_Type::ENABLED_MUPLUGINS_FILTER;
-		if ( '1' === $option_load_status && true !== $filtered_load_status ) {
-			$integration_type = Parsely_Integration_Type::ENABLED_MUPLUGINS_SILENT_OPTION;
-		}
-
-		Parsely_Loader_Info::set_integration_type( $integration_type );
+		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::ENABLED_MUPLUGINS_FILTER );
 	}
 
 	Parsely_Loader_Info::set_active( true );
@@ -406,16 +398,12 @@ function maybe_disable_some_features() {
  */
 abstract class Parsely_Integration_Type { // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace
 	// When parsely is active.
-	const ENABLED_MUPLUGINS_FILTER        = 'ENABLED_MUPLUGINS_FILTER';
-	const ENABLED_MUPLUGINS_SILENT_OPTION = 'ENABLED_MUPLUGINS_SILENT_OPTION';
-	const ENABLED_CONSTANT                = 'ENABLED_CONSTANT';
-
-	const SELF_MANAGED = 'SELF_MANAGED';
-
+	const ENABLED_MUPLUGINS_FILTER = 'ENABLED_MUPLUGINS_FILTER';
+	const ENABLED_CONSTANT         = 'ENABLED_CONSTANT';
+	const SELF_MANAGED             = 'SELF_MANAGED';
 	// When parsely is not active.
-	const DISABLED_MUPLUGINS_FILTER        = 'DISABLED_MUPLUGINS_FILTER';
-	const DISABLED_MUPLUGINS_SILENT_OPTION = 'DISABLED_MUPLUGINS_SILENT_OPTION';
-	const DISABLED_CONSTANT                = 'DISABLED_CONSTANT'; // Prevent loading of plugin based on integration meta attribute or customers can also define it.
+	const DISABLED_MUPLUGINS_FILTER = 'DISABLED_MUPLUGINS_FILTER';
+	const DISABLED_CONSTANT         = 'DISABLED_CONSTANT';          // Prevent loading of plugin based on integration meta attribute or customers can also define it.
 
 	const NONE = 'NONE';
 	const NULL = 'NULL';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -350,14 +350,13 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\maybe_load_plugin', 1 );
  * Enum which represent all options to integrate `wp-parsely`.
  */
 abstract class Parsely_Integration_Type { // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace
-	// When parsely is active.
+	// When Parse.ly is active.
 	const ENABLED_MUPLUGINS_FILTER = 'ENABLED_MUPLUGINS_FILTER';
 	const ENABLED_CONSTANT         = 'ENABLED_CONSTANT';
 	const SELF_MANAGED             = 'SELF_MANAGED';
-	// When parsely is not active.
+	// When Parse.ly is not active.
 	const DISABLED_MUPLUGINS_FILTER = 'DISABLED_MUPLUGINS_FILTER';
 	const DISABLED_CONSTANT         = 'DISABLED_CONSTANT';          // Prevent loading of plugin based on integration meta attribute or customers can also define it.
-
+	// When Parse.ly is not configured in any way.
 	const NONE = 'NONE';
-	const NULL = 'NULL';
 }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -180,11 +180,7 @@ final class Parsely_Loader_Info {
 		 *
 		 * @var array
 		 */
-		$parsely_options = array();
-
-		if ( isset( $GLOBALS['parsely'] ) && is_a( $GLOBALS['parsely'], 'Parsely\Parsely' ) ) {
-			$parsely_options = $GLOBALS['parsely']->get_options();
-		}
+		$parsely_options = get_option( 'parsely', [] );
 
 		return $parsely_options;
 	}
@@ -336,7 +332,9 @@ function maybe_load_plugin() {
 
 	require_once $entry_file;
 
-	Parsely_Loader_Info::set_version( $version );
+	if ( defined( '\Parsely\PARSELY_VERSION' ) ) {
+		Parsely_Loader_Info::set_version( constant( '\Parsely\PARSELY_VERSION' ) );
+	}
 
 	// Require VIP's customizations over wp-parsely.
 	$vip_parsely_plugin = __DIR__ . '/vip-parsely/vip-parsely.php';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -17,6 +17,8 @@
 
 namespace Automattic\VIP\WP_Parsely_Integration;
 
+use Parsely\Parsely;
+
 /**
  * The default version is the first entry in the SUPPORTED_VERSIONS list.
  */
@@ -268,29 +270,26 @@ function maybe_load_plugin() {
 
 	if ( defined( 'VIP_PARSELY_ENABLED' ) ) {
 		$parsely_enabled_constant = constant( 'VIP_PARSELY_ENABLED' );
+		Parsely_Loader_Info::set_active( $parsely_enabled_constant );
+		$integration_type = Parsely_Loader_Info::is_active() ? Parsely_Integration_Type::ENABLED_CONSTANT : Parsely_Integration_Type::DISABLED_CONSTANT;
+		Parsely_Loader_Info::set_integration_type( $integration_type );
 
 		// Opt out if constant value isn't true.
-		if ( true !== $parsely_enabled_constant ) {
-			Parsely_Loader_Info::set_active( false );
-			Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_CONSTANT );
-
+		if ( ! Parsely_Loader_Info::is_active() ) {
 			return;
 		}
-
-		Parsely_Loader_Info::set_active( true );
-		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::ENABLED_CONSTANT );
 	}
 
 	$filtered_load_status = apply_filters( 'wpvip_parsely_load_mu', null );
 
 	// If plugin isn't enabled via constant then check for filter if it's enabled.
-	if ( true !== $parsely_enabled_constant && true !== $filtered_load_status ) {
-		Parsely_Loader_Info::set_active( false );
+	Parsely_Loader_Info::set_active( (bool) $filtered_load_status );
 
-		if ( false === $filtered_load_status ) {
-			Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_MUPLUGINS_FILTER );
-		}
+	if ( false === $filtered_load_status ) {
+		Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_MUPLUGINS_FILTER );
+	}
 
+	if ( ! Parsely_Loader_Info::is_active() ) {
 		return;
 	}
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -176,11 +176,15 @@ final class Parsely_Loader_Info {
 		}
 
 		/**
-		 * Parse.ly options.
+		 * Parse.ly options, plugin may be not loaded at this moment in the runtime, but we want to check the options anyway.
 		 *
 		 * @var array
 		 */
-		$parsely_options = get_option( 'parsely', [] );
+		if ( isset( $GLOBALS['parsely'] ) && is_a( $GLOBALS['parsely'], 'Parsely\Parsely' ) ) {
+			$parsely_options = $GLOBALS['parsely']->get_options();
+		} else {
+			$parsely_options = get_option( 'parsely', [] );
+		}
 
 		return $parsely_options;
 	}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -258,6 +258,10 @@ function maybe_load_plugin() {
 		case class_exists( 'Parsely' ) || class_exists( 'Parsely\Parsely' ):
 			Parsely_Loader_Info::set_active( true );
 			Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::SELF_MANAGED );
+			$parsely_options = Parsely_Loader_Info::get_parsely_options();
+			if ( array_key_exists( 'plugin_version', $parsely_options ) ) {
+				Parsely_Loader_Info::set_version( $parsely_options['plugin_version'] );
+			}
 			break;
 		// Integrations-managed
 		case defined( 'VIP_PARSELY_ENABLED' ):
@@ -285,13 +289,8 @@ function maybe_load_plugin() {
 			break;
 	}
 
-	if ( ! Parsely_Loader_Info::is_active() ) {
+	if ( ! Parsely_Loader_Info::is_active() || Parsely_Integration_Type::SELF_MANAGED === Parsely_Loader_Info::get_integration_type() ) {
 		return;
-	}
-
-	$parsely_options = Parsely_Loader_Info::get_parsely_options();
-	if ( array_key_exists( 'plugin_version', $parsely_options ) ) {
-		Parsely_Loader_Info::set_version( $parsely_options['plugin_version'] );
 	}
 
 	$versions_to_try = SUPPORTED_VERSIONS;

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -265,7 +265,7 @@ function maybe_load_plugin() {
 			break;
 		// Integrations-managed
 		case defined( 'VIP_PARSELY_ENABLED' ):
-			Parsely_Loader_Info::set_active( constant( 'VIP_PARSELY_ENABLED' ) );
+			Parsely_Loader_Info::set_active( true === constant( 'VIP_PARSELY_ENABLED' ) );
 			Parsely_Loader_Info::set_integration_type(
 				Parsely_Loader_Info::is_active()
 					? Parsely_Integration_Type::ENABLED_CONSTANT

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -268,15 +268,20 @@ function maybe_load_plugin() {
 					: Parsely_Integration_Type::DISABLED_CONSTANT
 			);
 			break;
-		// Filter-managed
+		// Filter-managed - enabled
 		case $filtered_load_status:
 			Parsely_Loader_Info::set_active( true );
 			Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::ENABLED_MUPLUGINS_FILTER );
 			break;
-		// Disabled
+		// Filter-managed - disabled
+		case false === $filtered_load_status:
+			Parsely_Loader_Info::set_active( false );
+			Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_MUPLUGINS_FILTER );
+			break;
+		// Not configured in any way
 		default:
 			Parsely_Loader_Info::set_active( false );
-			Parsely_Loader_Info::set_integration_type( $filtered_load_status ? Parsely_Integration_Type::NULL : Parsely_Integration_Type::DISABLED_MUPLUGINS_FILTER );
+			Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::NONE );
 			break;
 	}
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -283,21 +283,15 @@ function maybe_load_plugin() {
 
 	$filtered_load_status = apply_filters( 'wpvip_parsely_load_mu', null );
 
-	// If plugin isn't enabled via constant then check for filter and option status.
-	if ( true !== $parsely_enabled_constant ) {
-		$should_load            = true === $filtered_load_status;
-		$should_prevent_loading = false === $filtered_load_status;
+	// If plugin isn't enabled via constant then check for filter if it's enabled.
+	if ( true !== $parsely_enabled_constant && true !== $filtered_load_status ) {
+		Parsely_Loader_Info::set_active( false );
 
-		// No integration: The site has not enabled parsely.
-		if ( ! $should_load || $should_prevent_loading ) {
-			Parsely_Loader_Info::set_active( false );
-
-			if ( $should_prevent_loading ) {
-				Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_MUPLUGINS_FILTER );
-			}
-
-			return;
+		if ( false === $filtered_load_status ) {
+			Parsely_Loader_Info::set_integration_type( Parsely_Integration_Type::DISABLED_MUPLUGINS_FILTER );
 		}
+
+		return;
 	}
 
 	$versions_to_try = SUPPORTED_VERSIONS;

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -298,10 +298,6 @@ function maybe_load_plugin() {
 
 			return;
 		}
-
-		// Enqueuing the disabling of Parse.ly features when the plugin is loaded (after the `plugins_loaded` hook)
-		// We need priority 0, so it's executed before `widgets_init`.
-		add_action( 'init', __NAMESPACE__ . '\maybe_disable_some_features', 0 );
 	}
 
 	$versions_to_try = SUPPORTED_VERSIONS;
@@ -360,38 +356,6 @@ function maybe_load_plugin() {
 	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\maybe_load_plugin', 1 );
-
-/**
- * Hides the UI if the plugin is loaded via silent option.
- */
-function maybe_disable_some_features() {
-	if ( ! isset( $GLOBALS['parsely'] ) || ! is_a( $GLOBALS['parsely'], 'Parsely\Parsely' ) ) {
-		return;
-	}
-
-	$filtered_load_status    = apply_filters( 'wpvip_parsely_load_mu', null );
-	$should_disable_features = apply_filters( 'wpvip_parsely_hide_ui_for_mu', true !== $filtered_load_status );
-
-	// If the plugin was not loaded via the filter, hide the UI by default.
-	if ( $should_disable_features ) {
-		remove_action( 'init', 'Parsely\parsely_wp_admin_early_register' );
-		remove_action( 'init', 'Parsely\init_recommendations_block' );
-		remove_action( 'enqueue_block_editor_assets', 'Parsely\init_content_helper' );
-		remove_action( 'admin_init', 'Parsely\parsely_admin_init_register' );
-		remove_action( 'widgets_init', 'Parsely\parsely_recommended_widget_register' );
-
-		// Don't show the row action links.
-		add_filter( 'wp_parsely_enable_row_action_links', '__return_false' );
-		add_filter( 'wp_parsely_enable_rest_api_support', '__return_false' );
-		add_filter( 'wp_parsely_enable_related_api_proxy', '__return_false' );
-
-		// Default to "repeated metas".
-		add_filter( 'option_parsely', __NAMESPACE__ . '\alter_option_use_repeated_metas' );
-
-		// Remove the Parse.ly Recommended Widget.
-		unregister_widget( 'Parsely_Recommended_Widget' );
-	}
-}
 
 /**
  * Enum which represent all options to integrate `wp-parsely`.


### PR DESCRIPTION
## Description

We're reducing the number of ways the plugin can be loaded. Eventually there will be only one way (via Integrations) and the rest will be gradually phased out.

Additionally, this fixes SDS reporting an `UNKNOWN` version by relying on raw `parsely` option rather than checking for the global instance of Parse.ly which may not exist at the moment of the version check call. 

## Changelog Description

### Removed
- Removed ability to load Parse.ly via an option.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out the PR
2. Set filter `add_filter( 'wpvip_parsely_load_mu', '__return_true' );` 
3. Activate the plugin from `plugins` folder
4. Make sure nothing fatals and the plugin is loaded through the core plugin system.
5. Deactivate the plugin and set `add_filter( 'wpvip_parsely_load_mu', '__return_false' );` 
6. Make sure the Parse.ly is not loaded