### PR TITLE
Deprecations: fix version number for get_page_by_path()

### DIFF
--- a/vip-helpers/vip-deprecated.php
+++ b/vip-helpers/vip-deprecated.php
@@ -1332,7 +1332,7 @@ function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
 /**
  * `get_page_by_path()` is now cached and no longer calls direct SQL.
  * 
- * @deprecated Since WP 6.1
+ * @deprecated Since WP 4.6.0
  * 
  * @param string        $page_path Page path
  * @param string        $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
@@ -1340,7 +1340,7 @@ function wpcom_vip_term_exists( $term, $taxonomy = '', $parent = null ) {
  * @return WP_Post|null WP_Post on success or null on failure
  */
 function wpcom_vip_get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
-	_deprecated_function( __FUNCTION__, '6.1', 'get_page_by_path' );
+	_deprecated_function( __FUNCTION__, '4.6', 'get_page_by_path' );
 
 	return get_page_by_path( $page_path, $output, $post_type ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
 }


### PR DESCRIPTION
## Description

The WordPress core function `get_page_by_path()` had caching added in WP 4.6.0 via https://core.trac.wordpress.org/ticket/36711.

The confusing bit is that the effort to make the function use WP_Query (adds priming of caches) internally is the bit that was tried and reverted in https://core.trac.wordpress.org/ticket/56689#comment:19 for WP 6.1.

See #5224.

## Changelog Description

### Fixed
- Deprecations: fix the WP version number for the deprecation of `wpcom_vip_get_page_by_path()` to use `get_page_by_path()`.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

No testing is needed as there is no functional change—the correct WordPress version number is now being used in deprecated function calls and documentation to avoid confusion.