### PR TITLE
fix(two-factor): move `load_plugin_textdomain()` to `init`

### DIFF
--- a/shared-plugins/two-factor/class-two-factor-core.php
+++ b/shared-plugins/two-factor/class-two-factor-core.php
@@ -93,7 +93,7 @@ class Two_Factor_Core {
 	 * @since 0.1-dev
 	 */
 	public static function add_hooks( $compat ) {
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_textdomain' ) );
+		add_action( 'init', array( __CLASS__, 'load_textdomain' ) );
 		add_action( 'init', array( __CLASS__, 'get_providers' ) );
 		add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
 		add_filter( 'wp_login_errors', array( __CLASS__, 'maybe_show_reset_password_notice' ) );


### PR DESCRIPTION
## Description

WordPress Nightly now spits a [doing-it-wrong deprecation warning](https://github.com/WordPress/wordpress-develop/blob/522a9091c3a48553e61800de1967c7d77ff26e1c/src/wp-includes/l10n.php#L1002-L1013) when `load_plugin_textdomain()` is invoked too early (like in `plugins_loaded`).

This breaks our tests, such as E2E tests in VIP CLI.

For now, we fix the affected plugins locally and then create a PR to the upstream.

Ref: https://github.com/Automattic/vip-cli/actions/runs/11130390882/job/30929621217?pr=2045

## Changelog Description

### Fixed
- Two Factor plugin: address a deprecation warning about `load_plugin_textdomain()`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease deployment (if applicable - especially for large-scale actions requiring writes).
- [ ] This change has relevant documentation additions/updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Tests must pass.
