### PR TITLE
Update integration's config management

### DIFF
--- a/integrations/enterprise-search.php
+++ b/integrations/enterprise-search.php
@@ -28,29 +28,6 @@ class EnterpriseSearchIntegration extends Integration {
 	}
 
 	/**
-	 * Activates this integration with given options array.
-	 *
-	 * @param array $options An associative options array for the integration.
-	 *                       This can contain common parameters and integration specific parameters in `config` key.
-	 *
-	 * @private
-	 */
-	public function activate( array $options = [] ): void {
-		// If integration is already available in customer code then don't activate it from platform side.
-		if ( $this->is_loaded() ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
-			// Do nothing.
-		}
-
-		// Don't do anything if integration is already activated.
-		if ( $this->is_active() ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
-			// Do nothing.
-		}
-
-		$this->is_active = true;
-		$this->options   = $options;
-	}
-
-	/**
 	 * Loads the plugin.
 	 */
 	public function load(): void {

--- a/integrations/enterprise-search.php
+++ b/integrations/enterprise-search.php
@@ -61,7 +61,7 @@ class EnterpriseSearchIntegration extends Integration {
 	 * Set the Elasticsearch credentials.
 	 */
 	public function vip_set_es_credentials(): void {
-		$config = $this->get_config();
+		$config = $this->get_env_config();
 		if ( isset( $config['username'] ) && isset( $config['password'] ) ) {
 			define( 'VIP_ELASTICSEARCH_USERNAME', $config['username'] );
 			define( 'VIP_ELASTICSEARCH_PASSWORD', $config['password'] );

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -130,13 +130,11 @@ class IntegrationVipConfig {
 			return Org_Integration_Status::BLOCKED;
 		}
 
-		$env_status = $this->get_value_from_config( 'env', 'status' );
-
-		if ( is_multisite() ) {
-			return $this->get_value_from_config( 'network_sites', 'status' ) ? : $env_status;
+		if ( ! is_multisite() ) {
+			return $this->get_value_from_config( 'env', 'status' );
 		}
 
-		return $env_status;
+		return $this->get_value_from_config( 'network_sites', 'status' ) ? : $this->get_value_from_config( 'env', 'status' );
 	}
 
 	public function get_env_config() {

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -132,7 +132,7 @@ class IntegrationVipConfig {
 	}
 
 	public function get_env_config() {
-		return $this->get_value_from_config( 'env', 'config' ) ?? [];
+		return $this->get_value_from_config( 'env', 'config' );
 	}
 
 	public function get_network_site_config() {
@@ -140,7 +140,7 @@ class IntegrationVipConfig {
 			return [];
 		}
 
-		return $this->get_value_from_config( 'network_sites', 'config' ) ?? [];
+		return $this->get_value_from_config( 'network_sites', 'config' );
 	}
 
 	/**

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -126,28 +126,21 @@ class IntegrationVipConfig {
 			return Org_Integration_Status::BLOCKED;
 		}
 
-		// Look into network_sites config before and then fallback to env config.
-		return $this->get_value_from_config( 'network_sites', 'status' ) ??
-			$this->get_value_from_config( 'env', 'status' );
+		// Look into network_sites config first, and then fallback to env config.
+		$network_site_status = is_multisite() ? $this->get_value_from_config( 'network_sites', 'status' ) : null;
+		return $network_site_status ? $network_site_status : $this->get_value_from_config( 'env', 'status' );
 	}
 
-	/**
-	 * Get site config.
-	 *
-	 * @return array
-	 */
-	public function get_site_config() {
-		if ( is_multisite() ) {
-			$config = $this->get_value_from_config( 'network_sites', 'config' );
-			// If network site config is not found then fallback to env config if it exists
-			if ( empty( $config ) && true === $this->get_value_from_config( 'env', 'cascade_config' ) ) {
-				$config = $this->get_value_from_config( 'env', 'config' );
-			}
-		} else {
-			$config = $this->get_value_from_config( 'env', 'config' );
+	public function get_env_config() {
+		return $this->get_value_from_config( 'env', 'config' ) ?? [];
+	}
+
+	public function get_network_site_config() {
+		if ( ! is_multisite() ) {
+			return [];
 		}
 
-		return $config ?? array(); // To keep function signature consistent.
+		return $this->get_value_from_config( 'network_sites', 'config' ) ?? [];
 	}
 
 	/**

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -118,35 +118,39 @@ class IntegrationVipConfig {
 	 * Get integration status for site.
 	 *
 	 * For single sites simply return global status.
-	 * For multisites,
-	 * try to get status based on current blog id,
+	 * For multisites, try to get status based on current blog id,
 	 * if not found then fallback to global environment status.
 	 *
 	 * @return string|null
-	 *
 	 */
 	public function get_site_status() {
 		if ( $this->get_value_from_config( 'org', 'status' ) === Org_Integration_Status::BLOCKED ) {
 			return Org_Integration_Status::BLOCKED;
 		}
 
-		if ( ! is_multisite() ) {
-			return $this->get_value_from_config( 'env', 'status' );
+		if ( is_multisite() ) {
+			$network_site_status = $this->get_value_from_config( 'network_sites', 'status' );
+
+			if ( $network_site_status ) {
+				return $network_site_status;
+			}
 		}
 
-		return $this->get_value_from_config( 'network_sites', 'status' ) ? : $this->get_value_from_config( 'env', 'status' );
+		return $this->get_value_from_config( 'env', 'status' );
 	}
 
-	public function get_env_config() {
-		return $this->get_value_from_config( 'env', 'config' );
+	public function get_env_config(): array {
+		$config = $this->get_value_from_config( 'env', 'config' );
+		return is_array( $config ) ? $config : [];
 	}
 
-	public function get_network_site_config() {
+	public function get_network_site_config(): array {
 		if ( ! is_multisite() ) {
 			return [];
 		}
 
-		return $this->get_value_from_config( 'network_sites', 'config' );
+		$config = $this->get_value_from_config( 'network_sites', 'config' );
+		return is_array( $config ) ? $config : [];
 	}
 
 	/**

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -115,20 +115,28 @@ class IntegrationVipConfig {
 	}
 
 	/**
-	 * Get site status.
+	 * Get integration status for site.
+	 *
+	 * For single sites simply return global status.
+	 * For multisites,
+	 * try to get status based on current blog id,
+	 * if not found then fallback to global environment status.
 	 *
 	 * @return string|null
 	 *
-	 * @private
 	 */
 	public function get_site_status() {
 		if ( $this->get_value_from_config( 'org', 'status' ) === Org_Integration_Status::BLOCKED ) {
 			return Org_Integration_Status::BLOCKED;
 		}
 
-		// Look into network_sites config first, and then fallback to env config.
-		$network_site_status = is_multisite() ? $this->get_value_from_config( 'network_sites', 'status' ) : null;
-		return $network_site_status ? $network_site_status : $this->get_value_from_config( 'env', 'status' );
+		$env_status = $this->get_value_from_config( 'env', 'status' );
+
+		if ( is_multisite() ) {
+			return $this->get_value_from_config( 'network_sites', 'status' ) ? : $env_status;
+		}
+
+		return $env_status;
 	}
 
 	public function get_env_config() {

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -159,26 +159,19 @@ class IntegrationVipConfig {
 	 * @return null|string|array Returns `null` if key is not found, `string` if key is "status" and `array` if key is "config".
 	 */
 	protected function get_value_from_config( string $config_type, string $key ) {
-		if ( ! in_array( $config_type, [ 'org', 'env', 'network_sites' ], true ) ) {
-			trigger_error( 'config_type param (' . esc_html( $config_type ) . ') must be one of org, env or network_sites.', E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			return null;
-		}
-
 		if ( ! isset( $this->config[ $config_type ] ) ) {
 			return null;
 		}
 
 		// Look for key inside org or env config.
-		if ( 'network_sites' !== $config_type && isset( $this->config[ $config_type ][ $key ] ) ) {
-			return $this->config[ $config_type ][ $key ];
+		if ( in_array( $config_type, [ 'env', 'org' ], true ) ) {
+			return $this->config[ $config_type ][ $key ] ?? null;
 		}
 
 		// Look for key inside network-sites config.
-		$network_site_id = get_current_blog_id();
-		if ( 'network_sites' === $config_type && isset( $this->config[ $config_type ][ $network_site_id ] ) ) {
-			if ( isset( $this->config[ $config_type ][ $network_site_id ][ $key ] ) ) {
-				return $this->config[ $config_type ][ $network_site_id ][ $key ];
-			}
+		if ( 'network_sites' === $config_type ) {
+			$network_site_id = get_current_blog_id();
+			return $this->config[ $config_type ][ $network_site_id ][ $key ] ?? null;
 		}
 
 		return null;

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -102,7 +102,7 @@ abstract class Integration {
 	public function get_env_config(): array {
 		// If the integration was activated manually, then return the passed-in config.
 		if ( ! isset( $this->vip_config ) ) {
-			return isset( $this->options['config'] ) ? $this->options['config'] : array();
+			return isset( $this->options['config'] ) && is_array( $this->options['config'] ) ? $this->options['config'] : [];
 		}
 
 		return $this->vip_config->get_env_config();
@@ -116,7 +116,7 @@ abstract class Integration {
 	public function get_network_site_config(): array {
 		// If the integration was activated manually, then return the passed in config.
 		if ( ! isset( $this->vip_config ) ) {
-			return isset( $this->options['config'] ) ? $this->options['config'] : array();
+			return isset( $this->options['config'] ) && is_array( $this->options['config'] ) ? $this->options['config'] : [];
 		}
 
 		return $this->vip_config->get_network_site_config();

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -78,17 +78,9 @@ abstract class Integration {
 	 * @private
 	 */
 	public function activate( array $options = [] ): void {
-		// If integration is already available in customer code then don't activate it from platform side.
-		if ( $this->is_loaded() ) {
-			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-				sprintf( 'Prevented activating of integration with slug "%s" because it is already loaded.', esc_html( $this->slug ) ),
-				E_USER_WARNING
-			);
-		}
-
-		// Don't do anything if integration is already activated.
-		if ( $this->is_active() ) {
-			trigger_error( sprintf( 'VIP Integration with slug "%s" is already activated.', esc_html( $this->get_slug() ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		// Don't do anything if integration is already loaded or activated.
+		if ( $this->is_loaded() || $this->is_active() ) {
+			return;
 		}
 
 		$this->is_active = true;
@@ -144,6 +136,7 @@ abstract class Integration {
 	public function set_vip_config( IntegrationVipConfig $vip_config ): void {
 		if ( ! $this->is_active() ) {
 			trigger_error( sprintf( 'Configuration info can only assigned if integration is active.' ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			return;
 		}
 
 		$this->vip_config = $vip_config;
@@ -160,8 +153,8 @@ abstract class Integration {
 	/**
 	 * Implement custom action and filter calls to load integration here.
 	 *
-	 * For plugins / integrations that can be added to customer repos, 
-	 * the implementation should hook into plugins_loaded and check if 
+	 * For plugins / integrations that can be added to customer repos,
+	 * the implementation should hook into plugins_loaded and check if
 	 * the plugin is already loaded first.
 	 *
 	 * @private
@@ -170,12 +163,12 @@ abstract class Integration {
 
 	/**
 	 * Configure the integration for VIP platform.
-	 * 
+	 *
 	 * If we want to implement functionality only if the integration is enabled via VIP
 	 * then we will use this function.
-	 * 
+	 *
 	 * By default, the implementation of this function will be empty.
-	 * 
+	 *
 	 * @private
 	 */
 	public function configure(): void {}

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -68,14 +68,12 @@ class Integrations {
 			$vip_config = $this->get_integration_vip_config( $slug );
 
 			if ( $vip_config->is_active_via_vip() ) {
-				$this->activate( $slug, [
-					'config' => $vip_config->get_site_config(),
-				] );
+				$this->activate( $slug );
 
 				// If integration is activated successfully without any error then configure.
 				if ( $integration->is_active() ) {
-					$integration->configure();
 					$integration->set_vip_config( $vip_config );
+					$integration->configure();
 				}
 			}
 		}

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -30,12 +30,14 @@ class Integrations {
 	public function register( $integration ): void {
 		if ( ! is_subclass_of( $integration, Integration::class ) ) {
 			trigger_error( sprintf( 'Integration class "%s" must extend %s.', esc_html( get_class( $integration ) ), esc_html( Integration::class ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			return;
 		}
 
 		$slug = $integration->get_slug();
 
 		if ( null !== $this->get_integration( $slug ) ) {
 			trigger_error( sprintf( 'Integration with slug "%s" is already registered.', esc_html( $slug ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			return;
 		}
 
 		$this->integrations[ $slug ] = $integration;
@@ -116,6 +118,7 @@ class Integrations {
 
 		if ( null === $integration ) {
 			trigger_error( sprintf( 'VIP Integration with slug "%s" is not a registered integration.', esc_html( $slug ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			return;
 		}
 
 		$integration->activate( $options );

--- a/integrations/parsely.php
+++ b/integrations/parsely.php
@@ -61,8 +61,7 @@ class ParselyIntegration extends Integration {
 	 * @return array
 	 */
 	public function wp_parsely_credentials_callback( $original_credentials ) {
-		$config      = $this->get_config();
-		$credentials = array();
+		$config = is_multisite() ? $this->get_network_site_config() : $this->get_env_config();
 
 		// If config provided by VIP is empty then take original credentials else take
 		// credentials from config.

--- a/tests/integrations/test-integration-vip-config.php
+++ b/tests/integrations/test-integration-vip-config.php
@@ -187,96 +187,39 @@ class VIP_Integration_Vip_Config_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_is_active_via_vip, $mock->is_active_via_vip() );
 	}
 
-	public function test__get_site_config_returns_value_from_environment_config(): void {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'Only valid for non multisite.' );
-		}
-
-		$this->do_test_get_site_config(
-			[
-				'env'           => [
+	public function test__get_env_config_returns_value_from_environment_config(): void {
+		$mock = $this->get_mock( [
+			'env'           => [
+				'status' => Env_Integration_Status::ENABLED,
+				'config' => array( 'env-config' ),
+			],
+			'network_sites' => [
+				'1' => [
 					'status' => Env_Integration_Status::ENABLED,
-					'config' => array( 'env-config' ),
-				],
-				'network_sites' => [
-					'1' => [
-						'status' => Env_Integration_Status::ENABLED,
-						'config' => array( 'network-site-config' ),
-					],
+					'config' => array( 'network-site-config' ),
 				],
 			],
-			array( 'env-config' ),
-		);
+		] );
+
+		$this->assertEquals( array( 'env-config' ), $mock->get_env_config() );
 	}
 
-	public function test__get_site_config_returns_value_from_network_site_config(): void {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Only valid for multisite.' );
-		}
-
-		$this->do_test_get_site_config(
-			[
-				'env'           => [
+	public function test__get_env_config_returns_value_from_network_site_config(): void {
+		$mock = $this->get_mock( [
+			'env'           => [
+				'status' => Env_Integration_Status::ENABLED,
+				'config' => array( 'env-config' ),
+			],
+			'network_sites' => [
+				'1' => [
 					'status' => Env_Integration_Status::ENABLED,
-					'config' => array( 'env-config' ),
-				],
-				'network_sites' => [
-					'1' => [
-						'status' => Env_Integration_Status::ENABLED,
-						'config' => array( 'network-site-config' ),
-					],
+					'config' => array( 'network-site-config' ),
 				],
 			],
-			array( 'network-site-config' ),
-		);
-	}
+		] );
 
-	public function test__get_site_config_with_cascading_config(): void {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Only valid for multisite.' );
-		}
-
-		$this->do_test_get_site_config(
-			[
-				'env'           => [
-					'status'         => Env_Integration_Status::ENABLED,
-					'config'         => array( 'env-config' ),
-					'cascade_config' => true,
-				],
-				'network_sites' => [
-					'1' => [
-						'status' => Env_Integration_Status::ENABLED,
-					],
-				],
-			],
-			array( 'env-config' ),
-		);
-	}
-
-	/**
-	 * Helper function for testing `get_site_config`.
-	 *
-	 * @param array $vip_config
-	 * @param mixed $expected_get_site_config
-	 *
-	 * @return void
-	 */
-	private function do_test_get_site_config(
-		$vip_config,
-		$expected_get_site_config
-	) {
-		$mock = $this->get_mock( $vip_config );
-
-		$this->assertEquals( $expected_get_site_config, $mock->get_site_config() );
-	}
-
-	public function test__get_value_from_vip_config_trigger_error_if_invalid_argument_is_passed(): void {
-		$this->expectException( ErrorException::class );
-		$this->expectExceptionCode( E_USER_WARNING );
-		$this->expectExceptionMessage( 'config_type param (invalid) must be one of org, env or network_sites.' );
-		$mocked_vip_configs = [];
-
-		$this->do_test_get_value_from_config( $mocked_vip_configs, 'invalid', 'key', '' );
+		$expected = is_multisite() ? array( 'network-site-config' ) : array();
+		$this->assertEquals( $expected, $mock->get_network_site_config() );
 	}
 
 	public function test__get_value_from_vip_config_returns_null_if_given_config_type_have_no_data(): void {

--- a/tests/integrations/test-integrations.php
+++ b/tests/integrations/test-integrations.php
@@ -44,9 +44,9 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 	}
 
 	public function test__integrations_are_activating_based_on_given_vip_config(): void {
-		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->onlyMethods( [ 'is_active_via_vip', 'get_site_config' ] )->getMock();
+		$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )->disableOriginalConstructor()->onlyMethods( [ 'is_active_via_vip', 'get_env_config' ] )->getMock();
 		$config_mock->expects( $this->exactly( 2 ) )->method( 'is_active_via_vip' )->willReturnOnConsecutiveCalls( true, false );
-		$config_mock->expects( $this->exactly( 1 ) )->method( 'get_site_config' )->willReturnOnConsecutiveCalls( [ 'config_key_1' => 'vip_value' ] );
+		$config_mock->expects( $this->exactly( 1 ) )->method( 'get_env_config' )->willReturnOnConsecutiveCalls( [ 'config_key_1' => 'vip_value' ] );
 
 		/**
 		 * Integrations mock.
@@ -70,11 +70,11 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 		$mock->activate_platform_integrations();
 
 		$this->assertTrue( $integration_1->is_active() );
-		$this->assertEquals( [ 'config_key_1' => 'value' ], $integration_1->get_config() );
+		$this->assertEquals( [ 'config_key_1' => 'value' ], $integration_1->get_env_config() );
 		$this->assertTrue( $integration_2->is_active() );
-		$this->assertEquals( [ 'config_key_1' => 'vip_value' ], $integration_2->get_config() );
+		$this->assertEquals( [ 'config_key_1' => 'vip_value' ], $integration_2->get_env_config() );
 		$this->assertFalse( $integration_3->is_active() );
-		$this->assertEquals( [], $integration_3->get_config() );
+		$this->assertEquals( [], $integration_3->get_env_config() );
 	}
 
 	public function test__expected_methods_are_getting_called_when_the_integration_is_activated_via_vip_config(): void {
@@ -100,7 +100,7 @@ class VIP_Integrations_Test extends WP_UnitTestCase {
 		$integrations_mock->activate_platform_integrations();
 
 		$this->assertTrue( $integration_mock->is_active() );
-		$this->assertEquals( [], $integration_mock->get_config() );
+		$this->assertEquals( [], $integration_mock->get_env_config() );
 	}
 
 	public function test__get_integration_vip_config_returns_instance_of_IntegrationVipConfig(): void {

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -35,10 +35,10 @@ IntegrationsSingleton::instance()->register( new EnterpriseSearchIntegration( 'e
  * Activates an integration with an optional configuration value.
  *
  * @param string              $slug A unique identifier for the integration.
- * @param array<string,mixed> $config An associative array of configuration values for the integration.
+ * @param array<string,mixed> $options An associative options array for the integration.
  */
-function activate( string $slug, array $config = [] ): void {
-	IntegrationsSingleton::instance()->activate( $slug, $config );
+function activate( string $slug, array $options = [] ): void {
+	IntegrationsSingleton::instance()->activate( $slug, $options );
 }
 
 // Load integrations in muplugins_loaded:5 to allow integrations to hook


### PR DESCRIPTION
There are two ways for an integration is be activated:

1) When an integration is activated via the platform mechanisms, then we'll always use the configs that come from the injected configmap.
2) When an integration is activated manually, we'll use whatever config is passed in during the code-activation. Notably, these manual activations will not pull their config from the configmap.

Behavior-wise, this PR doesn't really change the above. It does change some of the underlining ways that configs are retrieved though. Notably, there are now two methods for fetching the config: `Integration->get_env_config()` and `Integration->get_network_site_config()` rather than just one that attempts to merge those two.

This allows integrations to make decisions on their own about what data they want to find at the env level and what data they want to check for at the network_site level (if a multisite). So instead of having to cascade "all or nothing", integrations will have the ability to pick and choose how to interpret their own cascading needs.