### PR TITLE
Fix setting VIP_ORG_ID in Tracks_Event

### DIFF
--- a/telemetry/tracks/class-tracks-event-dto.php
+++ b/telemetry/tracks/class-tracks-event-dto.php
@@ -39,7 +39,7 @@ class Tracks_Event_DTO {
 
 	public string $vipgo_env;
 
-	public string $vipgo_org;
+	public int $vipgo_org;
 
 	public bool $is_vip_user = false;
 }

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -164,7 +164,7 @@ class Tracks_Event extends Telemetry_Event {
 		// Set VIP organization if it exists.
 		if ( defined( 'VIP_ORG_ID' ) ) {
 			$org_id = constant( 'VIP_ORG_ID' );
-			if ( is_string( $org_id ) && '' !== $org_id ) {
+			if ( is_scalar( $org_id ) && $org_id ) {
 				$event->vipgo_org = $org_id;
 			}
 		}

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -164,7 +164,7 @@ class Tracks_Event extends Telemetry_Event {
 		// Set VIP organization if it exists.
 		if ( defined( 'VIP_ORG_ID' ) ) {
 			$org_id = constant( 'VIP_ORG_ID' );
-			if ( is_scalar( $org_id ) && $org_id ) {
+			if ( is_integer( $org_id ) && $org_id > 0 ) {
 				$event->vipgo_org = $org_id;
 			}
 		}

--- a/tests/telemetry/tracks/test-class-tracks-event.php
+++ b/tests/telemetry/tracks/test-class-tracks-event.php
@@ -15,7 +15,7 @@ class Tracks_Event_Test extends WP_UnitTestCase {
 
 	protected const VIP_GO_APP_ENVIRONMENT = 'test';
 
-	protected const VIP_ORG_ID = '17';
+	protected const VIP_ORG_ID = 17;
 
 	private WP_User $user;
 


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description

Turns out `VIP_ORG_ID` is an integer. 

<!--
A few sentences providing more context and describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant publicly available sources (e.g. GitHub issues)
-->

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->


### Fixed
- A bug with registering organization ID in our tracks integration.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Unit tests.

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->