### PR TITLE
Add VIP_GO_APP_ID to telemetry event data

### DIFF
--- a/telemetry/tracks/class-tracks-event-dto.php
+++ b/telemetry/tracks/class-tracks-event-dto.php
@@ -41,5 +41,7 @@ class Tracks_Event_DTO {
 
 	public int $vipgo_org;
 
+	public int $vipgo_app;
+
 	public bool $is_vip_user = false;
 }

--- a/telemetry/tracks/class-tracks-event-dto.php
+++ b/telemetry/tracks/class-tracks-event-dto.php
@@ -41,7 +41,7 @@ class Tracks_Event_DTO {
 
 	public int $vipgo_org;
 
-	public int $vipgo_app;
+	public int $vip_env_id;
 
 	public bool $is_vip_user = false;
 }

--- a/telemetry/tracks/class-tracks-event-dto.php
+++ b/telemetry/tracks/class-tracks-event-dto.php
@@ -39,7 +39,7 @@ class Tracks_Event_DTO {
 
 	public string $vipgo_env;
 
-	public string $vipgo_org;
+	public int $vipgo_org;
 
 	public bool $is_vip_user = false;
 }

--- a/telemetry/tracks/class-tracks-event-dto.php
+++ b/telemetry/tracks/class-tracks-event-dto.php
@@ -10,10 +10,6 @@ declare(strict_types=1);
 namespace Automattic\VIP\Telemetry\Tracks;
 
 use AllowDynamicProperties;
-use stdClass;
-use WP_Error;
-use Automattic\VIP\Support_User\User as Support_User;
-use function Automattic\VIP\Logstash\log2logstash;
 
 /**
  * Class that holds necessary properties of Tracks events.
@@ -37,10 +33,13 @@ class Tracks_Event_DTO {
 	/** @var string */
 	public string $_via_ip; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
+	/** @var string VIP environment */
 	public string $vipgo_env;
 
-	public int $vipgo_org;
+	/** @var int VIP organization ID (from VIP_ORG_ID) */
+	public int $vip_org_id;
 
+	/** @var int VIP environment ID (also referenced as VIP_GO_APP_ID) */
 	public int $vip_env_id;
 
 	public bool $is_vip_user = false;

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -164,7 +164,7 @@ class Tracks_Event extends Telemetry_Event {
 		// Set VIP organization if it exists.
 		if ( defined( 'VIP_ORG_ID' ) ) {
 			$org_id = constant( 'VIP_ORG_ID' );
-			if ( is_string( $org_id ) && '' !== $org_id ) {
+			if ( is_scalar( $org_id ) && $org_id ) {
 				$event->vipgo_org = $org_id;
 			}
 		}

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -163,9 +163,10 @@ class Tracks_Event extends Telemetry_Event {
 
 		// Set VIP app ID if it exists.
 		if ( defined( 'VIP_GO_APP_ID' ) ) {
-			$app_id = constant( 'VIP_GO_APP_ID' );
-			if ( is_integer( $app_id ) && $app_id > 0 ) {
-				$event->vipgo_app = $app_id;
+			// APP_ID is incorrectly named; it actually references the environment ID
+			$env_id = constant( 'VIP_GO_APP_ID' );
+			if ( is_integer( $env_id ) && $env_id > 0 ) {
+				$event->vip_env_id = $env_id;
 			}
 		}
 

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -174,7 +174,7 @@ class Tracks_Event extends Telemetry_Event {
 		if ( defined( 'VIP_ORG_ID' ) ) {
 			$org_id = constant( 'VIP_ORG_ID' );
 			if ( is_integer( $org_id ) && $org_id > 0 ) {
-				$event->vipgo_org = $org_id;
+				$event->vip_org_id = $org_id;
 			}
 		}
 

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -164,7 +164,7 @@ class Tracks_Event extends Telemetry_Event {
 		// Set VIP organization if it exists.
 		if ( defined( 'VIP_ORG_ID' ) ) {
 			$org_id = constant( 'VIP_ORG_ID' );
-			if ( is_scalar( $org_id ) && $org_id ) {
+			if ( is_integer( $org_id ) && $org_id > 0 ) {
 				$event->vipgo_org = $org_id;
 			}
 		}

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -161,6 +161,14 @@ class Tracks_Event extends Telemetry_Event {
 			}
 		}
 
+		// Set VIP app ID if it exists.
+		if ( defined( 'VIP_GO_APP_ID' ) ) {
+			$app_id = constant( 'VIP_GO_APP_ID' );
+			if ( is_integer( $app_id ) && $app_id > 0 ) {
+				$event->vipgo_app = $app_id;
+			}
+		}
+
 		// Set VIP organization if it exists.
 		if ( defined( 'VIP_ORG_ID' ) ) {
 			$org_id = constant( 'VIP_ORG_ID' );

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -161,7 +161,7 @@ class Tracks_Event extends Telemetry_Event {
 			}
 		}
 
-		// Set VIP app ID if it exists.
+		// Set VIP environment ID if it exists.
 		if ( defined( 'VIP_GO_APP_ID' ) ) {
 			// APP_ID is incorrectly named; it actually references the environment ID
 			$env_id = constant( 'VIP_GO_APP_ID' );

--- a/tests/telemetry/tracks/test-class-tracks-event.php
+++ b/tests/telemetry/tracks/test-class-tracks-event.php
@@ -17,6 +17,8 @@ class Tracks_Event_Test extends WP_UnitTestCase {
 
 	protected const VIP_ORG_ID = 17;
 
+	protected const VIP_GO_APP_ID = 2000;
+
 	private WP_User $user;
 
 	public function setUp(): void {
@@ -40,6 +42,7 @@ class Tracks_Event_Test extends WP_UnitTestCase {
 	public function test_should_return_event_data() {
 		Constant_Mocker::define( 'VIP_TELEMETRY_SALT', self::VIP_TELEMETRY_SALT );
 		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', self::VIP_GO_APP_ENVIRONMENT );
+		Constant_Mocker::define( 'VIP_GO_APP_ID', self::VIP_GO_APP_ID );
 		Constant_Mocker::define( 'VIP_ORG_ID', self::VIP_ORG_ID );
 
 		$event = new Tracks_Event( 'prefix_', 'test_event', [
@@ -60,6 +63,7 @@ class Tracks_Event_Test extends WP_UnitTestCase {
 		$this->assertSame( hash_hmac( 'sha256', $this->user->user_email, self::VIP_TELEMETRY_SALT ), $event->get_data()->_ui );
 		$this->assertSame( 'vip:user_email', $event->get_data()->_ut );
 		$this->assertSame( self::VIP_GO_APP_ENVIRONMENT, $event->get_data()->vipgo_env );
+		$this->assertSame( self::VIP_GO_APP_ID, $event->get_data()->vipgo_app );
 		$this->assertSame( self::VIP_ORG_ID, $event->get_data()->vipgo_org );
 		$this->assertFalse( $event->get_data()->is_vip_user );
 		$this->assertTrue( $event->is_recordable() );

--- a/tests/telemetry/tracks/test-class-tracks-event.php
+++ b/tests/telemetry/tracks/test-class-tracks-event.php
@@ -63,7 +63,7 @@ class Tracks_Event_Test extends WP_UnitTestCase {
 		$this->assertSame( hash_hmac( 'sha256', $this->user->user_email, self::VIP_TELEMETRY_SALT ), $event->get_data()->_ui );
 		$this->assertSame( 'vip:user_email', $event->get_data()->_ut );
 		$this->assertSame( self::VIP_GO_APP_ENVIRONMENT, $event->get_data()->vipgo_env );
-		$this->assertSame( self::VIP_GO_APP_ID, $event->get_data()->vipgo_app );
+		$this->assertSame( self::VIP_GO_APP_ID, $event->get_data()->vip_env_id );
 		$this->assertSame( self::VIP_ORG_ID, $event->get_data()->vipgo_org );
 		$this->assertFalse( $event->get_data()->is_vip_user );
 		$this->assertTrue( $event->is_recordable() );

--- a/tests/telemetry/tracks/test-class-tracks-event.php
+++ b/tests/telemetry/tracks/test-class-tracks-event.php
@@ -64,7 +64,7 @@ class Tracks_Event_Test extends WP_UnitTestCase {
 		$this->assertSame( 'vip:user_email', $event->get_data()->_ut );
 		$this->assertSame( self::VIP_GO_APP_ENVIRONMENT, $event->get_data()->vipgo_env );
 		$this->assertSame( self::VIP_GO_APP_ID, $event->get_data()->vip_env_id );
-		$this->assertSame( self::VIP_ORG_ID, $event->get_data()->vipgo_org );
+		$this->assertSame( self::VIP_ORG_ID, $event->get_data()->vip_org_id );
 		$this->assertFalse( $event->get_data()->is_vip_user );
 		$this->assertTrue( $event->is_recordable() );
 	}

--- a/tests/telemetry/tracks/test-class-tracks-event.php
+++ b/tests/telemetry/tracks/test-class-tracks-event.php
@@ -15,7 +15,7 @@ class Tracks_Event_Test extends WP_UnitTestCase {
 
 	protected const VIP_GO_APP_ENVIRONMENT = 'test';
 
-	protected const VIP_ORG_ID = '17';
+	protected const VIP_ORG_ID = 17;
 
 	private WP_User $user;
 


### PR DESCRIPTION
## Description

This PR extends the recent Tracks telemetry work (https://github.com/Automattic/vip-go-mu-plugins/pull/5869, https://github.com/Automattic/vip-go-mu-plugins/pull/5921) to include VIP app IDs in a separate field on events. We already utilize app IDs for user identification:

https://github.com/Automattic/vip-go-mu-plugins/blob/7508ea94d7fdaecf603a73ac46fb36fdd8829560/telemetry/tracks/class-tracks-event.php#L206-L214

This tracks `userids` with values in the format `{{site_id}}_{{wp_user_id}}`. This is less useful for tracking per-app events, since we'd require parsing and preprocessing event data. This PR serves to explicitly track app IDs in a separate data point to make filtering easier. Note that we already track [the app environment](https://github.com/Automattic/vip-go-mu-plugins/blob/7508ea94d7fdaecf603a73ac46fb36fdd8829560/telemetry/tracks/class-tracks-event.php#L156-L162) (e.g. `local`/`develop`) as well as [organization ID](https://github.com/Automattic/vip-go-mu-plugins/blob/7508ea94d7fdaecf603a73ac46fb36fdd8829560/telemetry/tracks/class-tracks-event.php#L164-L170), so this fits right in.

## Changelog Description

### Changed

- Added `VIP_GO_APP_ID` to Tracks telemetry events

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Run unit tests:

```bash
./bin/test.sh --filter Tracks_Event_Test
```