### PR TITLE
Jetpack: Add shim for 13.9+ to prevent Jetpack_SSO fatal and admin notices for 13.5+

### DIFF
--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -26,3 +26,21 @@ add_action(
 		do_action( 'vip_admin_notice_init', $admin_notice_controller );
 	}
 );
+
+add_action(
+	'vip_admin_notice_init',
+	function ( $admin_notice_controller ) {
+		$message = 'Heads up! Your site is using a deprecated plugin <a href="https://github.com/Automattic/jetpack-force-2fa/">jetpack-force-2fa</a>. This functionality is already included in Jetpack as of version 13.5. Please remove the plugin to avoid potential conflicts with future Jetpack updates.';
+		$admin_notice_controller->add(
+			new Admin_Notice(
+				$message,
+				[
+					new Expression_Condition( class_exists( 'Jetpack_Force_2FA' ) && class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.5', '>=' ) ),
+					new Expression_Condition( is_super_admin() ),
+				],
+				'deprecated-standalone-jetpack-2fa-plugin',
+				'error'
+			)
+		);
+	}
+);

--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -36,7 +36,7 @@ add_action(
 				$message,
 				[
 					new Expression_Condition( class_exists( 'Jetpack_Force_2FA' ) && class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.5', '>=' ) ),
-					new Capability_Condition( is_super_admin() ),
+					new Expression_Condition( is_super_admin() ),
 				],
 				'deprecated-standalone-jetpack-2fa-plugin',
 				'error'

--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -36,7 +36,7 @@ add_action(
 				$message,
 				[
 					new Expression_Condition( class_exists( 'Jetpack_Force_2FA' ) && class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.5', '>=' ) ),
-					new Expression_Condition( is_super_admin() ),
+					new Capability_Condition( is_super_admin() ),
 				],
 				'deprecated-standalone-jetpack-2fa-plugin',
 				'error'

--- a/admin-notice/admin-notice.php
+++ b/admin-notice/admin-notice.php
@@ -36,7 +36,6 @@ add_action(
 				$message,
 				[
 					new Expression_Condition( class_exists( 'Jetpack_Force_2FA' ) && class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.5', '>=' ) ),
-					new Expression_Condition( is_super_admin() ),
 				],
 				'deprecated-standalone-jetpack-2fa-plugin',
 				'error'

--- a/vip-jetpack/jetpack-sso-dummy.php
+++ b/vip-jetpack/jetpack-sso-dummy.php
@@ -1,3 +1,7 @@
 <?php
 
-class Jetpack_SSO {}
+if ( ! class_exists( '\Automattic\Jetpack\Connection\SSO' ) ) {
+	return;
+}
+
+class Jetpack_SSO extends \Automattic\Jetpack\Connection\SSO {}

--- a/vip-jetpack/jetpack-sso-dummy.php
+++ b/vip-jetpack/jetpack-sso-dummy.php
@@ -1,0 +1,3 @@
+<?php
+
+class Jetpack_SSO {}

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -434,3 +434,15 @@ add_action( 'muplugins_loaded', function () {
 		unset( $_POST['invite_user_wpcom'] );
 	}
 });
+
+/**
+ * Jetpack 13.9 removes the legacy Jetpack_SSO class. Unfortunately, this class is still used by
+ * the deprecated standalone jetpack-force-2fa plugin (which is still in use by some). This is a dummy
+ * class to prevent fatal errors when the standalone plugin is enabled.
+ */
+add_action( 'plugins_loaded', function () {
+	if ( class_exists( 'Jetpack_Force_2FA' ) && ! class_exists( 'Jetpack_SSO' ) && class_exists( 'Jetpack' ) &&
+		defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.9', '>=' ) ) {
+		require_once __DIR__ . '/jetpack-sso-dummy.php';
+	}
+} );


### PR DESCRIPTION
## Description
Change introduced here for 13.9: https://github.com/Automattic/jetpack-production/commit/32a21eeeff0a07df1479e92e62b1eee867b3fdd5#diff-7e14e5575ebceead3f7e1bb047e5e5b96586af6e828aac63ce77fa0ca48945c4L28

## Changelog Description

### Added
- Jetpack 13.5+: Display admin notice for users using deprecated standalone plugin

### Fixed
- Jetpack 13.9+: Add shim for users using deprecated standalone plugin to prevent fatal errors

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->