### PR TITLE
WP Parse.ly: Fix issue with support user bypass

### DIFF
--- a/vip-parsely/vip-parsely.php
+++ b/vip-parsely/vip-parsely.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 use Automattic\VIP\Parsely\Telemetry\Telemetry;
 use Automattic\VIP\Parsely\Telemetry\Tracks;
+use Automattic\VIP\Support_User\User as Support_User;
 
 /**
  * This is determined by our value passed to the `WP_Widget` constructor.
@@ -89,7 +90,7 @@ if ( apply_filters( 'wp_parsely_enable_telemetry_backend', true ) ) {
 add_filter( 'wp_parsely_current_user_can_use_pch_feature', function ( $current_user_can_use_pch_feature, $feature_name, $current_user ) {
 	$user_id = $current_user->ID;
 
-	if ( user_can( $user_id, 'vip_support' ) ) {
+	if ( Support_User::user_has_vip_support_role( $user_id ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
## Description

This PR is a follow up of #5765. Using `user_can` to check for support users will return true, even if the user is a regular super admin. This is not the desired behaviour, as a certain Parse.ly Content Helper feature might be disabled on the site, which should still be visible to support users, but not regular super admins.

This PR changes how it is detecting a support user, and uses the `user_has_vip_support_role` method instead.

## Changelog Description

### Fixed
- WP Parse.ly: Fixed how Support Users are detected in the Parse.ly plugin.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Same as #5765.