### PR TITLE
FORNO-1632: Add job to clean up redundant VaultPress options

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -330,6 +330,12 @@ if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
 
 	$encloseme_cleaner = new VIP_Encloseme_Cleanup();
 	$encloseme_cleaner->init();
+
+	// Load vaultpress cleanup cron
+	require_once __DIR__ . '/lib/class-vip-vaultpress-ping-cleanup.php';
+
+	$vaultpress_cleaner = new VIP_VaultPress_Ping_Cleanup();
+	$vaultpress_cleaner->init();
 }
 
 // Add custom header for VIP

--- a/lib/class-vip-vaultpress-ping-cleanup.php
+++ b/lib/class-vip-vaultpress-ping-cleanup.php
@@ -6,6 +6,9 @@ class VIP_VaultPress_Ping_Cleanup {
 	const CRON_HOOK           = 'vip_vaultpress_ping_cleanup';
 	const CRON_INTERVAL       = 'hourly';
 
+	// How many options to delete per cron run.
+	const QUERY_LIMIT = 100;
+
 	public static function init(): void {
 		if ( ! class_exists( 'VaultPress' ) && defined( 'ENABLE_VIP_VAULTPRESS_PING_CLEANUP' ) && true === ENABLE_VIP_VAULTPRESS_PING_CLEANUP ) {
 			add_action( 'init', array( __CLASS__, 'schedule_cron' ), 99999 );
@@ -44,7 +47,13 @@ class VIP_VaultPress_Ping_Cleanup {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name LIKE %s", self::VP_PING_OPTION_NAME ) );
+		return $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM $wpdb->options WHERE option_name LIKE %s LIMIT %d",
+				self::VP_PING_OPTION_NAME,
+				self::QUERY_LIMIT
+			)
+		);
 	}
 
 	private static function requires_cleanup(): bool {

--- a/lib/class-vip-vaultpress-ping-cleanup.php
+++ b/lib/class-vip-vaultpress-ping-cleanup.php
@@ -1,0 +1,69 @@
+<?php
+
+class VIP_VaultPress_Ping_Cleanup {
+	const VP_PING_OPTION_NAME = '_vp_ai_ping%';
+	const OPTION_NAME         = 'vip_vaultpress_ping_cleanup_complete';
+	const CRON_HOOK           = 'vip_vaultpress_ping_cleanup';
+	const CRON_INTERVAL       = 'hourly';
+
+	// How many options to delete per cron run.
+	const QUERY_LIMIT = 500;
+
+	public static function init(): void {
+		if ( ! class_exists( 'VaultPress' ) && defined( 'ENABLE_VIP_VAULTPRESS_PING_CLEANUP' ) && true === ENABLE_VIP_VAULTPRESS_PING_CLEANUP ) {
+			add_action( 'init', array( __CLASS__, 'schedule_cron' ), 99999 );
+			add_action( self::CRON_HOOK, array( __CLASS__, 'do_cron' ) );
+		}
+	}
+
+	public static function schedule_cron(): void {
+		$completed = get_option( self::OPTION_NAME );
+
+		if ( $completed && wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_clear_scheduled_hook( self::CRON_HOOK );
+			return;
+		}
+
+		if ( false === $completed && ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), self::CRON_INTERVAL, self::CRON_HOOK );
+		}
+	}
+
+	public static function do_cron(): void {
+		if ( ! wp_doing_cron() ) {
+			return;
+		}
+
+		$option_names = self::get_vaultpress_option_names();
+
+		// Mark cleanup as complete if no options are found.
+		if ( empty( $option_names ) ) {
+			update_option( self::OPTION_NAME, time() );
+			return;
+		}
+
+		self::delete_options( $option_names );
+	}
+
+	private static function delete_options( array $option_names ): int|bool {
+		global $wpdb;
+
+		$option_name_placeholders = implode( ',', array_fill( 0, count( $option_names ), '%s' ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name IN ( $option_name_placeholders )", $option_names ) );
+	}
+
+	private static function get_vaultpress_option_names(): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s LIMIT %d",
+				self::VP_PING_OPTION_NAME,
+				self::QUERY_LIMIT
+			)
+		);
+	}
+}

--- a/lib/class-vip-vaultpress-ping-cleanup.php
+++ b/lib/class-vip-vaultpress-ping-cleanup.php
@@ -53,7 +53,7 @@ class VIP_VaultPress_Ping_Cleanup {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$has_option = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s LIMIT 1",
+				"SELECT 1 FROM $wpdb->options WHERE option_name LIKE %s LIMIT 1",
 				self::VP_PING_OPTION_NAME,
 			)
 		);

--- a/lib/class-vip-vaultpress-ping-cleanup.php
+++ b/lib/class-vip-vaultpress-ping-cleanup.php
@@ -43,7 +43,7 @@ class VIP_VaultPress_Ping_Cleanup {
 	private static function delete_options(): int|bool {
 		global $wpdb;
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name LIKE %s", self::VP_PING_OPTION_NAME ) );
 	}
 

--- a/lib/class-vip-vaultpress-ping-cleanup.php
+++ b/lib/class-vip-vaultpress-ping-cleanup.php
@@ -6,9 +6,6 @@ class VIP_VaultPress_Ping_Cleanup {
 	const CRON_HOOK           = 'vip_vaultpress_ping_cleanup';
 	const CRON_INTERVAL       = 'hourly';
 
-	// How many options to delete per cron run.
-	const QUERY_LIMIT = 500;
-
 	public static function init(): void {
 		if ( ! class_exists( 'VaultPress' ) && defined( 'ENABLE_VIP_VAULTPRESS_PING_CLEANUP' ) && true === ENABLE_VIP_VAULTPRESS_PING_CLEANUP ) {
 			add_action( 'init', array( __CLASS__, 'schedule_cron' ), 99999 );
@@ -34,36 +31,33 @@ class VIP_VaultPress_Ping_Cleanup {
 			return;
 		}
 
-		$option_names = self::get_vaultpress_option_names();
-
 		// Mark cleanup as complete if no options are found.
-		if ( empty( $option_names ) ) {
+		if ( ! self::requires_cleanup() ) {
 			update_option( self::OPTION_NAME, time() );
 			return;
 		}
 
-		self::delete_options( $option_names );
+		self::delete_options();
 	}
 
-	private static function delete_options( array $option_names ): int|bool {
+	private static function delete_options(): int|bool {
 		global $wpdb;
 
-		$option_name_placeholders = implode( ',', array_fill( 0, count( $option_names ), '%s' ) );
-
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name IN ( $option_name_placeholders )", $option_names ) );
+		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name LIKE %s", self::VP_PING_OPTION_NAME ) );
 	}
 
-	private static function get_vaultpress_option_names(): array {
+	private static function requires_cleanup(): bool {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		return $wpdb->get_col(
+		$has_option = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s LIMIT %d",
+				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s LIMIT 1",
 				self::VP_PING_OPTION_NAME,
-				self::QUERY_LIMIT
 			)
 		);
+
+		return ! is_null( $has_option );
 	}
 }


### PR DESCRIPTION
## Description

Adds a job to remove redundant `_vp_ai_ping` options [added by VaultPress](https://github.com/Automattic/vaultpress/blob/958c3d2ea6ca638105a1e6a85f58726b8911be6a/vaultpress.php#L1434). 

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Add an option `wp option add _vp_ai_ping_12345`
1. Set `ENABLE_VIP_VAULTPRESS_PING_CLEANUP` to `true`
1. `wp cron-control events list` and verify `vip_vaultpress_ping_cleanup` is scheduled
2. After the event runs, `wp option get _vp_ai_ping_12345` should return an error
2. Run the event again `wp cron event run vip_vaultpress_ping_cleanup`
1. Verify completion option is set `wp option get vip_vaultpress_ping_cleanup_complete`
2. Verify `vip_vaultpress_ping_cleanup` is no longer scheduled