### PR TITLE
Search: Allow sync manager queue to account for multisite context

### DIFF
--- a/search/includes/classes/class-queue.php
+++ b/search/includes/classes/class-queue.php
@@ -1028,11 +1028,11 @@ class Queue {
 			return $bail;
 		}
 
-		if ( empty( $sync_manager->sync_queue ) ) {
+		if ( empty( $sync_manager->get_sync_queue() ) ) {
 			return $bail;
 		}
 
-		$this->queue_objects( array_keys( $sync_manager->sync_queue ), $indexable_slug );
+		$this->queue_objects( array_keys( $sync_manager->get_sync_queue() ), $indexable_slug );
 
 		// If indexing operations are NOT currently ratelimited, queue up a cron event to process these immediately.
 		if ( ! static::is_indexing_ratelimited() ) {
@@ -1040,7 +1040,7 @@ class Queue {
 		}
 
 		// Empty out the queue now that we've queued those items up
-		$sync_manager->sync_queue = [];
+		$sync_manager->reset_sync_queue();
 
 		return true;
 	}
@@ -1081,12 +1081,12 @@ class Queue {
 			return $bail;
 		}
 
-		if ( empty( $sync_manager->sync_queue ) ) {
+		if ( empty( $sync_manager->get_sync_queue() ) ) {
 			return $bail;
 		}
 
 		// Increment first to prevent overrunning ratelimiting
-		$increment             = count( $sync_manager->sync_queue );
+		$increment             = count( $sync_manager->get_sync_queue() );
 		$index_count_in_period = static::index_count_incr( $increment );
 
 		// If indexing operation ratelimiting is hit, queue index operations

--- a/search/includes/classes/class-versioning.php
+++ b/search/includes/classes/class-versioning.php
@@ -845,7 +845,7 @@ class Versioning {
 		$inactive_versions = $this->get_inactive_versions( $indexable );
 
 		// If there are no inactive versions or nothing in the queue, we can just skip
-		if ( empty( $inactive_versions ) || empty( $sync_manager->sync_queue ) ) {
+		if ( empty( $inactive_versions ) || empty( $sync_manager->get_sync_queue() ) ) {
 			return $bail;
 		}
 
@@ -856,7 +856,7 @@ class Versioning {
 				'index_version' => $version['number'],
 			);
 
-			foreach ( $sync_manager->sync_queue as $object_id => $value ) {
+			foreach ( $sync_manager->get_sync_queue() as $object_id => $value ) {
 				/**
 				 * This filter is documented in Versioning::replicate_queued_objects_to_other_versions
 				 */

--- a/tests/search/includes/classes/test-class-versioning.php
+++ b/tests/search/includes/classes/test-class-versioning.php
@@ -1334,11 +1334,14 @@ class Versioning_Test extends WP_UnitTestCase {
 		$sync_manager = $indexable->sync_manager;
 
 		// Fake some changed posts
-		$sync_manager->sync_queue = array(
-			1 => true,
-			2 => true,
-			3 => true,
-		);
+		$sync_manager->sync_queue = [
+			get_current_blog_id() =>
+			[
+				1 => true,
+				2 => true,
+				3 => true,
+			],
+		];
 
 		// Then fire pre_ep_index_sync_queue to simulate EP performing indexing
 		$result = apply_filters( 'pre_ep_index_sync_queue', false, $sync_manager, 'post' );


### PR DESCRIPTION
## Description
Currently, multisite context switching in the sync manager queue is not supported right now. This adds it per https://github.com/Automattic/ElasticPress/pull/204. Should have no real material effect since `get_sync_queue()` replaces `$this->sync_queue` and has the same return.

## Changelog Description

### Fixed
- Enterprise Search: Allow syncmanager to support multisite context for queues

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->