### PR TITLE
Explicitly supply accept: image/webp for requests to webp images

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -207,6 +207,13 @@ class API_Client {
 			'filename' => $tmp_file,
 		];
 
+		// Prevent webp => jpg transform from running
+		if ( str_ends_with( strtok( $file_path, '?' ), '.webp' ) ) {
+			$request_args['headers'] = [
+				'Accept' => 'image/webp',
+			];
+		}
+
 		// not in cache so get from API
 		$response = $this->call_api( $file_path, 'GET', $request_args );
 


### PR DESCRIPTION
## Description

Currently the request for a webp image coming through StreamWrapper will be converted to jpg. This is an unwanted behavior. To address that we're passing the `Accept: image/webp` to File Service which indicates that the image should be served as-is. 

## Changelog Description

### Changed
- Requests to VIP File Service via the Stream Wrapper will not cause as webp => jpg transform anymore. 


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->