### PR TITLE
Add xmlrpc file to security to mitigate pingback attack 

### DIFF
--- a/security.php
+++ b/security.php
@@ -13,6 +13,7 @@ License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2
 require_once __DIR__ . '/security/class-lockout.php';
 require_once __DIR__ . '/security/machine-user.php';
 require_once __DIR__ . '/security/class-private-sites.php';
+require_once __DIR__ . '/security/xmlrpc.php';
 require_once __DIR__ . '/security/login-error.php';
 require_once __DIR__ . '/security/password.php';
 

--- a/security/xmlrpc.php
+++ b/security/xmlrpc.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Automattic\VIP\Security;
+
+function remove_xmlrpc_pingback_ping( $methods ) {
+    unset( $methods['pingback.ping'] );
+    return $methods;
+}
+
+add_filter( 'xmlrpc_methods', 'remove_xmlrpc_pingback_ping' );
+    


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences providing more context and describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant publicly available sources (e.g. GitHub issues)
-->
This PR removes the pingback xmlrpc endpoint which has resurfaced as an attack vector, more described here https://core.trac.wordpress.org/ticket/4137 and https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/wordpress-xml-rpc-pingback-vulnerability-analysis/

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Added
- Added mitigation for xmlrpc based pingback attack as described [here](https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/wordpress-xml-rpc-pingback-vulnerability-analysis/)

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. substituting site_one and site_two for two application urls,
```
```curl -D - "https://${site_one}/xmlrpc.php" -H "content-type: text/xml" -d '<methodCall><methodName>pingback.ping</methodName><params><param><value><string>https://${site_two}/</string></value></param><param><value><string>https://${site_one}/</string></value></param></params></methodCall>'
```
 
which results in
```
HTTP/2 200 
server: nginx
date: Wed, 06 Nov 2024 04:35:56 GMT
content-type: text/xml; charset=UTF-8
vary: Accept-Encoding
x-robots-tag: noindex, follow
cache-control: no-cache, must-revalidate, max-age=0, no-store
x-rq: syd1 123 242 443
accept-ranges: bytes
x-cache: BYPASS

<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
  <fault>
    <value>
      <struct>
        <member>
          <name>faultCode</name>
          <value><int>0</int></value>
        </member>
        <member>
          <name>faultString</name>
          <value><string>Invalid discovery target</string></value>
        </member>
      </struct>
    </value>
  </fault>
</methodResponse>
```
4. Check out PR.
5. attempt the same curl command results in 
```
HTTP/2 500 
date: Wed, 06 Nov 2024 04:44:35 GMT
content-type: text/html; charset=utf-8
expires: Wed, 11 Jan 1984 05:00:00 GMT
cache-control: no-cache, must-revalidate, max-age=0
strict-transport-security: max-age=31536000; includeSubDomains
```