### PR TITLE
Remove WP 6.0 related code since it's deprecated now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
       matrix:
         config:
         # PHP 8.1, Jetpack
-          - { wp: 6.0.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
-          - { wp: 6.0.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: 6.1.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: 6.1.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: 6.2.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
@@ -40,6 +38,8 @@ jobs:
           - { wp: 6.4.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: 6.5.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: 6.5.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.6.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
+          - { wp: 6.6.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: latest,  ms: 'no',  jp: 'yes', php: '8.1', phpunit: '', coverage: 'yes' }
           - { wp: latest,  ms: 'yes', jp: 'yes', php: '8.1', phpunit: '', coverage: 'yes' }
           - { wp: nightly, ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }

--- a/jetpack.php
+++ b/jetpack.php
@@ -19,10 +19,7 @@
 function vip_default_jetpack_version() {
 	global $wp_version;
 
-	if ( version_compare( $wp_version, '6.1', '<' ) ) {
-		// WordPress 6.0.x
-		return '12.0';
-	} elseif ( version_compare( $wp_version, '6.2', '<' ) ) {
+	if ( version_compare( $wp_version, '6.2', '<' ) ) {
 		// WordPress 6.1.x
 		return '12.5';
 	} elseif ( version_compare( $wp_version, '6.3', '<' ) ) {

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -11,7 +11,6 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 
 		$versions_map = [
 			// WordPress version => Jetpack version
-			'6.0' => '12.0',
 			'6.1' => '12.5',
 			'6.2' => '12.8',
 			'6.3' => '13.1',


### PR DESCRIPTION
## Description
Clean up code that is related to WP 6.0 since that's not available on our platform anymore. Also adds 6.6 in preparation for the 6.7 release

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->