### PR TITLE
WP Parse.ly: Update plugin to 3.17.0

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -23,6 +23,7 @@ use Parsely\Parsely;
  * The default version is the first entry in the SUPPORTED_VERSIONS list.
  */
 const SUPPORTED_VERSIONS = [
+	'3.17',
 	'3.16',
 	'3.15',
 	'3.14',


### PR DESCRIPTION
## Description
This PR updates the wp-parsely plugin to 3.17.0. It updates the submodule, and adds and set 3.17 as the default version in vip-go-mu-plugins. 

Any users who are not pinned to a specific wp-parsely version will automatically be upgraded to 3.17.x when this PR takes effect.

## Changelog Description

### Added
- Added wp-parsely version 3.17

### Changed
- Updated wp-parsely submodule to 3.17.0
- Changed the default version of wp-parsely from 3.16 to 3.17

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 