### PR TITLE
ci: use preconfigured WP image if available

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,6 +60,7 @@ jobs:
             playwright.azureedge.net:443
             production.cloudflare.docker.com:443
             public-api.wordpress.com:443
+            raw.githubusercontent.com:443
             registry-1.docker.io:443
             registry.npmjs.org:443
             s.w.org:443

--- a/__tests__/e2e/bin/setup-env.sh
+++ b/__tests__/e2e/bin/setup-env.sh
@@ -22,14 +22,26 @@ if [ -z "${version}" ]; then
     version=${WORDPRESS_VERSION:-latest}
 fi
 
+if [ "${version}" = "latest" ]; then
+    WPVER="$(wget https://github.com/Automattic/vip-container-images/raw/refs/heads/master/wordpress/versions.json -O - | jq -r '[.[] | select(.prerelease == false)] | max_by(.tag) | .tag')"
+else
+    WPVER="$(wget https://github.com/Automattic/vip-container-images/raw/refs/heads/master/wordpress/versions.json -O - | jq -r --arg ref_value "${version}" '.[] | select(.ref == $ref_value) | .tag')"
+fi
+
+if [ -z "${WPVER}" ]; then
+    WPVER=trunk
+fi
+
 # Destroy existing test site
 vip dev-env destroy --slug=e2e-test-site || true
 
 # Create and run test site
-vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --mailpit false --wordpress=trunk --multisite=false --app-code="${clientCodePath}" --php 8.2 --xdebug false --phpmyadmin false --elasticsearch true < /dev/null
+vip --slug=e2e-test-site dev-env create --title="E2E Testing site" --mu-plugins="${pluginPath}" --mailpit false --wordpress="${WPVER}" --multisite=false --app-code="${clientCodePath}" --php 8.2 --xdebug false --phpmyadmin false --elasticsearch true < /dev/null
 vip dev-env start --slug e2e-test-site --skip-wp-versions-check
-vip dev-env shell --root --slug e2e-test-site -- chown -R www-data:www-data /wp
+vip dev-env shell --root --slug e2e-test-site -- chown -R www-data:www-data /wp/wp-content/plugins
 vip dev-env exec --slug e2e-test-site --quiet -- wp plugin install --activate classic-editor
-vip dev-env exec --slug e2e-test-site --quiet -- wp core update --force --version="${version}"
-vip dev-env exec --slug e2e-test-site --quiet -- wp core update-db
+if [ "${WPVER}" = 'trunk' ]; then
+    vip dev-env exec --slug e2e-test-site --quiet -- wp core update --force --version="${version}"
+    vip dev-env exec --slug e2e-test-site --quiet -- wp core update-db
+fi
 vip dev-env exec --slug e2e-test-site --quiet -- wp rewrite structure '/%postname%/'


### PR DESCRIPTION
In this PR, we configure the E2E setup script to use a preconfigured WordPress image for the given version, if available.

This reduces the load on the WordPress servers, especially during release dates.

Otherwise, we have to deal with 502 errors 🤣 