### PR TITLE
Update `Tracks_Event_DTO` by adding new properties and updating the names of legacy properties

### DIFF
--- a/telemetry/tracks/class-tracks-event-dto.php
+++ b/telemetry/tracks/class-tracks-event-dto.php
@@ -33,9 +33,15 @@ class Tracks_Event_DTO {
 	/** @var string */
 	public string $_via_ip; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
-	public string $vipgo_env;
+	public string $vip_env;
 
-	public int $vipgo_org;
+	public int $vip_org;
+
+	public string $hosting_provider = 'other';
 
 	public bool $is_vip_user = false;
+
+	public bool $is_multisite = false;
+
+	public string $wp_version = '';
 }

--- a/telemetry/tracks/class-tracks-event.php
+++ b/telemetry/tracks/class-tracks-event.php
@@ -154,16 +154,28 @@ class Tracks_Event extends Telemetry_Event {
 
 		$base_props = get_base_properties_of_track_event();
 
-		if ( isset( $base_props['vipgo_env'] ) ) {
-			$event->vipgo_env = $base_props['vipgo_env'];
+		if ( isset( $base_props['vip_env'] ) ) {
+			$event->vip_env = $base_props['vip_env'];
 		}
 
-		if ( isset( $base_props['vipgo_org'] ) ) {
-			$event->vipgo_org = $base_props['vipgo_org'];
+		if ( isset( $base_props['vip_org'] ) ) {
+			$event->vip_org = $base_props['vip_org'];
+		}
+
+		if ( isset( $base_props['hosting_provider'] ) ) {
+			$event->hosting_provider = $base_props['hosting_provider'];
 		}
 
 		if ( isset( $base_props['is_vip_user'] ) ) {
 			$event->is_vip_user = $base_props['is_vip_user'];
+		}
+
+		if ( isset( $base_props['is_multisite'] ) ) {
+			$event->is_multisite = $base_props['is_multisite'];
+		}
+
+		if ( isset( $base_props['wp_version'] ) ) {
+			$event->wp_version = $base_props['wp_version'];
 		}
 
 		return $event;

--- a/telemetry/tracks/tracks-utils.php
+++ b/telemetry/tracks/tracks-utils.php
@@ -28,7 +28,7 @@ function get_base_properties_of_track_event(): array {
 	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 		$app_environment = constant( 'VIP_GO_APP_ENVIRONMENT' );
 		if ( is_string( $app_environment ) && '' !== $app_environment ) {
-			$props['vipgo_env'] = $app_environment;
+			$props['vip_env'] = $app_environment;
 		}
 	}
 
@@ -36,7 +36,7 @@ function get_base_properties_of_track_event(): array {
 	if ( defined( 'VIP_ORG_ID' ) ) {
 		$org_id = constant( 'VIP_ORG_ID' );
 		if ( is_integer( $org_id ) && $org_id > 0 ) {
-			$props['vipgo_org'] = $org_id;
+			$props['vip_org'] = $org_id;
 		}
 	}
 
@@ -82,6 +82,10 @@ function get_hosting_provider(): string {
  * @return array<string, mixed> The base properties.
  */
 function get_base_properties_of_track_user(): array {
+	if ( ! function_exists( 'wp_get_current_user' ) ) {
+		return [];
+	}
+
 	$props = [];
 
 	// Only track logged-in users.

--- a/tests/telemetry/tracks/test-class-tracks-event.php
+++ b/tests/telemetry/tracks/test-class-tracks-event.php
@@ -59,8 +59,11 @@ class Tracks_Event_Test extends WP_UnitTestCase {
 		$this->assertSame( '1.2.3.4', $event->get_data()->_via_ip );
 		$this->assertSame( hash_hmac( 'sha256', $this->user->user_email, self::VIP_TELEMETRY_SALT ), $event->get_data()->_ui );
 		$this->assertSame( 'vip:user_email', $event->get_data()->_ut );
-		$this->assertSame( self::VIP_GO_APP_ENVIRONMENT, $event->get_data()->vipgo_env );
-		$this->assertSame( self::VIP_ORG_ID, $event->get_data()->vipgo_org );
+		$this->assertSame( self::VIP_GO_APP_ENVIRONMENT, $event->get_data()->vip_env );
+		$this->assertSame( self::VIP_ORG_ID, $event->get_data()->vip_org );
+		$this->assertSame( 'other', $event->get_data()->hosting_provider );
+		$this->assertSame( is_multisite(), $event->get_data()->is_multisite );
+		$this->assertSame( get_bloginfo( 'version' ), $event->get_data()->wp_version );
 		$this->assertFalse( $event->get_data()->is_vip_user );
 		$this->assertTrue( $event->is_recordable() );
 	}


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description

- Update `vipgo_*` properties to `vip_*`.
- Adds `hosting_provider`, `is_multisite` and `wp_version` properties.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test


1. Add following code
    ```php
    function record_telemetry_event_in_footer() {
        $tracks = new \Automattic\VIP\Telemetry\Tracks();
        $tracks->record_event( 'local_event', [
            'hello' => 'vip',
        ] );
    }
    add_action('admin_footer', 'record_telemetry_event_in_footer');
   ```
   
2. Load the admin, wait for some time to see the event appear in Tracks and verify the event.