### PR TITLE
VIP Parse.ly: Add extra defensive check of VIP Support plugin

### DIFF
--- a/vip-parsely/vip-parsely.php
+++ b/vip-parsely/vip-parsely.php
@@ -18,6 +18,11 @@ use Automattic\VIP\Parsely\Telemetry\Telemetry;
 use Automattic\VIP\Parsely\Telemetry\Tracks;
 use Automattic\VIP\Support_User\User as Support_User;
 
+// Checks if the VIP Support plugin is active, and if not, includes it.
+if ( ! class_exists( 'Automattic\\VIP\\Support_User\\User' ) ) {
+	require __DIR__ . '/../vip-support/vip-support.php';
+}
+
 /**
  * This is determined by our value passed to the `WP_Widget` constructor.
  *


### PR DESCRIPTION
## Description
This PR adds a new defensive check in the VIP Parse.ly plugin, that validates if the VIP Support plugin has been loaded already. If not, it will require the respective file.

This fixes a potential Fatal error that could be thrown in certain scenarios:

```
PHP Fatal error:  Uncaught Error: Class "Automattic\VIP\Support_User\User" not found in /var/www/wp-content/mu-plugins/vip-parsely/vip-parsely.php:93
Stack trace:
#0 /var/www/wp-includes/class-wp-hook.php(312): {closure}(NULL, 'smart_linking', Object(WP_User))
#1 /var/www/wp-includes/plugin.php(205): WP_Hook->apply_filters(NULL, Array)
```

## Changelog Description

### Fixed
- VIP Parse.ly: Fixed a fatal error that happened in certain conditions within the VIP Parse.ly plugin.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 