### PR TITLE
Jetpack: Display correct Jetpack version in plugins list UI

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -359,16 +359,17 @@ add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );
  * @return string[] $plugin_meta Updated plugin's metadata.
  */
 function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
-	if ( defined( 'VIP_JETPACK_SKIP_LOAD' ) && VIP_JETPACK_SKIP_LOAD ) {
+	if ( defined( 'VIP_JETPACK_SKIP_LOAD' ) && constant( 'VIP_JETPACK_SKIP_LOAD' ) ) {
 		return $plugin_meta;
 	}
 
 	if ( 'jetpack.php' === $plugin_file ) {
-		$type = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && WPCOM_VIP_JETPACK_LOCAL ? 'Local': 'MU-Plugins';
+		$type = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? 'Local' : 
+			'MU-Plugins';
 		if ( defined( 'VIP_JETPACK_LOADED_VERSION' ) ) {
-			$version = VIP_JETPACK_LOADED_VERSION;
+			$version = constant( 'VIP_JETPACK_LOADED_VERSION' );
 		} else {
-			$version = JETPACK__VERSION;
+			$version = constant( 'JETPACK__VERSION' );
 		}
 
 		/* translators: Loaded Jetpack version number */

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -373,7 +373,7 @@ function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
 		}
 
 		/* translators: Loaded Jetpack version number */
-		$plugin_meta[0] = sprintf( esc_html__( '%s - Version %s' ), $type, $version );
+		$plugin_meta[0] = sprintf( esc_html__( '%1$s - Version %2$s' ), $type, $version );
 	}
 
 	return $plugin_meta;

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -351,15 +351,15 @@ function vip_jetpack_is_mobile( $matches, $kind, $return_matched_agent ) {
 add_filter( 'pre_jetpack_is_mobile', 'vip_jetpack_is_mobile', PHP_INT_MAX, 3 );
 
 /**
- * Display correct Jetpack version in wp-admin plugins UI for pinned or local versions.
+ * Display correct Jetpack version in wp-admin plugins UI for pinned, local or default versions.
  *
- * @param string[] $plugin_meta An array of the plugin's metadata, including
- *                              the version, author, author URI, and plugin URI.
- * @param string   $plugin_file Path to the plugin file relative to the plugins directory.
+ * @param string[]  plugin_meta  An array of the plugin's metadata, including
+ *                               the version, author, author URI, and plugin URI.
+ * @param string    $plugin_file Path to the plugin file relative to the plugins directory.
  * @return string[] $plugin_meta Updated plugin's metadata.
  */
 function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
-	if ( ! defined( 'VIP_JETPACK_PINNED_VERSION' ) && ! defined( 'WPCOM_VIP_JETPACK_LOCAL' ) ) {
+	if ( defined( 'VIP_JETPACK_SKIP_LOAD' ) && VIP_JETPACK_SKIP_LOAD ) {
 		return $plugin_meta;
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -364,9 +364,15 @@ function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
 	}
 
 	if ( 'jetpack.php' === $plugin_file ) {
-		$version = defined( 'VIP_JETPACK_LOADED_VERSION' ) ? VIP_JETPACK_LOADED_VERSION : JETPACK__VERSION;
+		$type = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && WPCOM_VIP_JETPACK_LOCAL ? 'Local': 'MU-Plugins';
+		if ( defined( 'VIP_JETPACK_LOADED_VERSION' ) ) {
+			$version = VIP_JETPACK_LOADED_VERSION;
+		} else {
+			$version = JETPACK__VERSION;
+		}
+
 		/* translators: Loaded Jetpack version number */
-		$plugin_meta[0] = sprintf( esc_html__( 'Version %s' ), $version );
+		$plugin_meta[0] = sprintf( esc_html__( '%s - Version %s' ), $type, $version );
 	}
 
 	return $plugin_meta;


### PR DESCRIPTION
## Description
For non-pinned versions, we load a default JP version that is in accordance with the minimum supported WP version. This will fix the UI to display it correctly.

## Changelog Description

### Fixed
- Jetpack: Correct version will display for non-pinned default loading in Plugins listing

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->