### PR TITLE
Simplify the logic to display where Jetpack is loaded from

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -365,7 +365,8 @@ function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
 
 	if ( 'jetpack.php' === $plugin_file ) {
 		$type           = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? '(Local)' : '';
-		$plugin_meta[0] = sprintf( '%s %s', constant( 'JETPACK__VERSION' ), $type );
+		/* translators: Loaded Jetpack version number */
+		$plugin_meta[0] = sprintf( esc_html__( 'Version %s %s' ), constant( 'JETPACK__VERSION' ), $type );
 		remove_filter( 'plugin_row_meta', 'vip_filter_plugin_version_jetpack', PHP_INT_MAX, 2 );
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -365,7 +365,7 @@ function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
 
 	if ( 'jetpack.php' === $plugin_file ) {
 		$type           = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? 'Local' : 'MU-Plugins';
-		$plugin_meta[0] = sprintf( '%s (%s)', $plugin_meta[0], $type );
+		$plugin_meta[0] = sprintf( '%s (%s)', constant( 'JETPACK__VERSION' ), $type );
 		remove_filter( 'plugin_row_meta', 'vip_filter_plugin_version_jetpack', PHP_INT_MAX, 2 );
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -364,8 +364,8 @@ function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
 	}
 
 	if ( 'jetpack.php' === $plugin_file ) {
-		$type           = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? 'Local' : 'MU-Plugins';
-		$plugin_meta[0] = sprintf( '%s (%s)', constant( 'JETPACK__VERSION' ), $type );
+		$type           = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? '(Local)' : '';
+		$plugin_meta[0] = sprintf( '%s %s', constant( 'JETPACK__VERSION' ), $type );
 		remove_filter( 'plugin_row_meta', 'vip_filter_plugin_version_jetpack', PHP_INT_MAX, 2 );
 	}
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -364,16 +364,9 @@ function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
 	}
 
 	if ( 'jetpack.php' === $plugin_file ) {
-		$type = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? 'Local' : 
-			'MU-Plugins';
-		if ( defined( 'VIP_JETPACK_LOADED_VERSION' ) ) {
-			$version = constant( 'VIP_JETPACK_LOADED_VERSION' );
-		} else {
-			$version = constant( 'JETPACK__VERSION' );
-		}
-
-		/* translators: Loaded Jetpack version number */
-		$plugin_meta[0] = sprintf( esc_html__( '%1$s - Version %2$s' ), $type, $version );
+		$type           = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? 'Local' : 'MU-Plugins';
+		$plugin_meta[0] = sprintf( '%s (%s)', $plugin_meta[0], $type );
+		remove_filter( 'plugin_row_meta', 'vip_filter_plugin_version_jetpack', PHP_INT_MAX, 2 );
 	}
 
 	return $plugin_meta;

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -364,9 +364,9 @@ function vip_filter_plugin_version_jetpack( $plugin_meta, $plugin_file ) {
 	}
 
 	if ( 'jetpack.php' === $plugin_file ) {
-		$type           = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? '(Local)' : '';
+		$type = defined( 'WPCOM_VIP_JETPACK_LOCAL' ) && constant( 'WPCOM_VIP_JETPACK_LOCAL' ) ? '(Local)' : '';
 		/* translators: Loaded Jetpack version number */
-		$plugin_meta[0] = sprintf( esc_html__( 'Version %s %s' ), constant( 'JETPACK__VERSION' ), $type );
+		$plugin_meta[0] = sprintf( esc_html__( 'Version %1$s %2$s' ), constant( 'JETPACK__VERSION' ), $type );
 		remove_filter( 'plugin_row_meta', 'vip_filter_plugin_version_jetpack', PHP_INT_MAX, 2 );
 	}
 


### PR DESCRIPTION
## Description

Follow-up to #6043 

## Changelog Description


### Added
- Displaying the source from where Jetpack is loaded from in Plugins list WP-Dashboard UI

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->