### PR TITLE
Implement platform-wide mitigation for wpcom-block-editor breakage

### DIFF
--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -453,3 +453,22 @@ add_action( 'plugins_loaded', function () {
 		require_once __DIR__ . '/jetpack-sso-dummy.php';
 	}
 } );
+
+// https://lobby.vip.wordpress.com/2024/12/10/notice-editor-issues-when-using-jetpack-version-13-7-and-wordpress-version-6-5/
+add_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
+function vip_jetpack_disable_wpcom_block_editor() {
+	global $wp_version;
+	$matching_jetpack_constraints = defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.7', '<' );
+	$matching_core_contstraints   = version_compare( $wp_version, '6.6', '<' );
+
+	if ( $matching_jetpack_constraints && $matching_core_contstraints ) {
+		add_filter( 'jetpack_tools_to_include', function ( $tools ) {
+			$key = array_search( 'wpcom-block-editor/class-jetpack-wpcom-block-editor.php', $tools );
+
+			if ( $key ) {
+				unset( $tools[ $key ] );
+			}
+			return $tools;
+		} );
+	}
+}

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -461,7 +461,7 @@ function vip_jetpack_disable_wpcom_block_editor() {
 	$matching_jetpack_constraints = defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.7', '<' );
 	$matching_core_constraints   = version_compare( $wp_version, '6.6', '<' );
 
-	if ( $matching_jetpack_constraints && $matching_core_contstraints ) {
+	if ( $matching_jetpack_constraints && $matching_core_constraints ) {
 		add_filter( 'jetpack_tools_to_include', function ( $tools ) {
 			$key = array_search( 'wpcom-block-editor/class-jetpack-wpcom-block-editor.php', $tools );
 

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -454,9 +454,11 @@ add_action( 'plugins_loaded', function () {
 	}
 } );
 
-// https://lobby.vip.wordpress.com/2024/12/10/notice-editor-issues-when-using-jetpack-version-13-7-and-wordpress-version-6-5/
-// Remove this filter to disable the hotfix:
-// remove_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
+/** 
+ * https://lobby.vip.wordpress.com/2024/12/10/notice-editor-issues-when-using-jetpack-version-13-7-and-wordpress-version-6-5/
+ * Remove this filter to disable the hotfix: 
+ * remove_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
+ */
 add_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
 function vip_jetpack_disable_wpcom_block_editor() {
 	global $wp_version;

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -455,7 +455,8 @@ add_action( 'plugins_loaded', function () {
 } );
 
 // https://lobby.vip.wordpress.com/2024/12/10/notice-editor-issues-when-using-jetpack-version-13-7-and-wordpress-version-6-5/
-add_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
+// Uncomment below line to enable the hotfix
+// add_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
 function vip_jetpack_disable_wpcom_block_editor() {
 	global $wp_version;
 	$matching_jetpack_constraints = defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.7', '<' );
@@ -472,3 +473,17 @@ function vip_jetpack_disable_wpcom_block_editor() {
 		} );
 	}
 }
+// Force cache flush
+add_action( 'plugins_loaded', function () {
+	add_filter( 'script_loader_src',
+		function ( $src, $handle ) {
+			if ( 'wpcom-block-editor-default-editor-script' === $handle ) {
+				return $src . '.vip';
+			}
+
+			return $src;
+		},
+		PHP_INT_MIN,
+		2
+	);
+} );

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -459,7 +459,7 @@ add_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
 function vip_jetpack_disable_wpcom_block_editor() {
 	global $wp_version;
 	$matching_jetpack_constraints = defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.7', '<' );
-	$matching_core_constraints   = version_compare( $wp_version, '6.6', '<' );
+	$matching_core_constraints    = version_compare( $wp_version, '6.6', '<' );
 
 	if ( $matching_jetpack_constraints && $matching_core_constraints ) {
 		add_filter( 'jetpack_tools_to_include', function ( $tools ) {

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -459,7 +459,7 @@ add_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
 function vip_jetpack_disable_wpcom_block_editor() {
 	global $wp_version;
 	$matching_jetpack_constraints = defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.7', '<' );
-	$matching_core_contstraints   = version_compare( $wp_version, '6.6', '<' );
+	$matching_core_constraints   = version_compare( $wp_version, '6.6', '<' );
 
 	if ( $matching_jetpack_constraints && $matching_core_contstraints ) {
 		add_filter( 'jetpack_tools_to_include', function ( $tools ) {

--- a/vip-jetpack/vip-jetpack.php
+++ b/vip-jetpack/vip-jetpack.php
@@ -455,8 +455,9 @@ add_action( 'plugins_loaded', function () {
 } );
 
 // https://lobby.vip.wordpress.com/2024/12/10/notice-editor-issues-when-using-jetpack-version-13-7-and-wordpress-version-6-5/
-// Uncomment below line to enable the hotfix
-// add_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
+// Remove this filter to disable the hotfix:
+// remove_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
+add_action( 'plugins_loaded', 'vip_jetpack_disable_wpcom_block_editor' );
 function vip_jetpack_disable_wpcom_block_editor() {
 	global $wp_version;
 	$matching_jetpack_constraints = defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.7', '<' );


### PR DESCRIPTION
## Description

Change in wpcom-block-editor external dependency resulted in broken Paragraph blocks if a site used <= Jetpack 13.6 and Core <= 6.5.

This is a hotfix disabling the functionality in question.  

## Changelog Description

### Fixed
- Mitigate paragraph block breakage wpcom-block-editor


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->