### PR TITLE
SDS: For search, track EP_IS_NETWORK constant

### DIFF
--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -259,9 +259,11 @@ class Site_Details_Index {
 		if ( class_exists( '\Automattic\VIP\Search\Search' ) ) {
 			$search_info['enabled']                   = true;
 			$search_info['query_integration_enabled'] = \Automattic\VIP\Search\Search::is_query_integration_enabled();
+			$search_info['network_enabled']           = defined( 'EP_IS_NETWORK' ) && true === constant( 'EP_IS_NETWORK' );
 		} else {
 			$search_info['enabled']                   = false;
 			$search_info['query_integration_enabled'] = false;
+			$search_info['network_enabled']           = false;
 		}
 
 		return $search_info;


### PR DESCRIPTION
## Description
For multisites, track in SDS whether `EP_IS_NETWORK` constant is set.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->