### PR TITLE
ci: install `svn` before running tests

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -60,6 +60,10 @@ runs:
           echo "ini=apc.enable_cli=1, opcache.enable_cli=1" >> $GITHUB_OUTPUT
         fi
 
+    - name: Install svn
+      run: sudo apt-get update && sudo apt-get install -y subversion
+      shell: bash
+
     - name: Set up PHP
       uses: shivammathur/setup-php@2.31.1
       with:


### PR DESCRIPTION
## Description

The latest Ubuntu-based runners do not have subversion installed, and this causes issues when trying to set up the WordPress Test Library.

This PR ensures that subversion is present.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

CI must pass.
