### PR TITLE
Actually bump minimum Parse.ly version to 3.15 in parsely.yml workflow

### DIFF
--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         config:
           # Oldest version of the parsely plugin
-          - { wp: latest, parsely: '3.5', mode: 'filter_enabled', php: '8.1' }
-          - { wp: latest, parsely: '3.5', mode: 'filter_disabled', php: '8.1' }
+          - { wp: latest, parsely: '3.15', mode: 'filter_enabled', php: '8.1' }
+          - { wp: latest, parsely: '3.15', mode: 'filter_disabled', php: '8.1' }
 
           # Latest version of the parsely plugin
           - { wp: latest, mode: 'filter_enabled', php: '8.1' }

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -339,8 +339,8 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		// Assert.
 		$this->assertEquals( array(
 			'is_pinned_version'            => has_filter( 'wpvip_parsely_version' ),
-			'site_id'                      => is_latest_version() ? 'site_id_value' : '',
-			'have_api_secret'              => is_latest_version() ? true : false,
+			'site_id'                      => 'site_id_value',
+			'have_api_secret'              => true,
 			'is_javascript_disabled'       => false,
 			'is_autotracking_disabled'     => false,
 			'should_track_logged_in_users' => false,

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -337,7 +337,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 		$configs = Parsely_Loader_Info::get_configs();
 
 		// Assert.
-		$this->assertEquals( $configs, array(
+		$this->assertEquals( array(
 			'is_pinned_version'            => has_filter( 'wpvip_parsely_version' ),
 			'site_id'                      => is_latest_version() ? 'site_id_value' : '',
 			'have_api_secret'              => is_latest_version() ? true : false,
@@ -358,7 +358,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 					'track_type' => 'do-not-track',
 				),
 			),
-		) );
+		), $configs );
 	}
 
 	public function test_alter_option_use_repeated_metas() {

--- a/tests/parsely/test-mu-parsely-integration.php
+++ b/tests/parsely/test-mu-parsely-integration.php
@@ -244,7 +244,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 			'have_api_secret'              => false,
 			'is_javascript_disabled'       => false,
 			'is_autotracking_disabled'     => false,
-			'should_track_logged_in_users' => is_latest_version() ? false : true,
+			'should_track_logged_in_users' => false,
 			'tracked_post_types'           => array(
 				array(
 					'name'       => 'post',
@@ -343,7 +343,7 @@ class MU_Parsely_Integration_Test extends WP_UnitTestCase {
 			'have_api_secret'              => is_latest_version() ? true : false,
 			'is_javascript_disabled'       => false,
 			'is_autotracking_disabled'     => false,
-			'should_track_logged_in_users' => is_latest_version() ? false : true,
+			'should_track_logged_in_users' => false,
 			'tracked_post_types'           => array(
 				array(
 					'name'       => 'post',


### PR DESCRIPTION
## Description

We've removed WP-Parse.ly < 3.15. This PR updates Parse.ly related CI workflows to specify the minimum version as 3.15. 

Additionally addresses test bugs. (props @sjinks)

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

CI should pass