### PR TITLE
Jetpack: Update to 14.2

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -34,8 +34,7 @@ function vip_default_jetpack_version() {
 	} elseif ( version_compare( $wp_version, '6.6', '<' ) ) {
 		// WordPress 6.5.x
 		return '14.0';
-	}
-	else {
+	} else {
 		// WordPress 6.6 and newer.
 		return '14.2';
 	}

--- a/jetpack.php
+++ b/jetpack.php
@@ -31,9 +31,13 @@ function vip_default_jetpack_version() {
 	} elseif ( version_compare( $wp_version, '6.5', '<' ) ) {
 		// WordPress 6.4.x
 		return '13.6';
-	} else {
-		// WordPress 6.5 and newer.
+	} elseif ( version_compare( $wp_version, '6.6', '<' ) ) {
+		// WordPress 6.5.x
 		return '14.0';
+	}
+	else {
+		// WordPress 6.6 and newer.
+		return '14.2';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '14.0';
+		$latest = '14.2';
 
 		$versions_map = [
 			// WordPress version => Jetpack version
@@ -15,7 +15,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 			'6.2' => '12.8',
 			'6.3' => '13.1',
 			'6.4' => '13.6',
-			'6.5' => $latest,
+			'6.5' => '14.0',
 			'6.6' => $latest,
 		];
 


### PR DESCRIPTION
## Description
Updates Jetpack to 14.2 for WP 6.6+

## Changelog Description

### Changed
-  Jetpack: Update to 14.2 for WP 6.6+


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->