### PR TITLE
Integrations: Implement network_wide_enable to disallow inheriting env status automatically

### DIFF
--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -134,6 +134,12 @@ class IntegrationVipConfig {
 			if ( $network_site_status ) {
 				return $network_site_status;
 			}
+
+			$env_config = $this->get_env_config();
+			if ( isset( $env_config['network_wide_enable'] ) && 'false' === $env_config['network_wide_enable'] ) {
+				// If network_wide_enable is false, then return disabled status (rather than inheriting) since $network_site_status wasn't found.
+				return Env_Integration_Status::DISABLED;
+			}
 		}
 
 		return $this->get_value_from_config( 'env', 'status' );


### PR DESCRIPTION
## Description

If `network_wide_enable` is set to `false`, do not fall back on the existing env status (which would be enabled).

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
0. Create multisite in dev-env with added subsites 2 and 3
1. `docker exec -it <container name> /bin/sh`
2. in `/wp/config/integrations-config/enterprise-search-config.php` put this in:
```
<?php

return array(
	'env' => array(
		'status' => 'enabled',
		'config' => array(
			'username' => 'test-username',
			'password' => 'test-password',
			'network_wide_enable' => 'false',
		),
	),
	'network_sites' => array(
		'1' => array(
			'status' => 'enabled',
			'config' => array(
				'offload_search' => 'true',
			)
		),
		'2' => array(
			'status' => 'disabled',
			'config' => array(
				'offload_search' => 'false',
			)
		),
	)
);
```
3. before the PR, going to subsite 3 would automatically enable it with the inheriting. after the PR, it should no longer enable ES.