### PR TITLE
Add Jetpack integration loader, add the way to load config in local dev env

### DIFF
--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -61,11 +61,7 @@ class IntegrationVipConfig {
 	 * @param string $slug A unique identifier for the integration.
 	 */
 	private function set_config( string $slug ): void {
-		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-			$config = $this->get_local_config_from_file( $slug );
-		} else {
-			$config = $this->get_vip_config_from_file( $slug );
-		}
+		$config = $this->get_vip_config_from_file( $slug );
 
 		if ( ! is_array( $config ) ) {
 			return;
@@ -86,51 +82,34 @@ class IntegrationVipConfig {
 			? constant( 'WPVIP_INTEGRATIONS_CONFIG_DIR' )
 			: ABSPATH . 'config/integrations-config';
 		$config_file_name      = $slug . '-config.php';
-		$config_file_path      = $config_file_directory . '/' . $config_file_name;
+		$config_file_path_orig = $config_file_directory . '/' . $config_file_name;
 
-		/**
-		 * Clear cache to always read data from latest config file.
-		 *
-		 * Kubernetes ConfigMap updates the file via symlink instead of actually replacing the file and
-		 * PHP cache can hold a reference to the old symlink that can cause fatal if we use require
-		 * on it.
-		 */
-		clearstatcache( true, $config_file_directory . '/' . $config_file_name );
-		// Clears cache for files created by k8s ConfigMap.
-		clearstatcache( true, $config_file_directory . '/..data' );
-		clearstatcache( true, $config_file_directory . '/..data/' . $config_file_name );
+		$config_file_path = apply_filters( 'vip_integrations_config_file_path', $config_file_path_orig, $slug );
+		$config_data      = apply_filters( 'vip_integrations_pre_load_config', null, $config_file_path, $slug );
 
-		if ( ! is_readable( $config_file_path ) ) {
-			return null;
+		if ( is_null( $config_data ) ) {
+			if ( $config_file_path_orig === $config_file_path ) {
+				/**
+				 * Clear cache to always read data from latest config file.
+				 *
+				 * Kubernetes ConfigMap updates the file via symlink instead of actually replacing the file and
+				 * PHP cache can hold a reference to the old symlink that can cause fatal if we use require
+				 * on it.
+				 */
+				clearstatcache( true, $config_file_directory . '/' . $config_file_name );
+				// Clears cache for files created by k8s ConfigMap.
+				clearstatcache( true, $config_file_directory . '/..data' );
+				clearstatcache( true, $config_file_directory . '/..data/' . $config_file_name );
+			}
+
+			if ( ! is_readable( $config_file_path ) ) {
+				return null;
+			}
+
+			$config_data = require $config_file_path;
 		}
 
-		return require $config_file_path;
-	}
-
-	/**
-	 * Get config for local dev env and Codespaces
-	 *
-	 * @param string $slug A unique identifier for the integration.
-	 *
-	 * @return null|mixed
-	 */
-	protected function get_local_config_from_file( string $slug ) {
-		$config_file = '/app/integrations.json';
-		if ( ! file_exists( $config_file ) ) {
-			return null;
-		}
-
-		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
-		$config = json_decode( file_get_contents( $config_file ), true );
-		if ( ! isset( $config[ $slug ] ) ) {
-			return null;
-		}
-
-		// We don't really care about the org config in local dev.
-		// Network config might be tricky if there's mismatch between data.
-		return [
-			'env' => $config[ $slug ],
-		];
+		return $config_data;
 	}
 
 	/**

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -61,7 +61,11 @@ class IntegrationVipConfig {
 	 * @param string $slug A unique identifier for the integration.
 	 */
 	private function set_config( string $slug ): void {
-		$config = $this->get_vip_config_from_file( $slug );
+		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			$config = $this->get_local_config_from_file( $slug );
+		} else {
+			$config = $this->get_vip_config_from_file( $slug );
+		}
 
 		if ( ! is_array( $config ) ) {
 			return;
@@ -101,6 +105,32 @@ class IntegrationVipConfig {
 		}
 
 		return require $config_file_path;
+	}
+
+	/**
+	 * Get config for local dev env and Codespaces
+	 *
+	 * @param string $slug A unique identifier for the integration.
+	 *
+	 * @return null|mixed
+	 */
+	protected function get_local_config_from_file( string $slug ) {
+		$config_file = '/app/integrations.json';
+		if ( ! file_exists( $config_file ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$config = json_decode( file_get_contents( $config_file ), true );
+		if ( ! isset( $config[ $slug ] ) ) {
+			return null;
+		}
+
+		// We don't really care about the org config in local dev.
+		// Network config might be tricky if there's mismatch between data.
+		return [
+			'env' => $config[ $slug ],
+		];
 	}
 
 	/**

--- a/integrations/jetpack.php
+++ b/integrations/jetpack.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Integration: Jetpack.
+ */
+namespace Automattic\VIP\Integrations;
+
+class JetpackIntegration extends Integration {
+	protected string $version = '';
+
+	public function is_loaded(): bool {
+		return class_exists( 'Jetpack' );
+	}
+
+	public function configure(): void {
+		if ( isset( $this->get_env_config()['version'] ) ) {
+			$this->version = $this->get_env_config()['version'];
+		} elseif ( defined( 'VIP_JETPACK_PINNED_VERSION' ) ) {
+			$this->version = constant( 'VIP_JETPACK_PINNED_VERSION' );
+		} else {
+			$this->version = vip_default_jetpack_version();
+		}
+	}
+
+	public function load(): void {
+		if ( $this->is_loaded() ) {
+			return;
+		}
+
+		// Pass through to the old code for now which will respect all existing constants
+		if ( ! defined( 'WP_INSTALLING' ) ) {
+			vip_jetpack_load();
+		}
+	}
+}

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -24,11 +24,19 @@ require_once __DIR__ . '/integrations/parsely.php';
 require_once __DIR__ . '/integrations/vip-governance.php';
 require_once __DIR__ . '/integrations/enterprise-search.php';
 
+if ( file_exists( __DIR__ . '/integrations/jetpack.php' ) ) {
+	require_once __DIR__ . '/integrations/jetpack.php';
+}
+
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
 IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
 IntegrationsSingleton::instance()->register( new EnterpriseSearchIntegration( 'enterprise-search' ) );
+
+if ( class_exists( __NAMESPACE__ . '\\JetpackIntegration' ) ) {
+	IntegrationsSingleton::instance()->register( new JetpackIntegration( 'jetpack' ) );
+}
 // @codeCoverageIgnoreEnd
 
 /**


### PR DESCRIPTION
## Description

There are two things happening:

Added JetpackIntegration class - very basic, but it does set up the version respecting both integrations or the legacy way.

Added ability to override config values via two filters:

`apply_filters( 'vip_integrations_config_file_path', $config_file_path_orig, $slug );`

This one allows us to override the file path in non-VIP environments (dev env/Codespaces)

`apply_filters( 'vip_integrations_pre_load_config', null, $config_file_path, $slug );`
Following core WP pattern, adding the `pre_` filter will short-circuit the prod logic and will allow to inject the values as needed.


## Changelog Description

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test


1. Add `integrations.json` into the root of dev env project with the following content:

```
{
	"jetpack": {
		"status": "enabled",
		"config": {
			"version": "14.0"
		}
	},
	"parsely": {
		"status": "disabled",
		"config": {
			"apikey": "myexampledomain.test"
		}
	}
}
```
2. In jetpack.php comment out the call to `vip_jetpack_load`
3. Refresh a page and verify that Jetpack is indeed loaded.
4. Flip the status and verify Jetpack is not loaded anymore.