### PR TITLE
fix: make Two Factor more deploy-friendly

### DIFF
--- a/shared-plugins/two-factor/providers/class-two-factor-backup-codes.php
+++ b/shared-plugins/two-factor/providers/class-two-factor-backup-codes.php
@@ -28,6 +28,15 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 */
 	const NUMBER_OF_CODES = 10;
 
+	public static function get_instance() {
+		static $instance;
+		$class = __CLASS__;
+		if ( ! is_a( $instance, $class ) ) {
+			$instance = new $class();
+		}
+		return $instance;
+	}
+
 	/**
 	 * Class constructor.
 	 *

--- a/shared-plugins/two-factor/providers/class-two-factor-email.php
+++ b/shared-plugins/two-factor/providers/class-two-factor-email.php
@@ -35,6 +35,15 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 */
 	const INPUT_NAME_RESEND_CODE = 'two-factor-email-code-resend';
 
+	public static function get_instance() {
+		static $instance;
+		$class = __CLASS__;
+		if ( ! is_a( $instance, $class ) ) {
+			$instance = new $class();
+		}
+		return $instance;
+	}
+
 	/**
 	 * Class constructor.
 	 *

--- a/shared-plugins/two-factor/providers/class-two-factor-totp.php
+++ b/shared-plugins/two-factor/providers/class-two-factor-totp.php
@@ -37,6 +37,15 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 */
 	private static $base_32_chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
+	public static function get_instance() {
+		static $instance;
+		$class = __CLASS__;
+		if ( ! is_a( $instance, $class ) ) {
+			$instance = new $class();
+		}
+		return $instance;
+	}
+
 	/**
 	 * Class constructor. Sets up hooks, etc.
 	 *


### PR DESCRIPTION
Add back `get_instance()` methods to providers to avoid fatal errors on deploy.