### PR TITLE
Dev Container: pin to MySQL to 8.4

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,8 +15,8 @@ services:
     ports:
       - 80:80
   database:
-    image: mysql:8.0
-    command: mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION --max_allowed_packet=67M --default-authentication-plugin=mysql_native_password
+    image: mysql:8.4
+    command: mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION --max_allowed_packet=67M --mysql-native-password=ON
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: wordpress

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - 80:80
   database:
-    image: mysql:8
+    image: mysql:8.0
     command: mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION --max_allowed_packet=67M --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION

## Description

Pin `docker-compose` MySQL service to v8.0 for compatibility with specified `command`. Currently `mysql-8` resolves to v8.4, results in the following errors, and the container refuses to start.

```
database-1   | 2025-02-06T18:40:08.436999Z 0 [Warning] [MY-010915] [Server] 'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
database-1   | 2025-02-06T18:40:09.515692Z 0 [ERROR] [MY-000067] [Server] unknown variable 'default-authentication-plugin=mysql_native_password'.
database-1   | 2025-02-06T18:40:09.515854Z 0 [ERROR] [MY-013236] [Server] The designated data directory /var/lib/mysql/ is unusable. You can remove all files that the server added to it.
database-1   | 2025-02-06T18:40:09.515858Z 0 [ERROR] [MY-010119] [Server] Aborting
database-1   | 2025-02-06T18:40:10.648272Z 0 [System] [MY-015018] [Server] MySQL Server Initialization - end.
database-1 exited with code 1
```

Relying on the default `command` allows MySQL to start but results in different errors. Pinning to v8.0 fixes everything, but I didn't test other versions.

## Steps to Test

Example:

1. Check out PR.
2. cd `.devcontainer`
1. `docker compose up`
