### PR TITLE
Disable Woo background image regeneration

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -155,3 +155,6 @@ function vip_divi_setup() {
 	});
 }
 add_action( 'after_setup_theme', 'vip_divi_setup' );
+
+// Disable WooCommerce background image regeneration - this is redundant
+add_filter( 'woocommerce_background_image_regeneration', '__return_false' );


### PR DESCRIPTION
## Description

Background image regeneration is redundant since we generate images on the fly.

## Changelog Description

### Changed
- WooCommerce: stop trying to regenerate images in background, as it's redundant on WPVIP platform


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->