### PR TITLE
BB8-12281: Update acl file logs

### DIFF
--- a/files/acl/pre-wp-utils.php
+++ b/files/acl/pre-wp-utils.php
@@ -14,19 +14,19 @@ namespace Automattic\VIP\Files\Acl\Pre_WP_Utils;
  * Encapsulates the logic into a helper function to avoid executing this in a global context and make it testable.
  *
  * @param string $file_request_uri The unvalidated / unsanitized file path.
- *
+ * @param string $logger The logger to use. Defaults to \Automattic\VIP\Logstash\log2logstash - this is a workaround to make the function testable.
  * @return boolean|array false on invalid request, otherwise returns value from Pre_WP_Utils\sanitize_and_split_path
  */
-function prepare_request( $file_request_uri ) {
+function prepare_request( $file_request_uri, $logger = '\Automattic\VIP\Logstash\log2logstash' ) {
 	if ( ! $file_request_uri ) {
-		log_warning( 'VIP Files ACL failed due to empty URI' );
+		log_warning( 'VIP Files ACL failed due to empty URI', $logger );
 
 		return false;
 	}
 
 	$file_path = parse_url( $file_request_uri, PHP_URL_PATH );  // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 
-	$is_valid_path = validate_path( $file_path );
+	$is_valid_path = validate_path( $file_path, $logger );
 	if ( ! $is_valid_path ) {
 		// validate_path calls trigger_error so no need to do it here
 		return false;
@@ -42,16 +42,16 @@ function prepare_request( $file_request_uri ) {
  *
  * @return boolean is the path valid?
  */
-function validate_path( $file_path ) {
+function validate_path( $file_path, $logger = '\Automattic\VIP\Logstash\log2logstash' ) {
 	if ( ! $file_path ) {
-		log_warning( 'VIP Files ACL failed due to empty path' );
+		log_warning( 'VIP Files ACL failed due to empty path', $logger );
 
 		return false;
 	}
 
 	// Relative path not allowed
 	if ( '/' !== $file_path[0] ) {
-		log_warning( 'VIP Files ACL failed due to relative path', htmlspecialchars( $file_path ) );
+		log_warning( 'VIP Files ACL failed due to relative path', $logger, htmlspecialchars( $file_path ) );
 
 		return false;
 	}
@@ -59,20 +59,20 @@ function validate_path( $file_path ) {
 	// Missing `/wp-content/uploads/`.
 	// Using `strpos` since we can have subsite / subdirectory paths.
 	if ( false === strpos( $file_path, '/wp-content/uploads/' ) ) {
-		log_warning( 'VIP Files ACL failed due to invalid path', htmlspecialchars( $file_path ) );
+		log_warning( 'VIP Files ACL failed due to invalid path', $logger, htmlspecialchars( $file_path ) );
 
 		return false;
 	}
 
 	$decoded = urldecode( $file_path );
 	if ( false !== strpos( $decoded, './' ) ) {
-		log_warning( 'VIP Files ACL failed due to a possible path traversal attack', htmlspecialchars( $file_path ) );
+		log_warning( 'VIP Files ACL failed due to a possible path traversal attack', $logger, htmlspecialchars( $file_path ) );
 		return false;
 	}
 
 	// Trailing whitespace (like %0A) in the filename. This won't work on our prod servers but will work in dev env.
 	if ( strlen( rtrim( $decoded ) ) !== strlen( $decoded ) ) {
-		log_warning( 'VIP Files ACL failed due to a possible attack', htmlspecialchars( $file_path ) );
+		log_warning( 'VIP Files ACL failed due to a possible attack', $logger, htmlspecialchars( $file_path ) );
 		return false;
 	}
 
@@ -85,10 +85,10 @@ function validate_path( $file_path ) {
  * @param string $message The error message.
  * @param string $file_path The file path that caused the error.
  */
-function log_warning( $message, $file_path = null ) {
-	\Automattic\VIP\Logstash\log2logstash(
+function log_warning( $message, $logger = '\Automattic\VIP\Logstash\log2logstash', $file_path = null ) {
+	$logger(
 		[
-			'severity' => 'warning', // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_log -- E_USER_WARNING is not used here
+			'severity' => 'warning',
 			'feature'  => 'files_acl_pre_wp_utils',
 			'message'  => $message,
 			'extra'    => [

--- a/files/acl/pre-wp-utils.php
+++ b/files/acl/pre-wp-utils.php
@@ -19,7 +19,7 @@ namespace Automattic\VIP\Files\Acl\Pre_WP_Utils;
  */
 function prepare_request( $file_request_uri ) {
 	if ( ! $file_request_uri ) {
-		trigger_error( 'VIP Files ACL failed due to empty URI', E_USER_WARNING );   // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		log_warning( 'VIP Files ACL failed due to empty URI' );
 
 		return false;
 	}
@@ -44,15 +44,14 @@ function prepare_request( $file_request_uri ) {
  */
 function validate_path( $file_path ) {
 	if ( ! $file_path ) {
-		trigger_error( 'VIP Files ACL failed due to empty path', E_USER_WARNING );  // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		log_warning( 'VIP Files ACL failed due to empty path' );
 
 		return false;
 	}
 
 	// Relative path not allowed
 	if ( '/' !== $file_path[0] ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error( sprintf( 'VIP Files ACL failed due to relative path (for %s)', htmlspecialchars( $file_path ) ), E_USER_WARNING );
+		log_warning( sprintf( 'VIP Files ACL failed due to relative path' ), htmlspecialchars( $file_path ) );
 
 		return false;
 	}
@@ -60,27 +59,43 @@ function validate_path( $file_path ) {
 	// Missing `/wp-content/uploads/`.
 	// Using `strpos` since we can have subsite / subdirectory paths.
 	if ( false === strpos( $file_path, '/wp-content/uploads/' ) ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error( sprintf( 'VIP Files ACL failed due to invalid path (for %s)', htmlspecialchars( $file_path ) ), E_USER_WARNING );
+		log_warning( sprintf( 'VIP Files ACL failed due to invalid path' ), htmlspecialchars( $file_path ) );
 
 		return false;
 	}
 
 	$decoded = urldecode( $file_path );
 	if ( false !== strpos( $decoded, './' ) ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error( sprintf( 'VIP Files ACL failed due to a possible path traversal attack (for %s)', htmlspecialchars( $file_path ) ), E_USER_WARNING );
+		log_warning( sprintf( 'VIP Files ACL failed due to a possible path traversal attack' ), htmlspecialchars( $file_path ) );
 		return false;
 	}
 
 	// Trailing whitespace (like %0A) in the filename. This won't work on our prod servers but will work in dev env.
 	if ( strlen( rtrim( $decoded ) ) !== strlen( $decoded ) ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error( sprintf( 'VIP Files ACL failed due to a possible attack (for %s)', htmlspecialchars( $file_path ) ), E_USER_WARNING );
+		log_warning( sprintf( 'VIP Files ACL failed due to a possible attack' ), htmlspecialchars( $file_path ) );
 		return false;
 	}
 
 	return true;
+}
+
+/**
+ * Log an error to Logstash.
+ *
+ * @param string $message The error message.
+ * @param string $file_path The file path that caused the error.
+ */
+function log_warning( $message, $file_path = null ) {
+	\Automattic\VIP\Logstash\log2logstash(
+		[
+			'severity' => 'warning', // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_log -- E_USER_WARNING is not used here
+			'feature'  => 'files_acl_pre_wp_utils',
+			'message'  => $message,
+			'extra'    => [
+				'file_path' => $file_path,
+			],
+		]
+	);
 }
 
 /**

--- a/files/acl/pre-wp-utils.php
+++ b/files/acl/pre-wp-utils.php
@@ -51,7 +51,7 @@ function validate_path( $file_path ) {
 
 	// Relative path not allowed
 	if ( '/' !== $file_path[0] ) {
-		log_warning( sprintf( 'VIP Files ACL failed due to relative path' ), htmlspecialchars( $file_path ) );
+		log_warning( 'VIP Files ACL failed due to relative path', htmlspecialchars( $file_path ) );
 
 		return false;
 	}
@@ -59,20 +59,20 @@ function validate_path( $file_path ) {
 	// Missing `/wp-content/uploads/`.
 	// Using `strpos` since we can have subsite / subdirectory paths.
 	if ( false === strpos( $file_path, '/wp-content/uploads/' ) ) {
-		log_warning( sprintf( 'VIP Files ACL failed due to invalid path' ), htmlspecialchars( $file_path ) );
+		log_warning( 'VIP Files ACL failed due to invalid path', htmlspecialchars( $file_path ) );
 
 		return false;
 	}
 
 	$decoded = urldecode( $file_path );
 	if ( false !== strpos( $decoded, './' ) ) {
-		log_warning( sprintf( 'VIP Files ACL failed due to a possible path traversal attack' ), htmlspecialchars( $file_path ) );
+		log_warning( 'VIP Files ACL failed due to a possible path traversal attack', htmlspecialchars( $file_path ) );
 		return false;
 	}
 
 	// Trailing whitespace (like %0A) in the filename. This won't work on our prod servers but will work in dev env.
 	if ( strlen( rtrim( $decoded ) ) !== strlen( $decoded ) ) {
-		log_warning( sprintf( 'VIP Files ACL failed due to a possible attack' ), htmlspecialchars( $file_path ) );
+		log_warning( 'VIP Files ACL failed due to a possible attack', htmlspecialchars( $file_path ) );
 		return false;
 	}
 

--- a/tests/files/acl/test-pre-wp-utils.php
+++ b/tests/files/acl/test-pre-wp-utils.php
@@ -44,7 +44,7 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 			],
 			'Invalid request URI' => [
 				'invalid/path.jpg',
-				'VIP Files ACL failed due to relative path (for invalid/path.jpg)',
+				'VIP Files ACL failed due to relative path',
 			],
 		];
 	}
@@ -53,11 +53,17 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 	 * @dataProvider data__prepare_request
 	 */
 	public function test__prepare_request__warning( string $request_uri, string $expected_message ): void {
-		$this->expectException( ErrorException::class );
-		$this->expectExceptionCode( E_USER_WARNING );
-		$this->expectExceptionMessage( $expected_message );
+		$log_data    = null;
+		$mock_logger = function ( $data ) use ( &$log_data ) {
+			$log_data = $data;
+		};
 
-		prepare_request( $request_uri );
+		prepare_request( $request_uri, $mock_logger );
+
+		$this->assertNotNull( $log_data, 'log2logstash was not called.' );
+		$this->assertEquals( 'warning', $log_data['severity'] );
+		$this->assertEquals( $expected_message, $log_data['message'] );
+		$this->assertEquals( $request_uri, $log_data['extra']['file_path'] );
 	}
 
 	/**
@@ -95,37 +101,37 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 
 			'path-no-wp-content'             => [
 				'/a/path/to/a/file.jpg',
-				'VIP Files ACL failed due to invalid path (for /a/path/to/a/file.jpg)',
+				'VIP Files ACL failed due to invalid path',
 			],
 
 			'relative-url-with-wp-content'   => [
 				'en/wp-content/uploads/file.png',
-				'VIP Files ACL failed due to relative path (for en/wp-content/uploads/file.png)',
+				'VIP Files ACL failed due to relative path',
 			],
 
 			'path-traversal-dot'             => [
 				'/wp-content/uploads/./file.jpg',
-				'VIP Files ACL failed due to a possible path traversal attack (for /wp-content/uploads/./file.jpg)',
+				'VIP Files ACL failed due to a possible path traversal attack',
 			],
 
 			'path-traversal'                 => [
 				'/wp-content/uploads/../file.jpg',
-				'VIP Files ACL failed due to a possible path traversal attack (for /wp-content/uploads/../file.jpg)',
+				'VIP Files ACL failed due to a possible path traversal attack',
 			],
 
 			'path-traversal-urlencoded'      => [
 				'/wp-content/uploads/..%2Ffile.jpg',
-				'VIP Files ACL failed due to a possible path traversal attack (for /wp-content/uploads/..%2Ffile.jpg)',
+				'VIP Files ACL failed due to a possible path traversal attack',
 			],
 
 			'trailing-whitespace'            => [
 				'/wp-content/uploads/file.jpg ',
-				'VIP Files ACL failed due to a possible attack (for /wp-content/uploads/file.jpg )',
+				'VIP Files ACL failed due to a possible attack',
 			],
 
 			'trailing-whitespace-urlencoded' => [
 				'/wp-content/uploads/file.jpg%0a',
-				'VIP Files ACL failed due to a possible attack (for /wp-content/uploads/file.jpg%0a)',
+				'VIP Files ACL failed due to a possible attack',
 			],
 		];
 	}
@@ -164,11 +170,17 @@ class VIP_Files_Acl_Pre_Wp_Utils_Test extends WP_UnitTestCase {
 	 * @dataProvider get_data__validate_path__invalid
 	 */
 	public function test__validate_path__invalid__warning( $file_path, $expected_warning ) {
-		$this->expectException( ErrorException::class );
-		$this->expectExceptionCode( E_USER_WARNING );
-		$this->expectExceptionMessage( $expected_warning );
+		$log_data    = null;
+		$mock_logger = function ( $data ) use ( &$log_data ) {
+			$log_data = $data;
+		};
 
-		validate_path( $file_path );
+		validate_path( $file_path, $mock_logger );
+
+		$this->assertNotNull( $log_data, 'log2logstash was not called.' );
+		$this->assertEquals( 'warning', $log_data['severity'] );
+		$this->assertEquals( $expected_warning, $log_data['message'] );
+		$this->assertEquals( $file_path, $log_data['extra']['file_path'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
Updates the ACL file warnings to use `log2logstash` method. 

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Changed
- Update to use ACL file warnings to use `log2logstash` method. 


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Go to `/wp-content/uploads/file.jpg%0a`
1. Verify ACL failed.
