### PR TITLE
Allow certain files to be routed to local FS versus VIP File Service

### DIFF
--- a/files/class-vip-filesystem.php
+++ b/files/class-vip-filesystem.php
@@ -83,6 +83,10 @@ class VIP_Filesystem {
 		$this->stream_wrapper = new VIP_Filesystem_Stream_Wrapper( new_api_client(),
 		self::PROTOCOL );
 		$this->stream_wrapper->register();
+
+		// Set local files
+		$local_files = apply_filters( 'vip_filesystem_local_files', [] );
+		$this->stream_wrapper->set_local_files( $local_files );
 	}
 
 	/**

--- a/files/class-wp-filesystem-vip.php
+++ b/files/class-wp-filesystem-vip.php
@@ -33,6 +33,10 @@ class WP_Filesystem_VIP extends \WP_Filesystem_Base {
 
 		$this->uploads = $filesystem_uploads;
 		$this->direct  = $filesystem_direct;
+
+		// Set local files
+		$local_files = apply_filters( 'vip_filesystem_local_files', [] );
+		$this->uploads->set_local_files( $local_files );
 	}
 
 	/**


### PR DESCRIPTION
Add logic to handle local files without making remote calls in various classes.

* **VIP_Filesystem_Stream_Wrapper**:
  - Add `$local_files` property to store local files.
  - Update `stream_open`, `stream_flush`, and `unlink` methods to handle local files.
  - Add `set_local_files` method to set the `$local_files` property.

* **VIP_Filesystem**:
  - Update `run` method to call `set_local_files` on `VIP_Filesystem_Stream_Wrapper` instance.

* **WP_Filesystem_VIP_Uploads**:
  - Add `$local_files` property to store local files.
  - Update `get_contents`, `put_contents`, and `delete` methods to handle local files.
  - Add `set_local_files` method to set the `$local_files` property.

* **WP_Filesystem_VIP**:
  - Update constructor to call `set_local_files` on `WP_Filesystem_VIP_Uploads` instance.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Automattic/vip-go-mu-plugins/pull/6156?shareId=4845955c-4952-47aa-8ecf-174e19b91eff).