### PR TITLE
feat(security): disallow creation of `admin` user

### DIFF
--- a/security.php
+++ b/security.php
@@ -397,3 +397,19 @@ function vip_send_wplogin_header( $user ) {
 	return $user;
 }
 add_filter( 'determine_current_user', 'vip_send_wplogin_header', 10000 );
+
+/**
+ * Filters the list of disallowed usernames.
+ *
+ * @param array $usernames Array of disallowed usernames.
+ * @return array $usernames Array of disallowed usernames.
+ */
+function vip_illegal_user_logins( $logins ) {
+	if ( ! is_array( $logins ) ) {
+		$logins = [];
+	}
+
+	$logins[] = 'admin';
+	return $logins;
+}
+add_filter( 'illegal_user_logins', 'vip_illegal_user_logins' );

--- a/security.php
+++ b/security.php
@@ -412,4 +412,7 @@ function vip_illegal_user_logins( $logins ) {
 	$logins[] = 'admin';
 	return $logins;
 }
-add_filter( 'illegal_user_logins', 'vip_illegal_user_logins' );
+
+if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
+	add_filter( 'illegal_user_logins', 'vip_illegal_user_logins' );
+}

--- a/tests/test-security.php
+++ b/tests/test-security.php
@@ -267,4 +267,14 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 		wp_cache_delete( $this->test_ip, CACHE_GROUP_LOGIN_LIMIT );
 		wp_cache_delete( $this->test_ip . '|' . $this->test_username, CACHE_GROUP_LOGIN_LIMIT );
 	}
+
+	public function test_create_admin_user() {
+		$result = wp_insert_user( [
+			'user_login' => 'admin',
+			'user_email' => 'admin@example.com',
+			'user_pass'  => '53cr3t!',
+		] );
+
+		$this->assertWPError( $result );
+	}
 }


### PR DESCRIPTION
## Description

This PR disables the creation of the `admin` user, see BB8-12340.

## Changelog Description

### Changed
- Creating the `admin` user on single site WordPress installation is impossible.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See BB8-12340 and the unit tests.
