### PR TITLE
Page Cache: When sandboxed, remove warning about it purging only on sandbox

### DIFF
--- a/wp-cli/vip-cache.php
+++ b/wp-cli/vip-cache.php
@@ -23,9 +23,6 @@ class VIP_Cache_CLI extends WPCOM_VIP_CLI_Command {
 		// This sets up the URL/regex to be banned.  There's no need to manually
 		// execute a purge since it is handled automatically on the `shutdown` hook.
 		WPCOM_VIP_Cache_Manager::instance()->purge_site_cache();
-		if ( defined( 'WPCOM_SANDBOXED' ) && WPCOM_SANDBOXED ) {
-			WP_CLI::line( 'Because you are sandboxed this has only purged the Page Cache on your sandbox host, un-sandbox and use the button in the site admin area if you need to purge the VIP Go edge cache.' );
-		}
 		WP_CLI::success( 'VIP Page Cache purged!' );
 	}
 
@@ -50,9 +47,7 @@ class VIP_Cache_CLI extends WPCOM_VIP_CLI_Command {
 
 		// Queue a specific URL purge.
 		wpcom_vip_purge_edge_cache_for_url( $args[0] );
-		if ( defined( 'WPCOM_SANDBOXED' ) && WPCOM_SANDBOXED ) {
-			WP_CLI::line( 'This has only purged the Page Cache on your sandbox. If you need to purge the production caches, please un-sandbox first and then run this command again..' );
-		}
+
 		WP_CLI::success( 'URL purged from the VIP page cache.' );
 	}
 }


### PR DESCRIPTION
## Description
No longer necessary; let's remove it since sandboxes have evolved since.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->