### PR TITLE
E2e: force clicking to bypass modal

### DIFF
--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -123,7 +123,7 @@ export class EditorPage {
 	 * Clear Title of page or post
 	 */
 	public async clearTitle(): Promise<void> {
-		await this.page.click( selectors.editorTitle, { force: true } );
+		await this.page.click( selectors.editorTitle );
 		await this.page.keyboard.down( 'Shift' );
 		await this.page.keyboard.press( 'Home' );
 		await this.page.keyboard.up( 'Shift' );

--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -123,7 +123,7 @@ export class EditorPage {
 	 * Clear Title of page or post
 	 */
 	public async clearTitle(): Promise<void> {
-		await this.page.click( selectors.editorTitle );
+		await this.page.click( selectors.editorTitle, { force: true } );
 		await this.page.keyboard.down( 'Shift' );
 		await this.page.keyboard.press( 'Home' );
 		await this.page.keyboard.up( 'Shift' );

--- a/__tests__/e2e/specs/page__edit.spec.ts
+++ b/__tests__/e2e/specs/page__edit.spec.ts
@@ -70,8 +70,12 @@ test( 'edit a Page', async ( { page } ) => {
 			'– Thomas A. Edison';
 		editorPage = new EditorPage( page );
 
+		await editorPage.dismissWelcomeTour();
+
 		await editorPage.clearText();
 		await editorPage.clearTitle();
+
+		await editorPage.dismissWelcomeTour();
 		await editorPage.enterTitle( titleText );
 		await editorPage.enterText( bodyText );
 	} );

--- a/__tests__/e2e/specs/page__edit.spec.ts
+++ b/__tests__/e2e/specs/page__edit.spec.ts
@@ -69,6 +69,7 @@ test( 'edit a Page', async ( { page } ) => {
 			'"Many of life’s failures are people who did not realize how close they were to success when they gave up. \n' +
 			'– Thomas A. Edison';
 		editorPage = new EditorPage( page );
+
 		await editorPage.clearText();
 		await editorPage.clearTitle();
 		await editorPage.enterTitle( titleText );


### PR DESCRIPTION
## Description

Need to bypass the welcome modal since it seemingly pops up x 2

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->