### PR TITLE
two-factor: Compat with Jetpack Account Protection

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -276,3 +276,17 @@ function wpcom_vip_two_factor_admin_notice() {
 	</div>
 	<?php
 }
+
+/**
+ * Jetpack Account Protection does not factor in a user's MFA status.
+ *
+ * If a user has MFA active, we should skip the Account Protection check.
+ */
+add_filter( 'jetpack_account_protection_user_requires_protection', 'wpcom_vip_two_factor_bypass_jetpack_account_protection', 10, 2 );
+function wpcom_vip_two_factor_bypass_jetpack_account_protection( $user_requires_protection, $user ) {
+	if ( Two_Factor_Core::is_user_using_two_factor( $user->ID ) ) {
+		return false;
+	}
+
+	return $user_requires_protection;
+}

--- a/two-factor.php
+++ b/two-factor.php
@@ -284,7 +284,7 @@ function wpcom_vip_two_factor_admin_notice() {
  */
 add_filter( 'jetpack_account_protection_user_requires_protection', 'wpcom_vip_two_factor_bypass_jetpack_account_protection', 10, 2 );
 function wpcom_vip_two_factor_bypass_jetpack_account_protection( $user_requires_protection, $user ) {
-	if ( Two_Factor_Core::is_user_using_two_factor( $user->ID ) ) {
+	if ( is_callable( array( 'Two_Factor_Core', 'is_user_using_two_factor' ) ) && Two_Factor_Core::is_user_using_two_factor( $user->ID ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Ensure that the two-factor plugin and Jetpack Account Protection work well together.

See https://wp.me/peb6dq-3Cr#comment-2273

See https://github.com/Automattic/jetpack/pull/42657

## Changelog Description

### Added

- We've made sure that the upcoming Jetpack Account Protection feature works well with the Two Factor plugin.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Install Jetpack 14.5 Beta
1. Log in with a user with a compromised password and no MFA. Should be forced to go through the Jetpack verification flow
2. Log in with a user with a compromised password and MFA active. Should be required to do MFA step and then be logged in.