### PR TITLE
WordPress Importer: update to 0.8.4

### DIFF
--- a/wordpress-importer/class-wp-import.php
+++ b/wordpress-importer/class-wp-import.php
@@ -599,7 +599,7 @@ class WP_Import extends WP_Importer {
 			}
 
 			// Export gets meta straight from the DB so could have a serialized string
-			$value = maybe_unserialize( $meta['value'] );
+			$value = $this->maybe_unserialize( $meta['value'] );
 
 			add_term_meta( $term_id, wp_slash( $key ), wp_slash_strings_only( $value ) );
 
@@ -854,7 +854,7 @@ class WP_Import extends WP_Importer {
 						do_action( 'wp_import_insert_comment', $inserted_comments[ $key ], $comment, $comment_post_id, $post );
 
 						foreach ( $comment['commentmeta'] as $meta ) {
-							$value = maybe_unserialize( $meta['value'] );
+							$value = $this->maybe_unserialize( $meta['value'] );
 
 							add_comment_meta( $inserted_comments[ $key ], wp_slash( $meta['key'] ), wp_slash_strings_only( $value ) );
 						}
@@ -888,7 +888,7 @@ class WP_Import extends WP_Importer {
 					if ( $key ) {
 						// export gets meta straight from the DB so could have a serialized string
 						if ( ! $value ) {
-							$value = maybe_unserialize( $meta['value'] );
+							$value = $this->maybe_unserialize( $meta['value'] );
 						}
 
 						add_post_meta( $post_id, wp_slash( $key ), wp_slash_strings_only( $value ) );
@@ -972,7 +972,7 @@ class WP_Import extends WP_Importer {
 		}
 
 		// wp_update_nav_menu_item expects CSS classes as a space separated string
-		$_menu_item_classes = maybe_unserialize( $_menu_item_classes );
+		$_menu_item_classes = $this->maybe_unserialize( $_menu_item_classes );
 		if ( is_array( $_menu_item_classes ) ) {
 			$_menu_item_classes = implode( ' ', $_menu_item_classes );
 		}
@@ -1492,5 +1492,25 @@ class WP_Import extends WP_Importer {
 		}
 
 		return isset( $map[ $mime_type ] ) ? $map[ $mime_type ] : null;
+	}
+
+	/**
+	 * Unserializes data only if it was serialized.
+	 *
+	 * @since 0.8.4
+	 *
+	 * @param string $data Data that might be unserialized.
+	 * @return mixed Unserialized data can be any type.
+	 */
+	protected function maybe_unserialize( $data ) {
+		// Don't attempt to unserialize data that wasn't serialized going in.
+		if ( is_serialized( $data ) ) {
+			// Transform the serialized objects to a stdClass object.
+			$data = preg_replace( '/O:\d+:"[^"]+":/', 'O:8:"stdClass":', $data );
+
+			return maybe_unserialize( $data );
+		}
+
+		return $data;
 	}
 }

--- a/wordpress-importer/readme.txt
+++ b/wordpress-importer/readme.txt
@@ -3,9 +3,9 @@ Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
 Requires at least: 5.2
-Tested up to: 6.7
+Tested up to: 6.7.2
 Requires PHP: 5.6
-Stable tag: 0.8.3
+Stable tag: 0.8.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,10 @@ If you would prefer to do things manually then follow these instructions:
 1. Go to the Tools -> Import screen, click on WordPress
 
 == Changelog ==
+
+= 0.8.4 =
+* Fix a bug on deserialization of untrusted input.
+* Update compatibility tested-up-to to WordPress 6.7.2.
 
 = 0.8.3 =
 

--- a/wordpress-importer/wordpress-importer.php
+++ b/wordpress-importer/wordpress-importer.php
@@ -6,7 +6,7 @@
  * Description:       Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
  * Author:            wordpressdotorg
  * Author URI:        https://wordpress.org/
- * Version:           0.8.3
+ * Version:           0.8.4
  * Requires at least: 5.2
  * Requires PHP:      5.6
  * Text Domain:       wordpress-importer


### PR DESCRIPTION
## Description
Updates to 0.8.4
## Changelog Description

### Changed
- WordPress Importer: update to 0.8.4


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->