### PR TITLE
add remote-data-blocks integration loader

### DIFF
--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -19,7 +19,7 @@ class RemoteDataBlocksIntegration extends Integration {
 	 *
 	 * @var string
 	 */
-	protected string $version = '0.10';
+	protected string $version = '0.11';
 
 	/**
 	 * Returns `true` if Remote Data Blocks is already available e.g. via customer code. We will use

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Integration: Remote Data Blocks.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+/**
+ * Loads Remote Data Blocks VIP Integration.
+ *
+ * @private
+ */
+class RemoteDataBlocksIntegration extends Integration {
+
+	/**
+	 * The version of Remote Data Blocks to load.
+	 *
+	 * @var string
+	 */
+	protected string $version = '0.10';
+
+	/**
+	 * Returns `true` if Remote Data Blocks is already available e.g. via customer code. We will use
+	 * this function to prevent loading of integration again from platform side.
+	 */
+	public function is_loaded(): bool {
+		// Check for the existence of the plugin version constant defined in the main plugin file.
+		return defined( 'REMOTE_DATA_BLOCKS__LOADED' );
+	}
+
+	/**
+	 * Loads the plugin.
+	 *
+	 * This is called after the integration is activated and configured.
+	 *
+	 * @private
+	 */
+	public function load(): void {
+		// Wait until plugins_loaded to give precedence to the plugin in the customer repo.
+		add_action( 'plugins_loaded', function () {
+			// Return if the integration is already loaded.
+			//
+			// In activate() method we do make sure to not activate the integration if its already loaded
+			// but still adding it here as a safety measure i.e. if load() is called directly.
+			if ( $this->is_loaded() ) {
+				return;
+			}
+
+			// Load the version of the plugin that should be set to the latest version, otherwise if it's not found deactivate the integration.
+			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-' . $this->version . '/remote-data-blocks.php';
+			if ( file_exists( $load_path ) ) {
+				require_once $load_path;
+			} else {
+				$this->is_active = false;
+			}
+		} );
+	}
+
+	/**
+	 * Configure Remote Data Blocks for VIP Platform.
+	 *
+	 * This is called after the integration is activated but before the plugin is loaded.
+	 *
+	 * @private
+	 */
+	public function configure(): void {
+		if ( ! defined( 'REMOTE_DATA_BLOCKS_CONFIGS' ) ) {
+			define( 'REMOTE_DATA_BLOCKS_CONFIGS', [] );
+		}
+	}
+}

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Test: Remote Data Blocks Integration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_UnitTestCase;
+use Automattic\Test\Constant_Mocker;
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
+	private string $slug = 'remote-data-blocks';
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		Constant_Mocker::clear();
+
+		// Clean up any action we might have added
+		remove_all_actions( 'plugins_loaded' );
+		
+		// Reset our global flag if it was set
+		if ( isset( $GLOBALS['_vip_remote_data_blocks_fired_action'] ) ) {
+			$GLOBALS['_vip_remote_data_blocks_fired_action'] = false;
+		}
+	}
+
+	public function test_is_loaded_returns_false_when_not_loaded(): void {
+		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
+		$this->assertFalse( $remote_data_blocks_integration->is_loaded() );
+	}
+
+	public function test_is_loaded_returns_true_when_constant_defined(): void {
+		Constant_Mocker::define( 'REMOTE_DATA_BLOCKS__LOADED', true );
+		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
+		$this->assertTrue( $remote_data_blocks_integration->is_loaded() );
+	}
+
+	public function test_load_registers_plugin_loaded_hook(): void {
+		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
+		$remote_data_blocks_integration->load();
+		
+		$this->assertNotFalse( has_action( 'plugins_loaded' ) );
+	}
+
+	public function test_load_returns_early_if_plugin_already_loaded(): void {
+		Constant_Mocker::define( 'REMOTE_DATA_BLOCKS__LOADED', true );
+		
+		/**
+		 * Integration mock that expects is_loaded to be called once and return true
+		 *
+		 * @var MockObject|RemoteDataBlocksIntegration
+		 */
+		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+			
+		$integration_mock->expects( $this->once() )
+			->method( 'is_loaded' )
+			->willReturn( true );
+		
+		$integration_mock->load();
+		
+		// Manually trigger the plugins_loaded action
+		do_action( 'plugins_loaded' );
+		
+		// This test passes if we reach here without errors, as the expectation of is_loaded being called once is met
+		$this->assertTrue( true );
+	}
+
+	public function test_configure_defines_config_constant(): void {
+		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
+		$remote_data_blocks_integration->configure();
+		
+		$this->assertTrue( defined( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
+		$this->assertEquals( [], constant( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
+	}
+
+	public function test_configure_does_not_redefine_constant(): void {
+		Constant_Mocker::define( 'REMOTE_DATA_BLOCKS_CONFIGS', [ 'test' => 'value' ] );
+		
+		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
+		$remote_data_blocks_integration->configure();
+		
+		$this->assertEquals( [ 'test' => 'value' ], constant( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
+	}
+}

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/integrations/block-data-api.php';
 require_once __DIR__ . '/integrations/parsely.php';
 require_once __DIR__ . '/integrations/vip-governance.php';
 require_once __DIR__ . '/integrations/enterprise-search.php';
+require_once __DIR__ . '/integrations/remote-data-blocks.php';
 
 if ( file_exists( __DIR__ . '/integrations/jetpack.php' ) ) {
 	require_once __DIR__ . '/integrations/jetpack.php';
@@ -33,7 +34,7 @@ IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
 IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
 IntegrationsSingleton::instance()->register( new EnterpriseSearchIntegration( 'enterprise-search' ) );
-
+IntegrationsSingleton::instance()->register( new RemoteDataBlocksIntegration( 'remote-data-blocks' ) );
 if ( class_exists( __NAMESPACE__ . '\\JetpackIntegration' ) ) {
 	IntegrationsSingleton::instance()->register( new JetpackIntegration( 'jetpack' ) );
 }

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -23,7 +23,10 @@ require_once __DIR__ . '/integrations/block-data-api.php';
 require_once __DIR__ . '/integrations/parsely.php';
 require_once __DIR__ . '/integrations/vip-governance.php';
 require_once __DIR__ . '/integrations/enterprise-search.php';
-require_once __DIR__ . '/integrations/remote-data-blocks.php';
+
+if ( file_exists( __DIR__ . '/integrations/remote-data-blocks.php' ) ) {
+	require_once __DIR__ . '/integrations/remote-data-blocks.php';
+}
 
 if ( file_exists( __DIR__ . '/integrations/jetpack.php' ) ) {
 	require_once __DIR__ . '/integrations/jetpack.php';
@@ -34,7 +37,9 @@ IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
 IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
 IntegrationsSingleton::instance()->register( new EnterpriseSearchIntegration( 'enterprise-search' ) );
-IntegrationsSingleton::instance()->register( new RemoteDataBlocksIntegration( 'remote-data-blocks' ) );
+if ( class_exists( __NAMESPACE__ . '\\RemoteDataBlocksIntegration' ) ) {
+	IntegrationsSingleton::instance()->register( new RemoteDataBlocksIntegration( 'remote-data-blocks' ) );
+}
 if ( class_exists( __NAMESPACE__ . '\\JetpackIntegration' ) ) {
 	IntegrationsSingleton::instance()->register( new JetpackIntegration( 'jetpack' ) );
 }

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -37,9 +37,11 @@ IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
 IntegrationsSingleton::instance()->register( new VipGovernanceIntegration( 'vip-governance' ) );
 IntegrationsSingleton::instance()->register( new EnterpriseSearchIntegration( 'enterprise-search' ) );
+
 if ( class_exists( __NAMESPACE__ . '\\RemoteDataBlocksIntegration' ) ) {
 	IntegrationsSingleton::instance()->register( new RemoteDataBlocksIntegration( 'remote-data-blocks' ) );
 }
+
 if ( class_exists( __NAMESPACE__ . '\\JetpackIntegration' ) ) {
 	IntegrationsSingleton::instance()->register( new JetpackIntegration( 'jetpack' ) );
 }


### PR DESCRIPTION
## Description

This PR is meant to add Remote Data Blocks as a VIP Integration, that can be activated in the same way as VIP Block Data API. The only difference is that, it has configs that can be provided as well. This has been specified, along with the necessary safety checks.

Please note that there is a corresponding PR with this to update the latest version of the plugin to 0.11.

https://github.com/Automattic/vip-go-mu-plugins-ext/pull/68

## Changelog Description

### Added
- Add Remote Data Blocks as a new VIP integration

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- Clone [RDB](https://github.com/Automattic/remote-data-blocks)
- Activate Remote Data Blocks
- Spin up a wp environment
- Ensure RDB is available in this plugin