### PR TITLE
Utilize X oEmbed proxy

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -158,3 +158,13 @@ add_action( 'after_setup_theme', 'vip_divi_setup' );
 
 // Disable WooCommerce background image regeneration - this is redundant
 add_filter( 'woocommerce_background_image_regeneration', '__return_false' );
+
+
+function vip_proxy_twitter_embed( $provider ) {
+	if ( ! str_starts_with( $provider, 'https://publish.twitter.com/oembed' ) ) {
+		return $provider;
+	}
+
+	return str_replace( 'https://publish.twitter.com/oembed', 'https://x-oembed-proxy.wpvip.com/oembed', $provider );
+}
+add_filter( 'oembed_fetch_url', 'vip_proxy_twitter_embed', 10 );

--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -159,7 +159,12 @@ add_action( 'after_setup_theme', 'vip_divi_setup' );
 // Disable WooCommerce background image regeneration - this is redundant
 add_filter( 'woocommerce_background_image_regeneration', '__return_false' );
 
-
+/**
+ * Proxy Twitter embeds to the x-oembed-proxy.wpvip.com endpoint.
+ *
+ * @param string $provider The provider URL.
+ * @return string The proxied provider URL.
+ */
 function vip_proxy_twitter_embed( $provider ) {
 	if ( ! str_starts_with( $provider, 'https://publish.twitter.com/oembed' ) ) {
 		return $provider;


### PR DESCRIPTION
## Description

This is to help with sporadic bad responses for Twitter oEmbed calls.

## Changelog Description

### Fixed
- Mitigation for sporadic bad responses from X (formerly Twitter) oEmbed endpoints

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

