### PR TITLE
Bump upload size limit to 3GB

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -73,10 +73,10 @@ class A8C_Files {
 
 	public function __construct() {
 
-		// Upload size limit is 2GB
+		// Upload size limit is 3GB
 		add_filter( 'upload_size_limit', function () {
-			return 2147483648; // 2^30 * 2
-		});
+			return GB_IN_BYTES * 3; 
+		} );
 
 		if ( defined( 'VIP_FILESYSTEM_USE_STREAM_WRAPPER' ) && true === VIP_FILESYSTEM_USE_STREAM_WRAPPER ) {
 			$this->init_vip_filesystem();


### PR DESCRIPTION
## Changelog Description


### Changed
- Increase upload size limit to 3GB


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->