### PR TITLE
Load the latest version for RDB

### DIFF
--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -43,7 +43,8 @@ class RemoteDataBlocksIntegration extends Integration {
 				return;
 			}
 
-			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/remote-data-blocks-<version>/ and check what versions are available.
+			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/remote-data-blocks-<version>/
+			// and check what versions are available.
 			$versions = $this->get_versions();
 
 			// if no versions are found, return early.
@@ -51,11 +52,6 @@ class RemoteDataBlocksIntegration extends Integration {
 				$this->is_active = false;
 				return;
 			}
-
-			// Sort the versions in descending order.
-			uksort($versions, function ( $a, $b ) use ( $versions ) {
-				return version_compare( $versions[ $b ], $versions[ $a ] );
-			});
 
 			// Load the latest version of the plugin.
 			$latest_directory = array_key_first( $versions );
@@ -71,22 +67,35 @@ class RemoteDataBlocksIntegration extends Integration {
 	}
 
 	/**
-	 * Get the available versions of Remote Data Blocks.
+	 * Get the available versions of Remote Data Blocks in descending order.
 	 *
-	 * @return array<string, string> An associative array of available versions, where the key is the directory name and the value is the version number.
+	 * @return array<string, string> An associative array of available versions, where the key is the
+	 *                               directory name and the value is the version number. The versions
+	 *                               are sorted in descending order.
 	 */
 	public function get_versions() {
 		$versions = [];
 		$dir      = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/';
+		if ( ! is_dir( $dir ) ) {
+			return $versions;
+		}
 
-		if ( is_dir( $dir ) ) {
-			$scan_entries = scandir( $dir );
-			foreach ( $scan_entries as $entry ) {
-				if ( preg_match( '/^remote-data-blocks-(\d+\.\d+)$/', $entry, $matches ) && is_dir( $dir . $entry ) && file_exists( $dir . $entry . '/remote-data-blocks.php' ) ) {
-					$versions[ $entry ] = $matches[1]; // Store directory name as key and version as value
-				}
+		$scan_entries = scandir( $dir );
+		foreach ( $scan_entries as $entry ) {
+			if (
+				str_contains( $entry, 'remote-data-blocks-' ) &&
+				is_dir( $dir . $entry ) &&
+				file_exists( $dir . $entry . '/remote-data-blocks.php' )
+			) {
+				// Extract the version number from the directory name
+				$versions[ $entry ] = str_replace( 'remote-data-blocks-', '', $entry );
 			}
 		}
+
+		// Sort the versions in descending order.
+		uksort( $versions, function ( $a, $b ) use ( $versions ) {
+			return version_compare( $versions[ $b ], $versions[ $a ] );
+		} );
 
 		return $versions;
 	}

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -44,13 +44,14 @@ class RemoteDataBlocksIntegration extends Integration {
 			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/remote-data-blocks-<version>/ and check what versions are available.
 			$versions = [];
 			$dir = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/';
+			
 			if ( is_dir( $dir ) ) {
-				$versions = array_filter(
-					scandir( $dir ),
-					function ( $entry ) use ( $dir ) {
-						return is_dir( $dir . $entry ) && preg_match( '/^remote-data-blocks-([0-9.]+)$/', $entry, $matches );
+				$scan_entries = scandir( $dir );
+				foreach ( $scan_entries as $entry ) {
+					if ( preg_match( '/^remote-data-blocks-(\d+\.\d+\.\d+)$/', $entry, $matches ) && is_dir( $dir . $entry ) && file_exists( $dir . $entry . '/remote-data-blocks.php' ) ) {
+						$versions[$entry] = $matches[1]; // Store directory name as key and version as value
 					}
-				);
+				}
 			}
 
 			// if no versions are found, return early.
@@ -60,12 +61,15 @@ class RemoteDataBlocksIntegration extends Integration {
 			}
 
 			// Sort the versions in descending order.
-			usort( $versions, function ( $a, $b ) {
-				return version_compare( $b, $a );
+			uksort( $versions, function ( $a, $b ) use ( $versions ) {
+				return version_compare( $versions[$b], $versions[$a] );
 			} );
 
 			// Load the latest version of the plugin.
-			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $versions[0] . '/remote-data-blocks.php';
+			$latest_directory = array_key_first( $versions );
+			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/remote-data-blocks.php';
+
+			// This check isn't strictly necessary, but better safe than sorry.
 			if ( file_exists( $load_path ) ) {
 				require_once $load_path;
 			} else {

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Integration: Remote Data Blocks.
  *
@@ -13,6 +14,7 @@ namespace Automattic\VIP\Integrations;
  * @private
  */
 class RemoteDataBlocksIntegration extends Integration {
+
 
 	/**
 	 * Returns `true` if Remote Data Blocks is already available e.g. via customer code. We will use
@@ -32,7 +34,7 @@ class RemoteDataBlocksIntegration extends Integration {
 	 */
 	public function load(): void {
 		// Wait until plugins_loaded to give precedence to the plugin in the customer repo.
-		add_action( 'plugins_loaded', function () {
+		add_action('plugins_loaded', function () {
 			// Return if the integration is already loaded.
 			//
 			// In activate() method we do make sure to not activate the integration if its already loaded
@@ -42,17 +44,7 @@ class RemoteDataBlocksIntegration extends Integration {
 			}
 
 			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/remote-data-blocks-<version>/ and check what versions are available.
-			$versions = [];
-			$dir      = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/';
-			
-			if ( is_dir( $dir ) ) {
-				$scan_entries = scandir( $dir );
-				foreach ( $scan_entries as $entry ) {
-					if ( preg_match( '/^remote-data-blocks-(\d+\.\d+)$/', $entry, $matches ) && is_dir( $dir . $entry ) && file_exists( $dir . $entry . '/remote-data-blocks.php' ) ) {
-						$versions[ $entry ] = $matches[1]; // Store directory name as key and version as value
-					}
-				}
-			}
+			$versions = $this->get_versions();
 
 			// if no versions are found, return early.
 			if ( empty( $versions ) ) {
@@ -61,9 +53,9 @@ class RemoteDataBlocksIntegration extends Integration {
 			}
 
 			// Sort the versions in descending order.
-			uksort( $versions, function ( $a, $b ) use ( $versions ) {
+			uksort($versions, function ( $a, $b ) use ( $versions ) {
 				return version_compare( $versions[ $b ], $versions[ $a ] );
-			} );
+			});
 
 			// Load the latest version of the plugin.
 			$latest_directory = array_key_first( $versions );
@@ -75,7 +67,28 @@ class RemoteDataBlocksIntegration extends Integration {
 			} else {
 				$this->is_active = false;
 			}
-		} );
+		});
+	}
+
+	/**
+	 * Get the available versions of Remote Data Blocks.
+	 *
+	 * @return array<string, string> An associative array of available versions, where the key is the directory name and the value is the version number.
+	 */
+	public function get_versions() {
+		$versions = [];
+		$dir      = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/';
+
+		if ( is_dir( $dir ) ) {
+			$scan_entries = scandir( $dir );
+			foreach ( $scan_entries as $entry ) {
+				if ( preg_match( '/^remote-data-blocks-(\d+\.\d+)$/', $entry, $matches ) && is_dir( $dir . $entry ) && file_exists( $dir . $entry . '/remote-data-blocks.php' ) ) {
+					$versions[ $entry ] = $matches[1]; // Store directory name as key and version as value
+				}
+			}
+		}
+
+		return $versions;
 	}
 
 	/**

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -43,13 +43,13 @@ class RemoteDataBlocksIntegration extends Integration {
 
 			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/remote-data-blocks-<version>/ and check what versions are available.
 			$versions = [];
-			$dir = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/';
+			$dir      = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/';
 			
 			if ( is_dir( $dir ) ) {
 				$scan_entries = scandir( $dir );
 				foreach ( $scan_entries as $entry ) {
-					if ( preg_match( '/^remote-data-blocks-(\d+\.\d+\.\d+)$/', $entry, $matches ) && is_dir( $dir . $entry ) && file_exists( $dir . $entry . '/remote-data-blocks.php' ) ) {
-						$versions[$entry] = $matches[1]; // Store directory name as key and version as value
+					if ( preg_match( '/^remote-data-blocks-(\d+\.\d+)$/', $entry, $matches ) && is_dir( $dir . $entry ) && file_exists( $dir . $entry . '/remote-data-blocks.php' ) ) {
+						$versions[ $entry ] = $matches[1]; // Store directory name as key and version as value
 					}
 				}
 			}
@@ -62,12 +62,12 @@ class RemoteDataBlocksIntegration extends Integration {
 
 			// Sort the versions in descending order.
 			uksort( $versions, function ( $a, $b ) use ( $versions ) {
-				return version_compare( $versions[$b], $versions[$a] );
+				return version_compare( $versions[ $b ], $versions[ $a ] );
 			} );
 
 			// Load the latest version of the plugin.
 			$latest_directory = array_key_first( $versions );
-			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/remote-data-blocks.php';
+			$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/remote-data-blocks.php';
 
 			// This check isn't strictly necessary, but better safe than sorry.
 			if ( file_exists( $load_path ) ) {

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -15,13 +15,6 @@ namespace Automattic\VIP\Integrations;
 class RemoteDataBlocksIntegration extends Integration {
 
 	/**
-	 * The version of Remote Data Blocks to load.
-	 *
-	 * @var string
-	 */
-	protected string $version = '0.11';
-
-	/**
 	 * Returns `true` if Remote Data Blocks is already available e.g. via customer code. We will use
 	 * this function to prevent loading of integration again from platform side.
 	 */
@@ -48,8 +41,31 @@ class RemoteDataBlocksIntegration extends Integration {
 				return;
 			}
 
-			// Load the version of the plugin that should be set to the latest version, otherwise if it's not found deactivate the integration.
-			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-' . $this->version . '/remote-data-blocks.php';
+			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/remote-data-blocks-<version>/ and check what versions are available.
+			$versions = [];
+			$dir = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/';
+			if ( is_dir( $dir ) ) {
+				$versions = array_filter(
+					scandir( $dir ),
+					function ( $entry ) use ( $dir ) {
+						return is_dir( $dir . $entry ) && preg_match( '/^remote-data-blocks-([0-9.]+)$/', $entry, $matches );
+					}
+				);
+			}
+
+			// if no versions are found, return early.
+			if ( empty( $versions ) ) {
+				$this->is_active = false;
+				return;
+			}
+
+			// Sort the versions in descending order.
+			usort( $versions, function ( $a, $b ) {
+				return version_compare( $b, $a );
+			} );
+
+			// Load the latest version of the plugin.
+			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $versions[0] . '/remote-data-blocks.php';
 			if ( file_exists( $load_path ) ) {
 				require_once $load_path;
 			} else {

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Test: Remote Data Blocks Integration.
  *
@@ -14,6 +15,7 @@ use Automattic\Test\Constant_Mocker;
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
+
 	private string $slug = 'remote-data-blocks';
 
 	public function tearDown(): void {
@@ -23,7 +25,7 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 
 		// Clean up any action we might have added
 		remove_all_actions( 'plugins_loaded' );
-		
+
 		// Reset our global flag if it was set
 		if ( isset( $GLOBALS['_vip_remote_data_blocks_fired_action'] ) ) {
 			$GLOBALS['_vip_remote_data_blocks_fired_action'] = false;
@@ -44,13 +46,13 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 	public function test_load_registers_plugin_loaded_hook(): void {
 		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
 		$remote_data_blocks_integration->load();
-		
+
 		$this->assertNotFalse( has_action( 'plugins_loaded' ) );
 	}
 
 	public function test_load_returns_early_if_plugin_already_loaded(): void {
 		Constant_Mocker::define( 'REMOTE_DATA_BLOCKS__LOADED', true );
-		
+
 		/**
 		 * Integration mock that expects is_loaded to be called once and return true
 		 *
@@ -60,16 +62,16 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 			->setConstructorArgs( [ $this->slug ] )
 			->onlyMethods( [ 'is_loaded' ] )
 			->getMock();
-			
+
 		$integration_mock->expects( $this->once() )
 			->method( 'is_loaded' )
 			->willReturn( true );
-		
+
 		$integration_mock->load();
-		
+
 		// Manually trigger the plugins_loaded action
 		do_action( 'plugins_loaded' );
-		
+
 		// This test passes if we reach here without errors, as the expectation of is_loaded being called once is met
 		$this->assertTrue( true );
 	}
@@ -77,17 +79,25 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 	public function test_configure_defines_config_constant(): void {
 		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
 		$remote_data_blocks_integration->configure();
-		
+
 		$this->assertTrue( defined( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
 		$this->assertEquals( [], constant( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
 	}
 
 	public function test_configure_does_not_redefine_constant(): void {
 		Constant_Mocker::define( 'REMOTE_DATA_BLOCKS_CONFIGS', [ 'test' => 'value' ] );
-		
+
 		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
 		$remote_data_blocks_integration->configure();
-		
+
 		$this->assertEquals( [ 'test' => 'value' ], constant( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
+	}
+
+	public function test_get_versions_returns_empty_array(): void {
+		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
+
+		$versions = $remote_data_blocks_integration->get_versions();
+
+		$this->assertEmpty( $versions );
 	}
 }

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -12,6 +12,72 @@ use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 use Automattic\Test\Constant_Mocker;
 
+// Define mocks for PHP built-in functions in the same namespace
+function is_dir( $dir ) {
+	// Mock implementation for different test cases
+	global $mock_filesystem_state;
+	if ( isset( $mock_filesystem_state ) && 'empty' === $mock_filesystem_state ) {
+		return false; // Directory doesn't exist
+	}
+
+	if ( isset( $mock_filesystem_state ) && 'non_matching' === $mock_filesystem_state ) {
+		return true; // All directories exist
+	}
+
+	// Default behavior - base dir exists, subdirs depending on naming
+	if ( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' === $dir ) {
+		return true;
+	}
+	
+	// Valid version directories
+	if ( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-1.0' === $dir ||
+		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-2.5' === $dir ) {
+		return true;
+	}
+	
+	return false;
+}
+
+function scandir( $dir ) {
+	// Mock implementation for different test cases
+	global $mock_filesystem_state;
+
+	if ( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' !== $dir ) {
+		return [ '.', '..' ];
+	}
+
+	if ( isset( $mock_filesystem_state ) && 'empty' === $mock_filesystem_state ) {
+		return [ '.', '..' ]; // Empty directory
+	}
+
+	if ( isset( $mock_filesystem_state ) && 'non_matching' === $mock_filesystem_state ) {
+		return [
+			'.',
+			'..',
+			'some-other-directory',
+			'not-remote-data-blocks-1.0',
+			'remote-data-blocks-abc', // Invalid version format
+		];
+	}
+
+	// Default behavior - return valid directories
+	return [
+		'.',
+		'..',
+		'remote-data-blocks-1.0',
+		'remote-data-blocks-2.5',
+		'some-other-directory',
+	];
+}
+
+function file_exists( $file ) {
+	// Valid RDB plugin files
+	return (
+		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-1.0/remote-data-blocks.php' === $file ||
+		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-2.5/remote-data-blocks.php' === $file
+	);
+}
+
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
@@ -31,6 +97,10 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		if ( isset( $GLOBALS['_vip_remote_data_blocks_fired_action'] ) ) {
 			$GLOBALS['_vip_remote_data_blocks_fired_action'] = false;
 		}
+
+		// Reset our mock state
+		global $mock_filesystem_state;
+		$mock_filesystem_state = null;
 	}
 
 	public function test_is_loaded_returns_false_when_not_loaded(): void {
@@ -94,14 +164,47 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		$this->assertEquals( [ 'test' => 'value' ], constant( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
 	}
 
-	public function test_get_versions_returns_versions_for_RDB(): void {
+	/**
+	 * Test that get_versions correctly parses directory names and returns correct versions.
+	 */
+	public function test_get_versions_parses_and_returns_correct_versions(): void {
 		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
-
-		$versions = $remote_data_blocks_integration->get_versions();
-
-		// ensure that versions are returned, with a size of at least 1
+		$versions                       = $remote_data_blocks_integration->get_versions();
+		
+		// Verify the returned versions
 		$this->assertIsArray( $versions );
-		$this->assertNotEmpty( $versions );
-		$this->assertGreaterThan( 0, count( $versions ) );
+		$this->assertCount( 2, $versions );
+		$this->assertArrayHasKey( 'remote-data-blocks-1.0', $versions );
+		$this->assertArrayHasKey( 'remote-data-blocks-2.5', $versions );
+		$this->assertEquals( '1.0', $versions['remote-data-blocks-1.0'] );
+		$this->assertEquals( '2.5', $versions['remote-data-blocks-2.5'] );
+	}
+
+	/**
+	 * Test that get_versions returns an empty array when the directory doesn't exist.
+	 */
+	public function test_get_versions_returns_empty_array_when_dir_does_not_exist(): void {
+		global $mock_filesystem_state;
+		$mock_filesystem_state = 'empty';
+		
+		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
+		$versions                       = $remote_data_blocks_integration->get_versions();
+		
+		$this->assertIsArray( $versions );
+		$this->assertEmpty( $versions );
+	}
+
+	/**
+	 * Test that get_versions ignores directories that don't match the pattern.
+	 */
+	public function test_get_versions_ignores_non_matching_directories(): void {
+		global $mock_filesystem_state;
+		$mock_filesystem_state = 'non_matching';
+		
+		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
+		$versions                       = $remote_data_blocks_integration->get_versions();
+		
+		$this->assertIsArray( $versions );
+		$this->assertEmpty( $versions );
 	}
 }

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -16,6 +16,7 @@ use Automattic\Test\Constant_Mocker;
 
 class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 
+
 	private string $slug = 'remote-data-blocks';
 
 	public function tearDown(): void {
@@ -93,11 +94,14 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		$this->assertEquals( [ 'test' => 'value' ], constant( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
 	}
 
-	public function test_get_versions_returns_empty_array(): void {
+	public function test_get_versions_returns_versions_for_RDB(): void {
 		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
 
 		$versions = $remote_data_blocks_integration->get_versions();
 
-		$this->assertEmpty( $versions );
+		// ensure that versions are returned, with a size of at least 1
+		$this->assertIsArray( $versions );
+		$this->assertNotEmpty( $versions );
+		$this->assertGreaterThan( 0, count( $versions ) );
 	}
 }

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -30,7 +30,8 @@ function is_dir( $dir ) {
 	}
 	
 	// Valid version directories
-	if ( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-1.0' === $dir ||
+	if ( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-1.2' === $dir ||
+		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-1.11' === $dir ||
 		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-2.5' === $dir ) {
 		return true;
 	}
@@ -64,7 +65,8 @@ function scandir( $dir ) {
 	return [
 		'.',
 		'..',
-		'remote-data-blocks-1.0',
+		'remote-data-blocks-1.2',
+		'remote-data-blocks-1.11',
 		'remote-data-blocks-2.5',
 		'some-other-directory',
 	];
@@ -73,7 +75,8 @@ function scandir( $dir ) {
 function file_exists( $file ) {
 	// Valid RDB plugin files
 	return (
-		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-1.0/remote-data-blocks.php' === $file ||
+		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-1.2/remote-data-blocks.php' === $file ||
+		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-1.11/remote-data-blocks.php' === $file ||
 		WPVIP_MU_PLUGIN_DIR . '/vip-integrations/remote-data-blocks-2.5/remote-data-blocks.php' === $file
 	);
 }
@@ -167,17 +170,22 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 	/**
 	 * Test that get_versions correctly parses directory names and returns correct versions.
 	 */
-	public function test_get_versions_parses_and_returns_correct_versions(): void {
+	public function test_get_versions_parses_and_returns_correct_ordered_versions(): void {
 		$remote_data_blocks_integration = new RemoteDataBlocksIntegration( $this->slug );
 		$versions                       = $remote_data_blocks_integration->get_versions();
 		
 		// Verify the returned versions
 		$this->assertIsArray( $versions );
-		$this->assertCount( 2, $versions );
-		$this->assertArrayHasKey( 'remote-data-blocks-1.0', $versions );
-		$this->assertArrayHasKey( 'remote-data-blocks-2.5', $versions );
-		$this->assertEquals( '1.0', $versions['remote-data-blocks-1.0'] );
+		$this->assertCount( 3, $versions );
+		$this->assertEquals( '1.2', $versions['remote-data-blocks-1.2'] );
+		$this->assertEquals( '1.11', $versions['remote-data-blocks-1.11'] );
 		$this->assertEquals( '2.5', $versions['remote-data-blocks-2.5'] );
+
+		// Check that the versions are correctly ordered by semantic version (2.5 > 1.11 > 1.2)
+		$keys = array_keys( $versions );
+		$this->assertEquals( 'remote-data-blocks-2.5', $keys[0] );
+		$this->assertEquals( 'remote-data-blocks-1.11', $keys[1] );
+		$this->assertEquals( 'remote-data-blocks-1.2', $keys[2] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

The purpose of this PR is to tweak the version that's loaded for RDB, so it's always the latest one found in mu-plugins. This way, we don't need to keep updating the version for the plugin in mu-plugins and instead can have it dynamically be updated by what's deployed via mu-plugins-ext.

## Changelog Description

### Changed
- Dynamically load the latest version of the RDB plugin

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out the PR
2. Create a dev-env with this PR, as well as with latest mu-plugins-ext
3. Activate remote-data-blocks
4. Ensure the latest version of the plugin is loaded. I made a tweak to the settings UI to verify this.