### PR TITLE
[PLTFRM-672] Data Cleanup: Iterate through all sites

### DIFF
--- a/wp-cli/vip-data-cleanup.php
+++ b/wp-cli/vip-data-cleanup.php
@@ -31,8 +31,19 @@ class VIP_Data_Cleanup_Command extends WPCOM_VIP_CLI_Command {
 		if ( ! is_multisite() ) {
 			$this->cleanup_site( $operation );
 		} else {
-			$sites = get_sites();
-			foreach ( $sites as $site ) {
+			global $wpdb;
+			$iterator_args  = [
+				'table'  => $wpdb->blogs,
+				'where'  => [
+					'spam'     => 0,
+					'deleted'  => 0,
+					'archived' => 0,
+				],
+				'fields' => [ 'blog_id' ],
+			];
+			$sites_iterator = new \WP_CLI\Iterators\Table( $iterator_args );
+
+			foreach ( $sites_iterator as $site ) {
 				switch_to_blog( $site->blog_id );
 
 				$this->cleanup_site( $operation );


### PR DESCRIPTION
get_sites() only returns 100 sites which means that sites 101+ do not get cleaned up.

Switch to using the WP_CLI Iterator to allow fetching, looping through, and processing all sites on a multisite install.

## Changelog Description

### Fixed

- The cleanup process after imports and data sync now currently runs the cleanup on all network sites, not just the first 100.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Make sure you're in a multisite install with 100+ blogs
1. Call `wp vip data-cleanup datasync`
1. Ensure all sites are processed.