### PR TITLE
Wildcard support for Stream Wrapper Local Passthrough

### DIFF
--- a/files/class-vip-filesystem-local-stream-wrapper.php
+++ b/files/class-vip-filesystem-local-stream-wrapper.php
@@ -1145,7 +1145,7 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 		}
 
 		// Check if pattern contains wildcards (* or ? or [).
-		$is_pattern = str_contains( $file_path, '*' ) || str_contains( $file_path, '?' ) ||
+		$is_pattern = strpbrk( $file_path, '*?[' ) !== false;
 			str_contains( $file_path, '[' );
 
 		if ( $is_pattern ) {

--- a/files/class-vip-filesystem-local-stream-wrapper.php
+++ b/files/class-vip-filesystem-local-stream-wrapper.php
@@ -116,13 +116,6 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	public static ?API_Client $default_client = null;
 
 	/**
-	 * List of files that should be handled locally
-	 *
-	 * @var array
-	 */
-	private static $local_files = array();
-
-	/**
 	 * HashMap for exact filename lookups to provide O(1) performance
 	 *
 	 * @var array
@@ -1151,7 +1144,7 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 			return false;
 		}
 
-		// Check if pattern contains wildcards (* or ? or [)
+		// Check if pattern contains wildcards (* or ? or [).
 		$is_pattern = str_contains( $file_path, '*' ) || str_contains( $file_path, '?' ) ||
 			str_contains( $file_path, '[' );
 
@@ -1161,7 +1154,7 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 			static::$local_files_map[ $file_path ] = true;
 		}
 
-		return false;
+		return true;
 	}
 
 	/**
@@ -1181,7 +1174,7 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	 * @return array List of file paths and patterns
 	 */
 	public static function get_local_files() {
-		return static::$local_files;
+		return array_merge( static::$local_files_map, static::$local_file_patterns );
 	}
 
 	/**

--- a/files/class-vip-filesystem-local-stream-wrapper.php
+++ b/files/class-vip-filesystem-local-stream-wrapper.php
@@ -120,7 +120,21 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	 *
 	 * @var array
 	 */
-	private static $local_files = [];
+	private static $local_files = array();
+
+	/**
+	 * HashMap for exact filename lookups to provide O(1) performance
+	 *
+	 * @var array
+	 */
+	private static $local_files_map = array();
+
+	/**
+	 * HashMap of wildcard patterns for local files
+	 *
+	 * @var array
+	 */
+	private static $local_file_patterns = array();
 
 	/**
 	 * File handle for local files
@@ -1129,7 +1143,7 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	/**
 	 * Add a file to the list of files that should be handled locally
 	 *
-	 * @param string $file_path Path to the file
+	 * @param string $file_path Path to the file or a pattern.
 	 * @return bool True if the file was added, false otherwise
 	 */
 	public static function add_local_file( $file_path ) {
@@ -1137,9 +1151,14 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 			return false;
 		}
 
-		if ( ! in_array( $file_path, static::$local_files, true ) ) {
-			static::$local_files[] = $file_path;
-			return true;
+		// Check if pattern contains wildcards (* or ? or [)
+		$is_pattern = str_contains( $file_path, '*' ) || str_contains( $file_path, '?' ) ||
+			str_contains( $file_path, '[' );
+
+		if ( $is_pattern ) {
+			static::$local_file_patterns[ $file_path ] = true;
+		} else {
+			static::$local_files_map[ $file_path ] = true;
 		}
 
 		return false;
@@ -1148,25 +1167,18 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	/**
 	 * Remove a file from the list of files that should be handled locally
 	 *
-	 * @param string $file_path Path to the file
-	 * @return bool True if the file was removed, false otherwise
+	 * @param string $file_path Path to the file or pattern
+	 * @return void
 	 */
 	public static function remove_local_file( $file_path ) {
-		$key = array_search( $file_path, static::$local_files, true );
-
-		if ( false !== $key ) {
-			unset( static::$local_files[ $key ] );
-			static::$local_files = array_values( static::$local_files ); // Reindex array
-			return true;
-		}
-
-		return false;
+		unset( static::$local_file_patterns[ $file_path ] );
+		unset( static::$local_files_map[ $file_path ] );
 	}
 
 	/**
 	 * Get the list of files that should be handled locally
 	 *
-	 * @return array List of file paths
+	 * @return array List of file paths and patterns
 	 */
 	public static function get_local_files() {
 		return static::$local_files;
@@ -1179,7 +1191,19 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	 * @return bool True if the file should be handled locally, false otherwise
 	 */
 	public static function is_local_file( $file_path ) {
-		return in_array( $file_path, static::$local_files, true );
+		// O(1) check for exact matches
+		if ( isset( static::$local_files_map[ $file_path ] ) ) {
+			return true;
+		}
+
+		// Check against wildcard patterns
+		foreach ( static::$local_file_patterns as $pattern => $value ) {
+			if ( fnmatch( $pattern, $file_path, FNM_PATHNAME ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/files/class-vip-filesystem-local-stream-wrapper.php
+++ b/files/class-vip-filesystem-local-stream-wrapper.php
@@ -1161,11 +1161,12 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	 * Remove a file from the list of files that should be handled locally
 	 *
 	 * @param string $file_path Path to the file or pattern
-	 * @return void
+	 * @return bool True if the file was removed, false otherwise
 	 */
 	public static function remove_local_file( $file_path ) {
 		unset( static::$local_file_patterns[ $file_path ] );
 		unset( static::$local_files_map[ $file_path ] );
+		return true;
 	}
 
 	/**

--- a/tests/files/test-vip-filesystem-local-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-local-stream-wrapper.php
@@ -312,51 +312,52 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
 		$this->stream_wrapper->register();
 		$this->should_unregister = true;
-		
+
 		// Test adding a file to the local files list
 		$test_file = 'vip://wp-content/uploads/test-local-file.txt';
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $test_file ) );
-		
+
 		// Test getting the local files list
 		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
-		$this->assertContains( $test_file, $local_files );
-		
+
+		$this->arrayHasKey( $test_file, $local_files );
+
 		// Test checking if a file is in the local files list
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $test_file ) );
 		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/non-local-file.txt' ) );
-		
+
 		// Test file operations with local files
 		$content = 'Test content for local file';
-		
+
 		// Test writing to a local file
 		$fp = fopen( $test_file, 'w' );
 		$this->assertNotFalse( $fp );
 		$bytes_written = fwrite( $fp, $content );
 		$this->assertEquals( strlen( $content ), $bytes_written );
 		fclose( $fp );
-		
+
 		// Test reading from a local file
 		$fp = fopen( $test_file, 'r' );
 		$this->assertNotFalse( $fp );
 		$read_content = fread( $fp, 1024 );
 		$this->assertEquals( $content, $read_content );
 		fclose( $fp );
-		
+
 		// Test file_get_contents and file_put_contents
 		$this->assertEquals( $content, file_get_contents( $test_file ) );
 		$new_content = 'Updated content';
 		$this->assertNotFalse( file_put_contents( $test_file, $new_content ) );
 		$this->assertEquals( $new_content, file_get_contents( $test_file ) );
-		
+
 		// Test file_exists
 		$this->assertTrue( file_exists( $test_file ) );
-		
+
 		// Test copy
 		$copy_file = 'vip://wp-content/uploads/test-local-file-copy.txt';
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $copy_file );
 		$this->assertTrue( copy( $test_file, $copy_file ) );
 		$this->assertEquals( $new_content, file_get_contents( $copy_file ) );
-		
+
 		// Test rename
 		$rename_file = 'vip://wp-content/uploads/test-local-file-renamed.txt';
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $rename_file );
@@ -364,17 +365,17 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		$this->assertFalse( file_exists( $copy_file ) );
 		$this->assertTrue( file_exists( $rename_file ) );
 		$this->assertEquals( $new_content, file_get_contents( $rename_file ) );
-		
+
 		// Test unlink
 		$this->assertTrue( unlink( $test_file ) );
 		$this->assertFalse( file_exists( $test_file ) );
 		$this->assertTrue( unlink( $rename_file ) );
 		$this->assertFalse( file_exists( $rename_file ) );
-		
+
 		// Test removing a file from the local files list
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $test_file ) );
 		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $test_file ) );
-		
+
 		// Clean up
 		if ( $this->should_unregister ) {
 			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );

--- a/tests/files/test-vip-filesystem-local-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-local-stream-wrapper.php
@@ -382,4 +382,101 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 			$this->should_unregister = false;
 		}
 	}
+
+	/**
+	 * Test wildcard pattern matching capabilities
+	 */
+	public function test_wildcard_matching() {
+		// Set up the API client mock
+		$this->api_client_mock = $this->createMock( API_Client::class );
+		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
+		$this->stream_wrapper->register();
+		$this->should_unregister = true;
+
+		// Add a wildcard pattern for image files
+		$image_pattern = 'vip://wp-content/uploads/*.jpg';
+		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $image_pattern );
+
+		// Test matching against pattern
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/image.jpg' ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/profile.jpg' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/document.pdf' ) );
+
+		// Add a pattern with question mark wildcard
+		$question_pattern = 'vip://wp-content/uploads/file-?.txt';
+		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $question_pattern );
+
+		// Test question mark wildcard
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/file-1.txt' ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/file-A.txt' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/file-12.txt' ) );
+
+		// Add a pattern with character class
+		$char_class_pattern = 'vip://wp-content/uploads/[a-z]*.pdf';
+		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $char_class_pattern );
+
+		// Test character class pattern
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/document.pdf' ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/abc.pdf' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/123.pdf' ) );
+
+		// Cleanup
+		VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $image_pattern );
+		VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $question_pattern );
+		VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $char_class_pattern );
+
+		if ( $this->should_unregister ) {
+			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );
+			$this->should_unregister = false;
+		}
+	}
+
+	/**
+	 * Test O(1) lookup optimizations
+	 */
+	public function test_lookup_optimization() {
+		// Set up the API client mock
+		$this->api_client_mock = $this->createMock( API_Client::class );
+		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
+		$this->stream_wrapper->register();
+		$this->should_unregister = true;
+
+		// Clean existing files before testing
+		$existing_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+		foreach ( $existing_files as $path => $value ) {
+			VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $path );
+		}
+
+		// First, verify no files are registered
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/exact-file.txt' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/pattern-123.txt' ) );
+
+		// Add exact file path
+		$exact_path = 'vip://wp-content/uploads/exact-file.txt';
+		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $exact_path );
+
+		// Verify exact file is now recognized
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $exact_path ) );
+
+		// Add wildcard pattern
+		$pattern = 'vip://wp-content/uploads/pattern-*.txt';
+		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern );
+
+		// Verify pattern-matched files are recognized (O(1) lookup optimization)
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/pattern-123.txt' ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/pattern-abc.txt' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/different-123.txt' ) );
+
+		// Test removing files
+		VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $exact_path );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $exact_path ) );
+
+		VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $pattern );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/pattern-123.txt' ) );
+
+		if ( $this->should_unregister ) {
+			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );
+			$this->should_unregister = false;
+		}
+	}
 }

--- a/tests/files/test-vip-filesystem-local-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-local-stream-wrapper.php
@@ -312,51 +312,51 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
 		$this->stream_wrapper->register();
 		$this->should_unregister = true;
-
+		
 		// Test adding a file to the local files list
 		$test_file = 'vip://wp-content/uploads/test-local-file.txt';
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $test_file ) );
-
+		
 		// Test getting the local files list
 		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
 		$this->assertContains( $test_file, $local_files );
-
+		
 		// Test checking if a file is in the local files list
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $test_file ) );
 		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/non-local-file.txt' ) );
-
+		
 		// Test file operations with local files
 		$content = 'Test content for local file';
-
+		
 		// Test writing to a local file
 		$fp = fopen( $test_file, 'w' );
 		$this->assertNotFalse( $fp );
 		$bytes_written = fwrite( $fp, $content );
 		$this->assertEquals( strlen( $content ), $bytes_written );
 		fclose( $fp );
-
+		
 		// Test reading from a local file
 		$fp = fopen( $test_file, 'r' );
 		$this->assertNotFalse( $fp );
 		$read_content = fread( $fp, 1024 );
 		$this->assertEquals( $content, $read_content );
 		fclose( $fp );
-
+		
 		// Test file_get_contents and file_put_contents
 		$this->assertEquals( $content, file_get_contents( $test_file ) );
 		$new_content = 'Updated content';
 		$this->assertNotFalse( file_put_contents( $test_file, $new_content ) );
 		$this->assertEquals( $new_content, file_get_contents( $test_file ) );
-
+		
 		// Test file_exists
 		$this->assertTrue( file_exists( $test_file ) );
-
+		
 		// Test copy
 		$copy_file = 'vip://wp-content/uploads/test-local-file-copy.txt';
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $copy_file );
 		$this->assertTrue( copy( $test_file, $copy_file ) );
 		$this->assertEquals( $new_content, file_get_contents( $copy_file ) );
-
+		
 		// Test rename
 		$rename_file = 'vip://wp-content/uploads/test-local-file-renamed.txt';
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $rename_file );
@@ -364,122 +364,17 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		$this->assertFalse( file_exists( $copy_file ) );
 		$this->assertTrue( file_exists( $rename_file ) );
 		$this->assertEquals( $new_content, file_get_contents( $rename_file ) );
-
+		
 		// Test unlink
 		$this->assertTrue( unlink( $test_file ) );
 		$this->assertFalse( file_exists( $test_file ) );
 		$this->assertTrue( unlink( $rename_file ) );
 		$this->assertFalse( file_exists( $rename_file ) );
-
+		
 		// Test removing a file from the local files list
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $test_file ) );
 		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $test_file ) );
-
-		// Clean up
-		if ( $this->should_unregister ) {
-			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );
-			$this->should_unregister = false;
-		}
-	}
-
-	/**
-	 * Test wildcard pattern matching functionality
-	 */
-	public function test_wildcard_pattern_matching() {
-		// Set up the API client mock
-		$this->api_client_mock = $this->createMock( API_Client::class );
-		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
-		$this->stream_wrapper->register();
-		$this->should_unregister = true;
-
-		// Test adding a wildcard pattern to the local files list
-		$pattern = 'vip://wp-content/uploads/*.jpg';
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern ) );
-
-		// Test if files matching the pattern are recognized as local files
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/image1.jpg' ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/subfolder/image2.jpg' ) );
-		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/document.pdf' ) );
-
-		// Test different pattern types
-
-		// Question mark wildcard
-		$pattern_question = 'vip://wp-content/uploads/image?.jpg';
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern_question ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/image1.jpg' ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/imageA.jpg' ) );
-		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/image10.jpg' ) );
-
-		// Character class wildcards
-		$pattern_char_class = 'vip://wp-content/uploads/file[0-9].txt';
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern_char_class ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/file1.txt' ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/file5.txt' ) );
-		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/fileA.txt' ) );
-
-		// Negative character class
-		$pattern_neg_class = 'vip://wp-content/uploads/doc[!0-9]*.pdf';
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern_neg_class ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/docA.pdf' ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/docB-draft.pdf' ) );
-		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/doc1.pdf' ) );
-
-		// Test removing a pattern
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $pattern ) );
-		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/new-image.jpg' ) );
-
-		// Clean up
-		if ( $this->should_unregister ) {
-			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );
-			$this->should_unregister = false;
-		}
-	}
-
-	/**
-	 * Test O(1) lookup for exact matches versus pattern matching
-	 */
-	public function test_lookup_performance() {
-		// Set up the API client mock
-		$this->api_client_mock = $this->createMock( API_Client::class );
-		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
-		$this->stream_wrapper->register();
-		$this->should_unregister = true;
-
-		// Add both exact paths and patterns
-		$exact_path = 'vip://wp-content/uploads/exact-file.txt';
-		$pattern    = 'vip://wp-content/uploads/pattern-*.txt';
-
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $exact_path ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern ) );
-
-		// Test that both matching methods work
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $exact_path ) );
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/pattern-123.txt' ) );
-
-		// Use reflection to access the local_files_map and local_file_patterns properties
-		$reflector            = new \ReflectionClass( VIP_Filesystem_Local_Stream_Wrapper::class );
-		$local_files_map_prop = $reflector->getProperty( 'local_files_map' );
-		$local_files_map_prop->setAccessible( true );
-		$local_file_patterns_prop = $reflector->getProperty( 'local_file_patterns' );
-		$local_file_patterns_prop->setAccessible( true );
-
-		// Verify that exact path is in the hash map
-		$local_files_map = $local_files_map_prop->getValue();
-		$this->assertArrayHasKey( $exact_path, $local_files_map );
-
-		// Verify that pattern is in the patterns hash map (not array)
-		$local_file_patterns = $local_file_patterns_prop->getValue();
-		$this->assertArrayHasKey( $pattern, $local_file_patterns );
 		
-		// Test O(1) removes
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $pattern ) );
-		$local_file_patterns = $local_file_patterns_prop->getValue();
-		$this->assertEmpty( $local_file_patterns );
-		
-		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $exact_path ) );
-		$local_files_map = $local_files_map_prop->getValue();
-		$this->assertEmpty( $local_files_map );
-
 		// Clean up
 		if ( $this->should_unregister ) {
 			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );

--- a/tests/files/test-vip-filesystem-local-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-local-stream-wrapper.php
@@ -312,51 +312,51 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
 		$this->stream_wrapper->register();
 		$this->should_unregister = true;
-		
+
 		// Test adding a file to the local files list
 		$test_file = 'vip://wp-content/uploads/test-local-file.txt';
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $test_file ) );
-		
+
 		// Test getting the local files list
 		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
 		$this->assertContains( $test_file, $local_files );
-		
+
 		// Test checking if a file is in the local files list
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $test_file ) );
 		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/non-local-file.txt' ) );
-		
+
 		// Test file operations with local files
 		$content = 'Test content for local file';
-		
+
 		// Test writing to a local file
 		$fp = fopen( $test_file, 'w' );
 		$this->assertNotFalse( $fp );
 		$bytes_written = fwrite( $fp, $content );
 		$this->assertEquals( strlen( $content ), $bytes_written );
 		fclose( $fp );
-		
+
 		// Test reading from a local file
 		$fp = fopen( $test_file, 'r' );
 		$this->assertNotFalse( $fp );
 		$read_content = fread( $fp, 1024 );
 		$this->assertEquals( $content, $read_content );
 		fclose( $fp );
-		
+
 		// Test file_get_contents and file_put_contents
 		$this->assertEquals( $content, file_get_contents( $test_file ) );
 		$new_content = 'Updated content';
 		$this->assertNotFalse( file_put_contents( $test_file, $new_content ) );
 		$this->assertEquals( $new_content, file_get_contents( $test_file ) );
-		
+
 		// Test file_exists
 		$this->assertTrue( file_exists( $test_file ) );
-		
+
 		// Test copy
 		$copy_file = 'vip://wp-content/uploads/test-local-file-copy.txt';
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $copy_file );
 		$this->assertTrue( copy( $test_file, $copy_file ) );
 		$this->assertEquals( $new_content, file_get_contents( $copy_file ) );
-		
+
 		// Test rename
 		$rename_file = 'vip://wp-content/uploads/test-local-file-renamed.txt';
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $rename_file );
@@ -364,17 +364,122 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		$this->assertFalse( file_exists( $copy_file ) );
 		$this->assertTrue( file_exists( $rename_file ) );
 		$this->assertEquals( $new_content, file_get_contents( $rename_file ) );
-		
+
 		// Test unlink
 		$this->assertTrue( unlink( $test_file ) );
 		$this->assertFalse( file_exists( $test_file ) );
 		$this->assertTrue( unlink( $rename_file ) );
 		$this->assertFalse( file_exists( $rename_file ) );
-		
+
 		// Test removing a file from the local files list
 		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $test_file ) );
 		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $test_file ) );
+
+		// Clean up
+		if ( $this->should_unregister ) {
+			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );
+			$this->should_unregister = false;
+		}
+	}
+
+	/**
+	 * Test wildcard pattern matching functionality
+	 */
+	public function test_wildcard_pattern_matching() {
+		// Set up the API client mock
+		$this->api_client_mock = $this->createMock( API_Client::class );
+		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
+		$this->stream_wrapper->register();
+		$this->should_unregister = true;
+
+		// Test adding a wildcard pattern to the local files list
+		$pattern = 'vip://wp-content/uploads/*.jpg';
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern ) );
+
+		// Test if files matching the pattern are recognized as local files
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/image1.jpg' ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/subfolder/image2.jpg' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/document.pdf' ) );
+
+		// Test different pattern types
+
+		// Question mark wildcard
+		$pattern_question = 'vip://wp-content/uploads/image?.jpg';
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern_question ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/image1.jpg' ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/imageA.jpg' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/image10.jpg' ) );
+
+		// Character class wildcards
+		$pattern_char_class = 'vip://wp-content/uploads/file[0-9].txt';
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern_char_class ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/file1.txt' ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/file5.txt' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/fileA.txt' ) );
+
+		// Negative character class
+		$pattern_neg_class = 'vip://wp-content/uploads/doc[!0-9]*.pdf';
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern_neg_class ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/docA.pdf' ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/docB-draft.pdf' ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/doc1.pdf' ) );
+
+		// Test removing a pattern
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $pattern ) );
+		$this->assertFalse( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/new-image.jpg' ) );
+
+		// Clean up
+		if ( $this->should_unregister ) {
+			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );
+			$this->should_unregister = false;
+		}
+	}
+
+	/**
+	 * Test O(1) lookup for exact matches versus pattern matching
+	 */
+	public function test_lookup_performance() {
+		// Set up the API client mock
+		$this->api_client_mock = $this->createMock( API_Client::class );
+		$this->stream_wrapper  = new VIP_Filesystem_Local_Stream_Wrapper( $this->api_client_mock );
+		$this->stream_wrapper->register();
+		$this->should_unregister = true;
+
+		// Add both exact paths and patterns
+		$exact_path = 'vip://wp-content/uploads/exact-file.txt';
+		$pattern    = 'vip://wp-content/uploads/pattern-*.txt';
+
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $exact_path ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $pattern ) );
+
+		// Test that both matching methods work
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( $exact_path ) );
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/pattern-123.txt' ) );
+
+		// Use reflection to access the local_files_map and local_file_patterns properties
+		$reflector            = new \ReflectionClass( VIP_Filesystem_Local_Stream_Wrapper::class );
+		$local_files_map_prop = $reflector->getProperty( 'local_files_map' );
+		$local_files_map_prop->setAccessible( true );
+		$local_file_patterns_prop = $reflector->getProperty( 'local_file_patterns' );
+		$local_file_patterns_prop->setAccessible( true );
+
+		// Verify that exact path is in the hash map
+		$local_files_map = $local_files_map_prop->getValue();
+		$this->assertArrayHasKey( $exact_path, $local_files_map );
+
+		// Verify that pattern is in the patterns hash map (not array)
+		$local_file_patterns = $local_file_patterns_prop->getValue();
+		$this->assertArrayHasKey( $pattern, $local_file_patterns );
 		
+		// Test O(1) removes
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $pattern ) );
+		$local_file_patterns = $local_file_patterns_prop->getValue();
+		$this->assertEmpty( $local_file_patterns );
+		
+		$this->assertTrue( VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $exact_path ) );
+		$local_files_map = $local_files_map_prop->getValue();
+		$this->assertEmpty( $local_files_map );
+
 		// Clean up
 		if ( $this->should_unregister ) {
 			stream_wrapper_unregister( VIP_Filesystem_Local_Stream_Wrapper::DEFAULT_PROTOCOL );


### PR DESCRIPTION
## Description

This is taking the initial implementation one step further.

Now we also support wildcard matches. E.g. if we want to ignore any Elementor cache-related file we can easily do so by 

```
VIP_Filesystem_Local_Stream_Wrapper::add_local_file( 'wp-content/uploads/et-cache/* );
```

This is still not 100% ready for prime-time so I'm omitting the changelog. 


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->