### PR TITLE
Prevent php errors from displaying in wp cli output

### DIFF
--- a/lib/wpcom-error-handler/wpcom-error-handler.php
+++ b/lib/wpcom-error-handler/wpcom-error-handler.php
@@ -170,7 +170,7 @@ function wpcom_custom_error_handler( $whether_i_may_die, $type, $message, $file,
 			$display_errors_format = "\n%s: %s in %s on line %d [%s] [%s]\n";
 		}
 
-		if ( 'stderr' === $display_errors && defined( 'STDERR' ) && is_resource( STDERR ) ) {
+		if ( 'stderr' === strtolower( $display_errors ) && defined( 'STDERR' ) && is_resource( STDERR ) ) {
 			fprintf( STDERR, $display_errors_format, $string, $message, $file, $line, htmlspecialchars( $source ), htmlspecialchars( $backtrace ) );
 		} else {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
WP CLI sets the `display_errors` to all-capitalized `STDERR` here: https://github.com/wp-cli/wp-cli/blob/8717a02af98b58f2821622d46339fdd8473bd974/php/utils-wp.php#L90

As a result, our error handler ends up outputting the errors directly. This messes up CLI output, and makes parsing results (like JSON) especially problematic.

With this change, the errors will correctly go into the stderr output rather than stdout. Fixes PLTFRM-378

## Testing

1) Ensure `ini_set( 'display_errors', 'STDERR' );` is set and kept (not overridden afterwards). For WP CLI, it does so when xdebug is not in use.
2) Have some code trigger a PHP warning, like `trigger_error( 'Test: This is a warning', E_USER_WARNING );`.
3) Run a CLI command and note the output contains the php error in the stdout: `wp option get home 2>/dev/null`
4) Then apply this patch, and note that the output no longer contains the error.