### PR TITLE
CI (WP Core tests): Remove new test added by 6.8 (N/A to VIP)

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -106,7 +106,10 @@ jobs:
         working-directory: wordpress
 
       - name: Run PHPUnit tests
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist
+        run: >
+          node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit
+          --verbose -c phpunit.xml.dist
+          --filter "^\(?!.*test_wp_generate_attachment_metadata_png_thumbnail_smaller_than_original\).*\$"
         working-directory: wordpress
 
       - name: Run AJAX tests


### PR DESCRIPTION
## Description
We disable it at https://github.com/Automattic/vip-go-mu-plugins/blob/b8db989b922fec48af1c27999aa792cd28c3fe5c/a8c-files.php#L701-L704

The test was added per https://github.com/WordPress/wordpress-develop/commit/7daa963e8061308b3bccb681e494487851371a9d. It will never scale down because it will never reach the "big threshold".