### PR TITLE
WP-CLI: in case there are no replicas available we should fallback to primary.

### DIFF
--- a/lib/helpers/wp-cli-db/class-config.php
+++ b/lib/helpers/wp-cli-db/class-config.php
@@ -74,21 +74,27 @@ class Config {
 			$db_servers
 		);
 
-		$server_objects = array_filter( $server_objects, function ( $candidate ) {
+		$filtered_server_objects = array_filter( $server_objects, function ( $candidate ) {
 			return $candidate instanceof DB_Server &&
 				$candidate->can_read() && ! (
 					$candidate->can_write() && ! $this->allow_writes()
 				);
 		} );
 
+		if ( ! $filtered_server_objects ) {
+			$filtered_server_objects = [
+				$server_objects[0],
+			];
+		}
+
 		// Sort the replicas in ascending order of the write priority (if allowed), else sort by read priority.
-		usort( $server_objects, function ( $c0, $c1 ) {
+		usort( $filtered_server_objects, function ( $c0, $c1 ) {
 			if ( $this->allow_writes() ) {
 				return $c0->write_priority() <=> $c1->write_priority();
 			}
 			return $c0->read_priority() <=> $c1->read_priority();
 		} );
 
-		return end( $server_objects );
+		return end( $filtered_server_objects );
 	}
 }


### PR DESCRIPTION
## Description

In certain conditions where replicas are not available WP-CLI db related commands might fail. This PR guards against it.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Pick a fataling site, apply the PR, verify the commands work.

b-1039