### PR TITLE
Improve/ignore platform required paths in new relic

### DIFF
--- a/prometheus/endpoint.php
+++ b/prometheus/endpoint.php
@@ -10,6 +10,10 @@ use Prometheus\Storage\APCng;
 use Prometheus\Storage\InMemory;
 
 // @codeCoverageIgnoreStart -- this is a standalone endpoint which doens't run in the context of the WP tests
+if ( extension_loaded( 'newrelic' ) ) { // Ensure PHP agent is available
+	newrelic_ignore_transaction();
+}
+
 require_once __DIR__ . '/vendor/autoload.php';
 require_once dirname( __DIR__ ) . '/lib/utils/class-context.php';
 


### PR DESCRIPTION
## Description

By default, New Relic runs for every request, including internal metrics endpoints which get hit often. Unfortunately, this has a negative impact on the accuracy because these internal endpoints are very fast, leading to skewing of stats like avg response time.  



## Changelog Description

### Added

- Added `newrelic_ignore_transaction` to some internal endpoints that should not be tracked in New Relic to ensure accuracy of the app stats.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

