### PR TITLE
Fix edge cache purge API call

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -271,11 +271,11 @@ class WPCOM_VIP_Cache_Manager {
 
 					$headers = [
 						'Content-Type: application/json',
-						sprintf( 'Authorization: Bearer %s', EDGE_CACHE_PURGE_CLIENT_TOKEN ),
+						sprintf( 'Authorization: bearer %s', EDGE_CACHE_PURGE_CLIENT_TOKEN ),
 					];
 					if ( 500 < strlen( $data ) ) {
 						$compressed_data = gzencode( $data );
-						$headers[]       = [ 'Content-Encoding: gzip' ];
+						$headers[]       = 'Content-Encoding: gzip';
 						curl_setopt( $curl, CURLOPT_POSTFIELDS, $compressed_data );
 					} else {
 						curl_setopt( $curl, CURLOPT_POSTFIELDS, $data );


### PR DESCRIPTION
## Description

This PR fixes the edge cache purge API call by sending the correct headers and using lowercase `bearer`.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->