### PR TITLE
skip loading remote data blocks on unsupported WP versions

### DIFF
--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -25,6 +25,11 @@ class RemoteDataBlocksIntegration extends Integration {
 		return defined( 'REMOTE_DATA_BLOCKS__LOADED' );
 	}
 
+	public function get_wp_version(): string {
+		global $wp_version;
+		return $wp_version;
+	}
+
 	/**
 	 * Returns `true` if the current WordPress version is supported by Remote Data Blocks.
 	 *
@@ -33,7 +38,7 @@ class RemoteDataBlocksIntegration extends Integration {
 	 *              version is defined, `false` otherwise.
 	 */
 	public function is_supported_wp_version(): bool {
-		global $wp_version;
+		$wp_version = $this->get_wp_version();
 
 		$config = $this->get_env_config();
 		if (

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -25,6 +25,11 @@ class RemoteDataBlocksIntegration extends Integration {
 		return defined( 'REMOTE_DATA_BLOCKS__LOADED' );
 	}
 
+	/**
+	 * Returns the current WordPress version.
+	 *
+	 * Wraps the global `$wp_version` variable in a function to make it easier to mock in tests.
+	 */
 	public function get_wp_version(): string {
 		global $wp_version;
 		return $wp_version;

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -26,35 +26,28 @@ class RemoteDataBlocksIntegration extends Integration {
 	}
 
 	/**
-	 * Returns the current WordPress version.
-	 *
-	 * Wraps the global `$wp_version` variable in a function to make it easier to mock in tests.
-	 */
-	public function get_wp_version(): string {
-		global $wp_version;
-		return $wp_version;
-	}
-
-	/**
 	 * Returns `true` if the current WordPress version is supported by Remote Data Blocks.
 	 *
 	 * @return bool `true` if the current WordPress version greater than or equal to the minimum
-	 *              WordPress version defined in the environment config or if no minimum WordPress
-	 *              version is defined, `false` otherwise.
+	 *              WordPress version defined in the environment config, `false` otherwise.
 	 */
 	public function is_supported_wp_version(): bool {
-		$wp_version = $this->get_wp_version();
+		$wp_version = get_bloginfo( 'version' );
 
 		$config = $this->get_env_config();
 		if (
 			isset( $config['minimum_wp_version'] ) &&
 			is_string( $config['minimum_wp_version'] ) &&
-			version_compare( $wp_version, $config['minimum_wp_version'], '<' )
+			version_compare( $wp_version, $config['minimum_wp_version'], '>=' )
 		) {
-			return false;
+			return true;
 		}
 
-		return true;
+		/**
+		 * Default to false if the minimum WordPress version is not set to avoid fatals due to
+		 * Remote Data Blocks being loaded on unsupported WordPress versions.
+		 */
+		return false;
 	}
 
 	/**

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -26,6 +26,28 @@ class RemoteDataBlocksIntegration extends Integration {
 	}
 
 	/**
+	 * Returns `true` if the current WordPress version is supported by Remote Data Blocks.
+	 *
+	 * @return bool `true` if the current WordPress version greater than or equal to the minimum
+	 *              WordPress version defined in the environment config or if no minimum WordPress
+	 *              version is defined, `false` otherwise.
+	 */
+	public function is_supported_wp_version(): bool {
+		global $wp_version;
+
+		$config = $this->get_env_config();
+		if (
+			isset( $config['minimum_wp_version'] ) &&
+			is_string( $config['minimum_wp_version'] ) &&
+			version_compare( $wp_version, $config['minimum_wp_version'], '<' )
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Loads the plugin.
 	 *
 	 * This is called after the integration is activated and configured.
@@ -40,6 +62,11 @@ class RemoteDataBlocksIntegration extends Integration {
 			// In activate() method we do make sure to not activate the integration if its already loaded
 			// but still adding it here as a safety measure i.e. if load() is called directly.
 			if ( $this->is_loaded() ) {
+				return;
+			}
+
+			if ( ! $this->is_supported_wp_version() ) {
+				$this->is_active = false;
 				return;
 			}
 

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -238,7 +238,6 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 			'wp_version equal to minimum with patch different' => [ '6.7.1', [ 'minimum_wp_version' => '6.7' ], true ],
 			'wp_version equal to minimum exact' => [ '6.7', [ 'minimum_wp_version' => '6.7' ], true ],
 			'wp_version equal to minimum but more specific' => [ '6.7.0', [ 'minimum_wp_version' => '6.7' ], true ],
-			'wp_version equal to minimum but less specific' => [ '6.7', [ 'minimum_wp_version' => '6.7.0' ], true ],
 		];
 	}
 

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -104,9 +104,6 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		// Reset our mock state
 		global $mock_filesystem_state;
 		$mock_filesystem_state = null;
-
-		// Unset global wp_version if set by a test
-		unset( $GLOBALS['wp_version'] );
 	}
 
 	public function test_is_loaded_returns_false_when_not_loaded(): void {
@@ -223,17 +220,14 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 	 * @dataProvider wp_version_support_provider
 	 */
 	public function test_is_supported_wp_version( string $current_wp_version, ?array $config, bool $expected_result ): void {
-		global $wp_version;
-		$wp_version = $current_wp_version; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
 		/** @var MockObject|RemoteDataBlocksIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'get_env_config' ] )
+			->onlyMethods( [ 'get_env_config', 'get_wp_version' ] )
 			->getMock();
 
 		$integration_mock->method( 'get_env_config' )->willReturn( $config ?? [] );
-
+		$integration_mock->method( 'get_wp_version' )->willReturn( $current_wp_version );
 		$this->assertEquals( $expected_result, $integration_mock->is_supported_wp_version() );
 	}
 

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -84,9 +84,14 @@ function file_exists( $file ) {
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
-
-
 	private string $slug = 'remote-data-blocks';
+	private static string $original_wp_version;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$original_wp_version = get_bloginfo( 'version' );
+	}
 
 	public function tearDown(): void {
 		parent::tearDown();
@@ -104,6 +109,10 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		// Reset our mock state
 		global $mock_filesystem_state;
 		$mock_filesystem_state = null;
+
+		// Reset the WordPress version
+		global $wp_version;
+		$wp_version = self::$original_wp_version; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	public function test_is_loaded_returns_false_when_not_loaded(): void {
@@ -223,21 +232,32 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		/** @var MockObject|RemoteDataBlocksIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'get_env_config', 'get_wp_version' ] )
+			->onlyMethods( [ 'get_env_config' ] )
 			->getMock();
 
 		$integration_mock->method( 'get_env_config' )->willReturn( $config ?? [] );
-		$integration_mock->method( 'get_wp_version' )->willReturn( $current_wp_version );
+
+		// Set the WordPress version
+		global $wp_version;
+		$wp_version = $current_wp_version; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
 		$this->assertEquals( $expected_result, $integration_mock->is_supported_wp_version() );
 	}
 
 	public static function wp_version_support_provider(): array {
 		return [
-			'no minimum_wp_version in config'   => [ '6.7', [], true ],
+			'no minimum_wp_version in config'   => [ '6.7', [], false ],
 			'wp_version less than minimum'      => [ '5.6', [ 'minimum_wp_version' => '6.7' ], false ],
 			'wp_version equal to minimum with patch different' => [ '6.7.1', [ 'minimum_wp_version' => '6.7' ], true ],
 			'wp_version equal to minimum exact' => [ '6.7', [ 'minimum_wp_version' => '6.7' ], true ],
-			'wp_version equal to minimum but more specific' => [ '6.7.0', [ 'minimum_wp_version' => '6.7' ], true ],
+			'wp_version is release candidate'   => [ '6.7-rc1', [ 'minimum_wp_version' => '6.7' ], false ],
+			'wp_version is beta version'        => [ '6.7-beta1', [ 'minimum_wp_version' => '6.7' ], false ],
+			'minimum_wp_version is release candidate with wp_version major release' => [ '6.7', [ 'minimum_wp_version' => '6.7-rc1' ], true ],
+			'minimum_wp_version is release candidate with wp_version patch release' => [ '6.7.1', [ 'minimum_wp_version' => '6.7-rc1' ], true ],
+			'minimum_wp_version is beta version with wp_version major release' => [ '6.7', [ 'minimum_wp_version' => '6.7-beta1' ], true ],
+			'minimum_wp_version is beta version with wp_version patch release' => [ '6.7.1', [ 'minimum_wp_version' => '6.7-beta1' ], true ],
+			'different minor versions'          => [ '6.8.2', [ 'minimum_wp_version' => '6.7.1' ], true ],
+			'different major versions'          => [ '7.0.1', [ 'minimum_wp_version' => '6.7' ], true ],
 		];
 	}
 

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -233,10 +233,12 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 
 	public static function wp_version_support_provider(): array {
 		return [
-			'no minimum_wp_version in config' => [ '6.7', [], true ],
-			'wp_version less than minimum'    => [ '5.6', [ 'minimum_wp_version' => '6.7' ], false ],
-			'wp_version equal to minimum'     => [ '6.7.1', [ 'minimum_wp_version' => '6.7' ], true ],
-			'wp_version greater than minimum' => [ '6.8.2', [ 'minimum_wp_version' => '6.7' ], true ],
+			'no minimum_wp_version in config'   => [ '6.7', [], true ],
+			'wp_version less than minimum'      => [ '5.6', [ 'minimum_wp_version' => '6.7' ], false ],
+			'wp_version equal to minimum with patch different' => [ '6.7.1', [ 'minimum_wp_version' => '6.7' ], true ],
+			'wp_version equal to minimum exact' => [ '6.7', [ 'minimum_wp_version' => '6.7' ], true ],
+			'wp_version equal to minimum but more specific' => [ '6.7.0', [ 'minimum_wp_version' => '6.7' ], true ],
+			'wp_version equal to minimum but less specific' => [ '6.7', [ 'minimum_wp_version' => '6.7.0' ], true ],
 		];
 	}
 

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -104,6 +104,9 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		// Reset our mock state
 		global $mock_filesystem_state;
 		$mock_filesystem_state = null;
+
+		// Unset global wp_version if set by a test
+		unset( $GLOBALS['wp_version'] );
 	}
 
 	public function test_is_loaded_returns_false_when_not_loaded(): void {
@@ -214,5 +217,71 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		
 		$this->assertIsArray( $versions );
 		$this->assertEmpty( $versions );
+	}
+
+	/**
+	 * @dataProvider wp_version_support_provider
+	 */
+	public function test_is_supported_wp_version( string $current_wp_version, ?array $config, bool $expected_result ): void {
+		global $wp_version;
+		$wp_version = $current_wp_version; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		/** @var MockObject|RemoteDataBlocksIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_env_config' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_env_config' )->willReturn( $config ?? [] );
+
+		$this->assertEquals( $expected_result, $integration_mock->is_supported_wp_version() );
+	}
+
+	public static function wp_version_support_provider(): array {
+		return [
+			'no minimum_wp_version in config' => [ '6.7', [], true ],
+			'wp_version less than minimum'    => [ '5.6', [ 'minimum_wp_version' => '6.7' ], false ],
+			'wp_version equal to minimum'     => [ '6.7.1', [ 'minimum_wp_version' => '6.7' ], true ],
+			'wp_version greater than minimum' => [ '6.8.2', [ 'minimum_wp_version' => '6.7' ], true ],
+		];
+	}
+
+	public function test_load_sets_inactive_and_returns_early_if_wp_version_not_supported(): void {
+		/** @var MockObject|RemoteDataBlocksIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'is_supported_wp_version', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->activate(); // Set is_active to true before testing load()
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		$integration_mock->method( 'is_supported_wp_version' )->willReturn( false );
+		$integration_mock->expects( $this->never() )->method( 'get_versions' );
+
+		$integration_mock->load();
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_load_sets_inactive_if_wp_version_supported_but_no_versions_found(): void {
+		/** @var MockObject|RemoteDataBlocksIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'is_supported_wp_version', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->activate(); // Initial state is active
+		$this->assertTrue( $integration_mock->is_active(), 'Initial: Integration should be active.' );
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		$integration_mock->method( 'is_supported_wp_version' )->willReturn( true );
+		$integration_mock->method( 'get_versions' )->willReturn( [] ); // No versions found
+
+		$integration_mock->load();
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
 	}
 }


### PR DESCRIPTION

## Description

Adds version compatibility check before loading the remote data blocks integration. The integration will only load if the current WordPress version meets or exceeds the minimum_wp_version specified in config. If no minimum version is configured, the integration loads normally. This check is required as currently Remote Data Blocks plugin relies on functionality not available in older versions of WordPress (<6.7).

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Added
- Added a WordPress version compatibility check before loading the remote data blocks integration.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Setup local dev environment with MU Plugins pointed to this checked out branch.

	```sh
	# Create a dev environment from a VIP deployed app with integrations configured and VIP GO MU Plugins pointed to the checked out branch
	vip dev-env create @app_id.environment_type -s <local_dev_environment_slug> -u <path_to_checked_out_branch>

	# Start the dev environment
	vip dev-env start <local_dev_environment_slug> --vscode
	```

3. When the VS Code window opens up, edit the `integrations/integrations-config/integrations.json` file to add a `remote-data-blocks` integration config -

	```json
	"remote-data-blocks": {
		"type": "remote-data-blocks",
		"org": {
			"status": "enabled"
		},
		"env": {
			"status": "enabled",
			"config": {
				"version": "latest",
				"minimum_wp_version": "6.7"
			}
		}
	}
	```

4. Verify that RDB integration is loaded as default WP version is greater than 6.7. 
5. Try changing the local dev environment's WordPress version to to different version and verify that RDB integration is loaded or not loaded based on the WordPress version.

	```sh
	# Change the WordPress version of the local dev environment
	vip dev-env update -s <local_dev_environment_slug> -w <wordpress_version>

	# Restart the local dev environment
	vip dev-env start <local_dev_environment_slug>
	```



