### PR TITLE
Adds log entry when user is locked out due to rate limits

### DIFF
--- a/security.php
+++ b/security.php
@@ -203,7 +203,7 @@ function _vip_maybe_temporary_lock_account( $username, $cache_group ) {
 		\Automattic\VIP\Logstash\log2logstash( array(
 			'severity' => 'warning',
 			'feature'  => 'security',
-			'message'  => sprintf( 'User %s locked out for %d seconds due to %s from IP %s', $username, $lock_interval, $lock_reason, $ip ),
+			'message'  => sprintf( 'User locked out due to $lock_reason. Username: %s, IP: %s, Interval: %d', $username, $ip, $lock_interval ),
 			'extra'    => [
 				'uri'              => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',
 				'http_method'      => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',

--- a/security.php
+++ b/security.php
@@ -197,8 +197,22 @@ function _vip_maybe_temporary_lock_account( $username, $cache_group ) {
 		 */
 		$lock_interval = apply_filters( "vip_{$event_type}_{$lock_reason}_lockout", $default_lockout, $username );
 
-
 		wp_cache_set( CACHE_KEY_LOCK_PREFIX . $cache_keys[ "{$lock_reason}_cache_key" ], true, $cache_group, $lock_interval ); // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+
+		// Log which user was locked out, what type of lockout, the lockout duration, and the IP address
+		\Automattic\VIP\Logstash\log2logstash( array(
+			'severity' => 'warning',
+			'feature'  => 'security',
+			'message'  => sprintf( 'User %s locked out for %d seconds due to %s from IP %s', $username, $lock_interval, $lock_reason, $ip ),
+			'extra'    => [
+				'uri'              => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',
+				'http_method'      => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',
+				'username'         => $username,
+				'lockout_type'     => $lock_reason,
+				'lockout_duration' => $lock_interval,
+				'ip_address'       => $ip,
+			],
+		) );
 	}
 }
 

--- a/security.php
+++ b/security.php
@@ -207,7 +207,7 @@ function _vip_maybe_temporary_lock_account( $username, $cache_group ) {
 			'extra'    => [
 				'uri'              => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',
 				'http_method'      => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',
-				'username'         => $username,
+				'username'         => vip_strict_sanitize_username( $username ),
 				'lockout_type'     => $lock_reason,
 				'lockout_duration' => $lock_interval,
 				'ip_address'       => $ip,

--- a/security.php
+++ b/security.php
@@ -202,7 +202,7 @@ function _vip_maybe_temporary_lock_account( $username, $cache_group ) {
 		// Log which user was locked out, what type of lockout, the lockout duration, and the IP address
 		\Automattic\VIP\Logstash\log2logstash( array(
 			'severity' => 'warning',
-			'feature'  => 'security',
+			'feature'  => "security_lockout_{$lock_reason}",
 			'message'  => sprintf( 'User locked out due to $lock_reason. Username: %s, IP: %s, Interval: %d', $username, $ip, $lock_interval ),
 			'extra'    => [
 				'uri'              => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',


### PR DESCRIPTION
## Description

This pull request enhances the logging functionality of the `_vip_maybe_temporary_lock_account` function in `security.php` to provide more detailed information about user lockout events.

## Changelog Description

### Added
- Added a log entry using `log2logstash` to record detailed information whenever a user is temporarily locked out. This includes the username, lockout duration, lockout reason, IP address, and additional context such as the request URI and HTTP method.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Fail to login a few times until you get locked out
2. When you do get locked out, check your debug log files and make sure it contains a log entry similar to the following:

```json
Automattic\VIP\Logstash\Logger: {
    "site_id": 1,
    "blog_id": 1,
    "http_host": "vip-security-boost.vipdev.lndo.site",
    "severity": "warning",
    "feature": "a8c_vip_security",
    "message": "User vipgo locked out for 300 seconds due to ip_username from IP 172.17.2.1",
    "user_id": 0,
    "extra": "{\n    \"uri\": \"\\\/wp-login.php\",\n    \"http_method\": \"POST\",\n    \"username\": \"vipgo\",\n    \"lockout_type\": \"ip_username\",\n    \"lockout_duration\": 300,\n    \"ip_address\": \"172.17.2.1\"\n}",
    "timestamp": "2025-05-16 13:11:22",
    "index": "log2logstash",
    "http_user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/135.0.0.0 Safari\/537.36",
    "file": "\/wp\/wp-content\/mu-plugins\/security.php",
    "line": "208"
}
```