### PR TITLE
[PLTFRM-841] Compatibility for Woo Downloadable product and VIP FS

### DIFF
--- a/vip-woocommerce/vip-woocommerce.php
+++ b/vip-woocommerce/vip-woocommerce.php
@@ -27,4 +27,16 @@ add_action( 'plugins_loaded', function () {
 
 		return $check_import_file_path;
 	}, 10, 2 );
+
+	add_filter( 'woocommerce_download_parse_file_path',
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		function ( $file_path, $remote_file ) {
+			if ( ! str_starts_with( $file_path, 'vip://wp-content' ) ) {
+				return 'vip://wp-content' . $file_path;
+			}
+
+			return $file_path;
+		},
+		10, 2 
+	);
 } );


### PR DESCRIPTION
## Description

Fixes the following fatal:

```
This message was triggered by woocommerce.

Call stack:

wp_die()
wp-content/plugins/woocommerce/includes/class-wc-download-handler.php:705
WC_Download_Handler::download_error()
wp-content/plugins/woocommerce/includes/class-wc-download-handler.php:491
WC_Download_Handler::download_file_force()
wp-includes/class-wp-hook.php:324
do_action('woocommerce_download_file_force')
wp-content/plugins/woocommerce/includes/class-wc-download-handler.php:254
WC_Download_Handler::download()
wp-content/plugins/woocommerce/includes/class-wc-download-handler.php:151
WC_Download_Handler::download_product()
wp-includes/class-wp-hook.php:324
do_action('init')
wp-settings.php:727
```

## Changelog Description

### Fixed
- Improved compatibility for Woocommerce Downloadable product and VIP File service

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

