### PR TITLE
Add new Parse.ly settings menus to Pendo allowed slugs

### DIFF
--- a/telemetry/pendo/class-pendo-javascript-library.php
+++ b/telemetry/pendo/class-pendo-javascript-library.php
@@ -65,11 +65,11 @@ class Pendo_JavaScript_Library {
 		'site-editor.php',
 		'themes.php',
 		'upload.php',
+		'parse-ly_page_parsely-settings',
+		'toplevel_page_parsely-dashboard-page',
 	];
-	
+
 	private static array $allowed_admin_screens = [
-		'parsely-dashboard-page',
-		'parsely-settings',
 		'vip-block-governance',
 	];
 

--- a/telemetry/pendo/class-pendo-javascript-library.php
+++ b/telemetry/pendo/class-pendo-javascript-library.php
@@ -195,12 +195,30 @@ class Pendo_JavaScript_Library {
 			return false;
 		}
 
-		if ( ! in_array( $screen, self::$allowed_screens, true ) ) {
+
+		/**
+		 * Filters the list of admin screens where the Pendo JavaScript library should be loaded.
+		 *
+		 * @param array $allowed_screens Array of admin $screen slugs where Pendo is enabled.
+		 */
+		$allowed_screens = apply_filters( 'vip_pendo_allowed_screens', self::$allowed_screens );
+
+		if ( ! in_array( $screen, $allowed_screens, true ) ) {
 			return false;
 		}
 
+		/**
+		 * Filters the list of admin.php pages where the Pendo JavaScript library should be loaded.
+		 *
+		 * These screens are accessed via admin.php?page=[screen_name] and are only used
+		 * when the current screen is admin.php.
+		 *
+		 * @param array $allowed_admin_screens Array of admin.php page slugs where Pendo is enabled.
+		 */
+		$allowed_admin_screens = apply_filters( 'vip_pendo_allowed_admin_screens', self::$allowed_admin_screens );
+
 		// admin.php is further restricted to specific query vars.
-		if ( 'admin.php' === $screen && ! in_array( get_query_var( 'page' ), self::$allowed_admin_screens, true ) ) {
+		if ( 'admin.php' === $screen && ! in_array( get_query_var( 'page' ), $allowed_admin_screens, true ) ) {
 			return false;
 		}
 

--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -35,9 +35,46 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 
 		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'production' );
 		Constant_Mocker::define( 'WPCOM_IS_VIP_ENV', true );
-		$wp_query->query_vars['page'] = 'parsely-dashboard-page';
+		$wp_query->query_vars['page'] = 'vip-block-governance';
 
 		$this->assertTrue( Pendo_JavaScript_Library::should_enqueue_script( 'admin.php' ) );
+	}
+
+	public function test_enabled_for_filter_allowed_screens() {
+		$user = $this->factory()->user->create_and_get( [ 'role' => 'author' ] );
+		wp_set_current_user( $user->ID );
+
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'production' );
+		Constant_Mocker::define( 'WPCOM_IS_VIP_ENV', true );
+
+		$allow_screen = function ( $screens ) {
+			$screens[] = 'newly-allowed-screen.php';
+			return $screens;
+		};
+
+		add_filter( 'vip_pendo_allowed_screens', $allow_screen );
+		$this->assertTrue( Pendo_JavaScript_Library::should_enqueue_script( 'newly-allowed-screen.php' ) );
+		remove_filter( 'vip_pendo_allowed_screens', $allow_screen );
+	}
+
+	public function test_enabled_for_filter_allowed_admin_screens() {
+		global $wp_query;
+
+		$user = $this->factory()->user->create_and_get( [ 'role' => 'author' ] );
+		wp_set_current_user( $user->ID );
+
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'production' );
+		Constant_Mocker::define( 'WPCOM_IS_VIP_ENV', true );
+		$wp_query->query_vars['page'] = 'admin-page-slug';
+
+		$allow_admin_screen = function ( $admin_screens ) {
+			$admin_screens[] = 'admin-page-slug';
+			return $admin_screens;
+		};
+
+		add_filter( 'vip_pendo_allowed_admin_screens', $allow_admin_screen );
+		$this->assertTrue( Pendo_JavaScript_Library::should_enqueue_script( 'admin.php' ) );
+		remove_filter( 'vip_pendo_allowed_admin_screens', $allow_admin_screen );
 	}
 
 	public function test_disabled_by_opt_out_constant() {


### PR DESCRIPTION
## Description

This PR adds two changes related to Pendo registration in mu-plugins:

1. Change Parse.ly menu slugs so that we will capture Pendo events in the Parsely Content Helper and Traffic Boost features. In the latest version of wp-parsely we've changed the menu from a submenu of "Settings" to a separate top-level menu:

    ![top-level-parsely](https://github.com/user-attachments/assets/ceb90815-70ad-40c5-85fc-3ce312b06420)

    This caused the slugs to change from admin-screen slugs to top-level slugs `parse-ly_page_parsely-settings` and `toplevel_page_parsely-dashboard-page`.

2. Adds two filters, `vip_pendo_allowed_screens` and `vip_pendo_allowed_admin_screens` that will allow plugins to register for Pendo enablement without a change to mu-plugins. This will allow our plugins to opt-in to Pendo analytics on the WordPress admin without requiring a mu-plugins PR each time a page is added or a slug is changed.

## Changelog Description

### Added

- Add client-side analytics for Parse.ly screens in the WordPress admin.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

I've tested this locally with these steps:

1. Set up a local `vip dev-env` instance with a custom `mu-plugins` directory set to this branch `update/pendo-allowed-screens`.
2. Locally edit `telemetry/pendo/class-pendo.php`'s [`is_pendo_enabled_for_environment()`](https://github.com/Automattic/vip-go-mu-plugins/blob/92a59e365ee8d715b07fa3796aa0ef3483dd6764/telemetry/pendo/class-pendo.php) function to always return true:

    ```diff
    final public static function is_pendo_enabled_for_environment(): bool {
    +   return true;
        // Do not run if disabled via constant.
        if ( defined( 'VIP_DISABLE_PENDO_TELEMETRY' ) && true === constant( 'VIP_DISABLE_PENDO_TELEMETRY' ) ) {
            return false;
        }
        /* ... */
   ```

    This will allow Pendo registration testing even though we're not on a production instance.

4. Install the [latest version of the Parse.ly plugin](https://github.com/Parsely/wp-parsely/releases/tag/3.19.1).
5. Open the WordPress admin dashboard and the developer network tools.
6. In the WordPress admin, go to the Parse.ly side menu and visit the "Settings" and "Traffic Boost (beta)" pages. Type "pendo" in the network tools search bar, and ensure you see requests for the Pendo agent on both pages:

    ![Screenshot 2025-05-20 at 4 14 18 PM](https://github.com/user-attachments/assets/c8e72051-f415-4bf0-b002-2dd2fd08e0c1)