### PR TITLE
configure rdb source configs

### DIFF
--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -154,11 +154,60 @@ class IntegrationVipConfig {
 		return $this->get_value_from_config( 'env', 'status' );
 	}
 
+	/**
+	 * Get environment-level configuration for this integration.
+	 *
+	 * @return array Environment configuration array, empty array if no config defined
+	 */
 	public function get_env_config(): array {
 		$config = $this->get_value_from_config( 'env', 'config' );
 		return is_array( $config ) ? $config : [];
 	}
 
+	/**
+	 * Get child integration configurations.
+	 *
+	 * Returns the 'children' array from the integration configuration, which contains
+	 * configuration data for child integrations. Each child can have its own 'env',
+	 * 'org', and 'network_sites' sections similar to the parent integration.
+	 *
+	 * @return array Array of child configurations, empty array if no children defined
+	 */
+	public function get_child_configs(): array {
+		if ( isset( $this->config['children'] ) && is_array( $this->config['children'] ) ) {
+			return $this->config['children'];
+		}
+
+		return [];
+	}
+
+	/**
+	 * Get environment configurations for child integrations.
+	 *
+	 * Extracts the 'config' field from the 'env' section of each child configuration,
+	 * preserving the integration slug as the key. This maintains the associative structure
+	 * and consistency with get_env_config() which returns only the config portion.
+	 *
+	 * @return array Associative array of child environment configurations keyed by integration slug
+	 */
+	public function get_child_env_configs(): array {
+		$child_configs = $this->get_child_configs();
+		$child_envs    = [];
+
+		foreach ( $child_configs as $child_slug => $child_config ) {
+			if ( isset( $child_config['env']['config'] ) && is_array( $child_config['env']['config'] ) ) {
+				$child_envs[ $child_slug ] = $child_config['env']['config'];
+			}
+		}
+
+		return $child_envs;
+	}
+
+	/**
+	 * Get network-site-level configuration for this integration.
+	 *
+	 * @return array Network site configuration array, empty array if not multisite or no config defined
+	 */
 	public function get_network_site_config(): array {
 		if ( ! is_multisite() ) {
 			return [];

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -109,6 +109,34 @@ abstract class Integration {
 	}
 
 	/**
+	 * Get child integration configurations.
+	 *
+	 * @return array Associative array of child configurations keyed by integration slug
+	 */
+	public function get_child_configs(): array {
+		// If the integration was activated manually
+		if ( ! isset( $this->vip_config ) ) {
+			return [];
+		}
+
+		return $this->vip_config->get_child_configs();
+	}
+
+	/**
+	 * Get environment configurations for child integrations.
+	 *
+	 * @return array Associative array of child environment configurations keyed by integration slug
+	 */
+	public function get_child_env_configs(): array {
+		// If the integration was activated manually
+		if ( ! isset( $this->vip_config ) ) {
+			return [];
+		}
+
+		return $this->vip_config->get_child_env_configs();
+	}
+
+	/**
 	 * Return the network-site-level configuration for this integration.
 	 *
 	 * @return array<string,array>

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -115,8 +115,27 @@ class RemoteDataBlocksIntegration extends Integration {
 	 * @private
 	 */
 	public function configure(): void {
+		$combined_sources  = [];
+		$child_env_configs = $this->get_child_env_configs();
+
+		foreach ( $child_env_configs as $child_slug => $env_config ) {
+			if (
+				is_array( $env_config ) &&
+				isset( $env_config['sources'] ) &&
+				is_array( $env_config['sources'] ) &&
+				! empty( $env_config['sources'] )
+			) {
+				// Add the service field to each source to identify which child integration it came from
+				$sources_with_service = array_map( function ( $source ) use ( $child_slug ) {
+					return array_merge( $source, [ 'service' => $child_slug ] );
+				}, $env_config['sources'] );
+				
+				$combined_sources = array_merge( $combined_sources, $sources_with_service );
+			}
+		}
+
 		if ( ! defined( 'REMOTE_DATA_BLOCKS_CONFIGS' ) ) {
-			define( 'REMOTE_DATA_BLOCKS_CONFIGS', [] );
+			define( 'REMOTE_DATA_BLOCKS_CONFIGS', $combined_sources );
 		}
 	}
 }

--- a/tests/integrations/test-integration-vip-config.php
+++ b/tests/integrations/test-integration-vip-config.php
@@ -300,6 +300,98 @@ class VIP_Integration_Vip_Config_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_value_from_vip_config, $config_value );
 	}
 
+	public function test__get_child_configs_returns_empty_array_when_no_children_defined(): void {
+		$mock = $this->get_mock( [] );
+
+		$this->assertEquals( [], $mock->get_child_configs() );
+	}
+
+	public function test__get_child_configs_returns_empty_array_when_children_is_not_array(): void {
+		$mock = $this->get_mock( [ 'children' => 'not-an-array' ] );
+
+		$this->assertEquals( [], $mock->get_child_configs() );
+	}
+
+	public function test__get_child_configs_returns_children_array_when_defined(): void {
+		$children_config = [
+			'airtable'      => [
+				'type' => 'airtable',
+				'env'  => [
+					'status' => 'enabled',
+					'config' => [ 'sources' => [] ],
+				],
+			],
+			'google-sheets' => [
+				'type' => 'google-sheets',
+				'env'  => [
+					'status' => 'enabled',
+					'config' => [ 'sources' => [] ],
+				],
+			],
+		];
+
+		$mock = $this->get_mock( [ 'children' => $children_config ] );
+
+		$this->assertEquals( $children_config, $mock->get_child_configs() );
+	}
+
+	public function test__get_child_env_configs_returns_empty_array_when_no_children_defined(): void {
+		$mock = $this->get_mock( [] );
+
+		$this->assertEquals( [], $mock->get_child_env_configs() );
+	}
+
+	public function test__get_child_env_configs_returns_only_config_portion_from_child_envs(): void {
+		$children_config = [
+			'airtable'      => [
+				'type' => 'airtable',
+				'env'  => [
+					'status' => 'enabled',
+					'config' => [ 'sources' => [ [ 'uuid' => 'test-1' ] ] ],
+				],
+			],
+			'google-sheets' => [
+				'type' => 'google-sheets',
+				'env'  => [
+					'status' => 'enabled',
+					'config' => [ 'sources' => [ [ 'uuid' => 'test-2' ] ] ],
+				],
+			],
+			'invalid-child' => [
+				'type' => 'invalid',
+				'env'  => [
+					'status' => 'enabled',
+					// No config field
+				],
+			],
+		];
+
+		$expected = [
+			'airtable'      => [ 'sources' => [ [ 'uuid' => 'test-1' ] ] ],
+			'google-sheets' => [ 'sources' => [ [ 'uuid' => 'test-2' ] ] ],
+		];
+
+		$mock = $this->get_mock( [ 'children' => $children_config ] );
+
+		$this->assertEquals( $expected, $mock->get_child_env_configs() );
+	}
+
+	public function test__get_child_env_configs_handles_non_array_config_gracefully(): void {
+		$children_config = [
+			'airtable' => [
+				'type' => 'airtable',
+				'env'  => [
+					'status' => 'enabled',
+					'config' => 'not-an-array',
+				],
+			],
+		];
+
+		$mock = $this->get_mock( [ 'children' => $children_config ] );
+
+		$this->assertEquals( [], $mock->get_child_env_configs() );
+	}
+
 	/**
 	 * Get mock.
 	 *

--- a/tests/integrations/test-integration.php
+++ b/tests/integrations/test-integration.php
@@ -133,4 +133,74 @@ class VIP_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $integration->is_active() );
 	}
+
+	public function test__get_child_configs_returns_empty_array_for_manual_activation(): void {
+		$integration = new FakeIntegration( 'fake' );
+
+		$this->assertEquals( [], $integration->get_child_configs() );
+	}
+
+	public function test__get_child_env_configs_returns_empty_array_for_manual_activation(): void {
+		$integration = new FakeIntegration( 'fake' );
+
+		$this->assertEquals( [], $integration->get_child_env_configs() );
+	}
+
+	public function test__get_child_configs_delegates_to_vip_config_when_present(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Only valid for multisite.' );
+		}
+
+		$children_config = [
+			'airtable' => [
+				'type' => 'airtable',
+				'env'  => [
+					'status' => 'enabled',
+					'config' => [],
+				],
+			],
+		];
+
+		/** @var MockObject&IntegrationVipConfig $vip_config_mock */
+		$vip_config_mock = $this->getMockBuilder( IntegrationVipConfig::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_child_configs' ] )
+			->getMock();
+
+		$vip_config_mock->expects( $this->once() )
+			->method( 'get_child_configs' )
+			->willReturn( $children_config );
+
+		$integration = new FakeIntegration( 'fake' );
+		$integration->activate();
+		$integration->set_vip_config( $vip_config_mock );
+
+		$this->assertEquals( $children_config, $integration->get_child_configs() );
+	}
+
+	public function test__get_child_env_configs_delegates_to_vip_config_when_present(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Only valid for multisite.' );
+		}
+
+		$child_env_configs = [
+			'airtable' => [ 'sources' => [ [ 'uuid' => 'test-1' ] ] ],
+		];
+
+		/** @var MockObject&IntegrationVipConfig $vip_config_mock */
+		$vip_config_mock = $this->getMockBuilder( IntegrationVipConfig::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_child_env_configs' ] )
+			->getMock();
+
+		$vip_config_mock->expects( $this->once() )
+			->method( 'get_child_env_configs' )
+			->willReturn( $child_env_configs );
+
+		$integration = new FakeIntegration( 'fake' );
+		$integration->activate();
+		$integration->set_vip_config( $vip_config_mock );
+
+		$this->assertEquals( $child_env_configs, $integration->get_child_env_configs() );
+	}
 }

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -104,6 +104,59 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		$this->assertEquals( [ 'test' => 'value' ], constant( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
 	}
 
+	public function test_configure_adds_service_field_to_child_sources(): void {
+		// Mock child env configs
+		$child_env_configs = [
+			'airtable'      => [
+				'sources' => [
+					[
+						'uuid'           => 'test-uuid-1',
+						'service_config' => [ 'key' => 'value1' ],
+					],
+					[
+						'uuid'           => 'test-uuid-2',
+						'service_config' => [ 'key' => 'value2' ],
+					],
+				],
+			],
+			'google-sheets' => [
+				'sources' => [
+					[
+						'uuid'           => 'test-uuid-3',
+						'service_config' => [ 'key' => 'value3' ],
+					],
+				],
+			],
+		];
+
+		// Create a mock integration that returns our test data
+		/** @var MockObject|RemoteDataBlocksIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_child_env_configs' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_child_env_configs' )->willReturn( $child_env_configs );
+
+		$integration_mock->configure();
+
+		$this->assertTrue( defined( 'REMOTE_DATA_BLOCKS_CONFIGS' ) );
+		
+		$configs = constant( 'REMOTE_DATA_BLOCKS_CONFIGS' );
+		$this->assertIsArray( $configs );
+		$this->assertCount( 3, $configs );
+
+		// Verify each source has the service field added
+		$this->assertEquals( 'airtable', $configs[0]['service'] );
+		$this->assertEquals( 'test-uuid-1', $configs[0]['uuid'] );
+		
+		$this->assertEquals( 'airtable', $configs[1]['service'] );
+		$this->assertEquals( 'test-uuid-2', $configs[1]['uuid'] );
+		
+		$this->assertEquals( 'google-sheets', $configs[2]['service'] );
+		$this->assertEquals( 'test-uuid-3', $configs[2]['uuid'] );
+	}
+
 	/**
 	 * @dataProvider wp_version_support_provider
 	 */


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description

This PR reads the configs from the source integrations and combines the configs for data sources to be set in the constant `REMOTE_DATA_BLOCKS_CONFIGS` from where the remote data blocks integration consumes it.

## Changelog Description

### Added
- Added `get_child_configs()` and `get_child_env_configs()` methods to `IntegrationVipConfig` and `Integration` classes to get the configs for child integrations
- Pass the data source configs to the remote-data-blocks plugins from the integrations framework via the `REMOTE_DATA_BLOCKS_CONFIGS` constant

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR and [install the dependencies](https://github.com/Automattic/vip-go-mu-plugins?tab=readme-ov-file#local-dev).
2. Setup local dev environment with MU Plugins pointed to this checked out branch.

	```sh
	# Create a dev environment from a VIP deployed app with integrations configured and VIP GO MU Plugins pointed to the checked out branch
	vip dev-env create @app_id.environment_type -s <local_dev_environment_slug> -u <path_to_checked_out_branch>

	# Start the dev environment
	vip dev-env start <local_dev_environment_slug> --vscode
	```

3. When the VS Code window opens up, edit the `integrations/integrations-config/integrations.json` file to add a `remote-data-blocks` integration config -

	```json
	"remote-data-blocks": {
		"type": "remote-data-blocks",
		"org": {
			"status": "enabled"
		},
		"env": {
			"status": "enabled",
			"config": {
				"version": "latest",
				"minimum_wp_version": "6.7"
			}
		}
		"children": {
            "airtable": {
                "type": "airtable",
                "org": {
                    "status": "enabled"
                },
                "env": {
                    "status": "enabled",
                    "config": {
                        "sources": [
                            {
                                "uuid": "1b2e1d2a-3c4f-4a5b-8c6d-7e8f9a0b1c2d",
                                "service_config": {
                                    "__version": 1,
                                    "access_token": "<token>",
                                    "base": {
                                        "id": "<base_id>",
                                        "name": "Event Planning"
                                    },
                                    "enable_blocks": true,
                                    "display_name": "Airtable Budget",
                                    "tables": [
                                        {
                                            "id": "<table_id>",
                                            "name": "<table_name"",
                                            "output_query_mappings": [
                                                {
                                                    "key": "Item",
                                                    "name": "Item",
                                                    "path": "$.fields[\"Item\"]",
                                                    "type": "string"
                                                },
                                                {
                                                    "key": "Quantity",
                                                    "name": "Quantity",
                                                    "path": "$.fields[\"Quantity\"]",
                                                    "type": "number"
                                                }
                                            ]
                                        }
                                    ]
                                }
                            }
                        ]
                    }
                }
            }
        }
	}
	```

4. Verify that RDB plugin is loaded by navigating to Settings > Remote Data Blocks in WP-Admin and verify that above data sources are listed.
5. To verify that block for the data source is loaded, replace the dummy values with actual values and verify that the block is loaded by navigating to editor and searching for the block. The block should have the name in the format <display_name>/<table_name>
