### PR TITLE
Add RDB to allowed screens list

### DIFF
--- a/telemetry/pendo/class-pendo-javascript-library.php
+++ b/telemetry/pendo/class-pendo-javascript-library.php
@@ -67,6 +67,7 @@ class Pendo_JavaScript_Library {
 		'upload.php',
 		'parse-ly_page_parsely-settings',
 		'toplevel_page_parsely-dashboard-page',
+		'settings_page_remote-data-blocks-settings',
 	];
 
 	private static array $allowed_admin_screens = [


### PR DESCRIPTION
## Description
Adding Remote Data Blocks configuration screen to the allowed array.

I had the wrong page name before. This will bring the Pendo agent to the settings screen.

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

### Added
- Remote Data Blocks configuration screen to Pendo telemetry configuration.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Install RDB
2. Set a constant like  define( 'VIP_PENDO_SNIPPET_API_KEY', '{talk to jacob about API key}' );
1. Go to `wp-admin` > `Settings` > `Remote Data Blocks`
1. View the console
1. Verify pendo-agent.js is included
-->