### PR TITLE
fix(security): exclude expired sessions from rate limiting

### DIFF
--- a/security.php
+++ b/security.php
@@ -258,10 +258,20 @@ add_filter( 'vip_login_ip_username_window', function ( $window, $username ) {
 	return $window;
 }, 10, 2 );
 
-function wpcom_vip_login_limiter( $username ) {
+/**
+ * @param string $username
+ * @param WP_Error $error
+ * @return void
+ */
+function wpcom_vip_login_limiter( $username, $error ) {
+	if ( in_array( 'expired_session', $error->get_error_codes() ) ) {
+		// Don't track login attempts for expired sessions.
+		return;
+	}
+
 	wpcom_vip_track_auth_attempt( $username, CACHE_GROUP_LOGIN_LIMIT );
 }
-add_action( 'wp_login_failed', 'wpcom_vip_login_limiter' );
+add_action( 'wp_login_failed', 'wpcom_vip_login_limiter', 10, 2 );
 
 function wpcom_vip_login_limiter_on_success( $username ) {
 	$cache_keys = _vip_login_cache_keys( $username );

--- a/security.php
+++ b/security.php
@@ -264,7 +264,8 @@ add_filter( 'vip_login_ip_username_window', function ( $window, $username ) {
  * @return void
  */
 function wpcom_vip_login_limiter( $username, $error ) {
-	if ( in_array( 'expired_session', $error->get_error_codes() ) ) {
+	// `expired_session` must be the only error
+	if ( 'expired_session' === $error->get_error_code() ) {
 		// Don't track login attempts for expired sessions.
 		return;
 	}

--- a/tests/test-security.php
+++ b/tests/test-security.php
@@ -316,4 +316,20 @@ class VIP_Go_Security_Test extends WP_UnitTestCase {
 		$this->assertNotWPError( $result );
 		$this->assertEquals( $user_id, $result->ID );
 	}
+
+	public function test_session_expiration(): void {
+		remove_all_filters( 'authenticate' );
+
+		$filter_invoked = false;
+
+		add_filter( 'authenticate', fn () => new WP_Error( 'expired_session', 'Your session has expired. Please log in again.' ), 99 );
+		add_filter( 'vip_login_username_window', static function ( $window ) use ( &$filter_invoked ) {
+			$filter_invoked = true;
+			return $window;
+		}, 10, 1 );
+
+		$user = wp_authenticate( 'some-user', 'some-password' );
+		$this->assertWPError( $user );
+		static::assertFalse( $filter_invoked );
+	}
 }


### PR DESCRIPTION
## Description

Do not increase the number of failed login attempts for expired sessions.

Fixes: #4746

## Changelog Description

### Changed
- Expired sessions do not count towards the login limit (#4746)

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See #4746 
