### PR TITLE
feat: per-file upload control via filter

### DIFF
--- a/files/class-wp-filesystem-vip-uploads.php
+++ b/files/class-wp-filesystem-vip-uploads.php
@@ -104,6 +104,22 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 	 * @return bool False upon failure, true otherwise.
 	 */
 	public function put_contents( $file_path, $contents, $mode = false ) {
+		/**
+		 * Filter to allow or disallow file uploads.
+		 *
+		 * @param bool|WP_Error $allow_upload Whether to allow the file upload. Default true.
+		 * @param string $file_path The path to the file being uploaded.
+		 */
+		$allow_upload = apply_filters( 'vipfs_allow_file_upload', true, $file_path );
+		if ( is_wp_error( $allow_upload ) ) {
+			$this->errors = $allow_upload;
+			return false;
+		}
+
+		if ( false === $allow_upload ) {
+			return false;
+		}
+
 		$uploads_path = $this->sanitize_uploads_path( $file_path );
 
 		$file_name     = basename( $file_path );

--- a/files/class-wp-filesystem-vip-uploads.php
+++ b/files/class-wp-filesystem-vip-uploads.php
@@ -107,17 +107,20 @@ class WP_Filesystem_VIP_Uploads extends \WP_Filesystem_Base {
 		/**
 		 * Filter to allow or disallow file uploads.
 		 *
-		 * @param bool|WP_Error $allow_upload Whether to allow the file upload. Default true.
-		 * @param string $file_path The path to the file being uploaded.
+		 * @param bool|WP_Error|string  $allow_upload Whether to allow the file upload. Default true.
+		 *                              `false` silently aborts the upload, `WP_Error` will set the `errors` property of this class,
+		 *                              and a string (filename) imitates successul upload.
+		 * @param string $file_path     The path to the file being uploaded.
+		 * @param string $contents      The contents of the file being uploaded.
 		 */
-		$allow_upload = apply_filters( 'vipfs_allow_file_upload', true, $file_path );
+		$allow_upload = apply_filters( 'vipfs_allow_file_upload', true, $file_path, $contents );
 		if ( is_wp_error( $allow_upload ) ) {
 			$this->errors = $allow_upload;
 			return false;
 		}
 
-		if ( false === $allow_upload ) {
-			return false;
+		if ( false === $allow_upload || is_string( $allow_upload ) ) {
+			return $allow_upload;
 		}
 
 		$uploads_path = $this->sanitize_uploads_path( $file_path );

--- a/files/init-filesystem.php
+++ b/files/init-filesystem.php
@@ -29,14 +29,6 @@ if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
 	add_filter( 'filesystem_method', function () {
 		return VIP_FILESYSTEM_METHOD; // The VIP base class transparently handles using the direct filesystem as well as the VIP Go File API
 	}, PHP_INT_MAX );
-
-	add_filter( 'vipfs_allow_file_upload', function ( $allow, $file_path ) {
-		if ( true === $allow ) {
-			$allow = ! preg_match( '/\.php$/i', $file_path );
-		}
-
-		return $allow;
-	}, 19, 2 );
 }
 
 add_filter( 'request_filesystem_credentials', function ( $credentials, $form_post, $type ) {

--- a/files/init-filesystem.php
+++ b/files/init-filesystem.php
@@ -29,6 +29,14 @@ if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
 	add_filter( 'filesystem_method', function () {
 		return VIP_FILESYSTEM_METHOD; // The VIP base class transparently handles using the direct filesystem as well as the VIP Go File API
 	}, PHP_INT_MAX );
+
+	add_filter( 'vipfs_allow_file_upload', function ( $allow, $file_path ) {
+		if ( true === $allow ) {
+			$allow = ! preg_match( '/\.php$/i', $file_path );
+		}
+
+		return $allow;
+	}, 9, 2 );
 }
 
 add_filter( 'request_filesystem_credentials', function ( $credentials, $form_post, $type ) {

--- a/files/init-filesystem.php
+++ b/files/init-filesystem.php
@@ -29,6 +29,14 @@ if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
 	add_filter( 'filesystem_method', function () {
 		return VIP_FILESYSTEM_METHOD; // The VIP base class transparently handles using the direct filesystem as well as the VIP Go File API
 	}, PHP_INT_MAX );
+
+	add_filter( 'vipfs_allow_file_upload', function ( $allow, $file_path ) {
+		if ( true === $allow ) {
+			$allow = ! preg_match( '/\.(php|html?)$/i', $file_path );
+		}
+
+		return $allow;
+	}, 19, 2 );
 }
 
 add_filter( 'request_filesystem_credentials', function ( $credentials, $form_post, $type ) {

--- a/files/init-filesystem.php
+++ b/files/init-filesystem.php
@@ -32,7 +32,7 @@ if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
 
 	add_filter( 'vipfs_allow_file_upload', function ( $allow, $file_path ) {
 		if ( true === $allow ) {
-			$allow = ! preg_match( '/\.(php|html?)$/i', $file_path );
+			$allow = ! preg_match( '/\.php$/i', $file_path );
 		}
 
 		return $allow;


### PR DESCRIPTION
## Description

This PR introduces a filter, `vipfs_allow_file_upload`, which can be used to allow or disallow uploads on a per-file basis.

See PLTFRM-940 for more details.

## Changelog Description

### Added
- VIP Filesystem: Added the `vipfs_allow_file_upload` filter to allow or disallow uploads on a per-file basis.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

N/A
