### PR TITLE
Update es-wp-query to 0.5.2

### DIFF
--- a/search/es-wp-query/class-es-wp-query-wrapper.php
+++ b/search/es-wp-query/class-es-wp-query-wrapper.php
@@ -796,9 +796,10 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 		if ( isset( $q['post_mime_type'] ) && '' !== $q['post_mime_type'] ) {
 			$es_mime = $this->post_mime_type_query( $q['post_mime_type'], $wpdb->posts );
 			if ( ! empty( $es_mime['filters'] ) ) {
-				$filter[] = $es_mime['filters'];
+				$filter = array_values( array_merge( $filter, $es_mime['filters'] ) );
 			}
 			if ( ! empty( $es_mime['query'] ) ) {
+				$query['minimum_should_match'] = 1;
 				if ( empty( $query['should'] ) ) {
 					$query['should'] = $es_mime['query'];
 				} else {
@@ -1216,7 +1217,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 			$size                  = apply_filters( 'es_query_max_results', 1000 );
 			$this->es_args['size'] = $size;
 		}
-		
+
 		// ES > 7.0 doesn't return the actual total hits by default (capped at 10k), but we need accurate counts
 		$this->es_args[ 'track_total_hits' ] = true;
 
@@ -1520,17 +1521,17 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 	 *
 	 * @param string|array $post_mime_types List of mime types or comma separated string of mime types.
 	 * @access public
-	 * @return string|array Array of filters and query on success, empty string on failure.
+	 * @return array Array of filters and query on success, empty array on failure.
 	 */
 	public function post_mime_type_query( $post_mime_types ) {
 		$wildcards         = array( '', '%', '%/%' );
 		$strict_mime_types = array();
-		$query             = array();
-		$filters           = array();
+		$prefix_mime_types = array();
 
 		if ( is_string( $post_mime_types ) ) {
 			$post_mime_types = array_map( 'trim', explode( ',', $post_mime_types ) );
 		}
+
 		foreach ( (array) $post_mime_types as $mime_type ) {
 			$mime_type = preg_replace( '/\s/', '', $mime_type );
 			$slashpos  = strpos( $mime_type, '/' );
@@ -1550,21 +1551,49 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 				}
 			}
 
-
 			if ( in_array( $mime_type, $wildcards, true ) ) {
-				return '';
+				return [];
 			}
 
 			if ( false !== strpos( $mime_pattern, '*' ) ) {
-				$mime_pattern = preg_replace( '/\*+/', '', $mime_pattern );
-				$query[]      = array( 'prefix' => array( $this->es_map( 'post_mime_type' ) => $mime_pattern ) );
+				$prefix_mime_types[] = preg_replace( '/\*+/', '', $mime_pattern );
 			} else {
 				$strict_mime_types[] = $mime_pattern;
 			}
 		}
 
-		if ( ! empty( $strict_mime_types ) ) {
-			$filters = $this->dsl_terms( $this->es_map( 'post_mime_type' ), $strict_mime_types );
+		$query   = array();
+		$filters = array();
+
+		// Support a mix of prefix and strict mime types (e.g. 'image/*,video/mp4').
+		if ( ! empty( $prefix_mime_types ) && ! empty( $strict_mime_types ) ) {
+			// Create a new bool query with multiple 'OR' conditions to support a mix
+			// of prefix and term queries.
+			$query = array(
+				'bool' => array(
+					'should' => array(
+						$this->dsl_terms( $this->es_map( 'post_mime_type' ), $strict_mime_types ),
+					),
+				),
+			);
+
+			foreach ( $prefix_mime_types as $prefix_mime_type ) {
+				$query['bool']['should'][] = array(
+					'prefix' => array(
+						$this->es_map( 'post_mime_type' ) => $prefix_mime_type,
+					),
+				);
+			}
+
+			$query = [ $query ];
+		} elseif ( ! empty( $prefix_mime_types ) ) {
+			foreach ( $prefix_mime_types as $prefix_mime_type ) {
+				$filters[] = array( 'prefix' => array( $this->es_map( 'post_mime_type' ) => $prefix_mime_type ) );
+			}
+		} elseif ( ! empty( $strict_mime_types ) ) {
+			$filters = [
+				$this->dsl_terms( $this->es_map( 'post_mime_type' ), $strict_mime_types ),
+			];
 		}
 
 		return compact( 'filters', 'query' );

--- a/search/es-wp-query/es-wp-query.php
+++ b/search/es-wp-query/es-wp-query.php
@@ -3,7 +3,7 @@
  * Plugin Name: Elasticsearch Wrapper for WP_Query
  * Plugin URI: https://github.com/alleyinteractive/es-wp-query
  * Description: A drop-in replacement for WP_Query to leverage Elasticsearch for complex queries.
- * Version: 0.4
+ * Version: 0.5.2
  * Author: Matthew Boynes
  * Author URI: http://www.alleyinteractive.com/
  *


### PR DESCRIPTION
## Description
Updates `es-wp-query` to fix two bugs:
1) Term queries aren't pulled in properly for mixed casing on category names
2) `post_mime_type` queries aren't pulling in multiple types. Only one type is typically returned.

## Changelog Description

### Changed
- Enterprise Search: Updated es-wp-query to 0.5.2

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->