### PR TITLE
Fix log message interpolation for lockout reason

### DIFF
--- a/security.php
+++ b/security.php
@@ -203,7 +203,7 @@ function _vip_maybe_temporary_lock_account( $username, $cache_group ) {
 		\Automattic\VIP\Logstash\log2logstash( array(
 			'severity' => 'warning',
 			'feature'  => "security_lockout_{$lock_reason}",
-			'message'  => sprintf( 'User locked out due to $lock_reason. Username: %s, IP: %s, Interval: %d', $username, $ip, $lock_interval ),
+			'message'  => sprintf( 'User locked out due to %s lockout. Username: %s, IP: %s, Interval: %d', $lock_reason, $username, $ip, $lock_interval ),
 			'extra'    => [
 				'uri'              => isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '',
 				'http_method'      => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : '',


### PR DESCRIPTION
## Description

This PR fixes a bug in the log message for user lockouts where `$lock_reason` was being used literally instead of being properly interpolated. The log message now correctly includes the actual lockout reason (e.g., "ip_username", "username", etc.) instead of the literal string "$lock_reason".

This is a follow-up to PR #6302 which added the logging functionality for user lockouts.

## Changelog Description

### Fixed
- Fixed log message interpolation for lockout reason to display the actual lockout type instead of literal "$lock_reason"

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out this PR branch
2. Trigger a user lockout by failing to login multiple times
3. Check the debug log files and verify the log message now shows the actual lockout reason instead of "$lock_reason"
4. The log message should look like: "User locked out due to ip_username lockout. Username: testuser, IP: 127.0.0.1, Interval: 300" instead of "User locked out due to $lock_reason lockout..."