### PR TITLE
VIPDOC-525: Add step in changelogs workflow to post to docs site

### DIFF
--- a/.github/workflows/changelog-summary-prod.yml
+++ b/.github/workflows/changelog-summary-prod.yml
@@ -83,3 +83,21 @@ jobs:
                 --wp-endpoint=https://public-api.wordpress.com/wp/v2/sites/wpvipchangelog.wordpress.com/posts \
                 --wp-status=draft \
                 --debug
+
+  changelog:
+    needs: execute
+    name: Docs Site Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: Automattic/vip-actions/changelog@fa05dc9293764a50401a293f2c9312924afbaab3 # trunk
+        with:
+          endpoint: ${{ vars.DOCS_CHANGELOG_POST_ENDPOINT }}
+          endpoint-token: ${{ secrets.DOCS_CHANGELOG_POST_TOKEN }}
+          endpoint-auth-type: 'basic'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          status: 'draft'
+          category-id: '98'
+          tag-id: '95'
+          link-to-pr: true
+

--- a/.github/workflows/changelog-summary-staging.yml
+++ b/.github/workflows/changelog-summary-staging.yml
@@ -37,3 +37,21 @@ jobs:
                 --wp-endpoint=https://public-api.wordpress.com/wp/v2/sites/wpvipchangelog.wordpress.com/posts \
                 --wp-status=draft \
                 --debug
+
+  changelog:
+    needs: execute
+    name: Docs Site Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: Automattic/vip-actions/changelog@fa05dc9293764a50401a293f2c9312924afbaab3 # trunk
+        with:
+          endpoint: ${{ vars.DOCS_CHANGELOG_POST_ENDPOINT }}
+          endpoint-token: ${{ secrets.DOCS_CHANGELOG_POST_TOKEN }}
+          endpoint-auth-type: 'basic'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          status: 'draft'
+          category-id: '97'
+          tag-id: '96'
+          link-to-pr: true
+


### PR DESCRIPTION
## Description

Adds a step to the changelog summary workflows to send changelog posts to the docs dev site using the shared changelogs workflow (consistent with the VIP-CLI and Dashboard repos). This is currently an additional step in the changelog workflow, but I expect the requirements can eventually be unified so that the shared workflow can be used exclusively.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 
- [ ] Secrets have been added to repo settings

## Steps to Test

1. The step being added can be tested in the repo for site 4812 at `/actions/workflows/changelog.yml`
