### PR TITLE
Fix fatal error during WordPress multisite activation by deferring VIP Support initialization

### DIFF
--- a/vip-support.php
+++ b/vip-support.php
@@ -7,6 +7,4 @@
  * License:      GPLv2 or later
  */
 
-if ( ! defined( 'WP_INSTALLING' ) ) {
-	require_once __DIR__ . '/vip-support/vip-support.php';
-}
+require_once __DIR__ . '/vip-support/vip-support.php';

--- a/vip-support/class-vip-support-role.php
+++ b/vip-support/class-vip-support-role.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\VIP\Support_User;
 
+use Automattic\VIP\Utils\Context;
 use WP_User;
 
 /**
@@ -183,4 +184,9 @@ class Role {
 	}
 }
 
-Role::init();
+// Skip the Role initialization if WP_INSTALLING is defined.
+// This prevents the Role from being initialized during the installation process, which could lead to issues if
+// the role is not yet fully set up or if the database is not ready for it.
+if ( ! Context::is_installing() ) {
+	Role::init();
+}

--- a/vip-support/class-vip-support-user.php
+++ b/vip-support/class-vip-support-user.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\VIP\Support_User;
 
+use Automattic\VIP\Utils\Context;
 use WP_Error;
 use WP_User;
 
@@ -1149,4 +1150,9 @@ class User {
 	}
 }
 
-User::init();
+// Skip the User initialization if WP_INSTALLING is defined.
+// This prevents the User from being initialized during the installation process, which could lead to issues if
+// the user is not yet fully set up or if the database is not ready for it.
+if ( ! Context::is_installing() ) {
+	User::init();
+}


### PR DESCRIPTION
## Description

The VIP Support plugin was causing fatal errors during WordPress multisite activation when accessing `/wp-activate.php` route:

```
PHP Fatal error: Uncaught Error: Class "Automattic\VIP\Support_User\User" not found in /wordpress/mu-plugins/telemetry/tracks/tracks-utils.php:22
```

The error occurred because during WordPress multisite activation, the constant `WP_INSTALLING` is `true`, which was preventing the `Automattic\VIP\Support_User\*` classes from being loaded in `vip-support.php`, making them unavailable for downstream code.

This PR fixes the issue by always loading the support user classes/files and deferring the initialization of VIP Support classes when `WP_INSTALLING` is true.

Changes made:
* Removed the `WP_INSTALLING` check from `vip-support.php` to ensure classes are always loaded;
* Added `WP_INSTALLING` guards around Role::init() and User::init() to prevent premature initialization during WordPress installation.