### PR TITLE
ES Integrations: Add offloading

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1269,6 +1269,12 @@ class Search {
 			return true;
 		}
 
+		// For integrations, we need to short-circuit whether we are offloading search or not.
+		$integrations_override_value = apply_filters( 'vip_search_query_integration_enabled', null );
+		if ( is_bool( $integrations_override_value ) ) {
+			return $integrations_override_value;
+		}
+
 		// Legacy constant name
 		$query_integration_enabled_legacy = defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) && true === constant( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' );
 

--- a/tests/integrations/test-enterprise-search.php
+++ b/tests/integrations/test-enterprise-search.php
@@ -101,4 +101,52 @@ class VIP_EnterpriseSearch_Integration_Test extends WP_UnitTestCase {
 		$this->assertEquals( Constant_Mocker::constant( 'VIP_ELASTICSEARCH_USERNAME' ), 'baz' );
 		$this->assertEquals( Constant_Mocker::constant( 'VIP_ELASTICSEARCH_PASSWORD' ), '123' );
 	}
+
+	public function test_configure_adds_query_integration_filter_when_offload_search_true(): void {
+		$es_integration = new EnterpriseSearchIntegration( $this->slug );
+
+		get_class_property_as_public( Integration::class, 'options' )->setValue( $es_integration, [
+			'config' => [ 'offload_search' => 'true' ],
+		] );
+
+		$es_integration->configure();
+		do_action( 'vip_search_loaded' );
+
+		$this->assertTrue( has_filter( 'vip_search_query_integration_enabled', '__return_true' ) !== false );
+		$this->assertTrue( apply_filters( 'vip_search_query_integration_enabled', null ) );
+		$this->assertTrue( \Automattic\VIP\Search\Search::is_query_integration_enabled() );
+	}
+
+	public function test_configure_adds_query_integration_filter_when_offload_search_false(): void {
+		Constant_Mocker::define( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION', true ); // Should have no effect
+
+		$es_integration = new EnterpriseSearchIntegration( $this->slug );
+
+		get_class_property_as_public( Integration::class, 'options' )->setValue( $es_integration, [
+			'config' => [ 'offload_search' => 'false' ],
+		] );
+
+		$es_integration->configure();
+		do_action( 'vip_search_loaded' );
+
+		$this->assertTrue( has_filter( 'vip_search_query_integration_enabled', '__return_false' ) !== false );
+		$this->assertFalse( apply_filters( 'vip_search_query_integration_enabled', null ) );
+		$this->assertFalse( \Automattic\VIP\Search\Search::is_query_integration_enabled() );
+	}
+
+	public function test_configure_does_not_add_query_integration_filter_when_offload_search_not_present(): void {
+		$es_integration = new EnterpriseSearchIntegration( $this->slug );
+
+		get_class_property_as_public( Integration::class, 'options' )->setValue( $es_integration, [
+			'config' => [],
+		] );
+
+		$es_integration->configure();
+		do_action( 'vip_search_loaded' );
+
+		$this->assertFalse( has_filter( 'vip_search_query_integration_enabled', '__return_true' ) );
+		$this->assertFalse( has_filter( 'vip_search_query_integration_enabled', '__return_false' ) );
+		$this->assertNull( apply_filters( 'vip_search_query_integration_enabled', null ) );
+		$this->assertFalse( \Automattic\VIP\Search\Search::is_query_integration_enabled() );
+	}
 }


### PR DESCRIPTION
## Description

### Enhancements to Enterprise Search Integration:

* **Added search offloading configuration logic:**
  - Introduced a new `vip_set_search_offloading` method in `integrations/enterprise-search.php` to set filters based on the `offload_search` configuration. The method applies filters to enable or disable query integration depending on the configuration value.

* **Updated `configure` method to handle search offloading:**
  - Modified the `configure` method in `integrations/enterprise-search.php` to include the new `vip_set_search_offloading` action, ensuring search offloading logic is executed when `vip_search_loaded` is triggered.

### Query Integration Logic Updates:

* **Short-circuit query integration based on filters:**
  - Updated the `is_query_integration_enabled` method in `search/includes/classes/class-search.php` to check for the `vip_search_query_integration_enabled` filter and short-circuit the logic if a boolean value is returned.
