### PR TITLE
Adds an internal filter to better detect when sites are overriding 2FA rules

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -130,8 +130,9 @@ function wpcom_vip_is_two_factor_forced() {
 	if ( ! wpcom_vip_should_force_two_factor() ) {
 		return false;
 	}
-
-	return apply_filters( 'wpcom_vip_is_two_factor_forced', false );
+	$is_enforced = apply_filters( 'wpcom_vip_is_two_factor_forced', false );
+	// apply an internal filter so that we can detect if a site uses the wpcom_vip_is_two_factor_forced filter
+	return apply_filters( 'wpcom_vip_internal_is_two_factor_forced', $is_enforced );
 }
 
 function wpcom_vip_enforce_two_factor_plugin() {
@@ -140,7 +141,7 @@ function wpcom_vip_enforce_two_factor_plugin() {
 		$limited = current_user_can( $cap );
 
 		// Calculate current_user_can outside map_meta_cap to avoid callback loop
-		add_filter( 'wpcom_vip_is_two_factor_forced', function () use ( $limited ) {
+		add_filter( 'wpcom_vip_internal_is_two_factor_forced', function () use ( $limited ) {
 			return $limited;
 		}, 9 );
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -141,7 +141,7 @@ function wpcom_vip_enforce_two_factor_plugin() {
 		$limited = current_user_can( $cap );
 
 		// Calculate current_user_can outside map_meta_cap to avoid callback loop
-		// while we could use the internal wpcom_vip_internal_is_two_factor_forced filter, we won't here, as it would take precedence over any old customer filter.
+		// While we could use the internal wpcom_vip_internal_is_two_factor_forced filter here, we intentionally don't to avoid taking precedence over existing customer filters.
 		add_filter( 'wpcom_vip_is_two_factor_forced', function () use ( $limited ) {
 			return $limited;
 		}, 9 );

--- a/two-factor.php
+++ b/two-factor.php
@@ -141,7 +141,8 @@ function wpcom_vip_enforce_two_factor_plugin() {
 		$limited = current_user_can( $cap );
 
 		// Calculate current_user_can outside map_meta_cap to avoid callback loop
-		add_filter( 'wpcom_vip_internal_is_two_factor_forced', function () use ( $limited ) {
+		// while we could use the internal wpcom_vip_internal_is_two_factor_forced filter, we won't here, as it would take precedence over any old customer filter.
+		add_filter( 'wpcom_vip_is_two_factor_forced', function () use ( $limited ) {
 			return $limited;
 		}, 9 );
 

--- a/vip-jetpack/connection-pilot/class-jetpack-connection-attendant.php
+++ b/vip-jetpack/connection-pilot/class-jetpack-connection-attendant.php
@@ -23,7 +23,8 @@ class Attendant {
 		add_filter( 'authenticate', [ $this, 'prevent_login' ], 30, 2 );
 		add_filter( 'wp_is_application_passwords_available_for_user', [ $this, 'disable_application_passwords' ], 15, 2 );
 		add_filter( 'map_meta_cap', [ $this, 'modify_user_capabilties' ], PHP_INT_MAX, 4 );
-		add_filter( 'wpcom_vip_is_two_factor_forced', [ $this, 'bypass_two_factor_auth' ], PHP_INT_MAX );
+		// using the internal filter for 2FA.
+		add_filter( 'wpcom_vip_internal_is_two_factor_forced', [ $this, 'bypass_two_factor_auth' ], PHP_INT_MAX );
 		add_action( 'plugins_loaded', [ $this, 'remove_my_jetpack_page' ], 30 );
 	}
 


### PR DESCRIPTION
## Description

The current `wpcom_vip_is_two_factor_forced` is used both by customers and also in our codebase. 

This makes it difficult to detect a site is using and leveraging this filter. This PR adds an extra filter (`wpcom_vip_internal_is_two_factor_forced`) outside of `wpcom_vip_is_two_factor_forced`, that's only used internally and is not meant for "public" usage.

Similarly, we changed Jetpack connection pilot to ensure it uses this new internal filter instead of the old one. 

Note: There is an extra usage of the`wpcom_vip_is_two_factor_forced` filter inside the codebase that we intentionally did not change because that would override the customer behavior if they have used it with a different priority. 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

* Have a test site that implements https://docs.wpvip.com/security/two-factor-authentication/#h-enforce-two-factor-authentication-for-user-roles-and-capabilities as an example.
* Create a contributor/editor (since the capability required there user and check that 2FA is still required and it's working.
