### PR TITLE
ES 8: Revert DCA routing to DFW

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1091,14 +1091,6 @@ class Health {
 					'actual'   => 'N/A',
 				);
 			} elseif ( $actual_settings[ $key ] != $desired_settings[ $key ] ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
-				// Special handling for DC routing: DCA ES8 indexes can have 'dfw' actual with 'dca' desired
-				// TODO: Remove once DCA is supported on ES8
-				if ( 'index.routing.allocation.include.dc' === $key && 
-					'dfw' === $actual_settings[ $key ] && 'dca' === $desired_settings[ $key ] &&
-					defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === '8' ) {
-					continue;
-				}
-
 				$diff[ $key ] = array(
 					'expected' => $desired_settings[ $key ],
 					'actual'   => $actual_settings[ $key ],

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2055,12 +2055,6 @@ class Search {
 			return null;
 		}
 
-		// For now, force all DCA ES8 indexes to be routed to DFW
-		// TODO: Remove once DCA is supported on ES8
-		if ( defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === '8' && 'dca' === $dc ) {
-			return 'dfw';
-		}
-
 		return $dc;
 	}
 

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -1491,26 +1491,4 @@ class Health_Test extends WP_UnitTestCase {
 		$correct_mapping = Health::validate_post_index_mapping( $index_name, $mapping );
 		$this->assertEquals( $expected_result, $correct_mapping );
 	}
-
-	// TODO: Remove once DCA is supported on ES8
-	public function test__health_check_dc_routing_ok_dca_es8() {
-		Constant_Mocker::define( 'VIP_ELASTICSEARCH_VERSION', '8' );
-
-		$actual_settings  = [ 'index.routing.allocation.include.dc' => 'dfw' ];
-		$desired_settings = [ 'index.routing.allocation.include.dc' => 'dca' ];
-
-		$diff = Health::get_index_settings_diff( $actual_settings, $desired_settings );
-
-		$this->assertArrayNotHasKey( 'index.routing.allocation.include.dc', $diff );
-	}
-
-	// TODO: Remove once DCA is supported on ES8
-	public function test__health_check_dc_routing_not_ok_dca_es7() {
-		$actual_settings  = [ 'index.routing.allocation.include.dc' => 'dfw' ];
-		$desired_settings = [ 'index.routing.allocation.include.dc' => 'dca' ];
-
-		$diff = Health::get_index_settings_diff( $actual_settings, $desired_settings );
-
-		$this->assertArrayHasKey( 'index.routing.allocation.include.dc', $diff );
-	}
 }

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -1470,31 +1470,6 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'dca', $origin_dc );
 	}
 
-	// TODO: Remove once DCA is supported on ES8
-	public function test__dca_es8_routing_to_dfw() {
-		$mock_search = $this->getMockBuilder( Search::class )
-			->onlyMethods( [ 'get_current_host' ] )
-			->getMock();
-		$mock_search->method( 'get_current_host' )->willReturn( 'https://es-ha.dca.vipv2.net' );
-
-		Constant_Mocker::define( 'VIP_ELASTICSEARCH_VERSION', '8' );
-
-		$result = $mock_search->get_index_routing_allocation_include_dc();
-		$this->assertEquals( 'dfw', $result );
-	}
-
-	// TODO: Remove once DCA is supported on ES8
-	public function test__dca_existing_es_version_does_not_route_to_dfw() {
-		$mock_search = $this->getMockBuilder( Search::class )
-			->onlyMethods( [ 'get_current_host' ] )
-			->getMock();
-		$mock_search->method( 'get_current_host' )->willReturn( 'https://es-ha.dca.vipv2.net' );
-
-		$result = $mock_search->get_index_routing_allocation_include_dc();
-
-		$this->assertEquals( 'dca', $result );
-	}
-
 	public function get_index_routing_allocation_include_dc_from_endpoints_data() {
 		return array(
 			// Valid


### PR DESCRIPTION
## Description
Reverts the DCA routing in https://github.com/Automattic/vip-go-mu-plugins/pull/6397.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->