### PR TITLE
WIP: prevent infinite recursion in wp_cache_get

### DIFF
--- a/lib/class-apc-cache-interceptor.php
+++ b/lib/class-apc-cache-interceptor.php
@@ -208,19 +208,33 @@ if ( ! class_exists( 'APC_Cache_Interceptor' ) ) :
 		 * wp_cache_get
 		 */
 		public function wp_cache_get( $value, $id, $flag, $force ) {
-			if ( true === $force ) {
-				// Don't intercept if we're explicitly bypassing local caches
-				return false;
-			}
+			// Guard to avoid infinite recursion
+			static $is_running = false;
 
-			$intercept = $this->do_intercept_key( $id, $flag );
-			if ( ! $intercept ) {
+			if ( $is_running ) {
 				return $value;
 			}
-			switch ( $intercept['model']['mode'] ) {
-				case 'passive':
-					return $this->passive_wp_cache_get( $intercept, $force );
+			
+			$is_running = true;
+
+			try {
+				if ( true === $force ) {
+					// Don't intercept if we're explicitly bypassing local caches
+					return false;
+				}
+
+				$intercept = $this->do_intercept_key( $id, $flag );
+				if ( ! $intercept ) {
+					return $value;
+				}
+				switch ( $intercept['model']['mode'] ) {
+					case 'passive':
+						return $this->passive_wp_cache_get( $intercept, $force );
+				}
+			} finally {
+				$is_running = false;
 			}
+
 			return $value;
 		}
 


### PR DESCRIPTION
## Description

This is untested. We've seen some infinite recursion with `APC_Cache_Interceptor->wp_cache_get` and this is an attempt to prevent that. 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

TODO