### PR TITLE
test: fix `VIP_Feed_Cache_Test` for WP nightly

### DIFF
--- a/tests/vip-feed-cache/test-vip-feed-cache.php
+++ b/tests/vip-feed-cache/test-vip-feed-cache.php
@@ -22,7 +22,14 @@ class VIP_Feed_Cache_Test extends WP_UnitTestCase {
 		$build = $feed->data['build'];
 		$this->assertIsNumeric( $build );
 
-		$transient = get_transient( 'feed_' . md5( $this->get_cache_filename( $url ) ) );
+		global $wp_version;
+		if ( version_compare( $wp_version, '6.8.99', '>' ) ) {
+			$transient = get_site_transient( 'feed_' . md5( $this->get_cache_filename( $url ) ) );
+		} else {
+			$transient = get_transient( 'feed_' . md5( $this->get_cache_filename( $url ) ) );
+		}
+
+		$this->assertIsArray( $transient );
 		$this->assertEquals( $transient['build'], $build );
 	}
 
@@ -30,19 +37,12 @@ class VIP_Feed_Cache_Test extends WP_UnitTestCase {
 	 * This mocks get_cache_filename in class-simplepie.php for WP versions 5.9+
 	 *
 	 * @see https://core.trac.wordpress.org/changeset/52393
-	 * @param $url string
-	 * @return $url string
+	 * @param string $url
+	 * @return string
 	 */
 	private function get_cache_filename( $url ) {
-		global $wp_version;
-		if ( $wp_version >= '5.9' ) {
-			$options                    = [];
-			$options[ CURLOPT_TIMEOUT ] = 3;
-			if ( ! empty( $options ) ) {
-				ksort( $options );
-				$url .= '#' . urlencode( var_export( $options, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
-			}
-		}
+		$options = [ CURLOPT_TIMEOUT => 3 ];
+		$url    .= '#' . urlencode( var_export( $options, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 		return $url;
 	}
 }


### PR DESCRIPTION
## Description

This pull request updates the feed cache test to improve compatibility with newer WordPress versions and clarify the cache filename logic. The most important changes are grouped below.

**WordPress version compatibility:**

* Updated `test__fetch_feed_build()` to use `get_site_transient()` instead of `get_transient()` for WordPress versions greater than or equal to `6.9`, ensuring the correct transient function is used based on the version.
* Added an assertion to verify that the transient data is an array, strengthening the test's reliability.

**Code clarity and maintenance:**

* Refactored the `get_cache_filename()` helper to simplify option handling and improve parameter documentation, making the code easier to read and maintain.
