### PR TITLE
Update default Jetpack version to 14.9

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 14.8
+ * Version: 14.9.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -36,7 +36,7 @@ function vip_default_jetpack_version() {
 		return '14.5';
 	} else {
 		// WordPress 6.7 and newer.
-		return '14.8';
+		return '14.9';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '14.8';
+		$latest = '14.9';
 
 		$versions_map = [
 			// WordPress version => Jetpack version


### PR DESCRIPTION
## Description
Sets Jetpack 14.9.1 as default version

## Changelog Description

### Changed
- Sets Jetpack 14.9.1 as default version

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->