### PR TITLE
[VIP-1715] Add real-time collaboration integration loader

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Integration: Real-Time Collaboration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+/**
+ * Loads Real-Time Collaboration VIP Integration.
+ *
+ * @private
+ */
+class RealTimeCollaborationIntegration extends Integration {
+
+	public function is_loaded(): bool {
+		// Check for the existence of the plugin version constant defined in the main plugin file.
+		return defined( 'VIP_REAL_TIME_COLLABORATION__LOADED' );
+	}
+
+	/**
+	 * Loads the plugin.
+	 *
+	 * This is called after the integration is activated and configured.
+	 *
+	 * @private
+	 */
+	public function load(): void {
+		/**
+		 * Return if the integration is already loaded.
+		 *
+		 * In activate() method we do make sure to not activate the integration if its already loaded
+		 * but still adding it here as a safety measure i.e. if load() is called directly.
+		 */
+		if ( $this->is_loaded() ) {
+			return;
+		}
+
+		/**
+		 * Load the custom build of Gutenberg from vip-integrations.
+		 *
+		 * Built from - https://github.com/Automattic/gutenberg/tree/add/experimental-collaborative-editing
+		 * This has the code required to support collaborative editing.
+		 */
+		$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/gutenberg/gutenberg.php';
+		if ( file_exists( $gutenberg_path ) ) {
+			require_once $gutenberg_path;
+		}
+
+		/**
+		 * Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/vip-real-time-collaboration-<version>/
+		 * and check what versions are available.
+		 */
+		$versions = $this->get_versions();
+
+		// if no versions are found, return early.
+		if ( empty( $versions ) ) {
+			$this->is_active = false;
+			return;
+		}
+
+		// Load the latest version of the plugin.
+		$latest_directory = array_key_first( $versions );
+		$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-real-time-collaboration.php';
+
+		// This check isn't strictly necessary, but better safe than sorry.
+		if ( file_exists( $load_path ) ) {
+			require_once $load_path;
+		} else {
+			$this->is_active = false;
+		}
+	}
+
+	/**
+	 * Get the available versions of Real-Time Collaboration in descending order.
+	 *
+	 * @return array<string, string> An associative array of available versions, where the key is the
+	 *                               directory name and the value is the version number. The versions
+	 *                               are sorted in descending order.
+	 */
+	public function get_versions() {
+		return get_available_versions(
+			WPVIP_MU_PLUGIN_DIR . '/vip-integrations/',
+			'vip-real-time-collaboration',
+			'vip-real-time-collaboration.php'
+		);
+	}
+
+	/**
+	 * Configure Real-Time Collaboration for VIP Platform.
+	 *
+	 * This is called after the integration is activated but before the plugin is loaded.
+	 *
+	 * @private
+	 */
+	public function configure(): void {
+		$env_config = $this->get_env_config();
+
+		// Set up WebSocket authentication secret constant
+		if ( isset( $env_config['web_socket_auth_secret'] ) && ! defined( 'VIP_RTC_WS_AUTH_SECRET' ) ) {
+			define( 'VIP_RTC_WS_AUTH_SECRET', $env_config['web_socket_auth_secret'] );
+		}
+
+		// Set up WebSocket URL constant with dummy value
+		if ( isset( $env_config['web_socket_url'] ) && ! defined( 'VIP_RTC_WS_URL' ) ) {
+			define( 'VIP_RTC_WS_URL', $env_config['web_socket_url'] );
+		}
+	}
+}

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -21,6 +21,13 @@ class RealTimeCollaborationIntegration extends Integration {
 	}
 
 	/**
+	 * Check if the Gutenberg plugin is active.
+	 */
+	private function is_gutenberg_plugin_active(): bool {
+		return defined( 'IS_GUTENBERG_PLUGIN' ) && constant( 'IS_GUTENBERG_PLUGIN' );
+	}
+
+	/**
 	 * Loads the plugin.
 	 *
 	 * This is called after the integration is activated and configured.
@@ -28,49 +35,65 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * @private
 	 */
 	public function load(): void {
-		/**
-		 * Return if the integration is already loaded.
-		 *
-		 * In activate() method we do make sure to not activate the integration if its already loaded
-		 * but still adding it here as a safety measure i.e. if load() is called directly.
-		 */
-		if ( $this->is_loaded() ) {
-			return;
-		}
+		/*
+		* Wait until plugins_loaded to give precedence to the plugin in the customer repo.
+		* Use priority 1 to ensure we load before any plugins hook into plugins_loaded.
+		*/
+		add_action('plugins_loaded', function () {
+			/**
+			 * Return if the integration is already loaded.
+			 *
+			 * In activate() method we do make sure to not activate the integration if its already loaded
+			 * but still adding it here as a safety measure i.e. if load() is called directly.
+			 */
+			if ( $this->is_loaded() ) {
+				return;
+			}
 
-		/**
-		 * Load the custom build of Gutenberg from vip-integrations.
-		 *
-		 * Built from - https://github.com/Automattic/gutenberg/tree/add/experimental-collaborative-editing
-		 * This has the code required to support collaborative editing.
-		 */
-		$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/gutenberg/gutenberg.php';
-		if ( file_exists( $gutenberg_path ) ) {
-			require_once $gutenberg_path;
-		}
+			/**
+			 * Load the custom build of Gutenberg from vip-integrations.
+			 *
+			 * Built from - https://github.com/Automattic/gutenberg/tree/add/experimental-collaborative-editing
+			 * This has the code required to support collaborative editing.
+			 */
+			$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/gutenberg/gutenberg.php';
+			if ( file_exists( $gutenberg_path ) && ! $this->is_gutenberg_plugin_active() ) {
+				require_once $gutenberg_path;
+			} else {
+				/**
+				 * Return early and don't load the plugin if either -
+				 * - Gutenberg is active separately as a plugin, so we don't load our custom build
+				 *   of Gutenberg to avoid conflicts.
+				 * - The custom build of Gutenberg is not available since that is required for the
+				 *   integration to work.
+				 */
+				$this->is_active = false;
+				return;
+			}
 
-		/**
-		 * Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/vip-real-time-collaboration-<version>/
-		 * and check what versions are available.
-		 */
-		$versions = $this->get_versions();
+			/**
+			 * Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/vip-real-time-collaboration-<version>/
+			 * and check what versions are available.
+			 */
+			$versions = $this->get_versions();
 
-		// if no versions are found, return early.
-		if ( empty( $versions ) ) {
-			$this->is_active = false;
-			return;
-		}
+			// if no versions are found, return early.
+			if ( empty( $versions ) ) {
+				$this->is_active = false;
+				return;
+			}
 
-		// Load the latest version of the plugin.
-		$latest_directory = array_key_first( $versions );
-		$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-real-time-collaboration.php';
+			// Load the latest version of the plugin.
+			$latest_directory = array_key_first( $versions );
+			$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-real-time-collaboration.php';
 
-		// This check isn't strictly necessary, but better safe than sorry.
-		if ( file_exists( $load_path ) ) {
-			require_once $load_path;
-		} else {
-			$this->is_active = false;
-		}
+			// This check isn't strictly necessary, but better safe than sorry.
+			if ( file_exists( $load_path ) ) {
+				require_once $load_path;
+			} else {
+				$this->is_active = false;
+			}
+		}, 1);
 	}
 
 	/**

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -28,11 +28,49 @@ class RealTimeCollaborationIntegration extends Integration {
 	}
 
 	/**
+	 * Check if all requirements are met to load the integration.
+	 */
+	private function can_load(): bool {
+		// Check required configuration constants
+		if ( ! defined( 'VIP_RTC_WS_AUTH_SECRET' ) || ! defined( 'VIP_RTC_WS_URL' ) ) {
+			return false;
+		}
+
+		// Check Gutenberg requirements
+		if ( $this->is_gutenberg_plugin_active() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private function get_gutenberg_path(): string|false {
+		$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/gutenberg/gutenberg.php';
+		if ( ! file_exists( $gutenberg_path ) ) {
+			return false;
+		}
+
+		return $gutenberg_path;
+	}
+
+	private function get_plugin_path(): string|false {
+		$versions = $this->get_versions();
+		if ( empty( $versions ) ) {
+			return false;
+		}
+		$latest_directory = array_key_first( $versions );
+		$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-real-time-collaboration.php';
+		if ( ! file_exists( $load_path ) ) {
+			return false;
+		}
+
+		return $load_path;
+	}
+
+	/**
 	 * Loads the plugin.
 	 *
 	 * This is called after the integration is activated and configured.
-	 *
-	 * @private
 	 */
 	public function load(): void {
 		/*
@@ -50,49 +88,25 @@ class RealTimeCollaborationIntegration extends Integration {
 				return;
 			}
 
-			/**
-			 * Load the custom build of Gutenberg from vip-integrations.
-			 *
-			 * Built from - https://github.com/Automattic/gutenberg/tree/add/experimental-collaborative-editing
-			 * This has the code required to support collaborative editing.
-			 */
-			$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/gutenberg/gutenberg.php';
-			if ( file_exists( $gutenberg_path ) && ! $this->is_gutenberg_plugin_active() ) {
-				require_once $gutenberg_path;
-			} else {
-				/**
-				 * Return early and don't load the plugin if either -
-				 * - Gutenberg is active separately as a plugin, so we don't load our custom build
-				 *   of Gutenberg to avoid conflicts.
-				 * - The custom build of Gutenberg is not available since that is required for the
-				 *   integration to work.
-				 */
+			if ( ! $this->can_load() ) {
+				$this->is_active = false;
+				return;
+			}
+
+			$gutenberg_path = $this->get_gutenberg_path();
+			$load_path      = $this->get_plugin_path();
+
+			if ( false === $gutenberg_path || false === $load_path ) {
 				$this->is_active = false;
 				return;
 			}
 
 			/**
-			 * Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/vip-real-time-collaboration-<version>/
-			 * and check what versions are available.
+			 * Load the custom build of Gutenberg from vip-integrations
+			 * and the latest version of the vip-real-time-collaboration plugin.
 			 */
-			$versions = $this->get_versions();
-
-			// if no versions are found, return early.
-			if ( empty( $versions ) ) {
-				$this->is_active = false;
-				return;
-			}
-
-			// Load the latest version of the plugin.
-			$latest_directory = array_key_first( $versions );
-			$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-real-time-collaboration.php';
-
-			// This check isn't strictly necessary, but better safe than sorry.
-			if ( file_exists( $load_path ) ) {
-				require_once $load_path;
-			} else {
-				$this->is_active = false;
-			}
+			require_once $gutenberg_path;
+			require_once $load_path;
 		}, 1);
 	}
 
@@ -115,8 +129,6 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Configure Real-Time Collaboration for VIP Platform.
 	 *
 	 * This is called after the integration is activated but before the plugin is loaded.
-	 *
-	 * @private
 	 */
 	public function configure(): void {
 		$env_config = $this->get_env_config();

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -138,7 +138,7 @@ class RealTimeCollaborationIntegration extends Integration {
 			define( 'VIP_RTC_WS_AUTH_SECRET', $env_config['web_socket_auth_secret'] );
 		}
 
-		// Set up WebSocket URL constant with dummy value
+		// Set up WebSocket URL constant
 		if ( isset( $env_config['web_socket_url'] ) && ! defined( 'VIP_RTC_WS_URL' ) ) {
 			define( 'VIP_RTC_WS_URL', $env_config['web_socket_url'] );
 		}

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -36,23 +36,18 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 
 	public function test_load_returns_early_if_plugin_already_loaded(): void {
 		/**
-		 * Integration mock that expects is_loaded to be called and return true,
-		 * and get_versions to never be called (proving early return)
+		 * Integration mock that expects is_loaded to be called and return true
 		 *
 		 * @var MockObject|RealTimeCollaborationIntegration
 		 */
 		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->onlyMethods( [ 'is_loaded' ] )
 			->getMock();
 
 		$integration_mock->expects( $this->once() )
 			->method( 'is_loaded' )
 			->willReturn( true );
-
-		// If early return works, get_versions should never be called
-		$integration_mock->expects( $this->never() )
-			->method( 'get_versions' );
 
 		$integration_mock->load();
 
@@ -61,17 +56,21 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_load_sets_inactive_if_no_versions_found(): void {
+		// Set up required constants
+		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
+		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
+		Constant_Mocker::define( 'WPVIP_MU_PLUGIN_DIR', '/nonexistent/path' );
+
 		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->onlyMethods( [ 'is_loaded' ] )
 			->getMock();
 
 		$integration_mock->activate(); // Initial state is active
 		$this->assertTrue( $integration_mock->is_active(), 'Initial: Integration should be active.' );
 
 		$integration_mock->method( 'is_loaded' )->willReturn( false );
-		$integration_mock->method( 'get_versions' )->willReturn( [] ); // No versions found
 
 		$integration_mock->load();
 
@@ -158,18 +157,77 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $versions );
 	}
 
+	public function test_load_sets_inactive_when_ws_auth_secret_missing(): void {
+		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
+		// VIP_RTC_WS_AUTH_SECRET is intentionally not defined
+
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_load_sets_inactive_when_ws_url_missing(): void {
+		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
+		// VIP_RTC_WS_URL is intentionally not defined
+
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_load_sets_inactive_when_both_ws_constants_missing(): void {
+		// Both VIP_RTC_WS_AUTH_SECRET and VIP_RTC_WS_URL are intentionally not defined
+
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
 	public function test_load_sets_inactive_when_gutenberg_plugin_active(): void {
+		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
+		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
 		Constant_Mocker::define( 'IS_GUTENBERG_PLUGIN', true );
 
 		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->onlyMethods( [ 'is_loaded' ] )
 			->getMock();
 
 		$integration_mock->method( 'is_loaded' )->willReturn( false );
-		// get_versions should never be called because we return early
-		$integration_mock->expects( $this->never() )->method( 'get_versions' );
 
 		$integration_mock->load();
 
@@ -180,17 +238,17 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_load_sets_inactive_when_gutenberg_file_missing(): void {
+		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
+		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
 		Constant_Mocker::define( 'WPVIP_MU_PLUGIN_DIR', '/nonexistent/path' );
 
 		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->onlyMethods( [ 'is_loaded' ] )
 			->getMock();
 
 		$integration_mock->method( 'is_loaded' )->willReturn( false );
-		// get_versions should never be called because we return early due to missing Gutenberg
-		$integration_mock->expects( $this->never() )->method( 'get_versions' );
 
 		$integration_mock->load();
 

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -100,18 +100,18 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 			->getMock();
 
 		$integration_mock->method( 'get_env_config' )->willReturn( [
-			'web_socket_url' => 'wss://test.example.com/ws',
+			'web_socket_url' => 'wss://test.example.com/_ws',
 		] );
 
 		$integration_mock->configure();
 
 		$this->assertTrue( defined( 'VIP_RTC_WS_URL' ) );
-		$this->assertEquals( 'wss://test.example.com/ws', constant( 'VIP_RTC_WS_URL' ) );
+		$this->assertEquals( 'wss://test.example.com/_ws', constant( 'VIP_RTC_WS_URL' ) );
 	}
 
 	public function test_configure_does_not_redefine_existing_constants(): void {
 		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'existing-secret' );
-		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://existing.example.com/ws' );
+		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://existing.example.com/_ws' );
 
 		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
@@ -121,13 +121,13 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 
 		$integration_mock->method( 'get_env_config' )->willReturn( [
 			'web_socket_auth_secret' => 'new-secret',
-			'web_socket_url'         => 'wss://new.example.com/ws',
+			'web_socket_url'         => 'wss://new.example.com/_ws',
 		] );
 
 		$integration_mock->configure();
 
 		$this->assertEquals( 'existing-secret', constant( 'VIP_RTC_WS_AUTH_SECRET' ) );
-		$this->assertEquals( 'wss://existing.example.com/ws', constant( 'VIP_RTC_WS_URL' ) );
+		$this->assertEquals( 'wss://existing.example.com/_ws', constant( 'VIP_RTC_WS_URL' ) );
 	}
 
 	public function test_configure_handles_missing_config_values(): void {

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -50,11 +50,14 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 			->method( 'is_loaded' )
 			->willReturn( true );
 
-		$integration_mock->load();
-
 		// If early return works, get_versions should never be called
 		$integration_mock->expects( $this->never() )
 			->method( 'get_versions' );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
 	}
 
 	public function test_load_sets_inactive_if_no_versions_found(): void {
@@ -71,6 +74,9 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$integration_mock->method( 'get_versions' )->willReturn( [] ); // No versions found
 
 		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
 
 		$this->assertFalse( $integration_mock->is_active() );
 	}
@@ -150,5 +156,47 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$versions        = $rtc_integration->get_versions();
 
 		$this->assertIsArray( $versions );
+	}
+
+	public function test_load_sets_inactive_when_gutenberg_plugin_active(): void {
+		Constant_Mocker::define( 'IS_GUTENBERG_PLUGIN', true );
+
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		// get_versions should never be called because we return early
+		$integration_mock->expects( $this->never() )->method( 'get_versions' );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_load_sets_inactive_when_gutenberg_file_missing(): void {
+		Constant_Mocker::define( 'WPVIP_MU_PLUGIN_DIR', '/nonexistent/path' );
+
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		// get_versions should never be called because we return early due to missing Gutenberg
+		$integration_mock->expects( $this->never() )->method( 'get_versions' );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
 	}
 }

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Test: Real-Time Collaboration Integration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_UnitTestCase;
+use Automattic\Test\Constant_Mocker;
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
+	private string $slug = 'real-time-collaboration';
+
+	public function tearDown(): void {
+		Constant_Mocker::clear();
+
+		parent::tearDown();
+	}
+
+	public function test_is_loaded_returns_false_when_not_loaded(): void {
+		$rtc_integration = new RealTimeCollaborationIntegration( $this->slug );
+		$this->assertFalse( $rtc_integration->is_loaded() );
+	}
+
+	public function test_is_loaded_returns_true_when_constant_defined(): void {
+		Constant_Mocker::define( 'VIP_REAL_TIME_COLLABORATION__LOADED', true );
+		$rtc_integration = new RealTimeCollaborationIntegration( $this->slug );
+		$this->assertTrue( $rtc_integration->is_loaded() );
+	}
+
+	public function test_load_returns_early_if_plugin_already_loaded(): void {
+		/**
+		 * Integration mock that expects is_loaded to be called and return true,
+		 * and get_versions to never be called (proving early return)
+		 *
+		 * @var MockObject|RealTimeCollaborationIntegration
+		 */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->expects( $this->once() )
+			->method( 'is_loaded' )
+			->willReturn( true );
+
+		// If early return works, get_versions should never be called
+		$integration_mock->expects( $this->never() )
+			->method( 'get_versions' );
+
+		$integration_mock->load();
+	}
+
+	public function test_load_sets_inactive_if_no_versions_found(): void {
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->activate(); // Initial state is active
+		$this->assertTrue( $integration_mock->is_active(), 'Initial: Integration should be active.' );
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		$integration_mock->method( 'get_versions' )->willReturn( [] ); // No versions found
+
+		$integration_mock->load();
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_configure_defines_websocket_auth_secret_constant(): void {
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_env_config' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_env_config' )->willReturn( [
+			'web_socket_auth_secret' => 'test-secret-key',
+		] );
+
+		$integration_mock->configure();
+
+		$this->assertTrue( defined( 'VIP_RTC_WS_AUTH_SECRET' ) );
+		$this->assertEquals( 'test-secret-key', constant( 'VIP_RTC_WS_AUTH_SECRET' ) );
+	}
+
+	public function test_configure_defines_websocket_url_constant(): void {
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_env_config' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_env_config' )->willReturn( [
+			'web_socket_url' => 'wss://test.example.com/ws',
+		] );
+
+		$integration_mock->configure();
+
+		$this->assertTrue( defined( 'VIP_RTC_WS_URL' ) );
+		$this->assertEquals( 'wss://test.example.com/ws', constant( 'VIP_RTC_WS_URL' ) );
+	}
+
+	public function test_configure_does_not_redefine_existing_constants(): void {
+		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'existing-secret' );
+		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://existing.example.com/ws' );
+
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_env_config' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_env_config' )->willReturn( [
+			'web_socket_auth_secret' => 'new-secret',
+			'web_socket_url'         => 'wss://new.example.com/ws',
+		] );
+
+		$integration_mock->configure();
+
+		$this->assertEquals( 'existing-secret', constant( 'VIP_RTC_WS_AUTH_SECRET' ) );
+		$this->assertEquals( 'wss://existing.example.com/ws', constant( 'VIP_RTC_WS_URL' ) );
+	}
+
+	public function test_configure_handles_missing_config_values(): void {
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_env_config' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_env_config' )->willReturn( [] );
+
+		$integration_mock->configure();
+
+		$this->assertFalse( defined( 'VIP_RTC_WS_AUTH_SECRET' ) );
+		$this->assertFalse( defined( 'VIP_RTC_WS_URL' ) );
+	}
+
+	public function test_get_versions_returns_array(): void {
+		$rtc_integration = new RealTimeCollaborationIntegration( $this->slug );
+		$versions        = $rtc_integration->get_versions();
+
+		$this->assertIsArray( $versions );
+	}
+}

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -50,11 +50,11 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 			->method( 'is_loaded' )
 			->willReturn( true );
 
+		$integration_mock->load();
+
 		// If early return works, get_versions should never be called
 		$integration_mock->expects( $this->never() )
 			->method( 'get_versions' );
-
-		$integration_mock->load();
 	}
 
 	public function test_load_sets_inactive_if_no_versions_found(): void {

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -34,6 +34,10 @@ if ( file_exists( __DIR__ . '/integrations/jetpack.php' ) ) {
 	require_once __DIR__ . '/integrations/jetpack.php';
 }
 
+if ( file_exists( __DIR__ . '/integrations/real-time-collaboration.php' ) ) {
+	require_once __DIR__ . '/integrations/real-time-collaboration.php';
+}
+
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
@@ -48,6 +52,11 @@ if ( class_exists( __NAMESPACE__ . '\\RemoteDataBlocksIntegration' ) ) {
 if ( class_exists( __NAMESPACE__ . '\\JetpackIntegration' ) ) {
 	IntegrationsSingleton::instance()->register( new JetpackIntegration( 'jetpack' ) );
 }
+
+if ( class_exists( __NAMESPACE__ . '\\RealTimeCollaborationIntegration' ) ) {
+	IntegrationsSingleton::instance()->register( new RealTimeCollaborationIntegration( 'real-time-collaboration' ) );
+}
+
 // @codeCoverageIgnoreEnd
 
 /**


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences providing more context and describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant publicly available sources (e.g. GitHub issues)
-->

Implements `RealTimeCollaborationIntegration` class that loads custom build of `gutenberg` along with latest version of `vip-real-time-collaboration` plugin. Configures the `VIP_RTC_WS_AUTH_SECRET` and `VIP_RTC_WS_URL` constants from the `web_socket_auth_secret` and `web_socket_url` integration config values.

The custom build of gutenberg is built from https://github.com/Automattic/gutenberg/tree/add/experimental-collaborative-editing. It has the code required to support collaborative editing feature which is enabled by `vip-real-time-collaboration` plugin. This is temporary solution until the code from that branch makes it way to Gutenberg release.

It currently assumes only one version of the gutenberg custom build is available in `/vip-integrations/gutenberg` dir unlike the vip-real-time-collaboration plugin which can have multiple versions in `/vip-integrations/vip-real-time-collaboration-<version>/` dirs.

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Added
- Add support for Real-Time Collaboration integration.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test


1. Check out PR.
2. Add built code of gutenberg to `/vip-integrations/gutenberg` dir.
3. Add built code of `vip-real-time-collaboration` to `/vip-integrations/vip-real-time-collaboration-<version>/` dir.
4. Run `composer install` and `npm install` to install dependencies.
5. Activate the 'Real-Time Collaboration' integration on one of your test sites and note down its application ID.
6. Spin up a local dev for that site using command - `vip dev-env create @<application_id>.production -s <slug> -a <path_to_app_code> -u <path_to_local_vip-go-mu-plugins_dir>`
7. Start it using the command - `vip dev-env start --slug <slug> --editor vscode`
8. That should open a VS Code window. Modify the `<app_name>/integrations-config/integrations.json` to add following entry -

	```json
	"real-time-collaboration": {
		"type": "real-time-collaboration",
		"org": {
			"status": "enabled"
		},
		"env": {
			"status": "enabled",
			"config": {
				"web_socket_auth_secret": "test-secret-key",
				"web_socket_url": "wss://test.example.com/_ws"
			}
		}
	}
	```
9. Spin up the websocket server by running `npm run dev` in the `websocket-server` directory of `vip-real-time-collaboration` plugin local cloned directory. Make sure to set the `VIP_RTC_WS_AUTH_SECRET` env variable with same value as above.
10. Verify that the collaborative editing feature is working. 
11. Try modifying the `integrations.json` and see if the changes are reflected in the local dev.