### PR TITLE
feat: Allow testing next ES version during migration

### DIFF
--- a/integrations/enterprise-search.php
+++ b/integrations/enterprise-search.php
@@ -58,7 +58,6 @@ class EnterpriseSearchIntegration extends Integration {
 			add_action( 'vip_search_loaded', array( $this, 'vip_set_es_credentials' ) );
 		}
 		add_action( 'vip_search_loaded', array( $this, 'vip_set_search_offloading' ) );
-		add_action( 'vip_search_loaded', array( $this, 'vip_set_es_version' ) );
 	}
 
 	/**
@@ -93,39 +92,6 @@ class EnterpriseSearchIntegration extends Integration {
 			add_filter( 'vip_search_query_integration_enabled', '__return_true', PHP_INT_MAX );
 		} elseif ( 'false' === $config['offload_search'] ) {
 			add_filter( 'vip_search_query_integration_enabled', '__return_false', PHP_INT_MAX );
-		}
-	}
-
-	/**
-	 * Set the Elasticsearch version.
-	 */
-	public function vip_set_es_version(): void {
-		$config = $this->get_env_config();
-
-		$es_version = isset( $config['elasticsearch_version'] ) ? $config['elasticsearch_version'] : '7';
-		define( 'VIP_ELASTICSEARCH_VERSION', $es_version );
-
-		$migration_in_progress = isset( $config['elasticsearch_migration_in_progress'] ) ? $config['elasticsearch_migration_in_progress'] 
-			: 'false';
-		if ( 'true' === $migration_in_progress ) {
-			define( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS', true );
-		}
-
-		if ( '7' === $es_version && defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) && 'true' === $migration_in_progress ) {
-			$original_hosts = constant( 'VIP_ELASTICSEARCH_ENDPOINTS' );
-			if ( ! is_array( $original_hosts ) || empty( $original_hosts ) ) {
-				return;
-			}
-
-			$migration_hosts = [];
-			if ( isset( $original_hosts[0] ) ) {
-				$migration_hosts[] = preg_replace( '/:\d+$/', ':9244', $original_hosts[0] );
-			}
-			if ( isset( $original_hosts[1] ) ) {
-				$migration_hosts[] = preg_replace( '/:\d+$/', ':9245', $original_hosts[1] );
-			}
-
-			define( 'VIP_ELASTICSEARCH_MIGRATION_ENDPOINTS', $migration_hosts );
 		}
 	}
 }

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1091,14 +1091,6 @@ class Health {
 					'actual'   => 'N/A',
 				);
 			} elseif ( $actual_settings[ $key ] != $desired_settings[ $key ] ) { // Intentionally weak comparison b/c some types like doubles don't translate to JSON
-				// Special handling for DC routing: DCA ES8 indexes can have 'dfw' actual with 'dca' desired
-				// TODO: Remove once DCA is supported on ES8
-				if ( 'index.routing.allocation.include.dc' === $key && 
-					'dfw' === $actual_settings[ $key ] && 'dca' === $desired_settings[ $key ] &&
-					defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === Search::ELASTICSEARCH_MIGRATION_NEXT ) {
-					continue;
-				}
-
 				$diff[ $key ] = array(
 					'expected' => $desired_settings[ $key ],
 					'actual'   => $actual_settings[ $key ],

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1095,7 +1095,7 @@ class Health {
 				// TODO: Remove once DCA is supported on ES8
 				if ( 'index.routing.allocation.include.dc' === $key && 
 					'dfw' === $actual_settings[ $key ] && 'dca' === $desired_settings[ $key ] &&
-					defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === '8' ) {
+					defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === Search::ELASTICSEARCH_MIGRATION_NEXT ) {
 					continue;
 				}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -17,8 +17,8 @@ class Search {
 	public const SEARCH_ALERT_LEVEL                 = 2; // Level 2 = 'alert'
 	public const MAX_RESULT_WINDOW                  = 10000;
 
-	private const ELASTICSEARCH_MIGRATION_SEVEN = '7';
-	private const ELASTICSEARCH_MIGRATION_NEXT  = '8';
+	public const ELASTICSEARCH_MIGRATION_SEVEN = '7';
+	public const ELASTICSEARCH_MIGRATION_NEXT  = '8';
 	/**
 	 * Empty for now. Will flesh out once migration path discussions are underway and/or the same meta are added to the filter across many
 	 * sites.

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2303,6 +2303,8 @@ class Search {
 
 	public function action__init() {
 		remove_action( 'wp_initialize_site', [ \ElasticPress\Indexables::factory()->get( 'post' )->sync_manager, 'action_create_blog_index' ] );
+
+		$this->handle_testing_next_version_session_update();
 	}
 
 	/**
@@ -2563,6 +2565,40 @@ class Search {
 		return $new_url;
 	}
 
+	private function current_user_can_test_next_version(): bool {
+		return current_user_can( apply_filters( 'vip_search_dev_tools_cap', 'manage_options' ) );
+	}
+
+	private function handle_testing_next_version_session_update(): void {
+		if ( ! defined( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) || ! constant( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) ) {
+			return;
+		}
+
+		if ( ! $this->current_user_can_test_next_version() ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['vip-search-test-es-next'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( 'session' === $_GET['vip-search-test-es-next'] ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+				setcookie(
+					'vip-search-test-es-next',
+					'1',
+					0, // Expires at the end of the session
+				);
+			} elseif ( isset( $_COOKIE['vip-search-test-es-next'] ) && ( 'false' === $_GET['vip-search-test-es-next'] || '0' === $_GET['vip-search-test-es-next'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+				setcookie(
+					'vip-search-test-es-next',
+					false,
+					0,
+				);
+			}
+		}
+	}
+
 	private function is_testing_next_version(): bool {
 		if ( ! defined( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) || ! constant( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) ) {
 			return false;
@@ -2572,13 +2608,21 @@ class Search {
 			return true;
 		}
 
+		if ( ! $this->current_user_can_test_next_version() ) {
+			return false;
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['vip-search-test-es-next'] ) && ( 'true' === $_GET['vip-search-test-es-next'] || '1' === $_GET['vip-search-test-es-next'] ) ) {
+		if ( isset( $_GET['vip-search-test-es-next'] ) &&
+			( 'true' === $_GET['vip-search-test-es-next'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				|| '1' === $_GET['vip-search-test-es-next'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				|| 'session' === $_GET['vip-search-test-es-next'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			) ) {
 			return true;
 		}
 
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
-		if ( isset( $_COOKIE['vip-search-test-es-next'] ) && ( 'true' === $_COOKIE['vip-search-test-es-next'] || '1' === $_COOKIE['vip-search-test-es-next'] ) ) {
+		if ( isset( $_COOKIE['vip-search-test-es-next'] ) && ( '1' === $_COOKIE['vip-search-test-es-next'] || 'true' === $_COOKIE['vip-search-test-es-next'] ) ) {
 			return true;
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -933,8 +933,10 @@ class Search {
 			$args['headers'][ $rq_header ] = $allheaders[ $rq_header ];
 		}
 
+		$is_testing_next_version = $this->is_testing_next_version();
+
 		// Cache handling
-		$is_cacheable    = $this->is_url_query_cacheable( $query['url'], $args );
+		$is_cacheable    = $this->is_url_query_cacheable( $query['url'], $args ) && ! $is_testing_next_version;
 		$cached_response = false;
 
 		if ( $is_cacheable ) {
@@ -954,8 +956,6 @@ class Search {
 		$start_time = microtime( true );
 
 		$timeout = $this->get_http_timeout_for_query( $query, $args );
-
-		$is_testing_next_version = $this->is_testing_next_version();
 
 		if ( $is_testing_next_version ) {
 			$url = $this->build_elasticsearch_url( $query['url'], self::ELASTICSEARCH_MIGRATION_NEXT );
@@ -2573,12 +2573,12 @@ class Search {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['vip-test-es-next'] ) && 'true' === $_GET['vip-test-es-next'] ) {
+		if ( isset( $_GET['vip-search-test-es-next'] ) && ( 'true' === $_GET['vip-search-test-es-next'] || '1' === $_GET['vip-search-test-es-next'] ) ) {
 			return true;
 		}
 
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
-		if ( isset( $_COOKIE['vip-test-es-next'] ) && 'true' === $_COOKIE['vip-test-es-next'] ) {
+		if ( isset( $_COOKIE['vip-search-test-es-next'] ) && ( 'true' === $_COOKIE['vip-search-test-es-next'] || '1' === $_COOKIE['vip-search-test-es-next'] ) ) {
 			return true;
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2516,31 +2516,20 @@ class Search {
 
 		$parsed_url = wp_parse_url( $url );
 
-		if ( ! $parsed_url ) {
-			// If parsing fails, return the original URL
+		if ( ! $parsed_url || ! $parsed_url['port'] ) {
 			return $url;
 		}
 
-		$port = $parsed_url['port'];
-
-		if ( ! $port ) {
-			// If no port is specified, return the original URL
-			return $url;
-		}
+		$elasticsearch_seven_ports = [ ':9234', ':9235' ];
+		$elasticsearch_next_ports  = [ ':9244', ':9245' ];
 
 		if ( self::ELASTICSEARCH_MIGRATION_SEVEN === $elasticsearch_version ) {
-			$from = [ '/:9244/', '/:9245/' ];
-			$to   = [ ':9234', ':9235' ];
-
-			// If the version is 7, replace the next version ports with the 7 ports
-			return preg_replace( $from, $to, $url, 1 );
+			// If the version is 7, replace the next version ports (when present) with the 7 ports
+			return str_replace( $elasticsearch_next_ports, $elasticsearch_seven_ports, $url );
+		} else {
+			// If the version is not 7, replace the 7 ports (when present) with the next version ports
+			return str_replace( $elasticsearch_seven_ports, $elasticsearch_next_ports, $url );
 		}
-
-		$from = [ '/:9234/', '/:9235/' ];
-		$to   = [ ':9244', ':9245' ];
-
-		// If the version is not 7, replace the 7 ports with the next version ports
-		return preg_replace( $from, $to, $url, 1 );
 	}
 
 	private function current_user_can_test_next_version(): bool {

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2533,7 +2533,7 @@ class Search {
 		$port = $parsed_url['port'];
 
 		if ( $port ) {
-			if ( $elasticsearch_version === self::ELASTICSEARCH_MIGRATION_SEVEN ) {
+			if ( self::ELASTICSEARCH_MIGRATION_SEVEN === $elasticsearch_version ) {
 				// If the version is 7, replace the next version ports (when present) with the 7 ports
 				$port = str_replace( $elasticsearch_next_ports, $elasticsearch_seven_ports, $port );
 			} else {
@@ -2578,11 +2578,13 @@ class Search {
 			return true;
 		}
 
-		if ( isset( $_GET['vip-test-es-next'] ) && $_GET['vip-test-es-next'] ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['vip-test-es-next'] ) && 'true' === $_GET['vip-test-es-next'] ) {
 			return true;
 		}
 
-		if ( isset( $_COOKIE['vip-test-es-next'] ) && $_COOKIE['vip-test-es-next'] ) {
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		if ( isset( $_COOKIE['vip-test-es-next'] ) && 'true' === $_COOKIE['vip-test-es-next'] ) {
 			return true;
 		}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2126,12 +2126,6 @@ class Search {
 			return null;
 		}
 
-		// For now, force all DCA ES8 indexes to be routed to DFW
-		// TODO: Remove once DCA is supported on ES8
-		if ( defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === self::ELASTICSEARCH_MIGRATION_NEXT && 'dca' === $dc ) {
-			return 'dfw';
-		}
-
 		return $dc;
 	}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -16,6 +16,9 @@ class Search {
 	public const SEARCH_ALERT_SLACK_CHAT            = '#vip-go-es-alerts';
 	public const SEARCH_ALERT_LEVEL                 = 2; // Level 2 = 'alert'
 	public const MAX_RESULT_WINDOW                  = 10000;
+
+	private const ELASTICSEARCH_MIGRATION_SEVEN = '7';
+	private const ELASTICSEARCH_MIGRATION_NEXT  = '8';
 	/**
 	 * Empty for now. Will flesh out once migration path discussions are underway and/or the same meta are added to the filter across many
 	 * sites.
@@ -455,6 +458,10 @@ class Search {
 
 		if ( ! defined( 'ES_SHIELD' ) && ( defined( 'VIP_ELASTICSEARCH_USERNAME' ) && defined( 'VIP_ELASTICSEARCH_PASSWORD' ) ) ) {
 			define( 'ES_SHIELD', sprintf( '%s:%s', constant( 'VIP_ELASTICSEARCH_USERNAME' ), constant( 'VIP_ELASTICSEARCH_PASSWORD' ) ) );
+		}
+
+		if ( ! defined( 'VIP_ELASTICSEARCH_VERSION' ) ) {
+			define( 'VIP_ELASTICSEARCH_VERSION', self::ELASTICSEARCH_MIGRATION_SEVEN );
 		}
 
 		// Do not allow sync via Dashboard (WP-CLI is preferred for indexing).
@@ -948,16 +955,28 @@ class Search {
 
 		$timeout = $this->get_http_timeout_for_query( $query, $args );
 
+		$is_testing_next_version = $this->is_testing_next_version();
+
+		if ( $is_testing_next_version ) {
+			$url = $this->build_elasticsearch_url( $query['url'], self::ELASTICSEARCH_MIGRATION_NEXT );
+
+			if ( ! headers_sent() ) {
+				header( sprintf( 'X-Elasticsearch-Version: %s', self::ELASTICSEARCH_MIGRATION_NEXT ) );
+			}
+		} else {
+			$url = $this->build_elasticsearch_url( $query['url'] );
+		}
+
 		/**
 		 * Skip vip_safe_wp_remote_request for non-query (search) requests
 		 * Any timeouts happening in non-search/non-query context shouldn't count towards the request disabling threshold.
 		 */
 		if ( 'query' === $type ) {
-			$response = vip_safe_wp_remote_request( $query['url'], false, 5, $timeout, 10, $args );
+			$response = vip_safe_wp_remote_request( $url, false, 5, $timeout, 10, $args );
 			self::query_count_incr();
 		} else {
 			$args['timeout'] = $timeout;
-			$response        = wp_remote_request( $query['url'], $args );
+			$response        = wp_remote_request( $url, $args );
 		}
 
 		$end_time = microtime( true );
@@ -1025,7 +1044,7 @@ class Search {
 		}
 
 		// Mirror write requests to migration ES hosts if in migration mode
-		$this->mirror_write_to_migration_hosts( $query, $args, $type );
+		$this->mirror_write_to_migration_hosts( $query, $args, $type, $is_testing_next_version );
 
 		if ( 'index_exists' === $type && in_array( $response_code, $valid_index_exists_response_codes, true ) ) {
 			// Cache index_exists into option since we didn't return a cached value earlier.
@@ -1047,12 +1066,8 @@ class Search {
 	 * @param array $args The original request args.
 	 * @param string|null $type The type of request.
 	 */
-	protected function mirror_write_to_migration_hosts( $query, $args, $type = null ) {
+	protected function mirror_write_to_migration_hosts( $query, $args, $type = null, $is_testing_next_version = false ) {
 		if ( ! defined( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) || ! constant( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) ) {
-			return;
-		}
-
-		if ( ! defined( 'VIP_ELASTICSEARCH_MIGRATION_ENDPOINTS' ) || ! is_array( constant( 'VIP_ELASTICSEARCH_MIGRATION_ENDPOINTS' ) ) ) {
 			return;
 		}
 
@@ -1065,18 +1080,15 @@ class Search {
 			return;
 		}
 
-		$migration_hosts = constant( 'VIP_ELASTICSEARCH_MIGRATION_ENDPOINTS' );
-		if ( ! is_array( $migration_hosts ) || empty( $migration_hosts ) ) {
-			return;
+		$version = self::ELASTICSEARCH_MIGRATION_NEXT;
+		if ( $is_testing_next_version ) {
+			// When testing the next version, we should mirror to version 7, since the regular requests are going to version 8.
+			$version = self::ELASTICSEARCH_MIGRATION_SEVEN;
 		}
 
-		$migration_host = $migration_hosts[ array_rand( $migration_hosts ) ];
-		$migration_url  = $this->build_migration_url( $query['url'], $migration_host );
-		if ( ! $migration_url ) {
-			return;
-		}
+		$url = $this->build_elasticsearch_url( $query['url'], $version );
 
-		$migration_response = wp_remote_request( $migration_url, $args );
+		$migration_response = wp_remote_request( $url, $args );
 		if ( is_wp_error( $migration_response ) || wp_remote_retrieve_response_code( $migration_response ) >= 400 ) {
 			$this->logger->log(
 				'error',
@@ -1085,7 +1097,7 @@ class Search {
 				[
 					'response_code'    => wp_remote_retrieve_response_code( $migration_response ),
 					'response_message' => wp_remote_retrieve_response_message( $migration_response ),
-					'migration_url'    => $migration_url,
+					'migration_url'    => $url,
 					'method'           => $args['method'] ?? null,
 					'request_body'     => isset( $args['body'] ) ? $this->sanitize_ep_query_for_logging( [ 'body' => $args['body'] ] ) : null,
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
@@ -2116,7 +2128,7 @@ class Search {
 
 		// For now, force all DCA ES8 indexes to be routed to DFW
 		// TODO: Remove once DCA is supported on ES8
-		if ( defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === '8' && 'dca' === $dc ) {
+		if ( defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === self::ELASTICSEARCH_MIGRATION_NEXT && 'dca' === $dc ) {
 			return 'dfw';
 		}
 
@@ -2500,35 +2512,80 @@ class Search {
 		} );
 	}
 
-	/**
-	 * Build migration URL by replacing the host while preserving path, query, and fragment
-	 *
-	 * @param string $original_url Original URL
-	 * @param string $migration_host Migration host URL
-	 * 
-	 * @return string|null Migration URL or null if parsing fails
-	 */
-	private function build_migration_url( string $original_url, string $migration_host ): ?string {
-		$parsed_url = wp_parse_url( $original_url );
-		
-		if ( ! $parsed_url ) {
-			return null;
+	private function build_elasticsearch_url( string $url, ?string $elasticsearch_version = null ): string {
+		if ( ! $elasticsearch_version ) {
+			// If no version is provided, we return the original URL
+			// which uses the host provided by the VIP_ELASTICSEARCH_ENDPOINTS constant
+			return $url;
 		}
 
-		$migration_url = $migration_host;
-		
+		$elasticsearch_seven_ports = [ 9234, 9235 ];
+		$elasticsearch_next_ports  = [ 9244, 9245 ];
+
+		$parsed_url = wp_parse_url( $url );
+
+		if ( ! $parsed_url ) {
+			// If parsing fails, return the original URL
+			return $url;
+		}
+
+		$host = $parsed_url['host'];
+		$port = $parsed_url['port'];
+
+		if ( $port ) {
+			if ( $elasticsearch_version === self::ELASTICSEARCH_MIGRATION_SEVEN ) {
+				// If the version is 7, replace the next version ports (when present) with the 7 ports
+				$port = str_replace( $elasticsearch_next_ports, $elasticsearch_seven_ports, $port );
+			} else {
+				// If the version is not 7, replace the 7 ports (when present) with the next version ports
+				$port = str_replace( $elasticsearch_seven_ports, $elasticsearch_next_ports, $port );
+			}
+		}
+
+		$new_url = '';
+
+		if ( isset( $parsed_url['scheme'] ) ) {
+			$new_url .= $parsed_url['scheme'] . '://';
+		}
+
+		$new_url .= $host;
+
+		if ( isset( $port ) ) {
+			$new_url .= sprintf( ':%d', $port );
+		}
+
 		if ( isset( $parsed_url['path'] ) ) {
-			$migration_url .= $parsed_url['path'];
+			$new_url .= $parsed_url['path'];
 		}
-		
+
 		if ( isset( $parsed_url['query'] ) ) {
-			$migration_url .= '?' . $parsed_url['query'];
+			$new_url .= '?' . $parsed_url['query'];
 		}
-		
+
 		if ( isset( $parsed_url['fragment'] ) ) {
-			$migration_url .= '#' . $parsed_url['fragment'];
+			$new_url .= '#' . $parsed_url['fragment'];
 		}
-		
-		return $migration_url;
+
+		return $new_url;
+	}
+
+	private function is_testing_next_version(): bool {
+		if ( ! defined( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) || ! constant( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) ) {
+			return false;
+		}
+
+		if ( defined( 'VIP_ELASTICSEARCH_TEST_ES_NEXT' ) && constant( 'VIP_ELASTICSEARCH_TEST_ES_NEXT' ) ) {
+			return true;
+		}
+
+		if ( isset( $_GET['vip-test-es-next'] ) && $_GET['vip-test-es-next'] ) {
+			return true;
+		}
+
+		if ( isset( $_COOKIE['vip-test-es-next'] ) && $_COOKIE['vip-test-es-next'] ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -960,9 +960,7 @@ class Search {
 		if ( $is_testing_next_version ) {
 			$url = $this->build_elasticsearch_url( $query['url'], self::ELASTICSEARCH_MIGRATION_NEXT );
 
-			if ( ! headers_sent() ) {
-				header( sprintf( 'X-Elasticsearch-Version: %s', self::ELASTICSEARCH_MIGRATION_NEXT ) );
-			}
+			add_action( 'send_headers', fn() => header( sprintf( 'X-Elasticsearch-Version: %s', self::ELASTICSEARCH_MIGRATION_NEXT ) ) );
 		} else {
 			$url = $this->build_elasticsearch_url( $query['url'] );
 		}

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1063,6 +1063,7 @@ class Search {
 	 * @param array $query The original query array.
 	 * @param array $args The original request args.
 	 * @param string|null $type The type of request.
+	 * @param bool $is_testing_next_version Whether we're testing the next version.
 	 */
 	protected function mirror_write_to_migration_hosts( $query, $args, $type = null, $is_testing_next_version = false ) {
 		if ( ! defined( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) || ! constant( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) ) {
@@ -2513,9 +2514,6 @@ class Search {
 			return $url;
 		}
 
-		$elasticsearch_seven_ports = [ 9234, 9235 ];
-		$elasticsearch_next_ports  = [ 9244, 9245 ];
-
 		$parsed_url = wp_parse_url( $url );
 
 		if ( ! $parsed_url ) {
@@ -2523,44 +2521,26 @@ class Search {
 			return $url;
 		}
 
-		$host = $parsed_url['host'];
 		$port = $parsed_url['port'];
 
-		if ( $port ) {
-			if ( self::ELASTICSEARCH_MIGRATION_SEVEN === $elasticsearch_version ) {
-				// If the version is 7, replace the next version ports (when present) with the 7 ports
-				$port = str_replace( $elasticsearch_next_ports, $elasticsearch_seven_ports, $port );
-			} else {
-				// If the version is not 7, replace the 7 ports (when present) with the next version ports
-				$port = str_replace( $elasticsearch_seven_ports, $elasticsearch_next_ports, $port );
-			}
+		if ( ! $port ) {
+			// If no port is specified, return the original URL
+			return $url;
 		}
 
-		$new_url = '';
+		if ( self::ELASTICSEARCH_MIGRATION_SEVEN === $elasticsearch_version ) {
+			$from = [ '/:9244/', '/:9245/' ];
+			$to   = [ ':9234', ':9235' ];
 
-		if ( isset( $parsed_url['scheme'] ) ) {
-			$new_url .= $parsed_url['scheme'] . '://';
+			// If the version is 7, replace the next version ports with the 7 ports
+			return preg_replace( $from, $to, $url, 1 );
 		}
 
-		$new_url .= $host;
+		$from = [ '/:9234/', '/:9235/' ];
+		$to   = [ ':9244', ':9245' ];
 
-		if ( isset( $port ) ) {
-			$new_url .= sprintf( ':%d', $port );
-		}
-
-		if ( isset( $parsed_url['path'] ) ) {
-			$new_url .= $parsed_url['path'];
-		}
-
-		if ( isset( $parsed_url['query'] ) ) {
-			$new_url .= '?' . $parsed_url['query'];
-		}
-
-		if ( isset( $parsed_url['fragment'] ) ) {
-			$new_url .= '#' . $parsed_url['fragment'];
-		}
-
-		return $new_url;
+		// If the version is not 7, replace the 7 ports with the next version ports
+		return preg_replace( $from, $to, $url, 1 );
 	}
 
 	private function current_user_can_test_next_version(): bool {

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -1491,28 +1491,4 @@ class Health_Test extends WP_UnitTestCase {
 		$correct_mapping = Health::validate_post_index_mapping( $index_name, $mapping );
 		$this->assertEquals( $expected_result, $correct_mapping );
 	}
-
-	// TODO: Remove once DCA is supported on ES8
-	public function test__health_check_dc_routing_ok_dca_es8() {
-		Constant_Mocker::clear();
-
-		Constant_Mocker::define( 'VIP_ELASTICSEARCH_VERSION', '8' );
-
-		$actual_settings  = [ 'index.routing.allocation.include.dc' => 'dfw' ];
-		$desired_settings = [ 'index.routing.allocation.include.dc' => 'dca' ];
-
-		$diff = Health::get_index_settings_diff( $actual_settings, $desired_settings );
-
-		$this->assertArrayNotHasKey( 'index.routing.allocation.include.dc', $diff );
-	}
-
-	// TODO: Remove once DCA is supported on ES8
-	public function test__health_check_dc_routing_not_ok_dca_es7() {
-		$actual_settings  = [ 'index.routing.allocation.include.dc' => 'dfw' ];
-		$desired_settings = [ 'index.routing.allocation.include.dc' => 'dca' ];
-
-		$diff = Health::get_index_settings_diff( $actual_settings, $desired_settings );
-
-		$this->assertArrayHasKey( 'index.routing.allocation.include.dc', $diff );
-	}
 }

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -1494,6 +1494,8 @@ class Health_Test extends WP_UnitTestCase {
 
 	// TODO: Remove once DCA is supported on ES8
 	public function test__health_check_dc_routing_ok_dca_es8() {
+		Constant_Mocker::clear();
+
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_VERSION', '8' );
 
 		$actual_settings  = [ 'index.routing.allocation.include.dc' => 'dfw' ];

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -1582,31 +1582,6 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'dca', $origin_dc );
 	}
 
-	// TODO: Remove once DCA is supported on ES8
-	public function test__dca_es8_routing_to_dfw() {
-		$mock_search = $this->getMockBuilder( Search::class )
-			->onlyMethods( [ 'get_current_host' ] )
-			->getMock();
-		$mock_search->method( 'get_current_host' )->willReturn( 'https://es-ha.dca.vipv2.net' );
-
-		Constant_Mocker::define( 'VIP_ELASTICSEARCH_VERSION', '8' );
-
-		$result = $mock_search->get_index_routing_allocation_include_dc();
-		$this->assertEquals( 'dfw', $result );
-	}
-
-	// TODO: Remove once DCA is supported on ES8
-	public function test__dca_existing_es_version_does_not_route_to_dfw() {
-		$mock_search = $this->getMockBuilder( Search::class )
-			->onlyMethods( [ 'get_current_host' ] )
-			->getMock();
-		$mock_search->method( 'get_current_host' )->willReturn( 'https://es-ha.dca.vipv2.net' );
-
-		$result = $mock_search->get_index_routing_allocation_include_dc();
-
-		$this->assertEquals( 'dca', $result );
-	}
-
 	public function get_index_routing_allocation_include_dc_from_endpoints_data() {
 		return array(
 			// Valid

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -406,7 +406,7 @@ class Search_Test extends WP_UnitTestCase {
 
 	public function test__vip_search_sends_queries_to_next_version_host_when_is_testing_next_version() {
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
-			'https://es-endpoint:9235',
+			'https://es-endpoint:9235/weirdpath:9235',
 		) );
 
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS', true );
@@ -422,9 +422,9 @@ class Search_Test extends WP_UnitTestCase {
 			->method( 'mock_wp_remote_request' )
 			->with( $this->callback( function ( $url ) {
 				return in_array( $url, [
-					'https://es-endpoint:9245/vip-123-post-1',       // Next version host
-					'https://es-endpoint:9245/vip-123-post-1/_bulk', // Next version host
-					'https://es-endpoint:9235/vip-123-post-1/_bulk', // Mirror to the current host
+					'https://es-endpoint:9245/weirdpath:9235/vip-123-post-1',       // Next version host
+					'https://es-endpoint:9245/weirdpath:9235/vip-123-post-1/_bulk', // Next version host
+					'https://es-endpoint:9235/weirdpath:9235/vip-123-post-1/_bulk', // Mirror to the current host
 				] );
 			} ) )
 			->willReturn([

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -333,7 +333,7 @@ class Search_Test extends WP_UnitTestCase {
 
 	public function test__vip_search_sends_http_requests_via_helper_functions() {
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
-			'https://es-endpoint1',
+			'https://es-endpoint1:9235',
 		) );
 
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_USERNAME', 'foo' );
@@ -346,8 +346,8 @@ class Search_Test extends WP_UnitTestCase {
 			->method( 'mock_wp_remote_request' )
 			->with( $this->callback( function ( $url ) {
 				return in_array( $url, [
-					'https://es-endpoint1/vip-123-post-1',
-					'https://es-endpoint1/vip-123-post-1/_bulk',
+					'https://es-endpoint1:9235/vip-123-post-1',
+					'https://es-endpoint1:9235/vip-123-post-1/_bulk',
 				] );
 			} ) )
 			->willReturn([
@@ -368,11 +368,7 @@ class Search_Test extends WP_UnitTestCase {
 
 	public function test__vip_search_sends_double_writes_when_upgrading() {
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
-			'https://es-endpoint7',
-		) );
-
-		Constant_Mocker::define( 'VIP_ELASTICSEARCH_MIGRATION_ENDPOINTS', array(
-			'https://es-endpoint8',
+			'https://es-endpoint:9235',
 		) );
 
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS', true );
@@ -387,9 +383,48 @@ class Search_Test extends WP_UnitTestCase {
 			->method( 'mock_wp_remote_request' )
 			->with( $this->callback( function ( $url ) {
 				return in_array( $url, [
-					'https://es-endpoint7/vip-123-post-1',
-					'https://es-endpoint7/vip-123-post-1/_bulk',
-					'https://es-endpoint8/vip-123-post-1/_bulk',
+					'https://es-endpoint:9235/vip-123-post-1',
+					'https://es-endpoint:9235/vip-123-post-1/_bulk',
+					'https://es-endpoint:9245/vip-123-post-1/_bulk',
+				] );
+			} ) )
+			->willReturn([
+				'response' => [ 'code' => 200 ],
+				'body'     => '',
+			]);
+
+		$this->init_es();
+		$indexable = Indexables::factory()->get( 'post' );
+
+		$post_id = $this->factory()->post->create( array(
+			'post_title'  => 'Test Post',
+			'post_status' => 'publish',
+		) );
+
+		$indexable->bulk_index( [ $post_id ] );
+	}
+
+	public function test__vip_search_sends_queries_to_next_version_host_when_is_testing_next_version() {
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
+			'https://es-endpoint:9235',
+		) );
+
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS', true );
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_TEST_ES_NEXT', true );
+
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_USERNAME', 'foo' );
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_PASSWORD', 'bar' );
+
+		$test_user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $test_user_id );
+
+		self::$mock_global_functions->expects( $this->exactly( 3 ) )
+			->method( 'mock_wp_remote_request' )
+			->with( $this->callback( function ( $url ) {
+				return in_array( $url, [
+					'https://es-endpoint:9245/vip-123-post-1',       // Next version host
+					'https://es-endpoint:9245/vip-123-post-1/_bulk', // Next version host
+					'https://es-endpoint:9235/vip-123-post-1/_bulk', // Mirror to the current host
 				] );
 			} ) )
 			->willReturn([

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -406,7 +406,7 @@ class Search_Test extends WP_UnitTestCase {
 
 	public function test__vip_search_sends_queries_to_next_version_host_when_is_testing_next_version() {
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
-			'https://es-endpoint:9235/weirdpath:9235',
+			'https://es-endpoint:9235/weirdpath9235',
 		) );
 
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS', true );
@@ -422,9 +422,9 @@ class Search_Test extends WP_UnitTestCase {
 			->method( 'mock_wp_remote_request' )
 			->with( $this->callback( function ( $url ) {
 				return in_array( $url, [
-					'https://es-endpoint:9245/weirdpath:9235/vip-123-post-1',       // Next version host
-					'https://es-endpoint:9245/weirdpath:9235/vip-123-post-1/_bulk', // Next version host
-					'https://es-endpoint:9235/weirdpath:9235/vip-123-post-1/_bulk', // Mirror to the current host
+					'https://es-endpoint:9245/weirdpath9235/vip-123-post-1',       // Next version host
+					'https://es-endpoint:9245/weirdpath9235/vip-123-post-1/_bulk', // Next version host
+					'https://es-endpoint:9235/weirdpath9235/vip-123-post-1/_bulk', // Mirror to the current host
 				] );
 			} ) )
 			->willReturn([


### PR DESCRIPTION
## Description

This PR introduces the ability to test Elasticsearch 8 during the ES7→ES8 migration process, enabling safer rollouts and validation before fully switching traffic. The implementation provides multiple trigger mechanisms and intelligent mirroring to ensure data consistency during testing.


### Changes Made

#### Core Functionality
- **Added ES version testing capability** via multiple trigger methods:
  - `VIP_ELASTICSEARCH_TEST_ES_NEXT` constant
  - `vip-test-es-next` cookie
  - `vip-test-es-next` query parameter
- **Enhanced URL building logic** with port-based version routing (ES7: 9234/9235, ES8: 9244/9245)
- **Intelligent mirroring** that reverses direction when testing next version
- **HTTP header injection** (`X-Elasticsearch-Version`) for debugging and monitoring

#### Code Refactoring
- **Removed migration setup from enterprise-search integration** - consolidated version logic in Search class
- **Replaced hardcoded migration endpoints** with dynamic URL building
- **Added version constants** for maintainable version references
- **Default ES version fallback** to version 7 when not explicitly set


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->