### PR TITLE
Update Jetpack version for WordPress 6.7 and newer to 15.0

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -36,7 +36,7 @@ function vip_default_jetpack_version() {
 		return '14.5';
 	} else {
 		// WordPress 6.7 and newer.
-		return '14.9';
+		return '15.0';
 	}
 }
 

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -7,7 +7,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 		global $wp_version;
 		$saved_wp_version = $wp_version;
 
-		$latest = '14.9';
+		$latest = '15.0';
 
 		$versions_map = [
 			// WordPress version => Jetpack version


### PR DESCRIPTION
## Description

This pull request updates the default Jetpack version for WordPress 6.7 and newer. The change ensures that new sites running the latest WordPress will use the most recent Jetpack release.

Version update:

* Updated the return value in the `vip_default_jetpack_version()` function in `jetpack.php` so that WordPress 6.7 and newer will now default to Jetpack version `15.0` instead of `14.9`.

## Changelog Description



### Updated
- Default Jetpack version to 15.0

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->