### PR TITLE
Update CI matrix to remove old (6.2,6.3) WordPress versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
       matrix:
         config:
         # PHP 8.1, Jetpack
-          - { wp: 6.2.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
-          - { wp: 6.2.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
-          - { wp: 6.3.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
-          - { wp: 6.3.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: 6.4.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: 6.4.x,   ms: 'yes', jp: 'yes', php: '8.1', phpunit: '' }
           - { wp: 6.5.x,   ms: 'no',  jp: 'yes', php: '8.1', phpunit: '' }


### PR DESCRIPTION
## Description

Removed outdated WordPress versions from CI matrix.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->