### PR TITLE
fix(tests): `test__fetch_feed_build` for WP Nightly

### DIFF
--- a/tests/vip-feed-cache/test-vip-feed-cache.php
+++ b/tests/vip-feed-cache/test-vip-feed-cache.php
@@ -10,15 +10,21 @@ class VIP_Feed_Cache_Test extends WP_UnitTestCase {
 				],
 				'cookies'     => [],
 				'filename'    => null,
-				'response'    => 200,
+				'response'    => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
 				'status_code' => 200,
 				'success'     => 1,
 				'body'        => file_get_contents( __DIR__ . '/test.rss' ),
 			];
 		}, 10, 3 );
 
-		$url   = 'https://www.example.com/test.rss';
-		$feed  = fetch_feed( $url );
+		$url  = 'https://www.example.com/test.rss';
+		$feed = fetch_feed( $url );
+
+		$this->assertNotWPError( $feed );
+
 		$build = $feed->data['build'];
 		$this->assertIsNumeric( $build );
 


### PR DESCRIPTION
## Description

This pull request makes minor improvements to the `test__fetch_feed_build` unit test in `tests/vip-feed-cache/test-vip-feed-cache.php`. The changes ensure that the test checks for errors when fetching the feed and updates the expected response format to match the actual structure.

Test robustness and accuracy improvements:

* Updated the expected `response` value from an integer to an array with `code` and `message` keys to match the actual response structure.
* Added an assertion to ensure that the fetched feed is not a `WP_Error` object, improving test reliability.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

CI must pass.