### PR TITLE
fix(files): allow `fflush()` on files opened in read mode

### DIFF
--- a/files/class-vip-filesystem-local-stream-wrapper.php
+++ b/files/class-vip-filesystem-local-stream-wrapper.php
@@ -371,13 +371,8 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 		}
 
 		if ( 'r' === $this->mode ) {
-			// No writes in 'read' mode
-			trigger_error(
-				sprintf( 'stream_flush failed for %s with error: No writes allowed in "read" mode #vip-go-streams', esc_html( $this->path ) ),
-				E_USER_WARNING
-			);
-
-			return false;
+			// No writes in 'read' mode; return true as there is nothing to do and to avoid warnings
+			return true;
 		}
 
 		try {


### PR DESCRIPTION
## Description

There are legitimate cases when the PHP core can issue a flush operation on a file that is open in read-only mode. We should avoid warnings in this case and silently ignore the operation.

This is consistent with how `fflush()` works on read-only resources such as `STDIN`.

## Changelog Description

### Fixed
- Flush operation on files open in read-only mode does not generate warnings.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See PLTFRM-1685.
