### PR TITLE
Edge cache purge use vip domain

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -264,7 +264,7 @@ class WPCOM_VIP_Cache_Manager {
 					}
 					$data = wp_json_encode( $req_array );
 
-					$curl = curl_init( sprintf( 'https://%s/.vip/edge-cache-purge', $host ) );
+					$curl = curl_init( 'https://go-vip.net/.vip/edge-cache-purge' );
 
 					curl_setopt( $curl, CURLOPT_HEADER, false );
 					curl_setopt( $curl, CURLOPT_RETURNTRANSFER, true );
@@ -272,6 +272,7 @@ class WPCOM_VIP_Cache_Manager {
 					curl_setopt( $curl, CURLOPT_POST, true );
 
 					$headers = [
+						sprintf( 'Host: %s', $host ),
 						'Content-Type: application/json',
 						sprintf( 'Authorization: bearer %s', EDGE_CACHE_PURGE_CLIENT_TOKEN ),
 					];


### PR DESCRIPTION
## Description

This PR modifies the edge cache purge functionality to use a fixed `go-vip.net` domain instead of the variable host domain. The original host is now passed as a header, ensuring that edge cache purge requests are routed directly through the VIP infrastructure and bypass any external reverse proxy that might be sitting in front of the site.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->