### PR TITLE
Show the proper ES version when the migration is not in progress anymore

### DIFF
--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -373,7 +373,11 @@ function get_current_elasticsearch_version() {
 	// Get the base ES version
 	$base_version = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version() ?: 'Unknown';
 
+	if ( defined( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) && constant( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) ) {
 		return sprintf( '%s (Migration: %s)', $base_version, \Automattic\VIP\Search\Search::instance()->is_testing_next_version() ? 'Using ES8' : 'Using ES7' );
+	}
+
+	return $base_version;
 }
 
 /**


### PR DESCRIPTION
## Description

The logic was not accounting for when migration is complete, this PR addresses that.
<img width="2546" height="1026" alt="CleanShot 2025-10-15 at 16 06 14@2x" src="https://github.com/user-attachments/assets/2e2563f9-d3d3-444b-815f-6d6019715d84" />


## Changelog Description

### Fixed
- Search Dev Tools now correctly shows the version when the migration is not in progress.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Pick a site that has the migration finished and the ES is set to 8, verify that Elasticsearch Version now shows 8.18.2