### PR TITLE
Improve support for proxies when checking vip_is_jetpack_request()

### DIFF
--- a/tests/vip-helpers/vip-utils/test-vip-utils-vip-is-jetpack-request.php
+++ b/tests/vip-helpers/vip-utils/test-vip-utils-vip-is-jetpack-request.php
@@ -38,4 +38,13 @@ class WPCOM_VIP_Utils_Vip_Is_Jetpack_Request_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( vip_is_jetpack_request() );
 	}
+
+	public function test__vip_is_jetpack_request__xff() {
+		//phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		$_SERVER['HTTP_USER_AGENT'] = 'jetpack';
+		//phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '127.0.0.1, 192.0.96.202, ::1';
+
+		self::assertTrue( vip_is_jetpack_request() );
+	}
 }

--- a/tests/vip-helpers/vip-utils/test-vip-utils-vip-is-jetpack-request.php
+++ b/tests/vip-helpers/vip-utils/test-vip-utils-vip-is-jetpack-request.php
@@ -39,12 +39,22 @@ class WPCOM_VIP_Utils_Vip_Is_Jetpack_Request_Test extends WP_UnitTestCase {
 		$this->assertTrue( vip_is_jetpack_request() );
 	}
 
-	public function test__vip_is_jetpack_request__xff() {
+	/**
+	 * @dataProvider data__vip_is_jetpack_request__xff
+	 */
+	public function test__vip_is_jetpack_request__xff( $xff, $expected ) {
 		//phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
 		$_SERVER['HTTP_USER_AGENT'] = 'jetpack';
 		//phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
-		$_SERVER['HTTP_X_FORWARDED_FOR'] = '127.0.0.1, 192.0.96.202, ::1';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = $xff;
 
-		self::assertTrue( vip_is_jetpack_request() );
+		$this->assertSame( $expected, vip_is_jetpack_request() );
+	}
+
+	public function data__vip_is_jetpack_request__xff() {
+		return [
+			'positive' => [ '127.0.0.1, 192.0.96.202, ::1', true ],
+			'negative' => [ '127.0.0.1, ::1', false ],
+		];
 	}
 }

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1533,7 +1533,7 @@ function vip_is_jetpack_request() {
 	$jetpack_ips = Jetpack_IP_Manager::get_jetpack_ips();
 
 	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
-	$all_ips = $_SERVER['REMOTE_ADDR'] ? [ trim( $_SERVER['REMOTE_ADDR'] ) ] : [];
+	$all_ips = ! empty( $_SERVER['REMOTE_ADDR'] ) ? [ trim( $_SERVER['REMOTE_ADDR'] ) ] : [];
 
 	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 	if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1533,15 +1533,14 @@ function vip_is_jetpack_request() {
 	$jetpack_ips = Jetpack_IP_Manager::get_jetpack_ips();
 
 	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
-	$remote_addr = $_SERVER['REMOTE_ADDR'] ? [ trim( $_SERVER['REMOTE_ADDR'] ) ] : [];
+	$all_ips = $_SERVER['REMOTE_ADDR'] ? [ trim( $_SERVER['REMOTE_ADDR'] ) ] : [];
 
-	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	$forwarded_for = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? '';
-
-	// Support multiple IPs in X_FORWARDED_FOR to handle proxies.
-	$forwarded_ips = strpos( $forwarded_for, ',' ) !== false ? array_map( 'trim', explode( ',', $forwarded_for ) ) : ( $forwarded_for ? [ $forwarded_for ] : [] );
-
-	$all_ips = array_merge( $remote_addr, $forwarded_ips );
+	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+	if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+		$forwarded_ips = array_map( 'trim', explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+		$all_ips       = array_merge( $all_ips, $forwarded_ips );
+	}
 
 	foreach ( $all_ips as $ip ) {
 		if ( IpUtils::check_ip( $ip, $jetpack_ips ) ) {

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -1509,7 +1509,7 @@ function is_local_env() {
 /**
  * Is the current request being made from Jetpack servers?
  *
- * NOTE - This checks the REMOTE_ADDR against known JP IPs. The IP can still be spoofed,
+ * NOTE - This checks the REMOTE_ADDR and HTTP_X_FORWARDED_FOR IPs against known JP IPs. The IP can still be spoofed,
  * (but usually an attacker cannot receive the response), so it is important to treat it accordingly
  *
  * @return bool Bool indicating if the current request came from JP servers
@@ -1533,7 +1533,24 @@ function vip_is_jetpack_request() {
 	$jetpack_ips = Jetpack_IP_Manager::get_jetpack_ips();
 
 	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
-	return IpUtils::check_ip( $_SERVER['REMOTE_ADDR'], $jetpack_ips ) || IpUtils::check_ip( $_SERVER['HTTP_X_FORWARDED_FOR'], $jetpack_ips );
+	$remote_addr = $_SERVER['REMOTE_ADDR'] ? [ trim( $_SERVER['REMOTE_ADDR'] ) ] : [];
+
+	// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$forwarded_for = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? '';
+
+	// Support multiple IPs in X_FORWARDED_FOR to handle proxies.
+	$forwarded_ips = strpos( $forwarded_for, ',' ) !== false ? array_map( 'trim', explode( ',', $forwarded_for ) ) : ( $forwarded_for ? [ $forwarded_for ] : [] );
+
+	$all_ips = array_merge( $remote_addr, $forwarded_ips );
+
+	foreach ( $all_ips as $ip ) {
+		if ( IpUtils::check_ip( $ip, $jetpack_ips ) ) {
+			// If any IP matches a Jetpack IP, return early.
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
## Description

When a site uses a proxy, `HTTP_X_FORWARDED_FOR` may contain multiple IPs, e.g., `192.0.98.145, 23.207.199.162`. Presently, `vip_is_jetpack_request()` expects a single IP in `HTTP_X_FORWARDED_FOR`. This adds support for multiple IPs and improves compatibility with proxies.

## Changelog Description

- Improve support for reverse proxies when checking if a request is coming from a Jetpack server.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

```
curl --socks5 127.0.0.1:8080 -A "Jetpack by WordPress.com" -is \
  -H 'Content-Type: text/xml' \
  --data '<?xml version="1.0"?><methodCall><methodName>system.listMethods</methodName><params/></methodCall>' \
  'https://example.com/xmlrpc.php?for=jetpack' && echo
```

If `HTTP_X_FORWARDED_FOR` contains multiple IPs, one of which is from a Jetpack server, the request should be validated as being from Jetpack.

Ref: PLTFRM-1788