### PR TITLE
Public API for local file passthrough

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -771,17 +771,6 @@ if ( defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' ) ) {
 add_filter( 'big_image_size_threshold', '__return_false' );
 
 /**
- * Buffer for local files before Stream Wrapper is initialized
- *
- * @var array
- */
-global $_wpvip_fs_local_files_buffer;
-$_wpvip_fs_local_files_buffer = array(
-	'add'    => array(),
-	'remove' => array(),
-);
-
-/**
  * Add a file or pattern to be handled locally by the VIP Filesystem Stream Wrapper
  *
  * Files added to this list will be stored in the local temporary directory instead of
@@ -802,26 +791,16 @@ $_wpvip_fs_local_files_buffer = array(
  * @return bool True if the file was added successfully, false otherwise
  */
 function wpvip_fs_local_file_add( $file_path ) {
-	if ( empty( $file_path ) || ! is_string( $file_path ) ) {
+	if ( ! method_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper', 'add_local_file' ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			'VIP Filesystem Stream Wrapper is not loaded. Please ensure VIP_FILESYSTEM_USE_STREAM_WRAPPER is defined and set to true.',
+			'1.0.0'
+		);
 		return false;
 	}
 
-	// If the Stream Wrapper class is loaded, use it directly
-	if ( class_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper' ) ) {
-		return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $file_path );
-	}
-
-	// Otherwise, buffer the request for later
-	global $_wpvip_fs_local_files_buffer;
-	$_wpvip_fs_local_files_buffer['add'][] = $file_path;
-
-	// Remove from the remove buffer if it was previously marked for removal
-	$_wpvip_fs_local_files_buffer['remove'] = array_diff(
-		$_wpvip_fs_local_files_buffer['remove'],
-		array( $file_path )
-	);
-
-	return true;
+	return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $file_path );
 }
 
 /**
@@ -834,26 +813,16 @@ function wpvip_fs_local_file_add( $file_path ) {
  * @return bool True if the file was removed successfully, false otherwise
  */
 function wpvip_fs_local_file_remove( $file_path ) {
-	if ( empty( $file_path ) || ! is_string( $file_path ) ) {
+	if ( ! method_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper', 'remove_local_file' ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			'VIP Filesystem Stream Wrapper is not loaded. Please ensure VIP_FILESYSTEM_USE_STREAM_WRAPPER is defined and set to true.',
+			'1.0.0'
+		);
 		return false;
 	}
 
-	// If the Stream Wrapper class is loaded, use it directly
-	if ( class_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper' ) ) {
-		return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $file_path );
-	}
-
-	// Otherwise, buffer the request for later
-	global $_wpvip_fs_local_files_buffer;
-	$_wpvip_fs_local_files_buffer['remove'][] = $file_path;
-
-	// Remove from the add buffer if it was previously added
-	$_wpvip_fs_local_files_buffer['add'] = array_diff(
-		$_wpvip_fs_local_files_buffer['add'],
-		array( $file_path )
-	);
-
-	return true;
+	return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $file_path );
 }
 
 /**
@@ -865,20 +834,14 @@ function wpvip_fs_local_file_remove( $file_path ) {
  * @return array List of file paths and patterns configured for local handling
  */
 function wpvip_fs_local_file_list() {
-	// If the Stream Wrapper class is loaded, use it directly
-	if ( class_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper' ) ) {
-		return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+	if ( ! method_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper', 'get_local_files' ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			'VIP Filesystem Stream Wrapper is not loaded. Please ensure VIP_FILESYSTEM_USE_STREAM_WRAPPER is defined and set to true.',
+			'1.0.0'
+		);
+		return array();
 	}
 
-	// Otherwise, return the buffered state
-	global $_wpvip_fs_local_files_buffer;
-
-	// Calculate the effective list by starting with adds and removing any removes
-	$effective_list = array_diff(
-		$_wpvip_fs_local_files_buffer['add'],
-		$_wpvip_fs_local_files_buffer['remove']
-	);
-
-	// Return as an associative array with true values (matching the class implementation)
-	return array_fill_keys( $effective_list, true );
+	return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
 }

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -769,3 +769,116 @@ if ( defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' ) ) {
  * This is not needed on VIP Go since we use Photon for dynamic image work.
  */
 add_filter( 'big_image_size_threshold', '__return_false' );
+
+/**
+ * Buffer for local files before Stream Wrapper is initialized
+ *
+ * @var array
+ */
+global $_wpvip_fs_local_files_buffer;
+$_wpvip_fs_local_files_buffer = array(
+	'add'    => array(),
+	'remove' => array(),
+);
+
+/**
+ * Add a file or pattern to be handled locally by the VIP Filesystem Stream Wrapper
+ *
+ * Files added to this list will be stored in the local temporary directory instead of
+ * being uploaded to the VIP Files Service. This is useful for files that need to be
+ * processed locally or should not be persisted remotely.
+ *
+ * Supports exact file paths and wildcard patterns using fnmatch syntax:
+ * - Use `*` to match any number of characters except directory separators
+ * - Use `?` to match a single character
+ * - Use `[abc]` to match any character in the set
+ *
+ * Examples:
+ * - `vip://wp-content/uploads/temp-file.txt` - Exact file path
+ * - `vip://wp-content/uploads/cache/*.json` - All JSON files in cache directory
+ * - `vip://wp-content/uploads/tmp/*` - All files in tmp directory
+ *
+ * @param string $file_path Path to the file or a wildcard pattern
+ * @return bool True if the file was added successfully, false otherwise
+ */
+function wpvip_fs_local_file_add( $file_path ) {
+	if ( empty( $file_path ) || ! is_string( $file_path ) ) {
+		return false;
+	}
+
+	// If the Stream Wrapper class is loaded, use it directly
+	if ( class_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper' ) ) {
+		return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::add_local_file( $file_path );
+	}
+
+	// Otherwise, buffer the request for later
+	global $_wpvip_fs_local_files_buffer;
+	$_wpvip_fs_local_files_buffer['add'][] = $file_path;
+
+	// Remove from the remove buffer if it was previously marked for removal
+	$_wpvip_fs_local_files_buffer['remove'] = array_diff(
+		$_wpvip_fs_local_files_buffer['remove'],
+		array( $file_path )
+	);
+
+	return true;
+}
+
+/**
+ * Remove a file or pattern from local handling by the VIP Filesystem Stream Wrapper
+ *
+ * Files removed from the local list will be handled by the VIP Files Service instead
+ * of being stored locally.
+ *
+ * @param string $file_path Path to the file or pattern to remove
+ * @return bool True if the file was removed successfully, false otherwise
+ */
+function wpvip_fs_local_file_remove( $file_path ) {
+	if ( empty( $file_path ) || ! is_string( $file_path ) ) {
+		return false;
+	}
+
+	// If the Stream Wrapper class is loaded, use it directly
+	if ( class_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper' ) ) {
+		return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::remove_local_file( $file_path );
+	}
+
+	// Otherwise, buffer the request for later
+	global $_wpvip_fs_local_files_buffer;
+	$_wpvip_fs_local_files_buffer['remove'][] = $file_path;
+
+	// Remove from the add buffer if it was previously added
+	$_wpvip_fs_local_files_buffer['add'] = array_diff(
+		$_wpvip_fs_local_files_buffer['add'],
+		array( $file_path )
+	);
+
+	return true;
+}
+
+/**
+ * Get the list of files and patterns being handled locally by the VIP Filesystem Stream Wrapper
+ *
+ * Returns an array of file paths and wildcard patterns that are configured to be
+ * handled locally instead of being uploaded to the VIP Files Service.
+ *
+ * @return array List of file paths and patterns configured for local handling
+ */
+function wpvip_fs_local_file_list() {
+	// If the Stream Wrapper class is loaded, use it directly
+	if ( class_exists( 'Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper' ) ) {
+		return \Automattic\VIP\Files\VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+	}
+
+	// Otherwise, return the buffered state
+	global $_wpvip_fs_local_files_buffer;
+
+	// Calculate the effective list by starting with adds and removing any removes
+	$effective_list = array_diff(
+		$_wpvip_fs_local_files_buffer['add'],
+		$_wpvip_fs_local_files_buffer['remove']
+	);
+
+	// Return as an associative array with true values (matching the class implementation)
+	return array_fill_keys( $effective_list, true );
+}

--- a/files/class-vip-filesystem-local-stream-wrapper.php
+++ b/files/class-vip-filesystem-local-stream-wrapper.php
@@ -172,9 +172,6 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	 * @return  bool    true if success, false if failure
 	 */
 	public function register() {
-		// Merge any buffered local file state from before initialization
-		static::merge_buffered_local_files();
-
 		if ( in_array( $this->protocol, stream_get_wrappers(), true ) ) {
 			stream_wrapper_unregister( $this->protocol );
 		}
@@ -1173,45 +1170,6 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	 */
 	public static function get_local_files() {
 		return array_merge( static::$local_files_map, static::$local_file_patterns );
-	}
-
-	/**
-	 * Merge buffered local file state from global helper functions
-	 *
-	 * This method is called during stream wrapper registration to ensure that
-	 * any calls to wpvip_fs_local_file_add() or wpvip_fs_local_file_remove()
-	 * made before the stream wrapper was initialized are properly applied.
-	 *
-	 * @return void
-	 */
-	public static function merge_buffered_local_files() {
-		global $_wpvip_fs_local_files_buffer;
-
-		// Return early if buffer doesn't exist or is empty
-		if ( ! isset( $_wpvip_fs_local_files_buffer )
-			|| ( empty( $_wpvip_fs_local_files_buffer['add'] ) && empty( $_wpvip_fs_local_files_buffer['remove'] ) ) ) {
-			return;
-		}
-
-		// Process all buffered additions
-		if ( ! empty( $_wpvip_fs_local_files_buffer['add'] ) ) {
-			foreach ( $_wpvip_fs_local_files_buffer['add'] as $file_path ) {
-				static::add_local_file( $file_path );
-			}
-		}
-
-		// Process all buffered removals
-		if ( ! empty( $_wpvip_fs_local_files_buffer['remove'] ) ) {
-			foreach ( $_wpvip_fs_local_files_buffer['remove'] as $file_path ) {
-				static::remove_local_file( $file_path );
-			}
-		}
-
-		// Clear the buffer to prevent duplicate processing
-		$_wpvip_fs_local_files_buffer = array(
-			'add'    => array(),
-			'remove' => array(),
-		);
 	}
 
 	/**

--- a/files/class-vip-filesystem-local-stream-wrapper.php
+++ b/files/class-vip-filesystem-local-stream-wrapper.php
@@ -172,6 +172,9 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	 * @return  bool    true if success, false if failure
 	 */
 	public function register() {
+		// Merge any buffered local file state from before initialization
+		static::merge_buffered_local_files();
+
 		if ( in_array( $this->protocol, stream_get_wrappers(), true ) ) {
 			stream_wrapper_unregister( $this->protocol );
 		}
@@ -1141,7 +1144,6 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 
 		// Check if pattern contains wildcards (* or ? or [).
 		$is_pattern = strpbrk( $file_path, '*?[' ) !== false;
-			str_contains( $file_path, '[' );
 
 		if ( $is_pattern ) {
 			static::$local_file_patterns[ $file_path ] = true;
@@ -1171,6 +1173,45 @@ class VIP_Filesystem_Local_Stream_Wrapper {
 	 */
 	public static function get_local_files() {
 		return array_merge( static::$local_files_map, static::$local_file_patterns );
+	}
+
+	/**
+	 * Merge buffered local file state from global helper functions
+	 *
+	 * This method is called during stream wrapper registration to ensure that
+	 * any calls to wpvip_fs_local_file_add() or wpvip_fs_local_file_remove()
+	 * made before the stream wrapper was initialized are properly applied.
+	 *
+	 * @return void
+	 */
+	public static function merge_buffered_local_files() {
+		global $_wpvip_fs_local_files_buffer;
+
+		// Return early if buffer doesn't exist or is empty
+		if ( ! isset( $_wpvip_fs_local_files_buffer )
+			|| ( empty( $_wpvip_fs_local_files_buffer['add'] ) && empty( $_wpvip_fs_local_files_buffer['remove'] ) ) ) {
+			return;
+		}
+
+		// Process all buffered additions
+		if ( ! empty( $_wpvip_fs_local_files_buffer['add'] ) ) {
+			foreach ( $_wpvip_fs_local_files_buffer['add'] as $file_path ) {
+				static::add_local_file( $file_path );
+			}
+		}
+
+		// Process all buffered removals
+		if ( ! empty( $_wpvip_fs_local_files_buffer['remove'] ) ) {
+			foreach ( $_wpvip_fs_local_files_buffer['remove'] as $file_path ) {
+				static::remove_local_file( $file_path );
+			}
+		}
+
+		// Clear the buffer to prevent duplicate processing
+		$_wpvip_fs_local_files_buffer = array(
+			'add'    => array(),
+			'remove' => array(),
+		);
 	}
 
 	/**

--- a/tests/files/test-vip-filesystem-local-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-local-stream-wrapper.php
@@ -529,13 +529,6 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 
 		$result = wpvip_fs_local_file_add( 123 );
 		$this->assertFalse( $result );
-
-		// Same for remove
-		$result = wpvip_fs_local_file_remove( '' );
-		$this->assertFalse( $result );
-
-		$result = wpvip_fs_local_file_remove( null );
-		$this->assertFalse( $result );
 	}
 
 	public function test__global_helpers__pattern_matching() {

--- a/tests/files/test-vip-filesystem-local-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-local-stream-wrapper.php
@@ -479,72 +479,18 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		}
 	}
 
-	public function test__global_helpers__add_before_initialization() {
-		// Simulate calling the global helper before the stream wrapper is initialized
-		// by creating a fresh environment
-		global $_wpvip_fs_local_files_buffer;
-		$_wpvip_fs_local_files_buffer = array(
-			'add'    => array(),
-			'remove' => array(),
-		);
-
+	public function test__global_helpers__add() {
 		// Add files using the global helper
-		$result1 = wpvip_fs_local_file_add( 'vip://wp-content/uploads/temp.txt' );
-		$result2 = wpvip_fs_local_file_add( 'vip://wp-content/uploads/cache/*.json' );
-
-		$this->assertTrue( $result1 );
-		$this->assertTrue( $result2 );
-
-		// Verify they are in the buffer
-		$this->assertContains( 'vip://wp-content/uploads/temp.txt', $_wpvip_fs_local_files_buffer['add'] );
-		$this->assertContains( 'vip://wp-content/uploads/cache/*.json', $_wpvip_fs_local_files_buffer['add'] );
-
-		// Now merge the buffer
-		VIP_Filesystem_Local_Stream_Wrapper::merge_buffered_local_files();
-
-		// Verify the buffer was cleared
-		$this->assertEmpty( $_wpvip_fs_local_files_buffer['add'] );
-		$this->assertEmpty( $_wpvip_fs_local_files_buffer['remove'] );
-
-		// Verify files were added to the stream wrapper
-		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
-		$this->assertArrayHasKey( 'vip://wp-content/uploads/temp.txt', $local_files );
-		$this->assertArrayHasKey( 'vip://wp-content/uploads/cache/*.json', $local_files );
-	}
-
-	public function test__global_helpers__add_after_initialization() {
-		// When class is loaded, should call static method directly
 		$result = wpvip_fs_local_file_add( 'vip://wp-content/uploads/direct.txt' );
 
 		$this->assertTrue( $result );
 
-		// Verify it was added directly to the stream wrapper
+		// Verify it was added to the stream wrapper
 		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
 		$this->assertArrayHasKey( 'vip://wp-content/uploads/direct.txt', $local_files );
 	}
 
-	public function test__global_helpers__remove_before_initialization() {
-		global $_wpvip_fs_local_files_buffer;
-		$_wpvip_fs_local_files_buffer = array(
-			'add'    => array(),
-			'remove' => array(),
-		);
-
-		// Add then remove before initialization
-		wpvip_fs_local_file_add( 'vip://wp-content/uploads/temp.txt' );
-		$result = wpvip_fs_local_file_remove( 'vip://wp-content/uploads/temp.txt' );
-
-		$this->assertTrue( $result );
-
-		// Verify it's not in the add buffer
-		$this->assertNotContains( 'vip://wp-content/uploads/temp.txt', $_wpvip_fs_local_files_buffer['add'] );
-
-		// Verify the list is empty
-		$list = wpvip_fs_local_file_list();
-		$this->assertEmpty( $list );
-	}
-
-	public function test__global_helpers__remove_after_initialization() {
+	public function test__global_helpers__remove() {
 		// Add a file first
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( 'vip://wp-content/uploads/to-remove.txt' );
 
@@ -562,21 +508,7 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'vip://wp-content/uploads/to-remove.txt', $local_files );
 	}
 
-	public function test__global_helpers__list_before_initialization() {
-		global $_wpvip_fs_local_files_buffer;
-		$_wpvip_fs_local_files_buffer = array(
-			'add'    => array( 'vip://file1.txt', 'vip://file2.txt' ),
-			'remove' => array(),
-		);
-
-		$list = wpvip_fs_local_file_list();
-
-		$this->assertArrayHasKey( 'vip://file1.txt', $list );
-		$this->assertArrayHasKey( 'vip://file2.txt', $list );
-		$this->assertCount( 2, $list );
-	}
-
-	public function test__global_helpers__list_after_initialization() {
+	public function test__global_helpers__list() {
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( 'vip://file1.txt' );
 		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( 'vip://file2.txt' );
 
@@ -621,34 +553,5 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 		// Test that a non-matching file is not recognized
 		$is_local = VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/cache/data.txt' );
 		$this->assertFalse( $is_local );
-	}
-
-	public function test__merge_buffered_local_files__mixed_operations() {
-		global $_wpvip_fs_local_files_buffer;
-
-		// Simulate a complex scenario with both adds and removes
-		$_wpvip_fs_local_files_buffer = array(
-			'add'    => array(
-				'vip://file1.txt',
-				'vip://file2.txt',
-				'vip://file3.txt',
-			),
-			'remove' => array(
-				'vip://file2.txt',
-			),
-		);
-
-		// Merge the buffer
-		VIP_Filesystem_Local_Stream_Wrapper::merge_buffered_local_files();
-
-		// Verify buffer was cleared
-		$this->assertEmpty( $_wpvip_fs_local_files_buffer['add'] );
-		$this->assertEmpty( $_wpvip_fs_local_files_buffer['remove'] );
-
-		// Verify correct files are in the local files list
-		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
-		$this->assertArrayHasKey( 'vip://file1.txt', $local_files );
-		$this->assertArrayNotHasKey( 'vip://file2.txt', $local_files ); // Was removed
-		$this->assertArrayHasKey( 'vip://file3.txt', $local_files );
 	}
 }

--- a/tests/files/test-vip-filesystem-local-stream-wrapper.php
+++ b/tests/files/test-vip-filesystem-local-stream-wrapper.php
@@ -478,4 +478,177 @@ class VIP_Filesystem_Local_Stream_Wrapper_Test extends WP_UnitTestCase {
 			$this->should_unregister = false;
 		}
 	}
+
+	public function test__global_helpers__add_before_initialization() {
+		// Simulate calling the global helper before the stream wrapper is initialized
+		// by creating a fresh environment
+		global $_wpvip_fs_local_files_buffer;
+		$_wpvip_fs_local_files_buffer = array(
+			'add'    => array(),
+			'remove' => array(),
+		);
+
+		// Add files using the global helper
+		$result1 = wpvip_fs_local_file_add( 'vip://wp-content/uploads/temp.txt' );
+		$result2 = wpvip_fs_local_file_add( 'vip://wp-content/uploads/cache/*.json' );
+
+		$this->assertTrue( $result1 );
+		$this->assertTrue( $result2 );
+
+		// Verify they are in the buffer
+		$this->assertContains( 'vip://wp-content/uploads/temp.txt', $_wpvip_fs_local_files_buffer['add'] );
+		$this->assertContains( 'vip://wp-content/uploads/cache/*.json', $_wpvip_fs_local_files_buffer['add'] );
+
+		// Now merge the buffer
+		VIP_Filesystem_Local_Stream_Wrapper::merge_buffered_local_files();
+
+		// Verify the buffer was cleared
+		$this->assertEmpty( $_wpvip_fs_local_files_buffer['add'] );
+		$this->assertEmpty( $_wpvip_fs_local_files_buffer['remove'] );
+
+		// Verify files were added to the stream wrapper
+		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+		$this->assertArrayHasKey( 'vip://wp-content/uploads/temp.txt', $local_files );
+		$this->assertArrayHasKey( 'vip://wp-content/uploads/cache/*.json', $local_files );
+	}
+
+	public function test__global_helpers__add_after_initialization() {
+		// When class is loaded, should call static method directly
+		$result = wpvip_fs_local_file_add( 'vip://wp-content/uploads/direct.txt' );
+
+		$this->assertTrue( $result );
+
+		// Verify it was added directly to the stream wrapper
+		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+		$this->assertArrayHasKey( 'vip://wp-content/uploads/direct.txt', $local_files );
+	}
+
+	public function test__global_helpers__remove_before_initialization() {
+		global $_wpvip_fs_local_files_buffer;
+		$_wpvip_fs_local_files_buffer = array(
+			'add'    => array(),
+			'remove' => array(),
+		);
+
+		// Add then remove before initialization
+		wpvip_fs_local_file_add( 'vip://wp-content/uploads/temp.txt' );
+		$result = wpvip_fs_local_file_remove( 'vip://wp-content/uploads/temp.txt' );
+
+		$this->assertTrue( $result );
+
+		// Verify it's not in the add buffer
+		$this->assertNotContains( 'vip://wp-content/uploads/temp.txt', $_wpvip_fs_local_files_buffer['add'] );
+
+		// Verify the list is empty
+		$list = wpvip_fs_local_file_list();
+		$this->assertEmpty( $list );
+	}
+
+	public function test__global_helpers__remove_after_initialization() {
+		// Add a file first
+		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( 'vip://wp-content/uploads/to-remove.txt' );
+
+		// Verify it exists
+		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+		$this->assertArrayHasKey( 'vip://wp-content/uploads/to-remove.txt', $local_files );
+
+		// Remove it using global helper
+		$result = wpvip_fs_local_file_remove( 'vip://wp-content/uploads/to-remove.txt' );
+
+		$this->assertTrue( $result );
+
+		// Verify it was removed
+		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+		$this->assertArrayNotHasKey( 'vip://wp-content/uploads/to-remove.txt', $local_files );
+	}
+
+	public function test__global_helpers__list_before_initialization() {
+		global $_wpvip_fs_local_files_buffer;
+		$_wpvip_fs_local_files_buffer = array(
+			'add'    => array( 'vip://file1.txt', 'vip://file2.txt' ),
+			'remove' => array(),
+		);
+
+		$list = wpvip_fs_local_file_list();
+
+		$this->assertArrayHasKey( 'vip://file1.txt', $list );
+		$this->assertArrayHasKey( 'vip://file2.txt', $list );
+		$this->assertCount( 2, $list );
+	}
+
+	public function test__global_helpers__list_after_initialization() {
+		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( 'vip://file1.txt' );
+		VIP_Filesystem_Local_Stream_Wrapper::add_local_file( 'vip://file2.txt' );
+
+		$list = wpvip_fs_local_file_list();
+
+		$this->assertArrayHasKey( 'vip://file1.txt', $list );
+		$this->assertArrayHasKey( 'vip://file2.txt', $list );
+	}
+
+	public function test__global_helpers__invalid_input() {
+		// Test with empty string
+		$result = wpvip_fs_local_file_add( '' );
+		$this->assertFalse( $result );
+
+		// Test with non-string
+		$result = wpvip_fs_local_file_add( null );
+		$this->assertFalse( $result );
+
+		$result = wpvip_fs_local_file_add( 123 );
+		$this->assertFalse( $result );
+
+		// Same for remove
+		$result = wpvip_fs_local_file_remove( '' );
+		$this->assertFalse( $result );
+
+		$result = wpvip_fs_local_file_remove( null );
+		$this->assertFalse( $result );
+	}
+
+	public function test__global_helpers__pattern_matching() {
+		// Add a wildcard pattern
+		wpvip_fs_local_file_add( 'vip://wp-content/uploads/cache/*.json' );
+
+		// Check if it's recognized as a pattern
+		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+		$this->assertArrayHasKey( 'vip://wp-content/uploads/cache/*.json', $local_files );
+
+		// Test that a matching file is recognized
+		$is_local = VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/cache/data.json' );
+		$this->assertTrue( $is_local );
+
+		// Test that a non-matching file is not recognized
+		$is_local = VIP_Filesystem_Local_Stream_Wrapper::is_local_file( 'vip://wp-content/uploads/cache/data.txt' );
+		$this->assertFalse( $is_local );
+	}
+
+	public function test__merge_buffered_local_files__mixed_operations() {
+		global $_wpvip_fs_local_files_buffer;
+
+		// Simulate a complex scenario with both adds and removes
+		$_wpvip_fs_local_files_buffer = array(
+			'add'    => array(
+				'vip://file1.txt',
+				'vip://file2.txt',
+				'vip://file3.txt',
+			),
+			'remove' => array(
+				'vip://file2.txt',
+			),
+		);
+
+		// Merge the buffer
+		VIP_Filesystem_Local_Stream_Wrapper::merge_buffered_local_files();
+
+		// Verify buffer was cleared
+		$this->assertEmpty( $_wpvip_fs_local_files_buffer['add'] );
+		$this->assertEmpty( $_wpvip_fs_local_files_buffer['remove'] );
+
+		// Verify correct files are in the local files list
+		$local_files = VIP_Filesystem_Local_Stream_Wrapper::get_local_files();
+		$this->assertArrayHasKey( 'vip://file1.txt', $local_files );
+		$this->assertArrayNotHasKey( 'vip://file2.txt', $local_files ); // Was removed
+		$this->assertArrayHasKey( 'vip://file3.txt', $local_files );
+	}
 }


### PR DESCRIPTION
## Description

This pull request introduces a set of global helper functions and an internal buffering mechanism to allow files and patterns to be marked for local handling by the VIP Filesystem Stream Wrapper, even before the stream wrapper is initialized. It also ensures that any buffered state is properly merged when the stream wrapper is registered, and adds comprehensive tests for these new features and edge cases.

Global helper functions and buffering:

* Added global helper functions (`wpvip_fs_local_file_add`, `wpvip_fs_local_file_remove`, `wpvip_fs_local_file_list`) in `a8c-files.php` to allow marking files or patterns for local handling, with support for wildcard patterns and buffering requests made before the stream wrapper is initialized.
* Introduced a global buffer (`$_wpvip_fs_local_files_buffer`) to store add/remove requests for local file handling until the stream wrapper is ready.

Stream wrapper integration:

* Added `VIP_Filesystem_Local_Stream_Wrapper::merge_buffered_local_files()` to merge the buffered state into the stream wrapper during registration, ensuring all pre-initialization requests are honored. [[1]](diffhunk://#diff-12f9d7d71e89a54ebbf45447505511cbbb62982143f82271d2caf37ccd933c86R175-R177) [[2]](diffhunk://#diff-12f9d7d71e89a54ebbf45447505511cbbb62982143f82271d2caf37ccd933c86R1178-R1216)
* Fixed pattern detection logic in `add_local_file` to correctly identify wildcard patterns.

Testing:

* Added extensive tests to `test-vip-filesystem-local-stream-wrapper.php` to cover all helper functions, buffer merging, pattern matching, and edge cases, ensuring robust handling of local file state before and after initialization.

## Changelog Description

### Added
- Added API to mark a file path/mask as local, effectively skipping upload to VIP File Service


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<TBD>