### PR TITLE
Re-fix the incorrect ES version showing in the admin bar

### DIFF
--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -374,7 +374,9 @@ function get_current_elasticsearch_version() {
 	$base_version = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version() ?: 'Unknown';
 
 	if ( defined( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) && constant( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS' ) ) {
-		return sprintf( '%s (Migration: %s)', $base_version, \Automattic\VIP\Search\Search::instance()->is_testing_next_version() ? 'Using ES8' : 'Using ES7' );
+		$constant_value          = defined( 'VIP_ELASTICSEARCH_VERSION' ) ? constant( 'VIP_ELASTICSEARCH_VERSION' ) : 'Unknown';
+		$is_testing_next_version = \Automattic\VIP\Search\Search::instance()->is_testing_next_version();
+		return sprintf( '%s (Migration: %s)', $base_version, '8' === $constant_value || $is_testing_next_version ? 'Using ES8' : 'Using ES7' );
 	}
 
 	return $base_version;


### PR DESCRIPTION
## Description

This pull request updates the logic for reporting the current Elasticsearch version during a migration. The change ensures that the migration status correctly reflects whether Elasticsearch 8 is being used, based on both the `VIP_ELASTICSEARCH_VERSION` constant and the result of the `is_testing_next_version()` method.

Migration status logic improvement:

* Updated the `get_current_elasticsearch_version()` function in `search-dev-tools.php` to check both the `VIP_ELASTICSEARCH_VERSION` constant and the `is_testing_next_version()` method when determining if ES8 is being used during a migration.

## Changelog Description

### Fixed
- Search Dev Tools incorrectly identifying ES version when version is `8` but the migration mode is still enabled.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->