### PR TITLE
Update Contact Form 7 plugin compatibility

### DIFF
--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -36,6 +36,33 @@ function vip_wpcf7_upload_dir() {
 add_filter( 'wpcf7_init', 'vip_wpcf7_upload_dir', 10, 0 ); 
 
 /**
+ * Versions of CF7 prior to v5.8.1 attempt to clean-up uploaded attachments
+ * somewhere within `wp-content`, ignoring the value of WPCF7_UPLOADS_TMP_DIR if
+ * it is not within `wp-content`. This does not work because we disable `open_dir()`,
+ * flooding the PHP logs with `opendir() Failed to open directory` warnings.
+ *
+ * @return void
+ */
+function vip_disable_wpcf7_cleanup_upload_files() {
+	if ( defined( 'WPCF7_VERSION' ) && version_compare( WPCF7_VERSION, '5.8.1', '>=' ) ) {
+		return; // CF7 v5.8.1 and later uses WP_TEMP_DIR correctly
+	} else {
+		// Return early if the relevant functions do not exist
+		if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) || ! function_exists( 'wpcf7_cleanup_upload_files' ) || ! function_exists( 'wpcf7_upload_tmp_dir' ) ) {
+			return;
+		}
+
+		// Check if the action is queued and if the tmp directories match
+		// (they might match if the plugin is an old version, or has been patched)
+		$priority = has_action( 'shutdown', 'wpcf7_cleanup_upload_files' );
+		if ( false !== $priority && WPCF7_UPLOADS_TMP_DIR !== wpcf7_upload_tmp_dir() ) {
+			remove_action( 'shutdown', 'wpcf7_cleanup_upload_files', $priority );
+		}
+	}
+}
+add_action( 'plugins_loaded', 'vip_disable_wpcf7_cleanup_upload_files' );
+
+/**
  * AMP for WordPress (https://github.com/ampproject/amp-wp)
  * Make sure the `amp` query var has an explicit value.
  * Avoids issues when filtering the deprecated `query_string` hook.

--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -27,13 +27,12 @@ if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) ) {
  * filter to set `WP_TEMP_DIR` to `/tmp/` so that the plugin will allow the
  * path that we defined earlier in `WPCF7_UPLOADS_TMP_DIR`.
  */
-// phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
 function vip_wpcf7_upload_dir() {
 	if ( ! defined( 'WP_TEMP_DIR' ) ) {
 		define( 'WP_TEMP_DIR', get_temp_dir() );
 	}
 }
-add_filter( 'wpcf7_init', 'vip_wpcf7_upload_dir', 10, 0 ); 
+add_action( 'wpcf7_init', 'vip_wpcf7_upload_dir', 10, 0 ); 
 
 /**
  * Versions of CF7 prior to v5.8.1 attempt to clean-up uploaded attachments
@@ -44,9 +43,7 @@ add_filter( 'wpcf7_init', 'vip_wpcf7_upload_dir', 10, 0 );
  * @return void
  */
 function vip_disable_wpcf7_cleanup_upload_files() {
-	if ( defined( 'WPCF7_VERSION' ) && version_compare( WPCF7_VERSION, '5.8.1', '>=' ) ) {
-		return; // CF7 v5.8.1 and later uses WP_TEMP_DIR correctly
-	} else {
+	if ( ! defined( 'WPCF7_VERSION' ) || ! version_compare( WPCF7_VERSION, '5.8.1', '>=' ) ) {
 		// Return early if the relevant functions do not exist
 		if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) || ! function_exists( 'wpcf7_cleanup_upload_files' ) || ! function_exists( 'wpcf7_upload_tmp_dir' ) ) {
 			return;

--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -23,21 +23,17 @@ if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) ) {
  *
  * The plugin ignores the value of `WPCF7_UPLOADS_TMP_DIR` if it is not
  * within a set of paths allowed by the plugin. The plugin allows the path
- * defined in `WP_TEMP_DIR`, so this fix uses the plugin's `wpcf7_upload_dir`
+ * defined in `WP_TEMP_DIR`, so this fix uses the plugin's `wpcf7_init`
  * filter to set `WP_TEMP_DIR` to `/tmp/` so that the plugin will allow the
  * path that we defined earlier in `WPCF7_UPLOADS_TMP_DIR`.
- *
- * @param array $uploads See wp_upload_dir() for description.
- * @return array Information about the upload directory.
  */
-function vip_wpcf7_upload_dir( $uploads ) {
+// phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
+function vip_wpcf7_upload_dir() {
 	if ( ! defined( 'WP_TEMP_DIR' ) ) {
 		define( 'WP_TEMP_DIR', get_temp_dir() );
 	}
-
-	return $uploads;
 }
-add_filter( 'wpcf7_upload_dir', 'vip_wpcf7_upload_dir', 10, 1 );
+add_filter( 'wpcf7_init', 'vip_wpcf7_upload_dir', 10, 0 ); 
 
 /**
  * AMP for WordPress (https://github.com/ampproject/amp-wp)

--- a/plugin-fixes.php
+++ b/plugin-fixes.php
@@ -40,29 +40,6 @@ function vip_wpcf7_upload_dir( $uploads ) {
 add_filter( 'wpcf7_upload_dir', 'vip_wpcf7_upload_dir', 10, 1 );
 
 /**
- * Recent versions of CF7 attempt to clean-up uploaded attachments
- * somewhere within `wp-content`, ignoring the value of WPCF7_UPLOADS_TMP_DIR if
- * it is not within `wp-content`. This does not work because we disable `open_dir()`,
- * flooding the PHP logs with `opendir() Failed to open directory` warnings.
- *
- * @return void
- */
-function vip_disable_wpcf7_cleanup_upload_files() {
-	// Return early if the relevant functions do not exist
-	if ( ! defined( 'WPCF7_UPLOADS_TMP_DIR' ) || ! function_exists( 'wpcf7_cleanup_upload_files' ) || ! function_exists( 'wpcf7_upload_tmp_dir' ) ) {
-		return;
-	}
-
-	// Check if the action is queued and if the tmp directories match
-	// (they might match if the plugin is an old version, or has been patched)
-	$priority = has_action( 'shutdown', 'wpcf7_cleanup_upload_files' );
-	if ( false !== $priority && WPCF7_UPLOADS_TMP_DIR !== wpcf7_upload_tmp_dir() ) {
-		remove_action( 'shutdown', 'wpcf7_cleanup_upload_files', $priority );
-	}
-}
-add_action( 'plugins_loaded', 'vip_disable_wpcf7_cleanup_upload_files' );
-
-/**
  * AMP for WordPress (https://github.com/ampproject/amp-wp)
  * Make sure the `amp` query var has an explicit value.
  * Avoids issues when filtering the deprecated `query_string` hook.


### PR DESCRIPTION
## Description

This PR updates two Contact Form 7 plugin compatibility fixes.

### Removes vip_disable_wpcf7_cleanup_upload_files() from Contact Form 7 < v5.8.1

Contact Form 7, version 6.1.1 (released August 5th, 2025), changed the behavior of the `wpcf7_upload_tmp_dir()` function to include a `static $output` variable, which causes the value defined by `wpcf7_upload_tmp_dir()` to persist across calls to the function: https://github.com/rocklobster-in/contact-form-7/commit/e4aa8201538f641377b941eca79cdef58898b156

One of the current VIP platform compatibility fixes for Contact Form 7 ([mu-plugins/plugin-fixes.php#L42-L63](https://github.com/Automattic/vip-go-mu-plugins/blob/fc3777028647fd59472c4e27532880f2819d5bcb/plugin-fixes.php#L42-L63)), is hooked onto `plugins_loaded` and therefore runs before another Contact Form 7 compatibility fix that defines `WP_TEMP_DIR` ([mu-plugins/plugin-fixes.php#L21-L40](https://github.com/Automattic/vip-go-mu-plugins/blob/fc3777028647fd59472c4e27532880f2819d5bcb/plugin-fixes.php#L21-L40)), 

As a result, when `wpcf7_upload_tmp_dir()` is called the first time by `vip_disable_wpcf7_cleanup_upload_files()`, it sets the value of `$output` to `'vip://wp-content/uploads/wpcf7_uploads'`, which then persists across subsequent calls to `wpcf7_upload_tmp_dir()`, even after the fix that properly sets `WP_TEMP_DIR` to `/tmp/`. This then leads to an infinite loop on [plugins/contact-form-7/includes/file.php#L311-L313](https://github.com/rocklobster-in/contact-form-7/blob/4b130fb2c96b7e1c33e5d080ea96773add979c16/includes/file.php#L311-L313), as the VIP platform always returns `true` for `file_exists()` in `wp-content/uploads/` paths.

The `vip_disable_wpcf7_cleanup_upload_files()` fix was put in place to address an issue where Contact Form 7 would attempt to clean up uploaded attachments within `wp-content/uploads/`. However, as of Contact Form 7 v5.8.1 ([released 2 years ago on September 28, 2023](https://github.com/rocklobster-in/contact-form-7/releases/tag/v5.8.1)), Contact Form 7 supports writing to `WP_TEMP_DIR`: https://github.com/rocklobster-in/contact-form-7/issues/1282. 

With the VIP platform now setting `WP_TEMP_DIR` to `/tmp/` for Contact Form 7, and Contact Form 7 >= v5.8.1 supporting `WP_TEMP_DIR`,  this cleanup process is no longer a problem.

### Updates vip_wpcf7_upload_dir

The `WP_TEMP_DIR` fix is currently hooked onto `wpcf7_upload_dir`, however that runs too late. We should instead hook onto `wpcf7_init`, following the lead of Contact Form 7 which hooks its own `wpcf7_init_uploads` onto `wpcf7_init` ([plugins/contact-form-7/includes/file.php#L257-L261](https://github.com/rocklobster-in/contact-form-7/blob/4b130fb2c96b7e1c33e5d080ea96773add979c16/includes/file.php#L257-L261)).

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Changed

- Improved plugin compatibility for files uploaded by Contact Form 7 


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Checkout the PR
1. Install the latest version of Contact Form 7 (tested with v6.1.2)
1. Create a new contact form: WP Admin -> Contact -> Add Contact Form
1. Click the 'file' form template to add a file upload field to the form, use the default options and click 'Insert Tag'
1. Switch to the 'Mail' tab and add the file mail tag you just created to the "File attachments" field (e.g., `[file-76]`)
1. Click 'Save' at the bottom
1. Copy the shortcode widget that's generated for the new form and paste it into a test page on the site
1. Publish the post and submit the form with a file attached

Without this PR's patch, submitting the form creates an infinite loop as described above. With the patch, the form submits successfully and the attached file is uploaded and emailed as expected.