### PR TITLE
Update the load check for RTC

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -8,8 +8,6 @@
 
 namespace Automattic\VIP\Integrations;
 
-defined( 'ABSPATH' ) || exit();
-
 /**
  * Loads Real-Time Collaboration VIP Integration.
  *
@@ -63,11 +61,6 @@ class RealTimeCollaborationIntegration extends Integration {
 
 		// Check WordPress version requirement
 		global $wp_version;
-
-		// Account for plugins overriding the $wp_version global, look at gutenberg.php for reference.
-		/** @psalm-suppress MissingFile */
-		// This is a built-in WordPress file, so we can ignore the warning here.
-		include ABSPATH . WPINC . '/version.php';
 
 		if ( isset( $wp_version ) && version_compare( $wp_version, '6.7', '<' ) ) {
 			return false;

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -26,7 +26,29 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Check if the Gutenberg plugin is active.
 	 */
 	private function is_gutenberg_plugin_active(): bool {
-		return defined( 'IS_GUTENBERG_PLUGIN' ) && constant( 'IS_GUTENBERG_PLUGIN' );
+		// Gutenberg plugin isn't active.
+		if ( ! defined( 'IS_GUTENBERG_PLUGIN' ) || ! constant( 'IS_GUTENBERG_PLUGIN' ) ) {
+			return false;
+		}
+
+		// Need to ensure that development mode bypasses this check.
+		// For dev builds, this is defined in the Gutenberg plugin's main file.
+		// For production builds, this is removed entirely.
+		// This is useful for when we are testing mu-plugins integration locally.
+		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && constant( 'GUTENBERG_DEVELOPMENT_MODE' ) ) {
+			return false;
+		}
+
+		// If its not development mode, and the version is set, check the version.
+		if ( defined( 'GUTENBERG_VERSION' ) && is_string( constant( 'GUTENBERG_VERSION' ) ) ) {
+			/** @var string $gutenberg_version */
+			$gutenberg_version = constant( 'GUTENBERG_VERSION' );
+			// TODO: Update this to 21.9.0 in 2 weeks.
+			return version_compare( $gutenberg_version, '21.7.0', '>=' );
+		}
+
+		// Gutenberg plugin is active but we can't determine the version, so assume it's incompatible.
+		return false;
 	}
 
 	/**
@@ -47,7 +69,7 @@ class RealTimeCollaborationIntegration extends Integration {
 		// This is a built-in WordPress file, so we can ignore the warning here.
 		include ABSPATH . WPINC . '/version.php';
 
-		if ( version_compare( $wp_version, '6.7', '<' ) ) {
+		if ( isset( $wp_version ) && version_compare( $wp_version, '6.7', '<' ) ) {
 			return false;
 		}
 

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\VIP\Integrations;
 
+defined( 'ABSPATH' ) || exit();
+
 /**
  * Loads Real-Time Collaboration VIP Integration.
  *
@@ -31,6 +33,24 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Check if all requirements are met to load the integration.
 	 */
 	private function can_load(): bool {
+		// Check PHP version requirement
+		$php_version = phpversion();
+		if ( is_string( $php_version ) && version_compare( $php_version, '8.2', '<' ) ) {
+			return false;
+		}
+
+		// Check WordPress version requirement
+		global $wp_version;
+
+		// Account for plugins overriding the $wp_version global, look at gutenberg.php for reference.
+		/** @psalm-suppress MissingFile */
+		// This is a built-in WordPress file, so we can ignore the warning here.
+		include ABSPATH . WPINC . '/version.php';
+
+		if ( version_compare( $wp_version, '6.7', '<' ) ) {
+			return false;
+		}
+
 		// Check required configuration constants
 		if ( ! defined( 'VIP_RTC_WS_AUTH_SECRET' ) || ! defined( 'VIP_RTC_WS_URL' ) ) {
 			return false;

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -29,15 +29,7 @@ class RealTimeCollaborationIntegration extends Integration {
 			return false;
 		}
 
-		// Need to ensure that development mode bypasses this check.
-		// For dev builds, this is defined in the Gutenberg plugin's main file.
-		// For production builds, this is removed entirely.
-		// This is useful for when we are testing mu-plugins integration locally.
-		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && constant( 'GUTENBERG_DEVELOPMENT_MODE' ) ) {
-			return false;
-		}
-
-		// If its not development mode, and the version is set, check the version.
+		// If the version is set, check the version.
 		if ( defined( 'GUTENBERG_VERSION' ) && is_string( constant( 'GUTENBERG_VERSION' ) ) ) {
 			/** @var string $gutenberg_version */
 			$gutenberg_version = constant( 'GUTENBERG_VERSION' );


### PR DESCRIPTION
## Description

Add a check for the WP/PHP/GB versions when trying to load the RTC integration. The GB version targets 21.7, just to be safe for now. It could be raised to 21.9 but I'd rather bump it up after 2 weeks when the final rebase we have done rolls out in https://github.com/Automattic/vip-go-mu-plugins-ext/pull/94.

## Changelog Description

### Changed

- VIP Real-time collaboration: Added a check to verify the PHP/WP/GB version before loading the integration.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x ] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Enable the VIP RTC integration
3. Change your PHP/WP version and see it failing to load
4. Change your GB version (easiest way is to tweak the Gutenberg.php file) and see it failing to load

I've kept it draft just to get some feedback on if there's a better approach I could go for here? We do have these checks in the plugin itself, so is there a benefit in adding it here as well?