### PR TITLE
Add new public helpers to get the app name, app environment and full app alias

### DIFF
--- a/000-pre-vip-config/requires.php
+++ b/000-pre-vip-config/requires.php
@@ -14,6 +14,7 @@ $files = [
 	'/lib/environment/class-environment.php',
 	'/lib/helpers/environment.php',
 	'/lib/utils/class-context.php',
+	'/lib/helpers/app.php',
 ];
 
 $cli_files = [

--- a/lib/helpers/app.php
+++ b/lib/helpers/app.php
@@ -1,0 +1,33 @@
+<?php
+
+use Automattic\VIP\Utils\Context;
+
+/**
+ * Get the application name (slug).
+ *
+ * @return string The application slug (e.g., 'example-app'), or empty string if not defined.
+ */
+function wpvip_get_app_name(): string {
+	return Context::get_app_slug();
+}
+
+/**
+ * Get the application alias in the format used by VIP-CLI.
+ *
+ * Returns the application alias in the format `<app-slug>.<environment>`,
+ * which can be used to target environments with VIP-CLI commands.
+ *
+ * @see https://docs.wpvip.com/vip-cli/target-environments/#application-alias-by-name
+ *
+ * @return string The application alias (e.g., 'example-app.develop'), or empty string if either constant is not defined.
+ */
+function wpvip_get_app_alias(): string {
+	$app_slug    = Context::get_app_slug();
+	$environment = Context::get_environment();
+
+	if ( '' === $app_slug || '' === $environment ) {
+		return '';
+	}
+
+	return $app_slug . '.' . $environment;
+}

--- a/lib/helpers/app.php
+++ b/lib/helpers/app.php
@@ -12,6 +12,15 @@ function wpvip_get_app_name(): string {
 }
 
 /**
+ * Get the application environment.
+ *
+ * @return string The application environment (e.g., 'production', 'develop', 'local'), or empty string if not defined.
+ */
+function wpvip_get_app_environment(): string {
+	return Context::get_environment();
+}
+
+/**
  * Get the application alias in the format used by VIP-CLI.
  *
  * Returns the application alias in the format `<app-slug>.<environment>`,

--- a/lib/utils/class-context.php
+++ b/lib/utils/class-context.php
@@ -81,4 +81,28 @@ class Context {
 		$request_uri = $_SERVER['REQUEST_URI'] ?? '';
 		return '/.vip-prom-metrics' === $request_uri;
 	}
+
+	/**
+	 * Get the application slug.
+	 *
+	 * @return string The application slug, or empty string if not defined.
+	 */
+	public static function get_app_slug(): string {
+		if ( defined( 'VIP_GO_APP_SLUG' ) ) {
+			return constant( 'VIP_GO_APP_SLUG' );
+		}
+		return '';
+	}
+
+	/**
+	 * Get the application environment.
+	 *
+	 * @return string The application environment, or empty string if not defined.
+	 */
+	public static function get_environment(): string {
+		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			return constant( 'VIP_GO_APP_ENVIRONMENT' );
+		}
+		return '';
+	}
 }

--- a/qm-plugins/qm-vip/class-qm-collector-vip.php
+++ b/qm-plugins/qm-vip/class-qm-collector-vip.php
@@ -59,6 +59,21 @@ class QM_Collector_VIP extends QM_Collector {
 	private function process_app() {
 		$env = constant( 'VIP_GO_APP_ENVIRONMENT' );
 
+		$app_slug = wpvip_get_app_name();
+		if ( '' !== $app_slug ) {
+			$this->data->app['slug'] = $app_slug;
+		}
+
+		$app_environment = wpvip_get_app_environment();
+		if ( '' !== $app_environment ) {
+			$this->data->app['environment'] = $app_environment;
+		}
+
+		$app_alias = wpvip_get_app_alias();
+		if ( '' !== $app_alias ) {
+			$this->data->app['alias'] = $app_alias;
+		}
+
 		if ( 'local' !== $env ) {
 			if ( defined( 'VIP_GO_APP_ID' ) ) {
 				$this->data->app['id'] = constant( 'VIP_GO_APP_ID' );

--- a/qm-plugins/qm-vip/class-qm-output-html-vip.php
+++ b/qm-plugins/qm-vip/class-qm-output-html-vip.php
@@ -34,6 +34,15 @@ class QM_Output_Html_VIP extends QM_Output_Html {
 
 		// App section
 		$this->output_before_section( 'Application' );
+		if ( isset( $data->app['slug'] ) ) {
+			$this->output_table_row( 'Name', $data->app['slug'] );
+		}
+		if ( isset( $data->app['environment'] ) ) {
+			$this->output_table_row( 'Environment', $data->app['environment'] );
+		}
+		if ( isset( $data->app['alias'] ) ) {
+			$this->output_table_row( 'Alias', $data->app['alias'] );
+		}
 		if ( isset( $data->app['id'] ) ) {
 			$this->output_table_row( 'ID', $data->app['id'] );
 		}

--- a/qm-plugins/qm-vip/class-qm-output-html-vip.php
+++ b/qm-plugins/qm-vip/class-qm-output-html-vip.php
@@ -34,36 +34,37 @@ class QM_Output_Html_VIP extends QM_Output_Html {
 
 		// App section
 		$this->output_before_section( 'Application' );
-		if ( isset( $data->app['slug'] ) ) {
-			$this->output_table_row( 'Name', $data->app['slug'] );
+
+		$app_fields = [
+			'slug'        => 'Name',
+			'environment' => 'Environment',
+			'alias'       => 'Alias',
+			'id'          => 'ID',
+			'name'        => 'Name',
+			'branch'      => 'Branch',
+			'commit'      => 'Commit',
+			'jetpack'     => 'Jetpack',
+			'es_version'  => 'Elasticsearch',
+			'fedramp'     => 'FedRAMP',
+		];
+
+		foreach ( $app_fields as $key => $label ) {
+			if ( ! isset( $data->app[ $key ] ) ) {
+				continue;
+			}
+
+			$value = $data->app[ $key ];
+			$link  = '';
+
+			if ( 'commit' === $key ) {
+				$link = 'https://github.com/automattic/vip-go-mu-plugins/commit/' . $value;
+			} elseif ( 'fedramp' === $key ) {
+				$value = $value ? 'Yes' : 'No';
+			}
+
+			$this->output_table_row( $label, $value, $link );
 		}
-		if ( isset( $data->app['environment'] ) ) {
-			$this->output_table_row( 'Environment', $data->app['environment'] );
-		}
-		if ( isset( $data->app['alias'] ) ) {
-			$this->output_table_row( 'Alias', $data->app['alias'] );
-		}
-		if ( isset( $data->app['id'] ) ) {
-			$this->output_table_row( 'ID', $data->app['id'] );
-		}
-		if ( isset( $data->app['name'] ) ) {
-			$this->output_table_row( 'Name', $data->app['name'] );
-		}
-		if ( isset( $data->app['branch'] ) ) {
-			$this->output_table_row( 'Branch', $data->app['branch'] );
-		}
-		if ( isset( $data->app['commit'] ) ) {
-			$this->output_table_row( 'Commit', $data->app['commit'] );
-		}
-		if ( isset( $data->app['jetpack'] ) ) {
-			$this->output_table_row( 'Jetpack', $data->app['jetpack'] );
-		}
-		if ( isset( $data->app['es_version'] ) ) {
-			$this->output_table_row( 'Elasticsearch', $data->app['es_version'] );
-		}
-		if ( isset( $data->app['fedramp'] ) ) {
-			$this->output_table_row( 'FedRAMP', $data->app['fedramp'] ? 'Yes' : 'No' );
-		}
+
 		$this->output_after_section();
 
 		$this->after_non_tabular_output();

--- a/tests/lib/helpers/test-app.php
+++ b/tests/lib/helpers/test-app.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Automattic\VIP\Helpers;
+
+require_once __DIR__ . '/../../../lib/helpers/app.php';
+
+use Automattic\Test\Constant_Mocker;
+use PHPUnit\Framework\TestCase;
+
+class App_Test extends TestCase {
+	public function setUp(): void {
+		parent::setUp();
+		Constant_Mocker::clear();
+	}
+
+	public function tearDown(): void {
+		Constant_Mocker::clear();
+		parent::tearDown();
+	}
+
+	public function test__wpvip_get_app_name__not_defined() {
+		$actual_result = wpvip_get_app_name();
+
+		$this->assertSame( '', $actual_result );
+	}
+
+	public function test__wpvip_get_app_name__returns_value() {
+		Constant_Mocker::define( 'VIP_GO_APP_SLUG', 'example-app' );
+
+		$actual_result = wpvip_get_app_name();
+
+		$this->assertSame( 'example-app', $actual_result );
+	}
+
+	public function test__wpvip_get_app_environment__not_defined() {
+		$actual_result = wpvip_get_app_environment();
+
+		$this->assertSame( '', $actual_result );
+	}
+
+	public function test__wpvip_get_app_environment__returns_value() {
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'production' );
+
+		$actual_result = wpvip_get_app_environment();
+
+		$this->assertSame( 'production', $actual_result );
+	}
+
+	public function test__wpvip_get_app_alias__slug_not_defined() {
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'develop' );
+
+		$actual_result = wpvip_get_app_alias();
+
+		$this->assertSame( '', $actual_result );
+	}
+
+	public function test__wpvip_get_app_alias__environment_not_defined() {
+		Constant_Mocker::define( 'VIP_GO_APP_SLUG', 'example-app' );
+
+		$actual_result = wpvip_get_app_alias();
+
+		$this->assertSame( '', $actual_result );
+	}
+
+	public function test__wpvip_get_app_alias__both_not_defined() {
+		$actual_result = wpvip_get_app_alias();
+
+		$this->assertSame( '', $actual_result );
+	}
+
+	public function test__wpvip_get_app_alias__returns_value() {
+		Constant_Mocker::define( 'VIP_GO_APP_SLUG', 'example-app' );
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'develop' );
+
+		$actual_result = wpvip_get_app_alias();
+
+		$this->assertSame( 'example-app.develop', $actual_result );
+	}
+
+	public function test__wpvip_get_app_alias__production_environment() {
+		Constant_Mocker::define( 'VIP_GO_APP_SLUG', 'my-production-site' );
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'production' );
+
+		$actual_result = wpvip_get_app_alias();
+
+		$this->assertSame( 'my-production-site.production', $actual_result );
+	}
+}

--- a/tests/lib/utils/context.php
+++ b/tests/lib/utils/context.php
@@ -207,4 +207,32 @@ class Context_Test extends TestCase {
 
 		$this->assertTrue( $actual_result );
 	}
+
+	public function test__get_app_slug__not_defined() {
+		$actual_result = Context::get_app_slug();
+
+		$this->assertSame( '', $actual_result );
+	}
+
+	public function test__get_app_slug__returns_value() {
+		Constant_Mocker::define( 'VIP_GO_APP_SLUG', 'example-app' );
+
+		$actual_result = Context::get_app_slug();
+
+		$this->assertSame( 'example-app', $actual_result );
+	}
+
+	public function test__get_environment__not_defined() {
+		$actual_result = Context::get_environment();
+
+		$this->assertSame( '', $actual_result );
+	}
+
+	public function test__get_environment__returns_value() {
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'develop' );
+
+		$actual_result = Context::get_environment();
+
+		$this->assertSame( 'develop', $actual_result );
+	}
 }


### PR DESCRIPTION
## Description

This pull request introduces new helper functions for retrieving application context information (name, environment, and alias) and adds corresponding tests to ensure correct behavior. The changes also extend the `Context` utility class to provide static methods for fetching these values, and register the new helper file in the application bootstrap.

**New application context helpers:**

* Added `wpvip_get_app_name`, `wpvip_get_app_environment`, and `wpvip_get_app_alias` helper functions in `lib/helpers/app.php` to retrieve the application slug, environment, and alias, respectively. These functions use the new static methods in the `Context` class.
* Registered the new helper file in the list of required files in `000-pre-vip-config/requires.php`.

**Enhancements to context utilities:**

* Added `Context::get_app_slug()` and `Context::get_environment()` static methods to retrieve the application slug and environment from constants, returning empty strings if not defined.

**Test coverage:**

* Added comprehensive tests for the new helper functions in `tests/lib/helpers/test-app.php`, covering all combinations of defined and undefined constants.
* Added tests for the new `Context` methods in `tests/lib/utils/context.php`.


## Changelog Description

### Added
- Added `wpvip_get_app_name`, `wpvip_get_app_environment`, and `wpvip_get_app_alias` helper functions, which return the application name, app environment and full alias. E.g. `example`, `develop` and `example.develop` respectively

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

