### PR TITLE
[PLTFRM-1839] Search: Prevent parse_query hooks from corrupting CLI `wp vip-search health validate-counts`

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -176,8 +176,10 @@ class Health {
 				add_filter( 'ep_exclude_password_protected_from_search', '__return_false' );
 			}
 
-			// Avoid modifying query_vars to avoid breaking `wp vip-search health validate-counts` CLI.
+			// Ensure query_vars stay un-modified because some third-party plugins modify it 
+			// (e.g. orderby) and break `wp health validate-counts` CLI.
 			remove_all_actions( 'parse_query' );
+
 			$query = self::query_objects( $query_args, $indexable->slug );
 			if ( 'user' === $indexable->slug && isset( $query->query_vars['blog_id'] ) ) {
 				// Since the user indexable is global, we want to include ALL in count.

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -176,6 +176,10 @@ class Health {
 				add_filter( 'ep_exclude_password_protected_from_search', '__return_false' );
 			}
 
+			// Avoid modifying query_vars to avoid breaking `wp vip-search health validate-counts` CLI.
+			if ( 'user' !== $indexable->slug ) {
+				remove_all_actions( 'parse_query' );
+			}
 			$query = self::query_objects( $query_args, $indexable->slug );
 			if ( 'user' === $indexable->slug && isset( $query->query_vars['blog_id'] ) ) {
 				// Since the user indexable is global, we want to include ALL in count.

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -177,9 +177,7 @@ class Health {
 			}
 
 			// Avoid modifying query_vars to avoid breaking `wp vip-search health validate-counts` CLI.
-			if ( 'user' !== $indexable->slug ) {
-				remove_all_actions( 'parse_query' );
-			}
+			remove_all_actions( 'parse_query' );
 			$query = self::query_objects( $query_args, $indexable->slug );
 			if ( 'user' === $indexable->slug && isset( $query->query_vars['blog_id'] ) ) {
 				// Since the user indexable is global, we want to include ALL in count.


### PR DESCRIPTION
## Description
When running `wp vip-search health validate-counts`, some third-party plugins hook into `parse_query` and mutate
the `orderby` clause, adding unsupported keys. This breaks things in `get_index_entity_count_from_elastic_search()` when we call `query_objects()` which calls the action `parse_query` in `new WP_Query()`. We should disallow those potential `query_vars` modifications by temporarily unhooking `parse_query` actions since `get_index_entity_count_from_elastic_search` is only called in a CLI context from the `validate-counts` command.

## Changelog Description

### Fixed
-  Enterprise Search: prevent parse_query hooks from corrupting CLI `wp vip-search health validate-counts`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1) Add the below snippet to break things in `plugin-loader.php`:
```
add_action( 'parse_query', function ( WP_Query $q ) {
	$orderby = (array) $q->get( 'orderby' );

	// Inject an unsupported key.
	$orderby['blabla'] = 'ASC';

	$q->set( 'orderby', $orderby );
}, 50 );
```
2) Run `wp vip-search health validate-counts` and see:
```
Validating post count

Warning: Error while validating count: failure querying ES. #vip-search
Warning: Error while validating count: failure querying ES. #vip-search
```