### PR TITLE
[PLTFRM-1818] Search: Disable query logging in CLI context

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -479,6 +479,8 @@ class Search {
 			if ( ! defined( 'EP_QUERY_LOG' ) ) {
 				define( 'EP_QUERY_LOG', false );
 			}
+
+			add_filter( 'ep_disable_query_logging', '__return_true' );
 		}
 	}
 

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -476,10 +476,6 @@ class Search {
 				define( 'SAVEQUERIES', false );
 			}
 
-			if ( ! defined( 'EP_QUERY_LOG' ) ) {
-				define( 'EP_QUERY_LOG', false );
-			}
-
 			add_filter( 'ep_disable_query_logging', '__return_true' );
 		}
 	}


### PR DESCRIPTION
## Description
We already disable it in other aspects: https://github.com/Automattic/vip-go-mu-plugins/blob/e64d608b3cfe503e6081c775c9ef7a05471d6c95/search/includes/classes/class-search.php#L475-L481

Might as well disable it w/ the new filter introduced via https://github.com/10up/ElasticPress/pull/4019.

Edit: Looks like `EP_QUERY_LOG` was deprecated and this replaces it.

## Changelog Description

### Changed
- Search: Disable query logging during CLI contexts to prevent memory leaks


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->