### PR TITLE
feat(files): retry requests on cURL error 18

### DIFF
--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -100,7 +100,7 @@ class API_Client {
 				$this->log_request( $path, $method, $request_args );
 			}
 
-			if ( ! is_wp_error( $response ) || ! in_array( $method, [ 'GET', 'HEAD' ], true ) || false === strpos( $response->get_error_message(), 'cURL error 18' ) ) {
+			if ( ! is_wp_error( $response ) || ! in_array( $method, [ 'GET', 'HEAD' ], true ) || ! str_contains( $response->get_error_message(), 'cURL error 18' ) ) {
 				break;
 			}
 

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -105,8 +105,10 @@ class API_Client {
 			}
 
 			--$attempts;
-			usleep( $delay * 1000 );
-			$delay += 250;
+			if ( $attempts > 0 ) {
+				usleep( $delay * 1000 );
+				$delay += 250;
+			}
 		}
 
 		return $response;

--- a/files/class-api-client.php
+++ b/files/class-api-client.php
@@ -89,12 +89,24 @@ class API_Client {
 			'user-agent' => $this->user_agent,
 		] );
 
-		$response = wp_remote_request( $request_url, $request_args );
+		$attempts = 5;
+		$delay    = 250;
+		while ( $attempts > 0 ) {
+			$response = wp_remote_request( $request_url, $request_args );
 
-		// Debug log
-		if ( defined( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) &&
-			true === constant( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) ) {
-			$this->log_request( $path, $method, $request_args );
+			// Debug log
+			if ( defined( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) &&
+				true === constant( 'VIP_FILESYSTEM_STREAM_WRAPPER_DEBUG' ) ) {
+				$this->log_request( $path, $method, $request_args );
+			}
+
+			if ( ! is_wp_error( $response ) || ! in_array( $method, [ 'GET', 'HEAD' ], true ) || false === strpos( $response->get_error_message(), 'cURL error 18' ) ) {
+				break;
+			}
+
+			--$attempts;
+			usleep( $delay * 1000 );
+			$delay += 250;
 		}
 
 		return $response;


### PR DESCRIPTION
## Description

Wrap `wp_remote_request()` in a bounded retry loop for GET/HEAD when the HTTP API returns a cURL error 18 (partial file transfer).

## Changelog Description

### Changed
- VIP File Service: Wrap `wp_remote_request()` in a bounded retry loop for GET/HEAD when the HTTP API returns a cURL error 18 (partial file transfer).

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

