### PR TITLE
[PLTFRM-1860] Search: Use additional status WHERE clause in update_jobs() to prevent race condition

### DIFF
--- a/tests/search/includes/classes/test-class-queue.php
+++ b/tests/search/includes/classes/test-class-queue.php
@@ -357,6 +357,45 @@ class Queue_Test extends WP_UnitTestCase {
 		$this->assertEquals( '2040-01-01 00:00:00', $job2->start_time );
 	}
 
+	public function test_update_jobs_with_where_condition() {
+		$this->queue->queue_object( 1, 'post' );
+		$this->queue->queue_object( 2, 'post' );
+
+		$job1 = $this->queue->get_next_job_for_object( 1, 'post' );
+		$job2 = $this->queue->get_next_job_for_object( 2, 'post' );
+
+		// Set job1 to 'scheduled' status
+		$this->queue->update_job( $job1->job_id, array( 'status' => 'scheduled' ) );
+
+		// Try to update both jobs to 'running', but only if status is 'scheduled'
+		// job1 is 'scheduled', job2 is 'queued', so only job1 should be updated
+		$this->queue->update_jobs( array( $job1->job_id, $job2->job_id ), array( 'status' => 'running' ), 'scheduled' );
+
+		// Verify job1 was updated
+		$job1_updated = $this->queue->get_jobs_by_ids( array( $job1->job_id ) );
+		$this->assertEquals( 'running', $job1_updated[0]->status );
+
+		// Verify job2 was NOT updated (still 'queued')
+		$job2_updated = $this->queue->get_jobs_by_ids( array( $job2->job_id ) );
+		$this->assertEquals( 'queued', $job2_updated[0]->status );
+	}
+
+	public function test_checkout_jobs_same_time() {
+		$this->queue->queue_object( 1, 'post' );
+		$job = $this->queue->get_next_job_for_object( 1, 'post' );
+
+		// Simulate another process already checking out this job
+		$this->queue->update_job( $job->job_id, array( 'status' => 'scheduled' ) );
+
+		// Try to checkout the job (should fail because it's no longer 'queued')
+		$checked_out_jobs = $this->queue->checkout_jobs( 10 );
+
+		// The job should not be in the checked out jobs because it was already scheduled
+		$checked_out_job_ids = wp_list_pluck( $checked_out_jobs, 'job_id' );
+		$this->assertNotContains( $job->job_id, $checked_out_job_ids, 'Job that was already scheduled should not be checked out again' );
+	}
+
+
 	public function test_delete_jobs() {
 		$this->queue->queue_object( 1, 'post' );
 		$this->queue->queue_object( 2, 'post' );
@@ -470,6 +509,10 @@ class Queue_Test extends WP_UnitTestCase {
 		$job_count = $this->queue->count_jobs( 'all' );
 
 		$this->assertEquals( $job_count, count( $object_ids ), 'job count in database should match jobs added to queue' );
+
+		// Set jobs to 'scheduled' status before processing
+		$job_ids = wp_list_pluck( $jobs, 'job_id' );
+		$this->queue->update_jobs( $job_ids, array( 'status' => 'scheduled' ) );
 
 		$this->queue->process_jobs( $jobs );
 


### PR DESCRIPTION
## Description
This pull request enhances the job queue system by adding support for conditional updates on jobs, improving concurrency safety. The main change is that the `update_jobs` method now accepts additional WHERE conditions, allowing updates to be restricted based on job state (such as only updating jobs with a specific status). This helps prevent race conditions when multiple processes interact with the queue. 

## Changelog Description

### Changed
- Search: Fix race condition causing duplicate key errors in the search index queue by adding a status WHERE condition to prevent concurrent updates of the same job.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->