### PR TITLE
tests(e2e): update E2E tests to work in WP 6.9

### DIFF
--- a/__tests__/e2e/lib/global-setup.ts
+++ b/__tests__/e2e/lib/global-setup.ts
@@ -46,10 +46,8 @@ async function globalSetup( config: FullConfig ) {
 			process.env.E2E_CLASSIC_TESTS = 'false';
 		}
 
-		// Dismiss editor welcome
+		await EditorPage.automaticallyDismissAnnoyingNuisances( page );
 		await goToPage( page, baseURL! + '/wp-admin/post-new.php' );
-		const editorPage = new EditorPage( page );
-		await editorPage.dismissWelcomeTour();
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
 		console.log( error );

--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -62,25 +62,18 @@ export class EditorPage {
 		this.page = page;
 	}
 
-	/**
-	 * Dismisses the Welcome Tour (card) if it is present.
-	 */
-	public dismissWelcomeTour(): Promise<void> {
-		return this.clickButtonIfExists( this.page.locator( selectors.welcomeTourCloseButton ) );
-	}
-
-	public dismissPatternSelector(): Promise<void> {
-		return this.clickButtonIfExists( this.page.locator( selectors.choosePatternCloseButton ) );
-	}
-
-	private async clickButtonIfExists( locator: Locator ): Promise<void> {
-		try {
-			await locator.click( { timeout: 5000, trial: true } );
-		} catch {
-			return;
-		}
-
-		return locator.click( { delay: 20, timeout: 1000 } );
+	public static automaticallyDismissAnnoyingNuisances( page: Page ): Promise<unknown[]> {
+		const clickLocatorHandler = ( locator: Locator ): Promise<void> => locator.click();
+		return Promise.all( [
+			page.addLocatorHandler(
+				page.locator( selectors.welcomeTourCloseButton ),
+				clickLocatorHandler,
+			),
+			page.addLocatorHandler(
+				page.locator( selectors.choosePatternCloseButton ),
+				clickLocatorHandler,
+			),
+		] );
 	}
 
 	/**
@@ -89,9 +82,8 @@ export class EditorPage {
 	 * @param {string} title Page/Post Title
 	 */
 	public async enterTitle( title: string ): Promise<void> {
-		await this.dismissPatternSelector();
-		await this.page.click( selectors.editorTitleContainer );
-		await this.page.fill( selectors.editorTitle, title );
+		await this.page.locator( selectors.editorTitleContainer ).click();
+		await this.page.locator( selectors.editorTitle ).fill( title );
 	}
 
 	/**
@@ -99,23 +91,27 @@ export class EditorPage {
 	 *
 	 * @param {string} text Text to enter
 	 */
-	public async enterText( text: string ): Promise<void> {
+	public async enterText( text: string ): Promise<unknown> {
 		const lines = text.split( '\n' );
+		let locator: Locator;
 		if ( await this.page.isVisible( selectors.blockAppender ) ) {
-			await this.page.click( selectors.blockAppender );
+			locator = this.page.locator( selectors.blockAppender );
 		} else {
-			await this.page.click( selectors.paragraphBlocks );
+			locator = this.page.locator( selectors.paragraphBlocks ).last();
 		}
+
+		await locator.click();
 
 		// Playwright does not break up newlines in Gutenberg. This causes issues when we expect
 		// text to be broken into new lines/blocks. This presents an unexpected issue when entering
 		// text such as 'First sentence\nSecond sentence', as it is all put in one line.
 		// frame.type() will respect newlines like a human would, but it is slow.
 		// This approach will run faster than using frame.type() while respecting the newline chars.
-		await Promise.all(
+		return Promise.all(
 			lines.map( async ( line, index ) => {
-				await this.page.fill( `${ selectors.paragraphBlocks }:nth-of-type(${ index + 1 })`, line );
-				await this.page.keyboard.press( 'Enter' );
+				const lineLocator = this.page.locator( `${ selectors.paragraphBlocks }:nth-of-type(${ index + 1 })` );
+				await lineLocator.fill( line );
+				await lineLocator.press( 'Enter' );
 			} ),
 		);
 	}
@@ -124,11 +120,10 @@ export class EditorPage {
 	 * Clear Title of page or post
 	 */
 	public async clearTitle(): Promise<void> {
-		await this.page.click( selectors.editorTitle );
-		await this.page.keyboard.down( 'Shift' );
-		await this.page.keyboard.press( 'Home' );
-		await this.page.keyboard.up( 'Shift' );
-		await this.page.keyboard.press( 'Backspace' );
+		const locator = this.page.locator( selectors.editorTitle );
+		await locator.click();
+		await locator.selectText();
+		await locator.press( 'Backspace' );
 	}
 
 	/**
@@ -136,13 +131,11 @@ export class EditorPage {
 	 */
 	public async clearText(): Promise<void> {
 		/* eslint-disable no-await-in-loop */
-		while ( await this.page.isVisible( selectors.block ) ) {
-			await this.page.click( selectors.block );
-			await this.page.keyboard.down( 'Shift' );
-			await this.page.keyboard.press( 'Home' );
-			await this.page.keyboard.up( 'Shift' );
-			await this.page.keyboard.press( 'Backspace' );
-			await this.page.keyboard.press( 'Backspace' );
+		const locator = this.page.locator( selectors.block );
+		while ( await locator.isVisible() ) {
+			await locator.click();
+			await locator.selectText();
+			await locator.press( 'Backspace' );
 		}
 		/* eslint-enable no-await-in-loop */
 	}
@@ -153,7 +146,6 @@ export class EditorPage {
 	 * @param {string} fileName Name of image file to add
 	 */
 	public async addImage( fileName: string ): Promise<void> {
-		await this.dismissPatternSelector();
 		if ( await this.page.isVisible( selectors.blockAppender ) ) {
 			await this.page.click( selectors.blockAppender );
 		} else {
@@ -210,14 +202,11 @@ export class EditorPage {
 	 * @param {string} url Url to visit
 	 */
 	private async visitPublishedPost( url: string ): Promise<unknown> {
-		const prebublishChecksLocator = this.page.getByRole( 'checkbox', { name: 'Always show pre-publish checks.' } );
-		if ( await prebublishChecksLocator.count() > 0 ) {
-			await prebublishChecksLocator.uncheck();
-		}
-
+		const locator = this.page.locator( selectors.viewButton );
+		await locator.evaluate( ( el ) => el.removeAttribute( 'target' ) );
 		return Promise.all( [
 			this.page.waitForURL( url, { waitUntil: 'load' } ),
-			this.page.click( selectors.viewButton ),
+			locator.click(),
 		] );
 	}
 }

--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -209,7 +209,12 @@ export class EditorPage {
 	 *
 	 * @param {string} url Url to visit
 	 */
-	private visitPublishedPost( url: string ): Promise<unknown> {
+	private async visitPublishedPost( url: string ): Promise<unknown> {
+		const prebublishChecksLocator = this.page.getByRole( 'checkbox', { name: 'Always show pre-publish checks.' } );
+		if ( await prebublishChecksLocator.count() > 0 ) {
+			await prebublishChecksLocator.uncheck();
+		}
+
 		return Promise.all( [
 			this.page.waitForURL( url, { waitUntil: 'load' } ),
 			this.page.click( selectors.viewButton ),

--- a/__tests__/e2e/specs/page__edit.spec.ts
+++ b/__tests__/e2e/specs/page__edit.spec.ts
@@ -54,6 +54,8 @@ test( 'edit a Page', async ( { page } ) => {
 	let editorPage: EditorPage;
 	let pageListPage: PageListPage;
 
+	await test.step( 'Automatically dismiss annoying nuisances', () => EditorPage.automaticallyDismissAnnoyingNuisances( page ) );
+
 	await test.step( 'Go to Page List page', () => {
 		pageListPage = new PageListPage( page );
 		return pageListPage.visit();
@@ -70,12 +72,9 @@ test( 'edit a Page', async ( { page } ) => {
 			'– Thomas A. Edison';
 		editorPage = new EditorPage( page );
 
-		await editorPage.dismissWelcomeTour();
-
 		await editorPage.clearText();
 		await editorPage.clearTitle();
 
-		await editorPage.dismissWelcomeTour();
 		await editorPage.enterTitle( titleText );
 		await editorPage.enterText( bodyText );
 	} );

--- a/__tests__/e2e/specs/page__publish.spec.ts
+++ b/__tests__/e2e/specs/page__publish.spec.ts
@@ -26,6 +26,8 @@ test( 'publish a Page', async ( { page } ) => {
 		await expect( wpAdminPage.adminBar ).toBeVisible();
 	} );
 
+	await test.step( 'Automatically dismiss annoying nuisances', () => EditorPage.automaticallyDismissAnnoyingNuisances( page ) );
+
 	await test.step( 'Select add new Page', async () => {
 		const wpAdminSidebarComponent = new WPAdminSidebarComponent( page );
 		await wpAdminSidebarComponent.clickMenuItem( 'Pages' );
@@ -34,7 +36,6 @@ test( 'publish a Page', async ( { page } ) => {
 
 	await test.step( 'Write Page', async () => {
 		editorPage = new EditorPage( page );
-		await editorPage.dismissPatternSelector();
 		await editorPage.enterTitle( titleText );
 		await editorPage.enterText( bodyText );
 		await editorPage.addImage( 'test_media/image_01.jpg' );

--- a/__tests__/e2e/specs/post__edit.spec.ts
+++ b/__tests__/e2e/specs/post__edit.spec.ts
@@ -59,6 +59,8 @@ test( 'edit a Post', async ( { page } ) => {
 		return postListPage.visit();
 	} );
 
+	await test.step( 'Automatically dismiss annoying nuisances', () => EditorPage.automaticallyDismissAnnoyingNuisances( page ) );
+
 	await test.step( 'Select post to edit', () => {
 		return postListPage.editPostByID( postID );
 	} );

--- a/__tests__/e2e/specs/post__publish.spec.ts
+++ b/__tests__/e2e/specs/post__publish.spec.ts
@@ -26,6 +26,8 @@ test( 'publish a Post', async ( { page } ) => {
 		return expect( wpAdminPage.adminBar ).toBeVisible();
 	} );
 
+	await test.step( 'Automatically dismiss annoying nuisances', () => EditorPage.automaticallyDismissAnnoyingNuisances( page ) );
+
 	await test.step( 'Select add new post', async () => {
 		const wpAdminSidebarComponent = new WPAdminSidebarComponent( page );
 		await wpAdminSidebarComponent.clickMenuItem( 'Posts' );


### PR DESCRIPTION
## Description

This PR tries to fix E2E tests; WordPress 6.9 broke them.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

E2E tests must pass; feel free to run them manually.
