### PR TITLE
refactor(tests): implement Copilot's suggestions

### DIFF
--- a/__tests__/e2e/lib/pages/wp-editor-page.ts
+++ b/__tests__/e2e/lib/pages/wp-editor-page.ts
@@ -91,7 +91,7 @@ export class EditorPage {
 	 *
 	 * @param {string} text Text to enter
 	 */
-	public async enterText( text: string ): Promise<unknown> {
+	public async enterText( text: string ): Promise<void> {
 		const lines = text.split( '\n' );
 		let locator: Locator;
 		if ( await this.page.isVisible( selectors.blockAppender ) ) {
@@ -107,13 +107,15 @@ export class EditorPage {
 		// text such as 'First sentence\nSecond sentence', as it is all put in one line.
 		// frame.type() will respect newlines like a human would, but it is slow.
 		// This approach will run faster than using frame.type() while respecting the newline chars.
-		return Promise.all(
-			lines.map( async ( line, index ) => {
-				const lineLocator = this.page.locator( `${ selectors.paragraphBlocks }:nth-of-type(${ index + 1 })` );
-				await lineLocator.fill( line );
-				await lineLocator.press( 'Enter' );
-			} ),
-		);
+		/* eslint-disable no-await-in-loop */
+		for ( let idx = 0; idx < lines.length; ++idx ) {
+			// eslint-disable-next-line security/detect-object-injection
+			const line = lines[ idx ];
+			const lineLocator = this.page.locator( `${ selectors.paragraphBlocks }:nth-of-type(${ idx + 1 })` );
+			await lineLocator.fill( line );
+			await lineLocator.press( 'Enter' );
+		}
+		/* eslint-enable no-await-in-loop */
 	}
 
 	/**
@@ -135,7 +137,8 @@ export class EditorPage {
 		while ( await locator.isVisible() ) {
 			await locator.click();
 			await locator.selectText();
-			await locator.press( 'Backspace' );
+			await locator.press( 'Backspace' ); // Kill the text
+			await locator.press( 'Backspace' ); // Kill the block
 		}
 		/* eslint-enable no-await-in-loop */
 	}
@@ -201,11 +204,11 @@ export class EditorPage {
 	 *
 	 * @param {string} url Url to visit
 	 */
-	private async visitPublishedPost( url: string ): Promise<unknown> {
+	private async visitPublishedPost( url: string ): Promise<unknown[]> {
 		const locator = this.page.locator( selectors.viewButton );
 		await locator.evaluate( ( el ) => el.removeAttribute( 'target' ) );
 		return Promise.all( [
-			this.page.waitForURL( url, { waitUntil: 'load' } ),
+			this.page.waitForURL( url, { waitUntil: 'domcontentloaded' } ),
 			locator.click(),
 		] );
 	}


### PR DESCRIPTION
This pull request refactors several methods in the `EditorPage` class to improve reliability and efficiency in the end-to-end test suite. The main changes include updating asynchronous patterns, enhancing block deletion logic, and adjusting navigation behavior for published posts.

**Refactoring and reliability improvements:**

* Changed the `enterText` method to use a `for` loop with `await` instead of `Promise.all`, ensuring that each line is entered sequentially for more reliable text input in multi-line scenarios. The return type was also updated from `Promise<unknown>` to `Promise<void>`. [[1]](diffhunk://#diff-600204b96c384530bbcb0833be09a6e7c40ba25fce0ab4dc69669b034276898fL94-R94) [[2]](diffhunk://#diff-600204b96c384530bbcb0833be09a6e7c40ba25fce0ab4dc69669b034276898fL110-R118)
* Improved the block deletion logic in the method that clears text: now, after deleting the text, an additional `Backspace` is sent to remove the block itself, making the cleanup more robust.

**Navigation and type safety:**

* Updated the `visitPublishedPost` method to return `Promise<unknown[]>` instead of `Promise<unknown>`, and changed the page navigation to wait for `'domcontentloaded'` instead of `'load'` for faster and more reliable test execution.