### PR TITLE
Switch the RDB, RTC, Block Data API and Governance plugins to use the latest versions

### DIFF
--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -56,7 +56,7 @@ class BlockDataApiIntegration extends Integration {
 			if ( file_exists( $load_path ) ) {
 				require_once $load_path;
 			} else {
-				$this->is_active = false;   
+				$this->is_active = false;
 			}
 		} );
 	}

--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -38,19 +38,16 @@ class BlockDataApiIntegration extends Integration {
 				return;
 			}
 
-			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/vip-block-data-api-<version>/
-			// and check what versions are available.
-			$versions = $this->get_versions();
+			// Load the latest version of the plugin.
+			$latest_directory = $this->get_latest_version();
 
-			// if no versions are found, return early.
-			if ( empty( $versions ) ) {
+			if ( empty( $latest_directory ) ) {
 				$this->is_active = false;
 				return;
 			}
 
-			// Load the latest version of the plugin.
-			$latest_directory = array_key_first( $versions );
-			$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-block-data-api.php';
+			// Load the plugin.
+			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-block-data-api.php';
 
 			// This check isn't strictly necessary, but better safe than sorry.
 			if ( file_exists( $load_path ) ) {
@@ -62,13 +59,11 @@ class BlockDataApiIntegration extends Integration {
 	}
 
 	/**
-	 * Get the available versions of Block Data API in descending order.
+	 * Get the latest version of Block Data API.
 	 *
-	 * @return array<string, string> An associative array of available versions, where the key is the
-	 *                               directory name and the value is the version number. The versions
-	 *                               are sorted in descending order.
+	 * @return string|null The latest version of Block Data API or null if no versions are found.
 	 */
-	public function get_versions() {
-		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-block-data-api', 'vip-block-data-api.php' );
+	public function get_latest_version() {
+		return get_latest_version( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-block-data-api', 'vip-block-data-api.php' );
 	}
 }

--- a/integrations/block-data-api.php
+++ b/integrations/block-data-api.php
@@ -15,14 +15,6 @@ namespace Automattic\VIP\Integrations;
 class BlockDataApiIntegration extends Integration {
 
 	/**
-	 * The version of the Block Data API plugin to load, that's set to the latest version.
-	 * This should be higher than the lowestVersion set in "vip-block-data-api" config (https://github.com/Automattic/vip-go-mu-plugins-ext/blob/trunk/config.json)
-	 *
-	 * @var string
-	 */
-	protected string $version = '1.4';
-
-	/**
 	 * Returns `true` if `Block Data API` is already available e.g. via customer code. We will use
 	 * this function to prevent activating of integration from platform side.
 	 */
@@ -46,13 +38,37 @@ class BlockDataApiIntegration extends Integration {
 				return;
 			}
 
-			// Load the version of the plugin that should be set to the latest version, otherwise if it's not found deactivate the integration.
-			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/vip-block-data-api-' . $this->version . '/vip-block-data-api.php';
+			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/vip-block-data-api-<version>/
+			// and check what versions are available.
+			$versions = $this->get_versions();
+
+			// if no versions are found, return early.
+			if ( empty( $versions ) ) {
+				$this->is_active = false;
+				return;
+			}
+
+			// Load the latest version of the plugin.
+			$latest_directory = array_key_first( $versions );
+			$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-block-data-api.php';
+
+			// This check isn't strictly necessary, but better safe than sorry.
 			if ( file_exists( $load_path ) ) {
 				require_once $load_path;
 			} else {
-				$this->is_active = false;
+				$this->is_active = false;   
 			}
 		} );
+	}
+
+	/**
+	 * Get the available versions of Block Data API in descending order.
+	 *
+	 * @return array<string, string> An associative array of available versions, where the key is the
+	 *                               directory name and the value is the version number. The versions
+	 *                               are sorted in descending order.
+	 */
+	public function get_versions() {
+		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-block-data-api', 'vip-block-data-api.php' );
 	}
 }

--- a/integrations/integration-utils.php
+++ b/integrations/integration-utils.php
@@ -39,3 +39,24 @@ function get_available_versions( string $dir, string $folder_prefix, string $ent
 
 	return $versions;
 }
+
+/**
+ * Get the latest version of the integration.
+ *
+ * @param string $dir The directory to scan for versions.
+ * @param string $folder_prefix The prefix of the folder name.
+ * @param string $entry_file The entry file of the integration.
+ * @return string|null The latest version of the integration or null if no versions are found.
+ */
+function get_latest_version( string $dir, string $folder_prefix, string $entry_file ): string|null {
+	// Get all the available versions in the directory, sorted in descending order.
+	$versions = get_available_versions( $dir, $folder_prefix, $entry_file );
+
+	// If no versions are found, return null.
+	if ( empty( $versions ) ) {
+		return null;
+	}
+
+	// Return the latest version.
+	return array_key_first( $versions );
+}

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -54,12 +54,13 @@ class RealTimeCollaborationIntegration extends Integration {
 	}
 
 	private function get_plugin_path(): string|false {
-		$versions = $this->get_versions();
-		if ( empty( $versions ) ) {
+		$latest_directory = $this->get_latest_version();
+		if ( empty( $latest_directory ) ) {
 			return false;
 		}
-		$latest_directory = array_key_first( $versions );
-		$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-real-time-collaboration.php';
+		// Load the plugin.
+		$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-real-time-collaboration.php';
+		// This check isn't strictly necessary, but better safe than sorry.
 		if ( ! file_exists( $load_path ) ) {
 			return false;
 		}
@@ -111,18 +112,12 @@ class RealTimeCollaborationIntegration extends Integration {
 	}
 
 	/**
-	 * Get the available versions of Real-Time Collaboration in descending order.
+	 * Get the latest version of Real-Time Collaboration.
 	 *
-	 * @return array<string, string> An associative array of available versions, where the key is the
-	 *                               directory name and the value is the version number. The versions
-	 *                               are sorted in descending order.
+	 * @return string|null The latest version of Real-Time Collaboration or null if no versions are found.
 	 */
-	public function get_versions() {
-		return get_available_versions(
-			WPVIP_MU_PLUGIN_DIR . '/vip-integrations/',
-			'vip-real-time-collaboration',
-			'vip-real-time-collaboration.php'
-		);
+	public function get_latest_version() {
+		return get_latest_version( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-real-time-collaboration', 'vip-real-time-collaboration.php' );
 	}
 
 	/**

--- a/integrations/remote-data-blocks.php
+++ b/integrations/remote-data-blocks.php
@@ -73,19 +73,16 @@ class RemoteDataBlocksIntegration extends Integration {
 				return;
 			}
 
-			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/remote-data-blocks-<version>/
-			// and check what versions are available.
-			$versions = $this->get_versions();
+			// Load the latest version of the plugin.
+			$latest_directory = $this->get_latest_version();
 
-			// if no versions are found, return early.
-			if ( empty( $versions ) ) {
+			if ( empty( $latest_directory ) ) {
 				$this->is_active = false;
 				return;
 			}
 
-			// Load the latest version of the plugin.
-			$latest_directory = array_key_first( $versions );
-			$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/remote-data-blocks.php';
+			// Load the plugin.
+			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/remote-data-blocks.php';
 
 			// This check isn't strictly necessary, but better safe than sorry.
 			if ( file_exists( $load_path ) ) {
@@ -97,14 +94,12 @@ class RemoteDataBlocksIntegration extends Integration {
 	}
 
 	/**
-	 * Get the available versions of Remote Data Blocks in descending order.
+	 * Get the latest version of Remote Data Blocks.
 	 *
-	 * @return array<string, string> An associative array of available versions, where the key is the
-	 *                               directory name and the value is the version number. The versions
-	 *                               are sorted in descending order.
+	 * @return string|null The latest version of Remote Data Blocks or null if no versions are found.
 	 */
-	public function get_versions() {
-		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'remote-data-blocks', 'remote-data-blocks.php' );
+	public function get_latest_version() {
+		return get_latest_version( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'remote-data-blocks', 'remote-data-blocks.php' );
 	}
 
 	/**

--- a/integrations/vip-governance.php
+++ b/integrations/vip-governance.php
@@ -38,19 +38,16 @@ class VipGovernanceIntegration extends Integration {
 				return;
 			}
 
-			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/vip-governance-<version>/
-			// and check what versions are available.
-			$versions = $this->get_versions();
+			// Load the latest version of the plugin.
+			$latest_directory = $this->get_latest_version();
 
-			// if no versions are found, return early.
-			if ( empty( $versions ) ) {
+			if ( empty( $latest_directory ) ) {
 				$this->is_active = false;
 				return;
 			}
 
-			// Load the latest version of the plugin.
-			$latest_directory = array_key_first( $versions );
-			$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-governance.php';
+			// Load the plugin.
+			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-governance.php';
 
 			// This check isn't strictly necessary, but better safe than sorry.
 			if ( file_exists( $load_path ) ) {
@@ -62,13 +59,11 @@ class VipGovernanceIntegration extends Integration {
 	}
 
 	/**
-	 * Get the available versions of VIP Governance in descending order.
+	 * Get the latest version of VIP Governance.
 	 *
-	 * @return array<string, string> An associative array of available versions, where the key is the
-	 *                               directory name and the value is the version number. The versions
-	 *                               are sorted in descending order.
+	 * @return string|null The latest version of VIP Governance or null if no versions are found.
 	 */
-	public function get_versions() {
-		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-governance', 'vip-governance.php' );
+	public function get_latest_version() {
+		return get_latest_version( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-governance', 'vip-governance.php' );
 	}
 }

--- a/integrations/vip-governance.php
+++ b/integrations/vip-governance.php
@@ -15,14 +15,6 @@ namespace Automattic\VIP\Integrations;
 class VipGovernanceIntegration extends Integration {
 
 	/**
-	 * The version of the VIP Governance plugin to load, that's set to the latest version.
-	 * This should be higher than the lowestVersion set in "vip-governance" config (https://github.com/Automattic/vip-go-mu-plugins-ext/blob/trunk/config.json)
-	 *
-	 * @var string
-	 */
-	protected string $version = '1.0';
-
-	/**
 	 * Returns `true` if `VIP Governance` is already available e.g. via customer code. We will use
 	 * this function to prevent activating of integration from platform side.
 	 */
@@ -46,13 +38,37 @@ class VipGovernanceIntegration extends Integration {
 				return;
 			}
 
-			// Load the version of the plugin that should be set to the latest version, otherwise if it's not found deactivate the integration.
-			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/vip-governance-' . $this->version . '/vip-governance.php';
+			// Get all the entries in the path of WPVIP_MU_PLUGIN_DIR/vip-integrations/vip-governance-<version>/
+			// and check what versions are available.
+			$versions = $this->get_versions();
+
+			// if no versions are found, return early.
+			if ( empty( $versions ) ) {
+				$this->is_active = false;
+				return;
+			}
+
+			// Load the latest version of the plugin.
+			$latest_directory = array_key_first( $versions );
+			$load_path        = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-governance.php';
+
+			// This check isn't strictly necessary, but better safe than sorry.
 			if ( file_exists( $load_path ) ) {
 				require_once $load_path;
 			} else {
 				$this->is_active = false;
 			}
 		} );
+	}
+
+	/**
+	 * Get the available versions of VIP Governance in descending order.
+	 *
+	 * @return array<string, string> An associative array of available versions, where the key is the
+	 *                               directory name and the value is the version number. The versions
+	 *                               are sorted in descending order.
+	 */
+	public function get_versions() {
+		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-governance', 'vip-governance.php' );
 	}
 }

--- a/tests/integrations/test-integration-utils.php
+++ b/tests/integrations/test-integration-utils.php
@@ -156,4 +156,28 @@ class VIP_Integration_Utils_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $versions );
 		$this->assertEmpty( $versions );
 	}
+
+	/**
+	 * Test that get_latest_version returns the latest version.
+	 */
+	public function test_get_latest_version_returns_latest_version(): void {
+		global $mock_filesystem_state;
+		$mock_filesystem_state = 'full';
+
+		$latest_version = get_latest_version( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'fake', 'fake.php' );
+
+		$this->assertEquals( '2.5', $latest_version );
+	}
+
+	/**
+	 * Test that get_latest_version returns null when no versions are found.
+	 */
+	public function test_get_latest_version_returns_null_when_no_versions_are_found(): void {
+		global $mock_filesystem_state;
+		$mock_filesystem_state = 'empty';
+
+		$latest_version = get_latest_version( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'fake', 'fake.php' );
+
+		$this->assertNull( $latest_version );
+	}
 }

--- a/tests/integrations/test-integration-utils.php
+++ b/tests/integrations/test-integration-utils.php
@@ -166,7 +166,7 @@ class VIP_Integration_Utils_Test extends WP_UnitTestCase {
 
 		$latest_version = get_latest_version( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'fake', 'fake.php' );
 
-		$this->assertEquals( '2.5', $latest_version );
+		$this->assertEquals( 'fake-2.5', $latest_version );
 	}
 
 	/**

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -150,11 +150,11 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( defined( 'VIP_RTC_WS_URL' ) );
 	}
 
-	public function test_get_latest_version_returns_latest_version(): void {
+	public function test_get_latest_version_returns_null_when_no_versions_are_found(): void {
 		$rtc_integration = new RealTimeCollaborationIntegration( $this->slug );
 		$latest_version  = $rtc_integration->get_latest_version();
 
-		$this->assertIsString( $latest_version );
+		$this->assertNull( $latest_version );
 	}
 
 	public function test_load_sets_inactive_when_ws_auth_secret_missing(): void {

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -150,11 +150,11 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( defined( 'VIP_RTC_WS_URL' ) );
 	}
 
-	public function test_get_versions_returns_array(): void {
+	public function test_get_latest_version_returns_latest_version(): void {
 		$rtc_integration = new RealTimeCollaborationIntegration( $this->slug );
-		$versions        = $rtc_integration->get_versions();
+		$latest_version  = $rtc_integration->get_latest_version();
 
-		$this->assertIsArray( $versions );
+		$this->assertIsString( $latest_version );
 	}
 
 	public function test_load_sets_inactive_when_ws_auth_secret_missing(): void {

--- a/tests/integrations/test-remote-data-blocks.php
+++ b/tests/integrations/test-remote-data-blocks.php
@@ -197,14 +197,14 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		/** @var MockObject|RemoteDataBlocksIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded', 'is_supported_wp_version', 'get_versions' ] )
+			->onlyMethods( [ 'is_loaded', 'is_supported_wp_version', 'get_latest_version' ] )
 			->getMock();
 
 		$integration_mock->activate(); // Set is_active to true before testing load()
 
 		$integration_mock->method( 'is_loaded' )->willReturn( false );
 		$integration_mock->method( 'is_supported_wp_version' )->willReturn( false );
-		$integration_mock->expects( $this->never() )->method( 'get_versions' );
+		$integration_mock->expects( $this->never() )->method( 'get_latest_version' );
 
 		$integration_mock->load();
 		do_action( 'plugins_loaded' );
@@ -216,7 +216,7 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 		/** @var MockObject|RemoteDataBlocksIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RemoteDataBlocksIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded', 'is_supported_wp_version', 'get_versions' ] )
+			->onlyMethods( [ 'is_loaded', 'is_supported_wp_version', 'get_latest_version' ] )
 			->getMock();
 
 		$integration_mock->activate(); // Initial state is active
@@ -224,7 +224,7 @@ class Remote_Data_Blocks_Integration_Test extends WP_UnitTestCase {
 
 		$integration_mock->method( 'is_loaded' )->willReturn( false );
 		$integration_mock->method( 'is_supported_wp_version' )->willReturn( true );
-		$integration_mock->method( 'get_versions' )->willReturn( [] ); // No versions found
+		$integration_mock->method( 'get_latest_version' )->willReturn( null ); // No versions found
 
 		$integration_mock->load();
 		do_action( 'plugins_loaded' );

--- a/tests/integrations/test-vip-block-data-api.php
+++ b/tests/integrations/test-vip-block-data-api.php
@@ -33,14 +33,14 @@ class Block_Data_API_Integration_Test extends WP_UnitTestCase {
 		/** @var MockObject|BlockDataApiIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( BlockDataApiIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->onlyMethods( [ 'is_loaded', 'get_latest_version' ] )
 			->getMock();
 
 		$integration_mock->activate(); // Initial state is active
 		$this->assertTrue( $integration_mock->is_active(), 'Initial: Integration should be active.' );
 
 		$integration_mock->method( 'is_loaded' )->willReturn( false );
-		$integration_mock->method( 'get_versions' )->willReturn( [] );
+		$integration_mock->method( 'get_latest_version' )->willReturn( null );
 
 		$integration_mock->load();
 

--- a/tests/integrations/test-vip-block-data-api.php
+++ b/tests/integrations/test-vip-block-data-api.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\VIP\Integrations;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
@@ -26,5 +27,26 @@ class Block_Data_API_Integration_Test extends WP_UnitTestCase {
 		$block_data_api_integration = new BlockDataApiIntegration( $this->slug );
 
 		$this->assertFalse( $block_data_api_integration->is_loaded() );
+	}
+
+	public function test_load_sets_inactive_if_no_versions_found(): void {
+		/** @var MockObject|BlockDataApiIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( BlockDataApiIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->activate(); // Initial state is active
+		$this->assertTrue( $integration_mock->is_active(), 'Initial: Integration should be active.' );
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		$integration_mock->method( 'get_versions' )->willReturn( [] );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
 	}
 }

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\VIP\Integrations;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
@@ -26,5 +27,26 @@ class VIP_Governance_Integration_Test extends WP_UnitTestCase {
 		$vip_governance_integration = new VipGovernanceIntegration( $this->slug );
 
 		$this->assertFalse( $vip_governance_integration->is_loaded() );
+	}
+
+	public function test_load_sets_inactive_if_no_versions_found(): void {
+		/** @var MockObject|VipGovernanceIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( VipGovernanceIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->activate(); // Initial state is active
+		$this->assertTrue( $integration_mock->is_active(), 'Initial: Integration should be active.' );
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		$integration_mock->method( 'get_versions' )->willReturn( [] );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
 	}
 }

--- a/tests/integrations/test-vip-governance.php
+++ b/tests/integrations/test-vip-governance.php
@@ -33,14 +33,14 @@ class VIP_Governance_Integration_Test extends WP_UnitTestCase {
 		/** @var MockObject|VipGovernanceIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( VipGovernanceIntegration::class )
 			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->onlyMethods( [ 'is_loaded', 'get_latest_version' ] )
 			->getMock();
 
 		$integration_mock->activate(); // Initial state is active
 		$this->assertTrue( $integration_mock->is_active(), 'Initial: Integration should be active.' );
 
 		$integration_mock->method( 'is_loaded' )->willReturn( false );
-		$integration_mock->method( 'get_versions' )->willReturn( [] );
+		$integration_mock->method( 'get_latest_version' )->willReturn( null );
 
 		$integration_mock->load();
 


### PR DESCRIPTION
## Description

Just like https://github.com/Automattic/vip-go-mu-plugins/pull/6246, this'll allow the VIP Block Data API and the VIP Governance plugins to use the latest available integration rather than hardcoding the version to use. This'd mean one less place to update should the major/minor version of the plugin change, rather than the patch version.

## Changelog Description

### Changed

- Dynamically load the latest version of the VIP Block Data API and VIP Governance plugins

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out the PR
2. Create a dev-env with this PR, as well as with latest mu-plugins-ext
3. Activate block data api and vip governance plugins
4. Ensure the latest version of the plugins are loaded