### PR TITLE
Fix `wp vip-search get-indexes --active=true`

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -113,7 +113,7 @@ class CoreCommand {
 		$blog_ids   = ( is_multisite() ) ? get_sites(
 			[
 				'fields' => 'ids',
-				'number' => PHP_INT_MAX,
+				'number' => 20000,
 			]
 		) : [ get_current_blog_id() ];
 		foreach ( $indexables as $indexable ) {

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -110,7 +110,12 @@ class CoreCommand {
 		$indexes    = [];
 		$search     = \Automattic\VIP\Search\Search::instance();
 		$indexables = $search->indexables->get_all();
-		$blog_ids   = ( is_multisite() ) ? get_sites( [ 'fields' => 'ids' ] ) : [ get_current_blog_id() ];
+		$blog_ids   = ( is_multisite() ) ? get_sites(
+			[
+				'fields' => 'ids',
+				'number' => PHP_INT_MAX,
+			]
+		) : [ get_current_blog_id() ];
 		foreach ( $indexables as $indexable ) {
 			if ( $indexable->global ) {
 				$active_version = $search->versioning->get_active_version_number( $indexable );


### PR DESCRIPTION
## Description
<!--
A few sentences providing more context and describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant publicly available sources (e.g. GitHub issues)
-->

## Changelog Description

### Fixed
- Fixes `active` parameter in `vip-search get-indexes` command to have a high limit instead of default `100`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->