### PR TITLE
Search: Disallow ngram filter in mapping

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -605,6 +605,9 @@ class Search {
 		add_filter( 'ep_term_mapping', array( $this, 'filter__ep_indexable_mapping' ) );
 		add_filter( 'ep_user_mapping', array( $this, 'filter__ep_indexable_mapping' ) );
 
+		// Strip ngram filters from config mapping
+		add_filter( 'ep_config_mapping', array( $this, 'filter__ep_config_mapping' ), PHP_INT_MAX );
+
 		// Better shard counts
 		add_filter( 'ep_default_index_number_of_shards', array( $this, 'filter__ep_default_index_number_of_shards' ) );
 		if ( defined( 'VIP_GO_ENV' ) && 'production' === constant( 'VIP_GO_ENV' ) ) {
@@ -1754,6 +1757,12 @@ class Search {
 		$mapping['settings']['index.indexing.slowlog.threshold.index.warn'] = '4900ms';
 		$mapping['settings']['index.indexing.slowlog.source']               = '1000';
 
+		// Strip ngram filters from analysis settings
+		$mapping = $this->strip_ngram_filters( $mapping );
+
+		// Strip ngram field from post_content
+		$mapping = $this->strip_ngram_post_fields( $mapping );
+
 		return $mapping;
 	}
 
@@ -2116,6 +2125,8 @@ class Search {
 			$this->alerts->send_to_chat( self::SEARCH_ALERT_SLACK_CHAT, $message, self::SEARCH_ALERT_LEVEL );
 		}
 
+		$mapping = $this->strip_ngram_filters( $mapping );
+
 		return $mapping;
 	}
 
@@ -2129,6 +2140,135 @@ class Search {
 		}
 
 		return $dc;
+	}
+
+	/**
+	 * Filter for ep_config_mapping to strip ngram filters
+	 *
+	 * @param array $mapping The mapping array to process
+	 * @param string $index The index name
+	 * 
+	 * @return array The mapping with ngram filters removed
+	 */
+	public function filter__ep_config_mapping( $mapping ) {
+		return $this->strip_ngram_filters( $mapping );
+	}
+	
+	/**
+	 * Strip ngram filters, tokenizers, analyzers, and settings from Elasticsearch mapping
+	 *
+	 * @param array $mapping The mapping array to process
+	 * 
+	 * @return array The mapping with ngram-related items removed
+	 */
+	private function strip_ngram_filters( $mapping ) {
+		if ( ! is_array( $mapping ) || ! isset( $mapping['settings']['analysis'] ) ) {
+			return $mapping;
+		}
+
+		$analysis                  =& $mapping['settings']['analysis'];
+		$filter_names_to_remove    = [];
+		$tokenizer_names_to_remove = [];
+
+		if ( isset( $analysis['filter'] ) && is_array( $analysis['filter'] ) ) {
+			foreach ( $analysis['filter'] as $name => $config ) {
+				if ( ! is_array( $config ) ) {
+					continue;
+				}
+
+				if ( isset( $config['type'] ) && 'ngram' === $config['type'] ) {
+					$filter_names_to_remove[] = $name;
+					unset( $analysis['filter'][ $name ] );
+				}
+			}
+		}
+
+		if ( isset( $analysis['tokenizer'] ) && is_array( $analysis['tokenizer'] ) ) {
+			foreach ( $analysis['tokenizer'] as $name => $config ) {
+				if ( ! is_array( $config ) ) {
+					continue;
+				}
+
+				if ( isset( $config['type'] ) && 'ngram' === $config['type'] ) {
+					$tokenizer_names_to_remove[] = $name;
+					unset( $analysis['tokenizer'][ $name ] );
+				}
+			}
+		}
+
+		if ( empty( $filter_names_to_remove ) && empty( $tokenizer_names_to_remove ) ) {
+			return $mapping;
+		}
+
+		if ( ! empty( $filter_names_to_remove ) || ! empty( $tokenizer_names_to_remove ) ) {
+			$blocked_items = array();
+			if ( ! empty( $filter_names_to_remove ) ) {
+				$blocked_items[] = 'filters: ' . implode( ', ', $filter_names_to_remove );
+			}
+			if ( ! empty( $tokenizer_names_to_remove ) ) {
+				$blocked_items[] = 'tokenizers: ' . implode( ', ', $tokenizer_names_to_remove );
+			}
+
+			$message = sprintf(
+				'Application %d - %s blocked ngram analysis from ES mapping (%s)',
+				FILES_CLIENT_SITE_ID,
+				home_url(),
+				implode( '; ', $blocked_items )
+			);
+
+			if ( ! is_wp_error( $this->alerts ) ) {
+				$this->alerts->send_to_chat( self::SEARCH_ALERT_SLACK_CHAT, $message, self::SEARCH_ALERT_LEVEL );
+			}
+		}
+
+		if ( isset( $analysis['analyzer'] ) && is_array( $analysis['analyzer'] ) ) {
+			foreach ( $analysis['analyzer'] as $name => $config ) {
+				if ( ! is_array( $config ) ) {
+					continue;
+				}
+
+				$should_remove = false;
+				$filters       = $config['filter'] ?? [];
+				foreach ( $filter_names_to_remove as $removed ) {
+					if ( in_array( $removed, $filters, true ) ) {
+						$should_remove = true;
+						break;
+					}
+				}
+
+				if ( ! $should_remove ) {
+					$tokenizer = $config['tokenizer'] ?? null;
+					if ( is_string( $tokenizer ) && in_array( $tokenizer, $tokenizer_names_to_remove, true ) ) {
+						$should_remove = true;
+					}
+				}
+
+				if ( $should_remove ) {
+					unset( $analysis['analyzer'][ $name ] );
+				}
+			}
+		}
+
+		return $mapping;
+	}
+
+	/**
+	 * Strip ngram field from post_content in post mappings
+	 *
+	 * @param array $mapping The mapping array to process
+	 * 
+	 * @return array The mapping with ngram fields removed
+	 */
+	private function strip_ngram_post_fields( $mapping ) {
+		if ( ! is_array( $mapping ) || ! isset( $mapping['mappings']['properties']['post_content']['fields'] ) ) {
+			return $mapping;
+		}
+
+		if ( isset( $mapping['mappings']['properties']['post_content']['fields']['ngram'] ) ) {
+			unset( $mapping['mappings']['properties']['post_content']['fields']['ngram'] );
+		}
+
+		return $mapping;
 	}
 
 	/**

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -2146,7 +2146,6 @@ class Search {
 	 * Filter for ep_config_mapping to strip ngram filters
 	 *
 	 * @param array $mapping The mapping array to process
-	 * @param string $index The index name
 	 * 
 	 * @return array The mapping with ngram filters removed
 	 */
@@ -2200,26 +2199,7 @@ class Search {
 			return $mapping;
 		}
 
-		if ( ! empty( $filter_names_to_remove ) || ! empty( $tokenizer_names_to_remove ) ) {
-			$blocked_items = array();
-			if ( ! empty( $filter_names_to_remove ) ) {
-				$blocked_items[] = 'filters: ' . implode( ', ', $filter_names_to_remove );
-			}
-			if ( ! empty( $tokenizer_names_to_remove ) ) {
-				$blocked_items[] = 'tokenizers: ' . implode( ', ', $tokenizer_names_to_remove );
-			}
-
-			$message = sprintf(
-				'Application %d - %s blocked ngram analysis from ES mapping (%s)',
-				FILES_CLIENT_SITE_ID,
-				home_url(),
-				implode( '; ', $blocked_items )
-			);
-
-			if ( ! is_wp_error( $this->alerts ) ) {
-				$this->alerts->send_to_chat( self::SEARCH_ALERT_SLACK_CHAT, $message, self::SEARCH_ALERT_LEVEL );
-			}
-		}
+		$this->send_ngram_blocking_alert( $filter_names_to_remove, $tokenizer_names_to_remove );
 
 		if ( isset( $analysis['analyzer'] ) && is_array( $analysis['analyzer'] ) ) {
 			foreach ( $analysis['analyzer'] as $name => $config ) {
@@ -2253,6 +2233,32 @@ class Search {
 	}
 
 	/**
+	 * Send an alert when ngram filters or tokenizers are blocked from ES mapping
+	 *
+	 * @param array $filter_names_to_remove Array of filter names that were blocked
+	 * @param array $tokenizer_names_to_remove Array of tokenizer names that were blocked
+	 */
+	private function send_ngram_blocking_alert( array $filter_names_to_remove, array $tokenizer_names_to_remove ) {
+		$blocked_items = [];
+		if ( ! empty( $filter_names_to_remove ) ) {
+			$blocked_items[] = 'filters: ' . implode( ', ', $filter_names_to_remove );
+		}
+		if ( ! empty( $tokenizer_names_to_remove ) ) {
+			$blocked_items[] = 'tokenizers: ' . implode( ', ', $tokenizer_names_to_remove );
+		}
+		$message = sprintf(
+			'Application %d - %s blocked ngram analysis from ES mapping (%s)',
+			FILES_CLIENT_SITE_ID,
+			home_url(),
+			implode( '; ', $blocked_items )
+		);
+
+		if ( ! is_wp_error( $this->alerts ) ) {
+			$this->alerts->send_to_chat( self::SEARCH_ALERT_SLACK_CHAT, $message, self::SEARCH_ALERT_LEVEL );
+		}
+	}
+
+	/**
 	 * Strip ngram field from post_content in post mappings
 	 *
 	 * @param array $mapping The mapping array to process
@@ -2264,8 +2270,15 @@ class Search {
 			return $mapping;
 		}
 
-		if ( isset( $mapping['mappings']['properties']['post_content']['fields']['ngram'] ) ) {
-			unset( $mapping['mappings']['properties']['post_content']['fields']['ngram'] );
+		$fields =& $mapping['mappings']['properties']['post_content']['fields'];
+
+		if ( isset( $fields['ngram'] ) ) {
+			unset( $fields['ngram'] );
+		}
+
+		// To ensure mapping is valid, remove unnecessary key if no fields are left
+		if ( empty( $fields ) ) {
+			unset( $fields );
 		}
 
 		return $mapping;

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2611,6 +2611,284 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertEquals( '1', get_option( 'vip_custom_results_existence' ) );
 	}
 
+	public function test__filter__ep_config_mapping_strips_ngram_filter() {
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(
+				'analysis' => array(
+					'filter' => array(
+						'ep_ngram_filter' => array(
+							'type'     => 'ngram',
+							'min_gram' => 3,
+							'max_gram' => 15,
+						),
+						'edge_ngram'      => array(
+							'type'     => 'edge_ngram',
+							'min_gram' => 3,
+							'max_gram' => 10,
+						),
+					),
+				),
+			),
+		);
+
+		$filtered = apply_filters( 'ep_config_mapping', $mapping, 'test-index' );
+
+		$this->assertArrayNotHasKey( 'ep_ngram_filter', $filtered['settings']['analysis']['filter'], 'ep_ngram_filter should be removed' );
+		$this->assertArrayHasKey( 'edge_ngram', $filtered['settings']['analysis']['filter'], 'edge_ngram should be kept' );
+	}
+
+	public function test__filter__ep_config_mapping_strips_ngram_analyzers_that_reference_removed_filters() {
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(
+				'analysis' => array(
+					'filter'   => array(
+						'ep_ngram_filter' => array(
+							'type'     => 'ngram',
+							'min_gram' => 3,
+							'max_gram' => 15,
+						),
+					),
+					'analyzer' => array(
+						'ep_ngram'        => array(
+							'type'      => 'custom',
+							'tokenizer' => 'standard',
+							'filter'    => array( 'lowercase', 'asciifolding', 'ep_ngram_filter' ),
+						),
+						'ep_ngram_search' => array(
+							'type'      => 'custom',
+							'tokenizer' => 'standard',
+							'filter'    => array( 'lowercase', 'asciifolding' ),
+						),
+						'default'         => array(
+							'tokenizer' => 'standard',
+							'filter'    => array( 'lowercase' ),
+						),
+					),
+				),
+			),
+		);
+
+		$filtered = apply_filters( 'ep_config_mapping', $mapping, 'test-index' );
+
+		// ep_ngram should be removed because it references ep_ngram_filter which was removed
+		$this->assertArrayNotHasKey( 'ep_ngram', $filtered['settings']['analysis']['analyzer'], 'ep_ngram analyzer should be removed because it references removed filter' );
+		// ep_ngram_search should NOT be removed because it doesn't reference the removed filter
+		$this->assertArrayHasKey( 'ep_ngram_search', $filtered['settings']['analysis']['analyzer'], 'ep_ngram_search analyzer should be kept because it does not reference removed filter' );
+		$this->assertArrayHasKey( 'default', $filtered['settings']['analysis']['analyzer'], 'default analyzer should be kept' );
+	}
+
+	public function test__filter__ep_indexable_mapping_strips_ngram_filter() {
+		Constant_Mocker::define( 'VIP_ORIGIN_DATACENTER', 'dfw' );
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(
+				'analysis' => array(
+					'filter' => array(
+						'ep_ngram_filter' => array(
+							'type'     => 'ngram',
+							'min_gram' => 3,
+							'max_gram' => 15,
+						),
+						'edge_ngram'      => array(
+							'type'     => 'edge_ngram',
+							'min_gram' => 3,
+							'max_gram' => 10,
+						),
+					),
+				),
+			),
+		);
+
+		$filtered = apply_filters( 'ep_post_mapping', $mapping );
+
+		$this->assertArrayNotHasKey( 'ep_ngram_filter', $filtered['settings']['analysis']['filter'], 'ep_ngram_filter should be removed' );
+		$this->assertArrayHasKey( 'edge_ngram', $filtered['settings']['analysis']['filter'], 'edge_ngram should be kept' );
+	}
+
+	public function test__filter__ep_post_mapping_strips_ngram_field() {
+		Constant_Mocker::define( 'VIP_GO_ENV', 'production' );
+		Constant_Mocker::define( 'VIP_ORIGIN_DATACENTER', 'dfw' );
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(),
+			'mappings' => array(
+				'properties' => array(
+					'post_content' => array(
+						'type'   => 'text',
+						'fields' => array(
+							'ngram' => array(
+								'type'            => 'text',
+								'analyzer'        => 'ep_ngram',
+								'search_analyzer' => 'ep_ngram_search',
+							),
+							'raw'   => array(
+								'type' => 'keyword',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$filtered = apply_filters( 'ep_post_mapping', $mapping );
+
+		$this->assertArrayNotHasKey( 'ngram', $filtered['mappings']['properties']['post_content']['fields'], 'post_content.ngram field should be removed' );
+		$this->assertArrayHasKey( 'raw', $filtered['mappings']['properties']['post_content']['fields'], 'post_content.raw field should be kept' );
+	}
+
+	public function test__filter__ep_post_mapping_strips_ngram_field_when_no_fields_exist() {
+		Constant_Mocker::define( 'VIP_GO_ENV', 'production' );
+		Constant_Mocker::define( 'VIP_ORIGIN_DATACENTER', 'dfw' );
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(),
+			'mappings' => array(
+				'properties' => array(
+					'post_content' => array(
+						'type' => 'text',
+					),
+				),
+			),
+		);
+
+		$indexable = Indexables::factory()->get( 'post' );
+		if ( ! $indexable ) {
+			$this->markTestSkipped( 'Post indexable not available' );
+		}
+
+		$filtered = apply_filters( 'ep_post_mapping', $mapping );
+
+		$this->assertArrayNotHasKey( 'fields', $filtered['mappings']['properties']['post_content'], 'post_content should not have fields when ngram field does not exist' );
+	}
+
+	public function test__filter__ep_config_mapping_strips_ngram_filter_by_type() {
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(
+				'analysis' => array(
+					'filter' => array(
+						'custom_ngram_filter' => array(
+							'type'     => 'ngram',
+							'min_gram' => 2,
+							'max_gram' => 10,
+						),
+						'edge_ngram'          => array(
+							'type'     => 'edge_ngram',
+							'min_gram' => 3,
+							'max_gram' => 10,
+						),
+					),
+				),
+			),
+		);
+
+		$filtered = apply_filters( 'ep_config_mapping', $mapping, 'test-index' );
+
+		$this->assertArrayNotHasKey( 'custom_ngram_filter', $filtered['settings']['analysis']['filter'], 'Filter with type ngram should be removed' );
+		$this->assertArrayHasKey( 'edge_ngram', $filtered['settings']['analysis']['filter'], 'edge_ngram should be kept' );
+	}
+
+	public function test__filter__ep_config_mapping_strips_ngram_tokenizers() {
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(
+				'analysis' => array(
+					'tokenizer' => array(
+						'custom_ngram_tokenizer' => array(
+							'type'     => 'ngram',
+							'min_gram' => 2,
+							'max_gram' => 10,
+						),
+						'standard'               => array(
+							'type' => 'standard',
+						),
+					),
+				),
+			),
+		);
+
+		$filtered = apply_filters( 'ep_config_mapping', $mapping, 'test-index' );
+
+		$this->assertArrayNotHasKey( 'custom_ngram_tokenizer', $filtered['settings']['analysis']['tokenizer'], 'Tokenizer with type ngram should be removed' );
+		$this->assertArrayHasKey( 'standard', $filtered['settings']['analysis']['tokenizer'], 'standard tokenizer should be kept' );
+	}
+
+	public function test__filter__ep_config_mapping_strips_analyzers_referencing_removed_tokenizers() {
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(
+				'analysis' => array(
+					'tokenizer' => array(
+						'my_ngram_tokenizer' => array(
+							'type'     => 'ngram',
+							'min_gram' => 2,
+							'max_gram' => 10,
+						),
+					),
+					'analyzer'  => array(
+						'custom_analyzer' => array(
+							'type'      => 'custom',
+							'tokenizer' => 'my_ngram_tokenizer',
+							'filter'    => array( 'lowercase' ),
+						),
+						'default'         => array(
+							'tokenizer' => 'standard',
+							'filter'    => array( 'lowercase' ),
+						),
+					),
+				),
+			),
+		);
+
+		$filtered = apply_filters( 'ep_config_mapping', $mapping, 'test-index' );
+		$this->assertArrayNotHasKey( 'custom_analyzer', $filtered['settings']['analysis']['analyzer'], 'Analyzer referencing removed ngram tokenizer should be removed' );
+		$this->assertArrayHasKey( 'default', $filtered['settings']['analysis']['analyzer'], 'default analyzer should be kept' );
+	}
+
+	public function test__filter__ep_config_mapping_strips_custom_analyzer_names_referencing_removed_filters() {
+		$this->init_es();
+
+		$mapping = array(
+			'settings' => array(
+				'analysis' => array(
+					'filter'   => array(
+						'my_custom_ngram' => array(
+							'type'     => 'ngram',
+							'min_gram' => 3,
+							'max_gram' => 15,
+						),
+					),
+					'analyzer' => array(
+						'my_custom_analyzer' => array(
+							'type'      => 'custom',
+							'tokenizer' => 'standard',
+							'filter'    => array( 'lowercase', 'my_custom_ngram' ),
+						),
+						'default'            => array(
+							'tokenizer' => 'standard',
+							'filter'    => array( 'lowercase' ),
+						),
+					),
+				),
+			),
+		);
+
+		$filtered = apply_filters( 'ep_config_mapping', $mapping, 'test-index' );
+
+		$this->assertArrayNotHasKey( 'my_custom_analyzer', $filtered['settings']['analysis']['analyzer'], 'Custom analyzer referencing removed ngram filter should be removed' );
+		$this->assertArrayHasKey( 'default', $filtered['settings']['analysis']['analyzer'], 'default analyzer should be kept' );
+	}
+
 	/**
 	 * Helper function for accessing protected methods.
 	 */


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
<!--
A few sentences providing more context and describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant publicly available sources (e.g. GitHub issues)
-->

## Changelog Description

### Changed
- Enterprise Search: Disallow use of ngram filters in mapping


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Add this snippet:
```
function vip_ngram_config_mapping( $mapping ) {

	// Ensure settings/analysis containers exist.
	if ( empty( $mapping['settings'] ) ) {
		$mapping['settings'] = [];
	}
	if ( empty( $mapping['settings']['analysis'] ) ) {
		$mapping['settings']['analysis'] = [];
	}
	if ( empty( $mapping['settings']['analysis']['filter'] ) ) {
		$mapping['settings']['analysis']['filter'] = [];
	}
	if ( empty( $mapping['settings']['analysis']['analyzer'] ) ) {
		$mapping['settings']['analysis']['analyzer'] = [];
	}

	$mapping['settings']['index.max_ngram_diff'] = 12;


	// Ngram token filter.
	$mapping['settings']['analysis']['filter']['ep_ngram_filter'] = [
		'type'     => 'ngram',
		'min_gram' => 3,
		'max_gram' => 15,
	];

	// Analyzer for indexing ngrams.
	$mapping['settings']['analysis']['analyzer']['ep_ngram'] = [
		'type'      => 'custom',
		'tokenizer' => 'standard',
		'filter'    => [ 'lowercase', 'asciifolding', 'ep_ngram_filter' ],
	];

	// Analyzer for searching ngram field (keep it “normal”).
	$mapping['settings']['analysis']['analyzer']['ep_ngram_search'] = [
		'type'      => 'custom',
		'tokenizer' => 'standard',
		'filter'    => [ 'lowercase', 'asciifolding' ],
	];

	return $mapping;

};

/**
 * Add ngram subfields so we can do substring search efficiently.
 */
function vip_ep_ngram_post_mapping( $post_mapping ) {

	// post_content.ngram
	if ( isset( $post_mapping['mappings']['properties']['post_content'] ) ) {
		if ( empty( $post_mapping['mappings']['properties']['post_content']['fields'] ) ) {
			$post_mapping['mappings']['properties']['post_content']['fields'] = [];
		}

		$post_mapping['mappings']['properties']['post_content']['fields']['ngram'] = [
			'type'            => 'text',
			'analyzer'        => 'ep_ngram',
			'search_analyzer' => 'ep_ngram_search',
		];
	}

	return $post_mapping;
}

```
2. `wp vip-search index --setup` for the new stuff (without the PR changes)
3. `wp vip-search get-mapping | grep ngram` should return stuff
4. apply PR and repeat step 2
5. repeat step 3 and it should return nothing