### PR TITLE
Search (debug): Properly log when settings are failing to heal

### DIFF
--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -249,8 +249,7 @@ class SettingsHealthJob {
 				}
 
 				$result = $this->health->heal_index_settings_for_indexable( $indexable, $options );
-
-				if ( is_wp_error( $result['result'] ) ) {
+				if ( is_wp_error( $result['result'] ) || false === $result['result'] ) {
 					/** @var WP_Error $result */
 					$message = sprintf(
 						'Application %s: Failed to heal index settings for indexable %s and index version %d on %s: %s',
@@ -258,7 +257,7 @@ class SettingsHealthJob {
 						$indexable_slug,
 						$result['index_version'],
 						home_url(),
-						$result['result']->get_error_message(),
+						is_wp_error( $result['result'] ) ? $result['result']->get_error_message() : 'Unknown error',
 					);
 
 					$this->send_alert( '#vip-go-es-alerts', $message, 2 );

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -250,7 +250,6 @@ class SettingsHealthJob {
 
 				$result = $this->health->heal_index_settings_for_indexable( $indexable, $options );
 				if ( is_wp_error( $result['result'] ) || false === $result['result'] ) {
-					/** @var WP_Error $result */
 					$message = sprintf(
 						'Application %s: Failed to heal index settings for indexable %s and index version %d on %s: %s',
 						FILES_CLIENT_SITE_ID,


### PR DESCRIPTION
## Description
Properly log on Slack when settings don't autoheal. It might not always return a wp_error