### PR TITLE
Search: Only heal active indices

### DIFF
--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -233,8 +233,14 @@ class SettingsHealthJob {
 				if ( empty( $result['diff'] ) ) {
 					continue;
 				}
-				// Check if active index needs to be re-built in the background.
-				if ( isset( $result['diff']['index.number_of_shards'] ) && $this->search->versioning->get_active_version_number( $indexable ) === $result['index_version'] ) {
+
+				// Only heal index settings if the index is active.
+				if ( $this->search->versioning->get_active_version_number( $indexable ) !== $result['index_version'] ) {
+					continue;
+				}
+
+				// Check if index needs to be re-built in the background.
+				if ( isset( $result['diff']['index.number_of_shards'] ) ) {
 					$this->maybe_process_build( $indexable );
 				}
 

--- a/tests/search/includes/classes/test-class-settingshealthjob.php
+++ b/tests/search/includes/classes/test-class-settingshealthjob.php
@@ -106,7 +106,7 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 	}
 
 	public function test__heal_index_settings__heal_indexables_with_diff() {
-		$indexable_versions_with_non_empty_diff = 1;
+		$indexable_versions_with_non_empty_diff = 1; // only post has diff
 		$unhealthy_indexables                   = [
 			'post' => [
 				[
@@ -133,6 +133,18 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 		$indexables_mock = $this->createMock( Indexables::class );
 		$indexables_mock->method( 'get' )->willReturn( $this->createMock( Indexable::class ) );
 
+		$versioning_mock = $this->getMockBuilder( Versioning::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_active_version_number' ] )
+			->getMock();
+
+		// Both indexables have version 1 as active
+		$versioning_mock->method( 'get_active_version_number' )
+			->willReturn( 1 );
+
+		$search_mock             = $this->createMock( Search::class );
+		$search_mock->versioning = $versioning_mock;
+
 		/** @var MockObject&Health */
 		$health_mock = $this->getMockBuilder( Health::class )
 			->disableOriginalConstructor()
@@ -153,9 +165,69 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 
 		$stub->indexables = $indexables_mock;
 		$stub->health     = $health_mock;
+		$stub->search     = $search_mock;
 
 		$health_mock->expects( $this->exactly( $indexable_versions_with_non_empty_diff ) )
 			->method( 'heal_index_settings_for_indexable' );
+
+		$stub->heal_index_settings( $unhealthy_indexables );
+	}
+
+	public function test__heal_index_settings__only_heals_active_index() {
+		$active_version       = 2;
+		$unhealthy_indexables = [
+			'post' => [
+				[
+					'index_version' => 1,
+					'diff'          => [ 'index.max_result_window' => [] ],
+				],
+				[
+					'index_version' => 2,
+					'diff'          => [ 'index.number_of_replicas' => [] ],
+				],
+			],
+		];
+
+		$indexable_mock  = $this->createMock( Indexable::class );
+		$indexables_mock = $this->createMock( Indexables::class );
+		$indexables_mock->method( 'get' )->with( 'post' )->willReturn( $indexable_mock );
+
+		$versioning_mock = $this->getMockBuilder( Versioning::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_active_version_number' ] )
+			->getMock();
+
+		$versioning_mock->method( 'get_active_version_number' )
+			->with( $indexable_mock )
+			->willReturn( $active_version );
+
+		$search_mock             = $this->createMock( Search::class );
+		$search_mock->versioning = $versioning_mock;
+
+		$health_mock = $this->getMockBuilder( Health::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'heal_index_settings_for_indexable' ] )
+			->getMock();
+
+		$health_mock->method( 'heal_index_settings_for_indexable' )->willReturn( array(
+			'result'        => true,
+			'index_version' => $active_version,
+			'index_name'    => 'foo-index',
+		) );
+
+		$stub = $this->getMockBuilder( SettingsHealthJob::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'send_alert', 'maybe_process_build' ] )
+			->getMock();
+
+		$stub->indexables = $indexables_mock;
+		$stub->health     = $health_mock;
+		$stub->search     = $search_mock;
+
+		// Only the active version (2) should be healed, not version 1
+		$health_mock->expects( $this->once() )
+			->method( 'heal_index_settings_for_indexable' )
+			->with( $indexable_mock, [ 'index_version' => $active_version ] );
 
 		$stub->heal_index_settings( $unhealthy_indexables );
 	}


### PR DESCRIPTION
## Description
This pull request strengthens the logic for healing index settings by ensuring that only the active index version is healed, preventing unnecessary operations on inactive index versions. 

## Changelog Description

### Changed
- Enterprise Search: Only active indices get healed


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->