### PR TITLE
Search: Fix CLI commmand get-index-settings

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -423,9 +423,23 @@ class CoreCommand {
 
 		$index_name = $indexable->get_index_name();
 
-		$settings = Elasticsearch::factory()->get_mapping( $index_name );
+		$settings = Elasticsearch::factory()->get_index_settings( $index_name );
+		
+		if ( is_wp_error( $settings ) ) {
+			WP_CLI::error( sprintf( 'Error getting index settings: %s', $settings->get_error_message() ) );
+		}
+		
+		if ( isset( $settings['error'] ) ) {
+			WP_CLI::error(
+				sprintf(
+					'Error getting index settings: %s',
+					isset( $settings['error']['root_cause'][0]['reason'] ) ? $settings['error']['root_cause'][0]['reason'] : 'Unknown error'
+				)
+			);
+		}
 
-		$keys = array_keys( $settings );
+		$settings = $settings[ $index_name ]['settings'] ?? [];
+		$keys     = array_keys( $settings );
 		\WP_CLI\Utils\format_items( $assoc_args['format'] ?? 'table', array( $settings ), $keys );
 	}
 

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -424,11 +424,10 @@ class CoreCommand {
 		$index_name = $indexable->get_index_name();
 
 		$settings = Elasticsearch::factory()->get_index_settings( $index_name );
-		
+
 		if ( is_wp_error( $settings ) ) {
 			WP_CLI::error( sprintf( 'Error getting index settings: %s', $settings->get_error_message() ) );
 		}
-		
 		if ( isset( $settings['error'] ) ) {
 			WP_CLI::error(
 				sprintf(


### PR DESCRIPTION
## Description
The command previously called get-mapping which is incorrect. This fixes it to use the correct ES endpoint.

Before it returned the mapping, now:
```
╰─$ vip dev-env --slug es-site exec -- wp vip-search get-index-settings post
+---------------------+--------------------------+------------------------+---------------------+---------------------------------------------------+------------------------+-----------------------+
| index.creation_date | index.number_of_replicas | index.number_of_shards | index.provided_name | index.routing.allocation.include._tier_preference | index.uuid             | index.version.created |
+---------------------+--------------------------+------------------------+---------------------+---------------------------------------------------+------------------------+-----------------------+
| 1768587197724       | 1                        | 1                      | vip-200508-post-1   | data_content                                      | d6xBl4pwSUGQaikLcMvMpA | 8525000               |
+---------------------+--------------------------+------------------------+---------------------+---------------------------------------------------+------------------------+-----------------------+
```

## Changelog Description

### Fixed
- Enterprise Search: Fix CLI command `wp vip-search get-index-settings`


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->