### PR TITLE
Search: Fix get-indexes --active=true to properly retrieve term indexes

### DIFF
--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -130,8 +130,8 @@ class CoreCommand {
 					continue;
 				}
 				
-				$index_name = $search->versioning->get_index_name( $indexable, $active_version );
-				$indexes[]  = $index_name;
+				$index_name             = $search->versioning->get_index_name( $indexable, $active_version );
+				$indexes[ $index_name ] = true;
 			}
 			
 			if ( is_multisite() ) {
@@ -139,7 +139,7 @@ class CoreCommand {
 			}
 		}
 		
-		return array_unique( $indexes );
+		return array_keys( $indexes );
 	}
 
 	/**

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -107,42 +107,45 @@ class CoreCommand {
 	 * @return array $indexes Array of active indexes.
 	 */
 	private function list_active_indexes() {
-		$indexes    = [];
-		$search     = \Automattic\VIP\Search\Search::instance();
-		$indexables = $search->indexables->get_all();
-		$blog_ids   = ( is_multisite() ) ? get_sites(
+		$indexes  = [];
+		$search   = \Automattic\VIP\Search\Search::instance();
+		$blog_ids = ( is_multisite() ) ? get_sites(
 			[
 				'fields' => 'ids',
 				'number' => 20000,
 			]
 		) : [ get_current_blog_id() ];
-		foreach ( $indexables as $indexable ) {
-			if ( $indexable->global ) {
-				$active_version = $search->versioning->get_active_version_number( $indexable );
-				if ( ! is_wp_error( $active_version ) ) {
-					$index_name = $search->versioning->get_index_name( $indexable, $active_version );
-					$indexes[]  = $index_name;
-				}
-				continue;
+		
+		foreach ( $blog_ids as $blog_id ) {
+			if ( is_multisite() ) {
+				switch_to_blog( $blog_id );
 			}
-
-			foreach ( $blog_ids as $blog_id ) {
-				if ( is_multisite() ) {
-					switch_to_blog( $blog_id );
-				}
-				
+			
+			\ElasticPress\Features::factory()->setup_features();
+			
+			$site_indexables = $search->indexables->get_all();
+			foreach ( $site_indexables as $indexable ) {
 				$active_version = $search->versioning->get_active_version_number( $indexable );
-				if ( ! is_wp_error( $active_version ) ) {
-					$index_name = $search->versioning->get_index_name( $indexable, $active_version );
-					$indexes[]  = $index_name;
+				
+				if ( is_wp_error( $active_version ) ) {
+					continue;
 				}
 				
-				if ( is_multisite() ) {
-					restore_current_blog();
+				$index_name = $search->versioning->get_index_name( $indexable, $active_version );
+				
+				// For global indexables, skip if already in the array
+				if ( $indexable->global && in_array( $index_name, $indexes, true ) ) {
+					continue;
 				}
+				
+				$indexes[] = $index_name;
+			}
+			
+			if ( is_multisite() ) {
+				restore_current_blog();
 			}
 		}
-
+		
 		return $indexes;
 	}
 

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -126,19 +126,12 @@ class CoreCommand {
 			$site_indexables = $search->indexables->get_all();
 			foreach ( $site_indexables as $indexable ) {
 				$active_version = $search->versioning->get_active_version_number( $indexable );
-				
 				if ( is_wp_error( $active_version ) ) {
 					continue;
 				}
 				
 				$index_name = $search->versioning->get_index_name( $indexable, $active_version );
-				
-				// For global indexables, skip if already in the array
-				if ( $indexable->global && in_array( $index_name, $indexes, true ) ) {
-					continue;
-				}
-				
-				$indexes[] = $index_name;
+				$indexes[]  = $index_name;
 			}
 			
 			if ( is_multisite() ) {
@@ -146,7 +139,7 @@ class CoreCommand {
 			}
 		}
 		
-		return $indexes;
+		return array_unique( $indexes );
 	}
 
 	/**

--- a/search/includes/classes/commands/class-corecommand.php
+++ b/search/includes/classes/commands/class-corecommand.php
@@ -121,21 +121,23 @@ class CoreCommand {
 				switch_to_blog( $blog_id );
 			}
 			
-			\ElasticPress\Features::factory()->setup_features();
-			
-			$site_indexables = $search->indexables->get_all();
-			foreach ( $site_indexables as $indexable ) {
-				$active_version = $search->versioning->get_active_version_number( $indexable );
-				if ( is_wp_error( $active_version ) ) {
-					continue;
-				}
+			try {
+				\ElasticPress\Features::factory()->setup_features();
 				
-				$index_name             = $search->versioning->get_index_name( $indexable, $active_version );
-				$indexes[ $index_name ] = true;
-			}
-			
-			if ( is_multisite() ) {
-				restore_current_blog();
+				$site_indexables = $search->indexables->get_all();
+				foreach ( $site_indexables as $indexable ) {
+					$active_version = $search->versioning->get_active_version_number( $indexable );
+					if ( is_wp_error( $active_version ) ) {
+						continue;
+					}
+					
+					$index_name             = $search->versioning->get_index_name( $indexable, $active_version );
+					$indexes[ $index_name ] = true;
+				}
+			} finally {
+				if ( is_multisite() ) {
+					restore_current_blog();
+				}
 			}
 		}
 		


### PR DESCRIPTION
## Description
Fixes get-indexes --active=true to properly retrieve term indexes in MS environments

This pull request refactors the way active indexes are listed in the `list_active_indexes` method to ensure more accurate handling of global and site-specific indexables, especially in multisite environments. The main changes include re-fetching indexables per site, initializing features for each site, and avoiding duplicate global indexes.

## Changelog Description

### Fixed
- Enterprise Search: Fix get-indexes --active=true to properly retrieve term indexes in MS environments


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->