### PR TITLE
Search: Only process active indexes in SettingsHealthJob

### DIFF
--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1012,7 +1012,7 @@ class Health {
 		$versions         = $this->search->versioning->get_versions( $indexable );
 		$version_to_check = 1;
 
-		// Check if this is the default version 1 (no versions stored yet))
+		// Check if this is the default version 1 (no versions stored yet)
 		$is_default_version = isset( $versions[1] ) && null === $versions[1]['created_time']
 			&& null === $versions[1]['activated_time'];
 		if ( ! $is_default_version ) {

--- a/search/includes/classes/class-health.php
+++ b/search/includes/classes/class-health.php
@@ -1009,18 +1009,26 @@ class Health {
 	}
 
 	public function get_index_versions_settings_diff_for_indexable( \ElasticPress\Indexable $indexable ) {
-		$versions = $this->search->versioning->get_versions( $indexable );
+		$versions         = $this->search->versioning->get_versions( $indexable );
+		$version_to_check = 1;
+
+		// Check if this is the default version 1 (no versions stored yet))
+		$is_default_version = isset( $versions[1] ) && null === $versions[1]['created_time']
+			&& null === $versions[1]['activated_time'];
+		if ( ! $is_default_version ) {
+			$version_to_check = $this->search->versioning->get_active_version_number( $indexable );
+			if ( is_wp_error( $version_to_check ) ) {
+				return $version_to_check;
+			}
+		}
+
+		$version_result = $this->get_index_settings_diff_for_indexable( $indexable, array(
+			'index_version' => $version_to_check,
+		) );
 
 		$diff = [];
-
-		foreach ( $versions as $version ) {
-			$version_result = $this->get_index_settings_diff_for_indexable( $indexable, array(
-				'index_version' => $version['number'],
-			) );
-
-			if ( is_array( $version_result ) && ! empty( $version_result ) ) {
-				$diff[] = $version_result;
-			}
+		if ( is_array( $version_result ) && ! empty( $version_result ) ) {
+			$diff[] = $version_result;
 		}
 
 		return $diff;

--- a/search/includes/classes/class-settingshealthjob.php
+++ b/search/includes/classes/class-settingshealthjob.php
@@ -179,12 +179,10 @@ class SettingsHealthJob {
 					continue;
 				}
 
-				$indexable = $this->indexables->get( $indexable_slug );
 				if ( isset( $result['diff']['index.number_of_shards'] ) && 1 === count( $result['diff'] )
-					&& $this->search->versioning->get_active_version_number( $indexable ) === $result['index_version']
 					&& false !== get_option( self::BUILD_LOCK_NAME ) ) {
-						// Don't keep alerting if it's an active index in process of being re-built.
-						continue;
+					// Don't keep alerting if it's an active index in process of being re-built.
+					continue;
 				}
 
 				$message = sprintf(
@@ -231,11 +229,6 @@ class SettingsHealthJob {
 			// Each individual entry in $versions is an array of results, one per index version.
 			foreach ( $versions as $result ) {
 				if ( empty( $result['diff'] ) ) {
-					continue;
-				}
-
-				// Only heal index settings if the index is active.
-				if ( $this->search->versioning->get_active_version_number( $indexable ) !== $result['index_version'] ) {
 					continue;
 				}
 

--- a/tests/search/includes/classes/test-class-health.php
+++ b/tests/search/includes/classes/test-class-health.php
@@ -1145,6 +1145,150 @@ class Health_Test extends WP_UnitTestCase {
 		$this->assertEmpty( $actual_diff );
 	}
 
+	public function test_get_index_versions_settings_diff_for_indexable__only_returns_active_version() {
+		$index_name     = 'vip-123-post-1';
+		$active_version = 2;
+		
+		/** @var Search&MockObject */
+		$mock_search = $this->createMock( Search::class );
+
+		/** @var Versioning&MockObject */
+		$versioning_mock = $this->getMockBuilder( Versioning::class )
+			->onlyMethods( [ 'get_versions', 'get_active_version_number', 'set_current_version_number', 'reset_current_version_number' ] )
+			->getMock();
+
+		$versions = [
+			1 => [
+				'number'         => 1,
+				'active'         => false,
+				'created_time'   => 1234567890,
+				'activated_time' => 1234567890,
+			],
+			2 => [
+				'number'         => 2,
+				'active'         => true,
+				'created_time'   => 1234567900,
+				'activated_time' => 1234567900,
+			],
+		];
+
+		$versioning_mock->method( 'get_versions' )->willReturn( $versions );
+		$versioning_mock->method( 'get_active_version_number' )->willReturn( $active_version );
+		$versioning_mock->method( 'set_current_version_number' )->willReturn( true );
+		$versioning_mock->method( 'reset_current_version_number' )->willReturn( true );
+
+		$mock_search->versioning = $versioning_mock;
+
+		$health = new Health( $mock_search );
+
+		/** @var Indexable&MockObject */
+		$mocked_indexable = $this->getMockBuilder( Indexable::class )
+			->onlyMethods( self::$indexable_methods )
+			->getMock();
+
+		$mocked_indexable->slug = 'post';
+		$mocked_indexable->method( 'index_exists' )->willReturn( true );
+		$mocked_indexable->method( 'get_index_name' )->willReturn( $index_name );
+
+		/** @var Elasticsearch&MockObject */
+		$health->elasticsearch = $this->getMockBuilder( Elasticsearch::class )
+			->onlyMethods( [ 'get_index_settings' ] )
+			->getMock();
+
+		$health->elasticsearch->method( 'get_index_settings' )
+			->willReturn( [
+				$index_name => [
+					'settings' => [ 'index.number_of_replicas' => 2 ],
+				],
+			] );
+
+		$mocked_indexable->method( 'generate_mapping' )
+			->willReturn( [
+				'settings' => [ 'index.number_of_replicas' => 1 ],
+			] );
+
+		// Verify that set_current_version_number is called with the active version (2), not version 1
+		$versioning_mock->expects( $this->once() )
+			->method( 'set_current_version_number' )
+			->with( $mocked_indexable, $active_version );
+
+		$result = $health->get_index_versions_settings_diff_for_indexable( $mocked_indexable );
+
+		$this->assertCount( 1, $result );
+		$this->assertEquals( $active_version, $result[0]['index_version'] );
+		$this->assertNotEmpty( $result[0]['diff'] );
+	}
+
+	public function test_get_index_versions_settings_diff_for_indexable__uses_default_version_when_no_versions_stored() {
+		$index_name = 'vip-123-post-1';
+		
+		// Mock search and the versioning instance
+		/** @var Search&MockObject */
+		$mock_search = $this->createMock( Search::class );
+
+		/** @var Versioning&MockObject */
+		$versioning_mock = $this->getMockBuilder( Versioning::class )
+			->onlyMethods( [ 'get_versions', 'get_active_version_number', 'set_current_version_number', 'reset_current_version_number' ] )
+			->getMock();
+
+		// Mock default version (no versions stored yet)
+		$default_versions = [
+			1 => [
+				'number'         => 1,
+				'active'         => true,
+				'created_time'   => null,
+				'activated_time' => null,
+			],
+		];
+
+		$versioning_mock->method( 'get_versions' )->willReturn( $default_versions );
+		$versioning_mock->method( 'set_current_version_number' )->willReturn( true );
+		$versioning_mock->method( 'reset_current_version_number' )->willReturn( true );
+
+		$mock_search->versioning = $versioning_mock;
+
+		$health = new Health( $mock_search );
+
+		/** @var Indexable&MockObject */
+		$mocked_indexable = $this->getMockBuilder( Indexable::class )
+			->onlyMethods( self::$indexable_methods )
+			->getMock();
+
+		$mocked_indexable->slug = 'post';
+		$mocked_indexable->method( 'index_exists' )->willReturn( true );
+		$mocked_indexable->method( 'get_index_name' )->willReturn( $index_name );
+
+		/** @var Elasticsearch&MockObject */
+		$health->elasticsearch = $this->getMockBuilder( Elasticsearch::class )
+			->onlyMethods( [ 'get_index_settings' ] )
+			->getMock();
+
+		$health->elasticsearch->method( 'get_index_settings' )
+			->willReturn( [
+				$index_name => [
+					'settings' => [ 'index.number_of_replicas' => 2 ],
+				],
+			] );
+
+		$mocked_indexable->method( 'generate_mapping' )
+			->willReturn( [
+				'settings' => [ 'index.number_of_replicas' => 1 ],
+			] );
+
+		$versioning_mock->expects( $this->once() )
+			->method( 'set_current_version_number' )
+			->with( $mocked_indexable, 1 );
+
+		$versioning_mock->expects( $this->never() )
+			->method( 'get_active_version_number' );
+
+		$result = $health->get_index_versions_settings_diff_for_indexable( $mocked_indexable );
+
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 1, $result[0]['index_version'] );
+		$this->assertNotEmpty( $result[0]['diff'] );
+	}
+
 	public function heal_index_settings_for_indexable_data() {
 		return array(
 			// Regular healing

--- a/tests/search/includes/classes/test-class-settingshealthjob.php
+++ b/tests/search/includes/classes/test-class-settingshealthjob.php
@@ -113,19 +113,11 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 					'index_version' => 1,
 					'diff'          => [ 'index.max_result_window' => [] ],
 				],
-				[
-					'index_version' => 2,
-					'diff'          => [],
-				],
 			],
 			'user' => [
 				[
 					'index_version' => 1,
-					'diff'          => [ 'index.max_shingle_diff' => [] ],
-				],
-				[
-					'index_version' => 2,
-					'diff'          => [],
+					'diff'          => [], // user has no diff, so won't be healed
 				],
 			],
 		];
@@ -169,65 +161,6 @@ class SettingsHealthJob_Test extends WP_UnitTestCase {
 
 		$health_mock->expects( $this->exactly( $indexable_versions_with_non_empty_diff ) )
 			->method( 'heal_index_settings_for_indexable' );
-
-		$stub->heal_index_settings( $unhealthy_indexables );
-	}
-
-	public function test__heal_index_settings__only_heals_active_index() {
-		$active_version       = 2;
-		$unhealthy_indexables = [
-			'post' => [
-				[
-					'index_version' => 1,
-					'diff'          => [ 'index.max_result_window' => [] ],
-				],
-				[
-					'index_version' => 2,
-					'diff'          => [ 'index.number_of_replicas' => [] ],
-				],
-			],
-		];
-
-		$indexable_mock  = $this->createMock( Indexable::class );
-		$indexables_mock = $this->createMock( Indexables::class );
-		$indexables_mock->method( 'get' )->with( 'post' )->willReturn( $indexable_mock );
-
-		$versioning_mock = $this->getMockBuilder( Versioning::class )
-			->disableOriginalConstructor()
-			->onlyMethods( [ 'get_active_version_number' ] )
-			->getMock();
-
-		$versioning_mock->method( 'get_active_version_number' )
-			->with( $indexable_mock )
-			->willReturn( $active_version );
-
-		$search_mock             = $this->createMock( Search::class );
-		$search_mock->versioning = $versioning_mock;
-
-		$health_mock = $this->getMockBuilder( Health::class )
-			->disableOriginalConstructor()
-			->onlyMethods( [ 'heal_index_settings_for_indexable' ] )
-			->getMock();
-
-		$health_mock->method( 'heal_index_settings_for_indexable' )->willReturn( array(
-			'result'        => true,
-			'index_version' => $active_version,
-			'index_name'    => 'foo-index',
-		) );
-
-		$stub = $this->getMockBuilder( SettingsHealthJob::class )
-			->disableOriginalConstructor()
-			->onlyMethods( [ 'send_alert', 'maybe_process_build' ] )
-			->getMock();
-
-		$stub->indexables = $indexables_mock;
-		$stub->health     = $health_mock;
-		$stub->search     = $search_mock;
-
-		// Only the active version (2) should be healed, not version 1
-		$health_mock->expects( $this->once() )
-			->method( 'heal_index_settings_for_indexable' )
-			->with( $indexable_mock, [ 'index_version' => $active_version ] );
 
 		$stub->heal_index_settings( $unhealthy_indexables );
 	}


### PR DESCRIPTION
## Description
Follow-up to https://github.com/Automattic/vip-go-mu-plugins/pull/6704. Instead of skipping the active index, let's just target for it in the results in the first place.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

`$es = new \Automattic\VIP\Search\Search();`
`$es->init();`
`$hj = new \Automattic\VIP\Search\SettingsHealthJob( $es );`
`$hj->check_settings_health();`
With the changes, the above should no longer alert.