### PR TITLE
Fix flaky test Pendo test

### DIFF
--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -20,16 +20,13 @@ require_once __DIR__ . '/../../integrations/fake-integration.php';
 
 class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 	public function tearDown(): void {
-		global $wp_query;
-
-		// Reset query vars to prevent test pollution
-		if ( isset( $wp_query ) && isset( $wp_query->query_vars ) ) {
-			unset( $wp_query->query_vars['page'] );
-		}
+		// Reset Pendo_JavaScript_Library singleton (removes admin_enqueue_scripts hook)
+		$pendo_property = get_class_property_as_public( Pendo_JavaScript_Library::class, 'instance' );
+		$pendo_property->setValue( null, null );
 
 		// Reset IntegrationsSingleton to ensure clean state between tests
-		$property = get_class_property_as_public( IntegrationsSingleton::class, 'instance' );
-		$property->setValue( null, null );
+		$integrations_property = get_class_property_as_public( IntegrationsSingleton::class, 'instance' );
+		$integrations_property->setValue( null, null );
 
 		Constant_Mocker::clear();
 		parent::tearDown();

--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -19,16 +19,26 @@ require_once __DIR__ . '/../../../vip-integrations.php';
 require_once __DIR__ . '/../../integrations/fake-integration.php';
 
 class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+
+		// Ensure singletons start fresh (protects against previous test's tearDown not running)
+		// this is duplicative of the tearDown method, but without it tests are flaky.
+		$pendo_property = get_class_property_as_public( Pendo_JavaScript_Library::class, 'instance' );
+		$pendo_property->setValue( null, null );
+
+		$integrations_property = get_class_property_as_public( IntegrationsSingleton::class, 'instance' );
+		$integrations_property->setValue( null, null );
+	}
+
 	public function tearDown(): void {
 		// Reset Pendo_JavaScript_Library singleton (removes admin_enqueue_scripts hook)
 		$pendo_property = get_class_property_as_public( Pendo_JavaScript_Library::class, 'instance' );
 		$pendo_property->setValue( null, null );
 
-		// Clear IntegrationsSingleton state without nulling the instance
-		// This avoids potential caching issues with reflection-modified static properties
-		$integrations_instance = IntegrationsSingleton::instance();
-		$integrations_array    = get_class_property_as_public( get_class( $integrations_instance ), 'integrations' );
-		$integrations_array->setValue( $integrations_instance, [] );
+		// Reset IntegrationsSingleton to ensure clean state between tests
+		$integrations_property = get_class_property_as_public( IntegrationsSingleton::class, 'instance' );
+		$integrations_property->setValue( null, null );
 
 		Constant_Mocker::clear();
 		parent::tearDown();

--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -19,11 +19,18 @@ require_once __DIR__ . '/../../../vip-integrations.php';
 require_once __DIR__ . '/../../integrations/fake-integration.php';
 
 class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
-	public function tearDown(): void {  
+	public function tearDown(): void {
+		global $wp_query;
+
+		// Reset query vars to prevent test pollution
+		if ( isset( $wp_query ) && isset( $wp_query->query_vars ) ) {
+			unset( $wp_query->query_vars['page'] );
+		}
+
 		// Reset IntegrationsSingleton to ensure clean state between tests
 		$property = get_class_property_as_public( IntegrationsSingleton::class, 'instance' );
 		$property->setValue( null, null );
-	
+
 		Constant_Mocker::clear();
 		parent::tearDown();
 	}
@@ -70,8 +77,11 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 		};
 
 		add_filter( 'vip_pendo_allowed_screens', $allow_screen );
-		$this->assertFalse( Pendo_JavaScript_Library::should_enqueue_script( 'newly-allowed-screen.php' ) );
-		remove_filter( 'vip_pendo_allowed_screens', $allow_screen );
+		try {
+			$this->assertFalse( Pendo_JavaScript_Library::should_enqueue_script( 'newly-allowed-screen.php' ) );
+		} finally {
+			remove_filter( 'vip_pendo_allowed_screens', $allow_screen );
+		}
 	}
 
 	public function test_disabled_for_filter_allowed_admin_screens_and_no_tracked_integrations() {
@@ -90,8 +100,11 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 		};
 
 		add_filter( 'vip_pendo_allowed_admin_screens', $allow_admin_screen );
-		$this->assertFalse( Pendo_JavaScript_Library::should_enqueue_script( 'admin.php' ) );
-		remove_filter( 'vip_pendo_allowed_admin_screens', $allow_admin_screen );
+		try {
+			$this->assertFalse( Pendo_JavaScript_Library::should_enqueue_script( 'admin.php' ) );
+		} finally {
+			remove_filter( 'vip_pendo_allowed_admin_screens', $allow_admin_screen );
+		}
 	}
 
 	public function test_enabled_for_users_with_edit_post_cap_and_a_tracked_integration() {
@@ -136,8 +149,11 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 		};
 
 		add_filter( 'vip_pendo_allowed_screens', $allow_screen );
-		$this->assertTrue( Pendo_JavaScript_Library::should_enqueue_script( 'newly-allowed-screen.php' ) );
-		remove_filter( 'vip_pendo_allowed_screens', $allow_screen );
+		try {
+			$this->assertTrue( Pendo_JavaScript_Library::should_enqueue_script( 'newly-allowed-screen.php' ) );
+		} finally {
+			remove_filter( 'vip_pendo_allowed_screens', $allow_screen );
+		}
 	}
 
 	public function test_enabled_for_filter_allowed_admin_screens_and_a_tracked_integration() {
@@ -158,8 +174,11 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 		};
 
 		add_filter( 'vip_pendo_allowed_admin_screens', $allow_admin_screen );
-		$this->assertTrue( Pendo_JavaScript_Library::should_enqueue_script( 'admin.php' ) );
-		remove_filter( 'vip_pendo_allowed_admin_screens', $allow_admin_screen );
+		try {
+			$this->assertTrue( Pendo_JavaScript_Library::should_enqueue_script( 'admin.php' ) );
+		} finally {
+			remove_filter( 'vip_pendo_allowed_admin_screens', $allow_admin_screen );
+		}
 	}
 
 	public function test_disabled_by_opt_out_constant() {

--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -24,9 +24,11 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 		$pendo_property = get_class_property_as_public( Pendo_JavaScript_Library::class, 'instance' );
 		$pendo_property->setValue( null, null );
 
-		// Reset IntegrationsSingleton to ensure clean state between tests
-		$integrations_property = get_class_property_as_public( IntegrationsSingleton::class, 'instance' );
-		$integrations_property->setValue( null, null );
+		// Clear IntegrationsSingleton state without nulling the instance
+		// This avoids potential caching issues with reflection-modified static properties
+		$integrations_instance = IntegrationsSingleton::instance();
+		$integrations_array    = get_class_property_as_public( get_class( $integrations_instance ), 'integrations' );
+		$integrations_array->setValue( $integrations_instance, [] );
 
 		Constant_Mocker::clear();
 		parent::tearDown();


### PR DESCRIPTION
## Description

Automattic\VIP\Telemetry\Pendo_JavaScript_Library_Test::test_enabled_for_filter_allowed_admin_screens_and_a_tracked_integration was randomly failing despite the code being correct. The issue was caused by global state pollution between test runs.

First, we weren't clearing the Pendo singleton; the filter wasn't being properly removed in all cases.

Even with these changes, tests still failed periodically, so we duplicated some of the tearDown logic in a new setup.

Thanks to [Claude Code](https://claude.com/claude-code) for the assist.

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Fixed
- An intermittently failing test related to telemetry integration.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [N/A] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Check out PR.
1. Run `./bin/test.sh`
1. They succeed!

You do need to run the whole suite, since the issue was with cross-test polution, so running the single test isn't a good test.