### PR TITLE
Search: Enable double writes for rollback after ES upgrade

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -1086,8 +1086,9 @@ class Search {
 		}
 
 		$version = self::ELASTICSEARCH_MIGRATION_NEXT;
-		if ( $is_testing_next_version ) {
-			// When testing the next version, we should mirror to version 7, since the regular requests are going to version 8.
+		if ( $is_testing_next_version || ( defined( 'VIP_ELASTICSEARCH_VERSION' ) && constant( 'VIP_ELASTICSEARCH_VERSION' ) === self::ELASTICSEARCH_MIGRATION_NEXT ) ) {
+			// If testing or already running the next Elasticsearch version, mirror write requests to the previous version.
+			// This duplicates writes to the older cluster to allow rollbacks during the post-migration rollback window.
 			$version = self::ELASTICSEARCH_MIGRATION_SEVEN;
 		}
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -404,6 +404,45 @@ class Search_Test extends WP_UnitTestCase {
 		$indexable->bulk_index( [ $post_id ] );
 	}
 
+	public function test__vip_search_sends_double_writes_after_upgrade_and_migration_in_progress() {
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
+			'https://es-endpoint:9245',
+		) );
+
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_VERSION', '8' );
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_MIGRATION_IN_PROGRESS', true );
+
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_USERNAME', 'foo' );
+		Constant_Mocker::define( 'VIP_ELASTICSEARCH_PASSWORD', 'bar' );
+
+		$test_user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $test_user_id );
+
+		self::$mock_global_functions->expects( $this->exactly( 3 ) )
+			->method( 'mock_wp_remote_request' )
+			->with( $this->callback( function ( $url ) {
+				return in_array( $url, [
+					'https://es-endpoint:9245/vip-123-post-1',       // Next version host
+					'https://es-endpoint:9245/vip-123-post-1/_bulk', // Next version host
+					'https://es-endpoint:9235/vip-123-post-1/_bulk', // Mirror to old version host
+				] );
+			} ) )
+			->willReturn([
+				'response' => [ 'code' => 200 ],
+				'body'     => '',
+			]);
+
+		$this->init_es();
+		$indexable = Indexables::factory()->get( 'post' );
+
+		$post_id = $this->factory()->post->create( array(
+			'post_title'  => 'Test Post',
+			'post_status' => 'publish',
+		) );
+
+		$indexable->bulk_index( [ $post_id ] );
+	}
+
 	public function test__vip_search_sends_queries_to_next_version_host_when_is_testing_next_version() {
 		Constant_Mocker::define( 'VIP_ELASTICSEARCH_ENDPOINTS', array(
 			'https://es-endpoint:9235/weirdpath9235',


### PR DESCRIPTION
## Description

This PR extends the double-write mechanism during Elasticsearch migrations to also apply after the upgrade is complete. Previously, write mirroring to the alternate cluster only occurred when testing the next version (`VIP_ELASTICSEARCH_IS_TESTING_NEXT`). This change ensures writes continue to be mirrored to the ES7 cluster after switching to ES8, keeping both clusters in sync during the post-migration rollback window.                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                           

## Changelog Description


### Changed
- Added double-write support for Elasticsearch migrations to continue mirroring writes to ES7 after upgrading to ES8, enabling safe rollbacks during the post-migration window


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->