### PR TITLE
feat(vip-support): enable 2FA email provider when creating support users

### DIFF
--- a/vip-support/class-vip-support-cli.php
+++ b/vip-support/class-vip-support-cli.php
@@ -58,6 +58,9 @@ class Command extends WP_CLI_Command {
 			\WP_CLI::error( $user_id );
 		}
 
+		// Enable Two-Factor Email authentication for the new support user.
+		update_user_meta( $user_id, '_two_factor_enabled_providers', array( 'Two_Factor_Email' ) );
+
 		$msg = "Added user $user_id with login {$user_login}, they are verified as a VIP Support user and ready to go";
 		\WP_CLI::success( $msg );
 	}


### PR DESCRIPTION
## Description

When creating VIP support users via the `wp vipsupport add_support_user` CLI command, Two-Factor Email authentication is now automatically enabled. This ensures support users have 2FA configured from the moment they're created, improving security posture.

Related: [PLTFRM-1911]

## Changelog Description

### Added
  - Automatically enable Two-Factor Email authentication when creating VIP support users via WP-CLI

## Steps to Test

  1. Check out PR.
  2. Run `wp vipsupport create-user vip_testuser testuser@automattic.com password123`
  3. Verify the user was created successfully.
  4. Check user meta: `wp user meta get <user_id> _two_factor_enabled_providers`
  5. Verify the meta contains `Two_Factor_Email`.