### PR TITLE
Support staged roll-out for the RTC integration

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -9,6 +9,19 @@
 namespace Automattic\VIP\Integrations;
 
 /**
+ * Version of the vip-real-time-collaboration plugin to load.
+ * Used to control staged rollouts (e.g., staging gets new version first).
+ */
+const VIP_RTC_PLUGIN_VERSION = '0.1';
+
+/**
+ * Version of the Gutenberg plugin to load.
+ * Empty string means load from the unversioned 'gutenberg' folder.
+ * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
+ */
+const VIP_RTC_GUTENBERG_VERSION = '';
+
+/**
  * Loads Real-Time Collaboration VIP Integration.
  *
  * @private
@@ -50,8 +63,20 @@ class RealTimeCollaborationIntegration extends Integration {
 		return true;
 	}
 
+	/**
+	 * Get the path to the Gutenberg plugin.
+	 *
+	 * @return string|false The path to the Gutenberg plugin, or false if not found.
+	 */
 	private function get_gutenberg_path(): string|false {
-		$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/gutenberg/gutenberg.php';
+		// Empty string means use the unversioned folder
+		if ( '' === VIP_RTC_GUTENBERG_VERSION ) {
+			$gutenberg_folder = 'gutenberg';
+		} else {
+			$gutenberg_folder = 'gutenberg-' . VIP_RTC_GUTENBERG_VERSION;
+		}
+
+		$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $gutenberg_folder . '/gutenberg.php';
 		if ( ! file_exists( $gutenberg_path ) ) {
 			return false;
 		}
@@ -59,14 +84,15 @@ class RealTimeCollaborationIntegration extends Integration {
 		return $gutenberg_path;
 	}
 
+	/**
+	 * Get the path to the RTC plugin.
+	 *
+	 * @return string|false The path to the RTC plugin, or false if not found.
+	 */
 	private function get_plugin_path(): string|false {
-		$latest_directory = $this->get_latest_version();
-		if ( empty( $latest_directory ) ) {
-			return false;
-		}
-		// Load the plugin.
-		$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $latest_directory . '/vip-real-time-collaboration.php';
-		// This check isn't strictly necessary, but better safe than sorry.
+		$plugin_directory = 'vip-real-time-collaboration-' . VIP_RTC_PLUGIN_VERSION;
+
+		$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $plugin_directory . '/vip-real-time-collaboration.php';
 		if ( ! file_exists( $load_path ) ) {
 			return false;
 		}
@@ -110,20 +136,11 @@ class RealTimeCollaborationIntegration extends Integration {
 
 			/**
 			 * Load the custom build of Gutenberg from vip-integrations
-			 * and the latest version of the vip-real-time-collaboration plugin.
+			 * and the configured version of the vip-real-time-collaboration plugin.
 			 */
 			require_once $gutenberg_path;
 			require_once $load_path;
 		}, 1);
-	}
-
-	/**
-	 * Get the latest version of Real-Time Collaboration.
-	 *
-	 * @return string|null The latest version of Real-Time Collaboration or null if no versions are found.
-	 */
-	public function get_latest_version() {
-		return get_latest_version( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-real-time-collaboration', 'vip-real-time-collaboration.php' );
 	}
 
 	/**

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -9,24 +9,24 @@
 namespace Automattic\VIP\Integrations;
 
 /**
- * Version of the vip-real-time-collaboration plugin to load.
- * Used to control staged rollouts (e.g., staging gets new version first).
- */
-const VIP_RTC_PLUGIN_VERSION = '0.1';
-
-/**
- * Version of the Gutenberg plugin to load.
- * Empty string means load from the unversioned 'gutenberg' folder.
- * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
- */
-const VIP_RTC_GUTENBERG_VERSION = '';
-
-/**
  * Loads Real-Time Collaboration VIP Integration.
  *
  * @private
  */
 class RealTimeCollaborationIntegration extends Integration {
+	/**
+	 * Version of the vip-real-time-collaboration plugin to load.
+	 * Used to control staged rollouts (e.g., staging gets new version first).
+	 */
+	const VIP_RTC_PLUGIN_VERSION = '0.1';
+
+	/**
+	 * Version of the Gutenberg plugin to load.
+	 * Empty string means load from the unversioned 'gutenberg' folder.
+	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
+	 */
+	const VIP_RTC_GUTENBERG_VERSION = '';
+
 	/**
 	 * Enable Pendo tracking for this integration.
 	 *
@@ -69,15 +69,13 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * @return string|false The path to the Gutenberg plugin, or false if not found.
 	 */
 	private function get_gutenberg_path(): string|false {
-		if ( ! defined( 'VIP_RTC_GUTENBERG_VERSION' ) ) {
-			return false;
-		}
-
 		// Empty string means use the unversioned folder
-		if ( '' === VIP_RTC_GUTENBERG_VERSION ) {
+		if ( defined( 'VIP_RTC_GUTENBERG_VERSION' ) && '' === constant( 'VIP_RTC_GUTENBERG_VERSION' ) ) {
 			$gutenberg_folder = 'gutenberg';
+		} elseif ( defined( 'VIP_RTC_GUTENBERG_VERSION' ) && '' !== constant( 'VIP_RTC_GUTENBERG_VERSION' ) ) {
+			$gutenberg_folder = 'gutenberg-' . constant( 'VIP_RTC_GUTENBERG_VERSION' );
 		} else {
-			$gutenberg_folder = 'gutenberg-' . VIP_RTC_GUTENBERG_VERSION;
+			return false;
 		}
 
 		$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $gutenberg_folder . '/gutenberg.php';
@@ -94,11 +92,11 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * @return string|false The path to the RTC plugin, or false if not found.
 	 */
 	private function get_plugin_path(): string|false {
-		if ( ! defined( 'VIP_RTC_PLUGIN_VERSION' ) ) {
+		if ( defined( 'VIP_RTC_PLUGIN_VERSION' ) ) {
+			$plugin_directory = 'vip-real-time-collaboration-' . constant( 'VIP_RTC_PLUGIN_VERSION' );
+		} else {
 			return false;
 		}
-
-		$plugin_directory = 'vip-real-time-collaboration-' . VIP_RTC_PLUGIN_VERSION;
 
 		$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $plugin_directory . '/vip-real-time-collaboration.php';
 		if ( ! file_exists( $load_path ) ) {

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -69,6 +69,10 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * @return string|false The path to the Gutenberg plugin, or false if not found.
 	 */
 	private function get_gutenberg_path(): string|false {
+		if ( ! defined( 'VIP_RTC_GUTENBERG_VERSION' ) ) {
+			return false;
+		}
+
 		// Empty string means use the unversioned folder
 		if ( '' === VIP_RTC_GUTENBERG_VERSION ) {
 			$gutenberg_folder = 'gutenberg';
@@ -90,6 +94,10 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * @return string|false The path to the RTC plugin, or false if not found.
 	 */
 	private function get_plugin_path(): string|false {
+		if ( ! defined( 'VIP_RTC_PLUGIN_VERSION' ) ) {
+			return false;
+		}
+
 		$plugin_directory = 'vip-real-time-collaboration-' . VIP_RTC_PLUGIN_VERSION;
 
 		$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $plugin_directory . '/vip-real-time-collaboration.php';

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -55,7 +55,7 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		do_action( 'plugins_loaded' );
 	}
 
-	public function test_load_sets_inactive_if_no_versions_found(): void {
+	public function test_load_sets_inactive_if_plugin_file_not_found(): void {
 		// Set up required constants
 		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
 		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
@@ -150,11 +150,11 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( defined( 'VIP_RTC_WS_URL' ) );
 	}
 
-	public function test_get_latest_version_returns_null_when_no_versions_are_found(): void {
-		$rtc_integration = new RealTimeCollaborationIntegration( $this->slug );
-		$latest_version  = $rtc_integration->get_latest_version();
-
-		$this->assertNull( $latest_version );
+	public function test_version_constants_are_defined(): void {
+		$this->assertTrue( defined( 'Automattic\VIP\Integrations\VIP_RTC_PLUGIN_VERSION' ) );
+		$this->assertTrue( defined( 'Automattic\VIP\Integrations\VIP_RTC_GUTENBERG_VERSION' ) );
+		$this->assertSame( '0.1', VIP_RTC_PLUGIN_VERSION );
+		$this->assertSame( '', VIP_RTC_GUTENBERG_VERSION );
 	}
 
 	public function test_load_sets_inactive_when_ws_auth_secret_missing(): void {

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -150,13 +150,6 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( defined( 'VIP_RTC_WS_URL' ) );
 	}
 
-	public function test_version_constants_are_defined(): void {
-		$this->assertTrue( defined( 'Automattic\VIP\Integrations\VIP_RTC_PLUGIN_VERSION' ) );
-		$this->assertTrue( defined( 'Automattic\VIP\Integrations\VIP_RTC_GUTENBERG_VERSION' ) );
-		$this->assertSame( '0.1', VIP_RTC_PLUGIN_VERSION );
-		$this->assertSame( '', VIP_RTC_GUTENBERG_VERSION );
-	}
-
 	public function test_load_sets_inactive_when_ws_auth_secret_missing(): void {
 		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
 		// VIP_RTC_WS_AUTH_SECRET is intentionally not defined


### PR DESCRIPTION
## Description

Supports staged roll-out for the RTC integration. This is accomplished through constants that specify which version of the Gutenberg plugin and the RTC plugin to load. When those constants are updated, they'll be deployed with this repo on the normal staged released.

## Changelog Description

### Added
- Add support for staged roll-out of the Real-Time Collaboration integration

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->