### PR TITLE
Update gutenberg version string for RTC to 0.2

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '22.4.1-f48ad9c';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Description
Update version string for Gutenberg to match what is used in https://github.com/Automattic/vip-go-mu-plugins-ext/pull/104

## Changelog Description

### Changed
- Updated Gutenberg version string for the Real-Time Collaboration integration

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.