### PR TITLE
Fix vip-real-time-collaboration integration failed constant checks

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '22.4.1-f48ad9c';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2';
 
 	/**
 	 * Enable Pendo tracking for this integration.
@@ -70,12 +70,10 @@ class RealTimeCollaborationIntegration extends Integration {
 	 */
 	private function get_gutenberg_path(): string|false {
 		// Empty string means use the unversioned folder
-		if ( defined( 'VIP_RTC_GUTENBERG_VERSION' ) && '' === constant( 'VIP_RTC_GUTENBERG_VERSION' ) ) {
+		if ( self::VIP_RTC_GUTENBERG_VERSION === '' ) {
 			$gutenberg_folder = 'gutenberg';
-		} elseif ( defined( 'VIP_RTC_GUTENBERG_VERSION' ) && '' !== constant( 'VIP_RTC_GUTENBERG_VERSION' ) ) {
-			$gutenberg_folder = 'gutenberg-' . constant( 'VIP_RTC_GUTENBERG_VERSION' );
 		} else {
-			return false;
+			$gutenberg_folder = 'gutenberg-' . self::VIP_RTC_GUTENBERG_VERSION;
 		}
 
 		$gutenberg_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $gutenberg_folder . '/gutenberg.php';
@@ -92,11 +90,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * @return string|false The path to the RTC plugin, or false if not found.
 	 */
 	private function get_plugin_path(): string|false {
-		if ( defined( 'VIP_RTC_PLUGIN_VERSION' ) ) {
-			$plugin_directory = 'vip-real-time-collaboration-' . constant( 'VIP_RTC_PLUGIN_VERSION' );
-		} else {
-			return false;
-		}
+		$plugin_directory = 'vip-real-time-collaboration-' . self::VIP_RTC_PLUGIN_VERSION;
 
 		$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $plugin_directory . '/vip-real-time-collaboration.php';
 		if ( ! file_exists( $load_path ) ) {


### PR DESCRIPTION
## Description
Fixes an issue from https://github.com/Automattic/vip-go-mu-plugins/pull/6731 where the `vip-real-time-collaboration` integration constants were moved to class constants but the `defined()` checks weren't removed.

## Changelog Description

### Fixed
- The vip-real-time-collaboration integration loading issues.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.