### PR TITLE
style: fix issues found by ESLint

### DIFF
--- a/__tests__/e2e/specs/searchdevtools.spec.ts
+++ b/__tests__/e2e/specs/searchdevtools.spec.ts
@@ -14,18 +14,28 @@ test( 'Search Dev Tools', async ( { page } ) => {
 	let query: string;
 
 	await test.step( 'Do a search', () => searchPage.visit( 'Hello' ) );
+
 	await test.step( 'Open DevTools', () => searchPage.openSearchDevTools() );
+
 	await test.step( 'Check number of queries', () => expect( searchPage.getNumberOfQueries() ).resolves.toBeGreaterThanOrEqual( 1 ) );
+
 	await test.step( 'Check number of results', () => expect( searchPage.getNumberOfFirstResults() ).resolves.toBe( 1 ) );
+
 	await test.step( 'Expand search results', () => expect( searchPage.expandFirstResults() ).resolves.toBeTruthy() );
+
 	await test.step( 'Ensure WP_Query is functional', () => expect( searchPage.getWPQuery() ).resolves.toMatch( 'search_terms: ["Hello"]' ) );
+
 	await test.step( 'Ensure Trace is functional', () => expect( searchPage.getTrace() ).resolves.toMatch( 'ElasticPress\\Elasticsearch->remote_request' ) );
+
 	await test.step( 'Get the query', async () => {
 		query = await searchPage.getQuery();
 		return expect( query ).toMatch( '"query": "Hello",' );
 	} );
+
 	await test.step( 'Modify the query', () => searchPage.editQuery( query.replace( /"Hello"/g, '"world"' ) ) );
+
 	await test.step( 'Ensure Reset works', () => expect( searchPage.resetQuery() ).resolves.toBe( query ) );
+
 	await test.step( 'Run a new query', async () => {
 		const newQuery = query.replace( /"Hello"/g, '"world"' );
 		await searchPage.editQuery( newQuery );
@@ -38,5 +48,6 @@ test( 'Search Dev Tools', async ( { page } ) => {
 
 		return searchPage.ensureQueryResponse( 'world' );
 	} );
+
 	await test.step( 'Close DevTools', () => searchPage.closeSearchDevTools() );
 } );


### PR DESCRIPTION
## Description

This PR addresses the `playwright/consistent-spacing-between-blocks` warning by ESLint that pollutes diff views in GitHub.

There are no functional changes, only cosmetic ones.
