### PR TITLE
fix: convert public-facing inline scripts into external assets

### DIFF
--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -21,7 +21,7 @@ add_action( 'admin_bar_menu', __NAMESPACE__ . '\admin_bar_node', PHP_INT_MAX );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 11 );
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 11 );
 add_filter( 'js_do_concat', __NAMESPACE__ . '\skip_js_do_concat', 10, 2 );
-add_action( 'wp_footer', __NAMESPACE__ . '\print_data', 5 );
+add_action( 'wp_footer', __NAMESPACE__ . '\print_data', 5 ); // Must be below 20 (`wp_print_footer_scripts`)
 add_action( 'admin_footer', __NAMESPACE__ . '\print_data', 5 );
 
 /**
@@ -288,10 +288,8 @@ function print_data() {
 		'__webpack_public_path__' => plugin_dir_url( __FILE__ ) . 'build',
 	];
 
+	wp_print_inline_script_tag( sprintf( 'var VIPSearchDevTools = %s;', wp_json_encode( $data, JSON_PRETTY_PRINT ) ) );
 	?>
-<script>
-	var VIPSearchDevTools = <?php echo wp_json_encode( $data, JSON_PRETTY_PRINT ); ?>;
-</script>
 <div id="search-dev-tools-portal"></div>
 	<?php
 }

--- a/vip-helpers/assets/nonprod.css
+++ b/vip-helpers/assets/nonprod.css
@@ -1,0 +1,39 @@
+#vip-non-prod-bar {
+	z-index: 9991;
+	font: 14px/28px 'Helvetica Neue',Arial,Helvetica,sans-serif;
+	left: 0;
+	bottom: 145px;
+	position:fixed;
+	margin:0;
+	padding: 0 20px;
+	height: 28px;
+}
+#vip-non-prod-bar span {
+	display: none;
+	float: left;
+	padding: 0 10px;
+	background: #fff;
+	color: #333;
+}
+
+#vip-non-prod-bar:before {
+	content: 'Non-production';
+	text-transform: uppercase;
+	background: #4c2c92;
+	color: #fff;
+	letter-spacing: 0.2em;
+	text-shadow: none;
+	font-size: 9px;
+	font-weight: bold;
+	padding: 0 10px;
+	float: left;
+	cursor: pointer;
+}
+#vip-non-prod-bar.which-env span {
+	display: inline-block;
+}
+@media print {
+	div#vip-non-prod-bar {
+		display: none !important;
+	}
+}

--- a/vip-helpers/assets/nonprod.js
+++ b/vip-helpers/assets/nonprod.js
@@ -1,0 +1,22 @@
+(function() {
+	function callback() {
+		const nonProdBar = document.getElementById('vip-non-prod-bar');
+		if (nonProdBar) {
+			nonProdBar.addEventListener('click', function() {
+				this.classList.toggle('which-env');
+			} );
+
+			const debugBar = document.getElementById('a8c-debug-flag');
+			if (debugBar) {
+				// Account for proper stacking of the debug bar
+				nonProdBar.style.bottom = '180px';
+			}
+		}
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', callback );
+	} else {
+		callback();
+	}
+})();

--- a/vip-helpers/assets/sandbox.css
+++ b/vip-helpers/assets/sandbox.css
@@ -1,0 +1,41 @@
+#wpcom-sandboxed-bar {
+	z-index: 9991;
+	color:<?php echo esc_html( apply_filters( 'wpcom_sandbox_bar_debug_info_color', '#ddd' ) ); ?>;
+	font: 14px/28px 'Helvetica Neue',Arial,Helvetica,sans-serif;
+	bottom: 110px;
+	left: 0;
+	position:fixed;
+	margin:0;
+	padding: 0 20px;
+	width: 100%;
+	height: 28px;
+}
+#wpcom-sandboxed-bar span {
+	display: none;
+	float: left;
+	padding: 0 10px;
+	background: #fff;
+	color: #333;
+}
+
+#wpcom-sandboxed-bar:before {
+	content: 'Sandboxed';
+	text-transform: uppercase;
+	background: #d54e21;
+	color: #fff;
+	letter-spacing: 0.2em;
+	text-shadow: none;
+	font-size: 9px;
+	font-weight: bold;
+	padding: 0 10px;
+	float: left;
+	cursor: pointer;
+}
+#wpcom-sandboxed-bar.sbx-debug span {
+	display: inline-block;
+}
+@media print {
+	div#wpcom-sandboxed-bar {
+		display: none !important;
+	}
+}

--- a/vip-helpers/assets/sandbox.js
+++ b/vip-helpers/assets/sandbox.js
@@ -1,0 +1,16 @@
+(function() {
+	function callback() {
+		const bar = document.querySelector('#wpcom-sandboxed-bar');
+		if (bar) {
+			bar.addEventListener('click', function() {
+				this.classList.toggle('sbx-debug');
+			});
+		}
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', callback);
+	} else {
+		callback();
+	}
+})();

--- a/vip-helpers/sandbox.php
+++ b/vip-helpers/sandbox.php
@@ -4,15 +4,12 @@ if ( ! defined( 'WPCOM_SANDBOXED' ) || ! WPCOM_SANDBOXED ) {
 	return;
 }
 
-add_action( 'wp_footer', 'wpcom_do_sandbox_bar', 100 );
-add_action( 'admin_footer', 'wpcom_do_sandbox_bar', 100 );
-
 function wpcom_do_sandbox_bar() {
 	if ( is_user_logged_in() && ! is_admin_bar_showing() ) {
 		return;
 	}
 
-	if ( apply_filters( 'wpcom_show_sandbox_bar', false ) ) :
+	if ( apply_filters( 'wpcom_show_sandbox_bar', false ) ) {
 		$template   = get_template();
 		$stylesheet = get_stylesheet();
 		$theme      = ( $stylesheet != $template ) ? sprintf( '%s => %s', $stylesheet, $template ) : $template;
@@ -34,57 +31,42 @@ function wpcom_do_sandbox_bar() {
 				</span>
 			<?php endforeach; ?>
 		</div>
-		<script>
-			document.querySelector('#wpcom-sandboxed-bar').addEventListener( 'click', function() {
-				this.classList.toggle('sbx-debug');
-			} );
-		</script>
-		<style>
-		#wpcom-sandboxed-bar {
-			z-index: 9991;
-			color:<?php echo esc_html( apply_filters( 'wpcom_sandbox_bar_debug_info_color', '#ddd' ) ); ?>;
-			font: 14px/28px 'Helvetica Neue',Arial,Helvetica,sans-serif;
-			bottom: 110px;
-			left: 0;
-			position:fixed;
-			margin:0;
-			padding: 0 20px;
-			width: 100%;
-			height: 28px;
-		}
-		#wpcom-sandboxed-bar span {
-			display: none;
-			float: left;
-			padding: 0 10px;
-			background: #fff;
-			color: #333;
-		}
-
-		#wpcom-sandboxed-bar:before {
-			content: 'Sandboxed';
-			text-transform: uppercase;
-			background: #d54e21;
-			color: #fff;
-			letter-spacing: 0.2em;
-			text-shadow: none;
-			font-size: 9px;
-			font-weight: bold;
-			padding: 0 10px;
-			float: left;
-			cursor: pointer;
-		}
-		#wpcom-sandboxed-bar.sbx-debug span {
-			display: inline-block;
-		}
-		@media print {
-			div#wpcom-sandboxed-bar {
-				display: none !important;
-			}
-		}
-		</style>
 		<?php
-	endif;
+	}
 }
+
+function wpcom_sandbox_enqueue_scripts() {
+	if ( is_user_logged_in() && ! is_admin_bar_showing() ) {
+		return;
+	}
+
+	if ( apply_filters( 'wpcom_show_sandbox_bar', false ) ) {
+		wp_register_style( 'wpcom-sandbox-bar', plugins_url( '/assets/sandbox.css', __FILE__ ), [], '1.0' );
+		wp_register_script( 'wpcom-sandbox-bar', plugins_url( '/assets/sandbox.js', __FILE__ ), [], '1.0', true );
+
+		wp_enqueue_style( 'wpcom-sandbox-bar' );
+		wp_enqueue_script( 'wpcom-sandbox-bar' );
+	}
+
+	if ( apply_filters( 'wpcom_show_sandbox_bar', false ) ) {
+		wp_register_style( 'wpcom-sandboxed-bar', plugins_url( '/assets/sandboxed.css', __FILE__ ), [], '1.0' );
+		wp_register_script( 'wpcom-sandboxed-bar', plugins_url( '/assets/sandboxed.js', __FILE__ ), [], '1.0', true );
+
+		wp_enqueue_style( 'wpcom-sandboxed-bar' );
+		wp_enqueue_script( 'wpcom-sandboxed-bar' );
+
+		add_action( 'wp_footer', 'wpcom_do_sandbox_bar', 100 );
+		add_action( 'admin_footer', 'wpcom_do_sandbox_bar', 100 );
+	}
+}
+
+add_action( 'wp_enqueue_scripts', 'wpcom_sandbox_enqueue_scripts' );
+add_action( 'admin_enqueue_scripts', 'wpcom_sandbox_enqueue_scripts' );
+
+
+add_action( 'wp_footer', 'wpcom_do_sandbox_bar', 100 );
+add_action( 'admin_footer', 'wpcom_do_sandbox_bar', 100 );
+
 add_filter( 'wpcom_show_sandbox_bar', '__return_true' );
 
 /**

--- a/vip-helpers/vip-non-production.php
+++ b/vip-helpers/vip-non-production.php
@@ -4,79 +4,36 @@ if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'production' === constant( 'VIP_GO
 	return;
 }
 
-add_action( 'wp_footer', 'vip_do_non_prod_bar', 10000 );
-add_action( 'admin_footer', 'vip_do_non_prod_bar', 10000 );
-
 function vip_do_non_prod_bar() {
+	$environment = constant( 'VIP_GO_APP_ENVIRONMENT' );
+	if ( 'local' === $environment && 'true' === getenv( 'CODESPACES' ) ) {
+		$environment = 'codespaces';
+	}
+	?>
+	<div id="vip-non-prod-bar">
+		<span>
+			<strong><?php echo esc_html( $environment ); ?></strong>
+		</span>
+	</div>
+	<?php
+}
+
+function vip_non_prod_enqueue_scripts() {
 	if ( ! current_user_can( 'edit_posts' ) ) {
 		return;
 	}
 
-	if ( apply_filters( 'vip_show_non_prod_bar', true ) ) :
-		$environment = constant( 'VIP_GO_APP_ENVIRONMENT' );
-		if ( 'local' === $environment && 'true' === getenv( 'CODESPACES' ) ) {
-			$environment = 'codespaces';
-		}
+	if ( apply_filters( 'vip_show_non_prod_bar', true ) ) {
+		wp_register_style( 'vip-non-prod-bar', plugins_url( '/assets/nonprod.css', __FILE__ ), [], '1.0' );
+		wp_register_script( 'vip-non-prod-bar', plugins_url( '/assets/nonprod.js', __FILE__ ), [], '1.0', true );
 
-		?>
-		<div id="vip-non-prod-bar">
-			<span>
-				<strong><?php echo esc_html( $environment ); ?></strong>
-			</span>
-		</div>
-		<script>
-			const nonProdBar = document.getElementById('vip-non-prod-bar');
-			nonProdBar.addEventListener( 'click', function() {
-				this.classList.toggle('which-env');
-			} );
+		wp_enqueue_style( 'vip-non-prod-bar' );
+		wp_enqueue_script( 'vip-non-prod-bar' );
 
-			const debugBar = document.getElementById('a8c-debug-flag');
-			if ( debugBar ) {
-				// Account for proper stacking of the debug bar
-				nonProdBar.style.bottom = '180px';
-			}
-		</script>
-		<style>
-		#vip-non-prod-bar {
-			z-index: 9991;
-			font: 14px/28px 'Helvetica Neue',Arial,Helvetica,sans-serif;
-			left: 0;
-			bottom: 145px;
-			position:fixed;
-			margin:0;
-			padding: 0 20px;
-			height: 28px;
-		}
-		#vip-non-prod-bar span {
-			display: none;
-			float: left;
-			padding: 0 10px;
-			background: #fff;
-			color: #333;
-		}
-
-		#vip-non-prod-bar:before {
-			content: 'Non-production';
-			text-transform: uppercase;
-			background: #4c2c92;
-			color: #fff;
-			letter-spacing: 0.2em;
-			text-shadow: none;
-			font-size: 9px;
-			font-weight: bold;
-			padding: 0 10px;
-			float: left;
-			cursor: pointer;
-		}
-		#vip-non-prod-bar.which-env span {
-			display: inline-block;
-		}
-		@media print {
-			div#vip-non-prod-bar {
-				display: none !important;
-			}
-		}
-		</style>
-		<?php
-	endif;
+		add_action( 'wp_footer', 'vip_do_non_prod_bar', 10000 );
+		add_action( 'admin_footer', 'vip_do_non_prod_bar', 10000 );
+	}
 }
+
+add_action( 'wp_enqueue_scripts', 'vip_non_prod_enqueue_scripts' );
+add_action( 'admin_enqueue_scripts', 'vip_non_prod_enqueue_scripts' );

--- a/vip-jetpack/jetpack-mandatory.php
+++ b/vip-jetpack/jetpack-mandatory.php
@@ -90,11 +90,7 @@ class WPCOM_VIP_Jetpack_Mandatory {
 		}
 
 		$output = 'var wpcom_vip_jetpack_forced = ' . wp_json_encode( $forced_modules ) . ';';
-		echo "<script type='text/javascript'>", PHP_EOL; // CDATA and type='text/javascript' is not needed for HTML 5
-		echo '/* <![CDATA[ */', PHP_EOL;
-		echo $output, PHP_EOL;  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo '/* ]]> */', PHP_EOL;
-		echo '</script>', PHP_EOL;
+		wp_print_inline_script_tag( $output );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR converts public-facing inline JavaScript (and some inline CSS) into external assets or refactors the code to use `wp_print_inline_script()` to print dynamic inline content.

This allows for using Content-Security-Policy without `unsafe-inline` (provided that no external plugin or theme interferes).

Ref: PLTFRM-1918

## Changelog Description

### Fixed
- Converted inline scripts into external components to allow for Content-Security-Policy without `unsafe-inline`.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Manually in Codespaces or Dev Env.

```php
function verify_fix( $attrs ) {
	$attrs['fixed'] = 'true';
	return $attrs;
}

add_filter( 'wp_inline_script_attributes', 'verify_fix' );
add_filter( 'wp_script_attributes', 'verify_fix' );
```

In the browser's Dev Tools:

```js
document.querySelectorAll('script:not([fixed])').length === 0
```

must yield `true`.
