### PR TITLE
fix(two-factor): otpauth link in QR code URL

### DIFF
--- a/shared-plugins/two-factor/providers/class-two-factor-totp.php
+++ b/shared-plugins/two-factor/providers/class-two-factor-totp.php
@@ -292,7 +292,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<?php esc_html_e( 'Please scan the QR code or manually copy the shared secret key from below to your Authenticator app:', 'two-factor' ); ?>
 			</p>
 			<p id="two-factor-qr-code">
-				<a href="<?php echo esc_url( $totp_url ); ?>">
+				<a href="<?php echo esc_url( $totp_url, array( 'otpauth' ) ); ?>">
 					<?php esc_html_e( 'Loading…', 'two-factor' ); ?>
 					<img src="<?php echo esc_url( admin_url( 'images/spinner.gif' ) ); ?>" alt="" />
 				</a>


### PR DESCRIPTION
## Description

Fix OTP Auth link generation in the TOTP Provider of the Two Factor plugin.

Ref: WordPress/two-factor#783, WordPress/two-factor#784

## Changelog Description

### Fixed

- Two Factor: OTP Authentication URL is rendered correctly.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Log in.
2. Got to /wp-admin/profile.php
3. Check the link around the QR code under the "Please scan the QR code or manually copy the shared secret key from below to your Authenticator app:" label.
