### PR TITLE
Add email to WordPress telemetry

### DIFF
--- a/telemetry/pendo/class-pendo-javascript-library.php
+++ b/telemetry/pendo/class-pendo-javascript-library.php
@@ -174,6 +174,7 @@ class Pendo_JavaScript_Library {
 			'visitor'   => [
 				'id'             => $user_properties['visitor_id'],
 				'country_code'   => $user_properties['country_code'],
+				'email'          => $user_properties['email'],
 				'full_name'      => $user_properties['visitor_name'],
 				// This suffix ensures we don't override role attributes from other
 				// contexts, such as the VIP Dashboard.

--- a/telemetry/pendo/pendo-utils.php
+++ b/telemetry/pendo/pendo-utils.php
@@ -58,7 +58,7 @@ function get_base_properties_of_pendo_user(): array|null {
 		'country_code'   => sanitize_text_field( $_SERVER['GEOIP_COUNTRY_CODE'] ?? 'unknown' ),
 		'org_id'         => (string) $vip_org_id,
 		'role_wordpress' => $wp_user->roles[0] ?? 'unknown', // The suffix helps prevent collisions with other contexts like the VIP Dashboard.
-		'email'          => $wp_user->user_email,
+		'email'          => strtolower( sanitize_email( $wp_user->user_email ) ),
 		'visitor_id'     => (string) $user_id,
 		'visitor_name'   => $wp_user->display_name,
 	];

--- a/telemetry/pendo/pendo-utils.php
+++ b/telemetry/pendo/pendo-utils.php
@@ -58,6 +58,7 @@ function get_base_properties_of_pendo_user(): array|null {
 		'country_code'   => sanitize_text_field( $_SERVER['GEOIP_COUNTRY_CODE'] ?? 'unknown' ),
 		'org_id'         => (string) $vip_org_id,
 		'role_wordpress' => $wp_user->roles[0] ?? 'unknown', // The suffix helps prevent collisions with other contexts like the VIP Dashboard.
+		'email'          => $wp_user->user_email,
 		'visitor_id'     => (string) $user_id,
 		'visitor_name'   => $wp_user->display_name,
 	];

--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -314,6 +314,7 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 			'visitor'   => [
 				'id'             => '2a69efbe98bed50d3fee619f409b5ded12fb63f1fab2dd52e211e2b626b49408',
 				'country_code'   => 'unknown',
+				'email'          => 'frances@ha.com',
 				'full_name'      => 'Frances Ha',
 				'role_wordpress' => 'author',
 			],

--- a/tests/telemetry/pendo/test-pendo-utils.php
+++ b/tests/telemetry/pendo/test-pendo-utils.php
@@ -45,6 +45,7 @@ class Pendo_Utils_Test extends WP_UnitTestCase {
 			'country_code'   => 'unknown',
 			'org_id'         => '11',
 			'role_wordpress' => 'administrator',
+			'email'          => 'admin@example.org',
 			'visitor_id'     => 'f492ac7d4b4e1b795d8ebe8a142d003fdac45e33490d47573a7b78a91a52bde9',
 			'visitor_name'   => 'admin',
 		];
@@ -69,6 +70,7 @@ class Pendo_Utils_Test extends WP_UnitTestCase {
 			'country_code'   => 'unknown',
 			'org_id'         => '22',
 			'role_wordpress' => 'unknown',
+			'email'          => 'frances@ha.com',
 			'visitor_id'     => '2a69efbe98bed50d3fee619f409b5ded12fb63f1fab2dd52e211e2b626b49408',
 			'visitor_name'   => 'frances',
 		];


### PR DESCRIPTION
## Description

This change adds the user's email address to the Pendo telemetry visitor data, enabling better user identification and analysis in Pendo analytics.

## Changelog Description

### Added
- Email address is now included in Pendo visitor telemetry data

## Steps to Test

1. Verify that user email is correctly passed from WordPress to Pendo initialization data
2. Check test suite passes with the updated expectations