### PR TITLE
fix(two-factor): ensure execution stops after redirects

### DIFF
--- a/shared-plugins/two-factor/class-two-factor-core.php
+++ b/shared-plugins/two-factor/class-two-factor-core.php
@@ -1407,7 +1407,7 @@ class Two_Factor_Core {
 		// Validate the request.
 		if ( true !== self::verify_login_nonce( $user->ID, $nonce ) ) {
 			wp_safe_redirect( home_url() );
-			return;
+			exit;
 		}
 
 		$provider = self::get_provider_for_user( $user, $provider );
@@ -1495,6 +1495,7 @@ class Two_Factor_Core {
 
 		$redirect_to = apply_filters( 'login_redirect', $redirect_to, $redirect_to, $user );
 		wp_safe_redirect( $redirect_to );
+		exit;
 	}
 
 
@@ -1530,7 +1531,7 @@ class Two_Factor_Core {
 	public static function _login_form_revalidate_2fa( $nonce = '', $provider = '', $redirect_to = '', $is_post_request = false ) {
 		if ( ! is_user_logged_in() ) {
 			wp_safe_redirect( home_url() );
-			return;
+			exit;
 		}
 
 		$user = wp_get_current_user();
@@ -1538,7 +1539,7 @@ class Two_Factor_Core {
 		// Validate the nonce for POST requests. GET requests do not perform actions, and such do not require the nonce (such as the initial request).
 		if ( $is_post_request && ! wp_verify_nonce( $nonce, 'two_factor_revalidate_' . $user->ID ) ) {
 			wp_safe_redirect( home_url() );
-			return;
+			exit;
 		}
 
 		$provider = self::get_provider_for_user( $user, $provider );
@@ -1593,7 +1594,7 @@ class Two_Factor_Core {
 
 		$redirect_to = apply_filters( 'login_redirect', $redirect_to, $redirect_to, $user );
 		wp_safe_redirect( $redirect_to );
-		return;
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR ensures that code execution stops after calling `wp_safe_redirect()` in the two-factor authentication validation functions. Without `exit()`, PHP continues executing code after sending redirect headers, which could lead to security vulnerabilities or unintended behavior.

This follows WordPress best practices and aligns with the existing [function documentation](https://developer.wordpress.org/reference/functions/wp_safe_redirect/) that states "[wp_safe_redirect()](https://developer.wordpress.org/reference/functions/wp_safe_redirect/) does not exit automatically, and should almost always be followed by a call to `exit;`."

Ref: WordPress/two-factor#786

## Changelog Description

### Fixed
- Exit after redirect in Two Factor

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

N/A
