### PR TITLE
Switch Pendo visitor ID from hashed email to plain email

### DIFF
--- a/telemetry/pendo/pendo-utils.php
+++ b/telemetry/pendo/pendo-utils.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Automattic\VIP\Telemetry\Pendo;
 
 use function Automattic\VIP\Telemetry\Tracks\get_base_properties_of_track_event;
-use function Automattic\VIP\Telemetry\Tracks\get_base_properties_of_track_user;
 
 /**
  * Returns the base properties for a Pendo event. Reuse the corresponding Tracks
@@ -46,20 +45,20 @@ function get_base_properties_of_pendo_user(): array|null {
 	}
 
 	$event_props = get_base_properties_of_pendo_track_event();
-	$user_props  = get_base_properties_of_track_user();
 
 	$is_vip_user = $event_props['is_vip_user'];
-	$user_id     = $is_vip_user ? 'vip-' . $user_props['_ui'] : $user_props['_ui'];
 	$vip_org_id  = $event_props['vip_org'] ?? 'unknown';
 	$sf_org_id   = defined( 'VIP_SF_ACCOUNT_ID' ) ? constant( 'VIP_SF_ACCOUNT_ID' ) : sprintf( 'nosfid_wordpress_%s', $vip_org_id );
+	$email       = strtolower( sanitize_email( $wp_user->user_email ) );
+	$visitor_id  = $is_vip_user ? 'vip-' . $email : $email;
 
 	return [
 		'account_id'     => (string) $sf_org_id,
 		'country_code'   => sanitize_text_field( $_SERVER['GEOIP_COUNTRY_CODE'] ?? 'unknown' ),
 		'org_id'         => (string) $vip_org_id,
 		'role_wordpress' => $wp_user->roles[0] ?? 'unknown', // The suffix helps prevent collisions with other contexts like the VIP Dashboard.
-		'email'          => strtolower( sanitize_email( $wp_user->user_email ) ),
-		'visitor_id'     => (string) $user_id,
+		'email'          => $email,
+		'visitor_id'     => $visitor_id,
 		'visitor_name'   => $wp_user->display_name,
 	];
 }

--- a/telemetry/pendo/pendo-utils.php
+++ b/telemetry/pendo/pendo-utils.php
@@ -50,7 +50,12 @@ function get_base_properties_of_pendo_user(): array|null {
 	$vip_org_id  = $event_props['vip_org'] ?? 'unknown';
 	$sf_org_id   = defined( 'VIP_SF_ACCOUNT_ID' ) ? constant( 'VIP_SF_ACCOUNT_ID' ) : sprintf( 'nosfid_wordpress_%s', $vip_org_id );
 	$email       = strtolower( sanitize_email( $wp_user->user_email ) );
-	$visitor_id  = $is_vip_user ? 'vip-' . $email : $email;
+
+	if ( '' === $email ) {
+		return null;
+	}
+
+	$visitor_id = $is_vip_user ? 'vip-' . $email : $email;
 
 	return [
 		'account_id'     => (string) $sf_org_id,

--- a/telemetry/pendo/pendo-utils.php
+++ b/telemetry/pendo/pendo-utils.php
@@ -50,12 +50,7 @@ function get_base_properties_of_pendo_user(): array|null {
 	$vip_org_id  = $event_props['vip_org'] ?? 'unknown';
 	$sf_org_id   = defined( 'VIP_SF_ACCOUNT_ID' ) ? constant( 'VIP_SF_ACCOUNT_ID' ) : sprintf( 'nosfid_wordpress_%s', $vip_org_id );
 	$email       = strtolower( sanitize_email( $wp_user->user_email ) );
-
-	if ( '' === $email ) {
-		return null;
-	}
-
-	$visitor_id = $is_vip_user ? 'vip-' . $email : $email;
+	$visitor_id  = $is_vip_user ? 'vip-' . $email : $email;
 
 	return [
 		'account_id'     => (string) $sf_org_id,

--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -279,6 +279,53 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 		$this->assertSame( $instance, Pendo_JavaScript_Library::init( 'test_api_key' ) );
 	}
 
+	public function test_initialization_data_for_vip_user() {
+		$this->enable_fake_integration_with_pendo_tracking();
+
+		$user = $this->factory()->user->create_and_get( [
+			'role'         => 'author',
+			'display_name' => 'VIP User',
+			'user_email'   => 'vip@example.com',
+		] );
+		$user->add_role( 'vip_support' );
+		wp_set_current_user( $user->ID );
+
+		Constant_Mocker::define( 'VIP_GO_APP_ENVIRONMENT', 'production' );
+		Constant_Mocker::define( 'VIP_ORG_ID', 555 );
+		Constant_Mocker::define( 'VIP_SF_ACCOUNT_ID', 111 );
+		Constant_Mocker::define( 'VIP_TELEMETRY_SALT', 'test_salt' );
+		Constant_Mocker::define( 'WPCOM_IS_VIP_ENV', true );
+
+		$instance = Pendo_JavaScript_Library::init( 'test_api_key' );
+		$instance->enqueue_scripts( 'index.php' );
+
+		$registered_scripts = wp_scripts()->registered;
+		$this->assertArrayHasKey( 'vip-pendo-agent-script', $registered_scripts );
+
+		$expected_data = [
+			'apiKey'    => 'test_api_key',
+			'account'   => [
+				'id'         => '111',
+				'vip_org_id' => '555',
+				'wp_version' => get_bloginfo( 'version' ),
+			],
+			'env'       => 'io',
+			'globalKey' => 'VIP_PENDO_MU_PLUGINS',
+			'plugins'   => [],
+			'visitor'   => [
+				'id'             => 'vip-vip@example.com',
+				'country_code'   => 'unknown',
+				'email'          => 'vip@example.com',
+				'full_name'      => 'VIP User',
+				'role_wordpress' => 'author',
+			],
+		];
+
+		$serialized_data = sprintf( 'var %s = %s;', 'VIP_PENDO_MU_PLUGINS_INIT_DATA', wp_json_encode( $expected_data ) );
+
+		$this->assertSame( $serialized_data, $registered_scripts['vip-pendo-agent-script']->extra['data'] );
+	}
+
 	public function test_initialization_data() {
 		$this->enable_fake_integration_with_pendo_tracking();
 

--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -40,6 +40,7 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 		$integrations_property = get_class_property_as_public( IntegrationsSingleton::class, 'instance' );
 		$integrations_property->setValue( null, null );
 
+		wp_deregister_script( 'vip-pendo-agent-script' );
 		Constant_Mocker::clear();
 		parent::tearDown();
 	}
@@ -287,6 +288,7 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 			'display_name' => 'VIP User',
 			'user_email'   => 'vip@example.com',
 		] );
+		wp_roles()->add_role( 'vip_support', 'VIP Support' );
 		$user->add_role( 'vip_support' );
 		wp_set_current_user( $user->ID );
 

--- a/tests/telemetry/pendo/test-class-pendo-javascript-library.php
+++ b/tests/telemetry/pendo/test-class-pendo-javascript-library.php
@@ -312,7 +312,7 @@ class Pendo_JavaScript_Library_Test extends WP_UnitTestCase {
 			'globalKey' => 'VIP_PENDO_MU_PLUGINS',
 			'plugins'   => [],
 			'visitor'   => [
-				'id'             => '2a69efbe98bed50d3fee619f409b5ded12fb63f1fab2dd52e211e2b626b49408',
+				'id'             => 'frances@ha.com',
 				'country_code'   => 'unknown',
 				'email'          => 'frances@ha.com',
 				'full_name'      => 'Frances Ha',

--- a/tests/telemetry/pendo/test-class-pendo-track-event.php
+++ b/tests/telemetry/pendo/test-class-pendo-track-event.php
@@ -96,6 +96,7 @@ class Pendo_Track_Event_Test extends WP_UnitTestCase {
 		$user = $this->factory()->user->create_and_get( [
 			'user_email' => 'vip@example.com',
 		] );
+		wp_roles()->add_role( 'vip_support', 'VIP Support' );
 		$user->add_role( 'vip_support' );
 		wp_set_current_user( $user->ID );
 

--- a/tests/telemetry/pendo/test-class-pendo-track-event.php
+++ b/tests/telemetry/pendo/test-class-pendo-track-event.php
@@ -92,6 +92,27 @@ class Pendo_Track_Event_Test extends WP_UnitTestCase {
 		$this->assertTrue( $event->is_recordable() );
 	}
 
+	public function test_should_return_vip_prefixed_visitor_id() {
+		$user = $this->factory()->user->create_and_get( [
+			'user_email' => 'vip@example.com',
+		] );
+		$user->add_role( 'vip_support' );
+		wp_set_current_user( $user->ID );
+
+		Constant_Mocker::define( 'VIP_TELEMETRY_SALT', self::VIP_TELEMETRY_SALT );
+		Constant_Mocker::define( 'VIP_ORG_ID', self::VIP_ORG_ID );
+		Constant_Mocker::define( 'VIP_SF_ACCOUNT_ID', self::VIP_SF_ACCOUNT_ID );
+		Constant_Mocker::define( 'WP_ENVIRONMENT_TYPE', self::WP_ENVIRONMENT_TYPE );
+
+		$event = new Pendo_Track_Event( 'prefix_', 'test_event' );
+
+		if ( $event->get_data() instanceof WP_Error ) {
+			$this->fail( sprintf( '%s: %s', $event->get_data()->get_error_code(), $event->get_data()->get_error_message() ) );
+		}
+
+		$this->assertSame( 'vip-vip@example.com', $event->get_data()->visitorId );
+	}
+
 	public function test_should_not_add_prefix_twice() {
 		$event = new Pendo_Track_Event( 'prefixed_', 'prefixed_event_name' );
 

--- a/tests/telemetry/pendo/test-class-pendo-track-event.php
+++ b/tests/telemetry/pendo/test-class-pendo-track-event.php
@@ -71,7 +71,7 @@ class Pendo_Track_Event_Test extends WP_UnitTestCase {
 		$this->assertIsFloat( $event->get_data()->timestamp );
 		$this->assertGreaterThan( ( time() - 10 ) * 1000, $event->get_data()->timestamp );
 		$this->assertSame( 'track', $event->get_data()->type );
-		$this->assertSame( hash_hmac( 'sha256', $this->user->user_email, self::VIP_TELEMETRY_SALT ), $event->get_data()->visitorId );
+		$this->assertSame( strtolower( $this->user->user_email ), $event->get_data()->visitorId );
 
 		// Test event context.
 		$this->assertSame( 'http://test.cool/page', $event->get_data()->context->url );

--- a/tests/telemetry/pendo/test-pendo-utils.php
+++ b/tests/telemetry/pendo/test-pendo-utils.php
@@ -52,6 +52,22 @@ class Pendo_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $props, $output );
 	}
 
+	public function test_get_base_properties_of_vip_user(): void {
+		$user = $this->factory()->user->create_and_get( [
+			'user_login' => 'vip-support',
+			'user_email' => 'vip@example.com',
+		] );
+		$user->add_role( 'vip_support' );
+		wp_set_current_user( $user->ID );
+
+		Constant_Mocker::define( 'VIP_ORG_ID', 33 );
+		Constant_Mocker::define( 'VIP_TELEMETRY_SALT', 'test_salt' );
+
+		$output = get_base_properties_of_pendo_user();
+
+		$this->assertSame( 'vip-vip@example.com', $output['visitor_id'] );
+	}
+
 	public function test_get_base_properties_of_user_with_no_role(): void {
 		$user = $this->factory()->user->create_and_get( [
 			'role'       => [],

--- a/tests/telemetry/pendo/test-pendo-utils.php
+++ b/tests/telemetry/pendo/test-pendo-utils.php
@@ -57,6 +57,7 @@ class Pendo_Utils_Test extends WP_UnitTestCase {
 			'user_login' => 'vip-support',
 			'user_email' => 'vip@example.com',
 		] );
+		wp_roles()->add_role( 'vip_support', 'VIP Support' );
 		$user->add_role( 'vip_support' );
 		wp_set_current_user( $user->ID );
 

--- a/tests/telemetry/pendo/test-pendo-utils.php
+++ b/tests/telemetry/pendo/test-pendo-utils.php
@@ -46,7 +46,7 @@ class Pendo_Utils_Test extends WP_UnitTestCase {
 			'org_id'         => '11',
 			'role_wordpress' => 'administrator',
 			'email'          => 'admin@example.org',
-			'visitor_id'     => 'f492ac7d4b4e1b795d8ebe8a142d003fdac45e33490d47573a7b78a91a52bde9',
+			'visitor_id'     => 'admin@example.org',
 			'visitor_name'   => 'admin',
 		];
 		$this->assertEquals( $props, $output );
@@ -71,7 +71,7 @@ class Pendo_Utils_Test extends WP_UnitTestCase {
 			'org_id'         => '22',
 			'role_wordpress' => 'unknown',
 			'email'          => 'frances@ha.com',
-			'visitor_id'     => '2a69efbe98bed50d3fee619f409b5ded12fb63f1fab2dd52e211e2b626b49408',
+			'visitor_id'     => 'frances@ha.com',
 			'visitor_name'   => 'frances',
 		];
 		$this->assertEquals( $props, $output );


### PR DESCRIPTION
## Description

Changed telemetry visitor identification from an HMAC-SHA256 hash of the user's email to the plain email address. The email hashing algorithm remains for other telemetry purposes.

## Changelog Description

### Changed
- Application telemetry now uses plain email addresses (instead of hashed values) to identify visitors

## Steps to Test

1. Check out PR
2. Verify the `get_base_properties_of_pendo_user()` function returns plain email addresses in the `visitor_id` field
3. Confirm tests pass with the updated expectations