### PR TITLE
Add checks for HTTP_CF_CONNECTING_IP

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -54,8 +54,7 @@ class VIP_Request_Block {
 		$true_ip = '';
 		if ( ! empty( $_SERVER['HTTP_TRUE_CLIENT_IP'] ) ) {
 			$true_ip = $_SERVER['HTTP_TRUE_CLIENT_IP'];
-		} 
-		elseif ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
+		} elseif ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
 			$true_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
 		} 
 		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -59,8 +59,8 @@ class VIP_Request_Block {
 			$true_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
 		}
 		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.
-		if ( ! empty( true_ip ) ) {
-			$hdr = strtolower( true_ip );
+		if ( ! empty( $true_ip ) ) {
+			$hdr = strtolower( $true_ip );
 			$bin = inet_pton( $hdr );
 			if ( $bin === $ip || $hdr === $value ) {
 				return static::block_and_log( $value, 'true-client-ip' );

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -24,7 +24,7 @@ class VIP_Request_Block {
 	protected static $should_log = true;
 
 	/**
-	 * Block a specific IP based either on true-client-ip ( or HTTP_CF_CONNECTING_IP for non-enterprise CloudFront accounts ), falling back to x-forwarded-for
+	 * Block a specific IP based either on true-client-ip (or HTTP_CF_CONNECTING_IP for non-enterprise Cloudflare accounts), falling back to x-forwarded-for
 	 *
 	 * 🛑 BE CAREFUL: blocking a reverse proxy IP instead of the client's IP will result in legitimate traffic being blocked!!!
 	 * 🛑 ALWAYS: use `whois {IP}` to look up the IP before making the changes.

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -55,7 +55,7 @@ class VIP_Request_Block {
 		if ( ! empty( $_SERVER['HTTP_TRUE_CLIENT_IP'] ) ) {
 			$true_ip = $_SERVER['HTTP_TRUE_CLIENT_IP'];
 		}
-		else if ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
+		elseif ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
 			$true_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
 		}
 		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -55,8 +55,8 @@ class VIP_Request_Block {
 		if ( ! empty( $_SERVER['HTTP_TRUE_CLIENT_IP'] ) ) {
 			$true_ip = $_SERVER['HTTP_TRUE_CLIENT_IP'];
 		}
-		else if ( ! empty( $_SERVER['HTTP_CF_CONNECTING'] ) ) {
-			$true_ip = $_SERVER['HTTP_CF_CONNECTING'];
+		else if ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
+			$true_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
 		}
 		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.
 		if ( ! empty( true_ip ) ) {

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -24,7 +24,7 @@ class VIP_Request_Block {
 	protected static $should_log = true;
 
 	/**
-	 * Block a specific IP based either on true-client-ip, falling back to x-forwarded-for
+	 * Block a specific IP based either on true-client-ip ( or HTTP_CF_CONNECTING_IP for non-enterprise CloudFront accounts ), falling back to x-forwarded-for
 	 *
 	 * 🛑 BE CAREFUL: blocking a reverse proxy IP instead of the client's IP will result in legitimate traffic being blocked!!!
 	 * 🛑 ALWAYS: use `whois {IP}` to look up the IP before making the changes.

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -54,10 +54,10 @@ class VIP_Request_Block {
 		$true_ip = '';
 		if ( ! empty( $_SERVER['HTTP_TRUE_CLIENT_IP'] ) ) {
 			$true_ip = $_SERVER['HTTP_TRUE_CLIENT_IP'];
-		}
+		} 
 		elseif ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
 			$true_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
-		}
+		} 
 		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.
 		if ( ! empty( $true_ip ) ) {
 			$hdr = strtolower( $true_ip );

--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -51,10 +51,16 @@ class VIP_Request_Block {
 		}
 
 		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-
-		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.
+		$true_ip = '';
 		if ( ! empty( $_SERVER['HTTP_TRUE_CLIENT_IP'] ) ) {
-			$hdr = strtolower( $_SERVER['HTTP_TRUE_CLIENT_IP'] );
+			$true_ip = $_SERVER['HTTP_TRUE_CLIENT_IP'];
+		}
+		else if ( ! empty( $_SERVER['HTTP_CF_CONNECTING'] ) ) {
+			$true_ip = $_SERVER['HTTP_CF_CONNECTING'];
+		}
+		// This is explicit because we only want to try x-forwarded-for if the true-client-ip is not set.
+		if ( ! empty( true_ip ) ) {
+			$hdr = strtolower( true_ip );
 			$bin = inet_pton( $hdr );
 			if ( $bin === $ip || $hdr === $value ) {
 				return static::block_and_log( $value, 'true-client-ip' );

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -33,7 +33,7 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-		unset( $_SERVER['HTTP_TRUE_CLIENT_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['HTTP_USER_AGENT'] );
+		unset( $_SERVER['HTTP_TRUE_CLIENT_IP'], $_SERVER['HTTP_CF_CONNECTING_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['HTTP_USER_AGENT'] );
 		parent::tearDown();
 	}
 
@@ -80,7 +80,34 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 		self::assertFalse( $actual );
 	}
 
+	public function test__true_client_ip_takes_precedence_over_cf_connecting_ip(): void {
+		$_SERVER['HTTP_TRUE_CLIENT_IP']   = '4.4.4.4';
+		$_SERVER['HTTP_CF_CONNECTING_IP'] = '5.5.5.5';
 
+		$actual = VIP_Request_Block::ip( '4.4.4.4' );
+		self::assertTrue( $actual, 'Expected request to be blocked when blocking IP from HTTP_TRUE_CLIENT_IP' );
+
+		$actual = VIP_Request_Block::ip( '5.5.5.5' );
+		self::assertFalse( $actual, 'Expected request not to be blocked when IP only in HTTP_CF_CONNECTING_IP, since HTTP_TRUE_CLIENT_IP takes precedence' );
+	}
+
+	public function test__cf_connecting_ip_takes_precedence_over_x_forwarded_for(): void {
+		$_SERVER['HTTP_CF_CONNECTING_IP'] = '5.5.5.5';
+		$_SERVER['HTTP_X_FORWARDED_FOR']   = '1.1.1.1, 8.8.8.8';
+
+		$actual = VIP_Request_Block::ip( '5.5.5.5' );
+		self::assertTrue( $actual, 'Expected request to be blocked when blocking IP from HTTP_CF_CONNECTING_IP (takes precedence over HTTP_X_FORWARDED_FOR)' );
+
+		$actual = VIP_Request_Block::ip( '1.1.1.1' );
+		self::assertTrue( $actual, 'Expected request to be blocked when blocking IP from HTTP_X_FORWARDED_FOR' );
+	}
+
+	public function test__error_raised_when_cf_connecting_ip(): void {
+		$_SERVER['HTTP_CF_CONNECTING_IP'] = '5.5.5.5';
+
+		$actual = VIP_Request_Block::ip( '5.5.5.5' );
+		self::assertTrue( $actual );
+	}
 
 	public function test__no_error_log_when_suppressed(): void {
 		$_SERVER['HTTP_TRUE_CLIENT_IP'] = '1.1.1.1';

--- a/tests/lib/test-vip-request-block.php
+++ b/tests/lib/test-vip-request-block.php
@@ -93,7 +93,7 @@ class VIP_Request_Block_Test extends WP_UnitTestCase {
 
 	public function test__cf_connecting_ip_takes_precedence_over_x_forwarded_for(): void {
 		$_SERVER['HTTP_CF_CONNECTING_IP'] = '5.5.5.5';
-		$_SERVER['HTTP_X_FORWARDED_FOR']   = '1.1.1.1, 8.8.8.8';
+		$_SERVER['HTTP_X_FORWARDED_FOR']  = '1.1.1.1, 8.8.8.8';
 
 		$actual = VIP_Request_Block::ip( '5.5.5.5' );
 		self::assertTrue( $actual, 'Expected request to be blocked when blocking IP from HTTP_CF_CONNECTING_IP (takes precedence over HTTP_X_FORWARDED_FOR)' );


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description

Non-Enterprise CloudFlare accounts cannot set TRUE_CLIENT_IP, update the check in lib/class-vip-request-block.php accordingly
https://docs.wpvip.com/reverse-proxy/configure/#:~:text=Cloudflare%2Dspecific%20settings-,Top%20%E2%86%91,%C2%A0instead%3B%20this%20is%20the%20same%20value%20under%20a%20different%20key.,-Amend%20the%C2%A0


## Changelog Description
<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

### Fixed

Update `TRUE_CLIENT_IP` check to also encompass `HTTP_CF_CONNECTING_IP`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.
