### PR TITLE
[VIP-2842] Add org-level config support for Agentforce integration

### DIFF
--- a/integrations/agentforce.php
+++ b/integrations/agentforce.php
@@ -26,7 +26,10 @@ class AgentforceIntegration extends Integration {
 	}
 
 	public function configure(): void {
-		$configs = $this->get_env_config();
+		$org_config = $this->get_org_config();
+		$env_config = $this->get_env_config();
+		// Env config takes precedence over org config
+		$configs = array_merge( $org_config, $env_config );
 
 		if ( ! defined( 'VIP_AGENTFORCE_CONFIGS' ) ) {
 			define( 'VIP_AGENTFORCE_CONFIGS', $configs );

--- a/integrations/agentforce.php
+++ b/integrations/agentforce.php
@@ -28,7 +28,6 @@ class AgentforceIntegration extends Integration {
 	public function configure(): void {
 		$org_config = $this->get_org_config();
 		$env_config = $this->get_env_config();
-		// Env config takes precedence over org config
 		$configs = array_merge( $org_config, $env_config );
 
 		if ( ! defined( 'VIP_AGENTFORCE_CONFIGS' ) ) {

--- a/integrations/agentforce.php
+++ b/integrations/agentforce.php
@@ -28,7 +28,7 @@ class AgentforceIntegration extends Integration {
 	public function configure(): void {
 		$org_config = $this->get_org_config();
 		$env_config = $this->get_env_config();
-		$configs = array_merge( $org_config, $env_config );
+		$configs    = array_merge( $org_config, $env_config );
 
 		if ( ! defined( 'VIP_AGENTFORCE_CONFIGS' ) ) {
 			define( 'VIP_AGENTFORCE_CONFIGS', $configs );

--- a/integrations/integration-vip-config.php
+++ b/integrations/integration-vip-config.php
@@ -165,6 +165,16 @@ class IntegrationVipConfig {
 	}
 
 	/**
+	 * Get organization-level configuration for this integration.
+	 *
+	 * @return array Organization configuration array, empty array if no config defined
+	 */
+	public function get_org_config(): array {
+		$config = $this->get_value_from_config( 'org', 'config' );
+		return is_array( $config ) ? $config : [];
+	}
+
+	/**
 	 * Get child integration configurations.
 	 *
 	 * Returns the 'children' array from the integration configuration, which contains

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -118,7 +118,7 @@ abstract class Integration {
 	/**
 	 * Return the organization-level configuration for this integration.
 	 *
-	 * @return array<string,array>
+	 * @return array<string,mixed>
 	 */
 	public function get_org_config(): array {
 		// If the integration was activated manually, org config is not available.

--- a/integrations/integration.php
+++ b/integrations/integration.php
@@ -116,6 +116,20 @@ abstract class Integration {
 	}
 
 	/**
+	 * Return the organization-level configuration for this integration.
+	 *
+	 * @return array<string,array>
+	 */
+	public function get_org_config(): array {
+		// If the integration was activated manually, org config is not available.
+		if ( ! isset( $this->vip_config ) ) {
+			return [];
+		}
+
+		return $this->vip_config->get_org_config();
+	}
+
+	/**
 	 * Get child integration configurations.
 	 *
 	 * @return array Associative array of child configurations keyed by integration slug

--- a/tests/integrations/test-agentforce.php
+++ b/tests/integrations/test-agentforce.php
@@ -10,6 +10,7 @@ namespace Automattic\VIP\Integrations;
 
 use WP_UnitTestCase;
 use Automattic\Test\Constant_Mocker;
+use PHPUnit\Framework\MockObject\MockObject;
 
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
@@ -63,6 +64,67 @@ class Agentforce_Integration_Test extends WP_UnitTestCase {
 		$agentforce_integration->configure();
 
 		$this->assertEquals( [ 'test' => 'value' ], constant( 'VIP_AGENTFORCE_CONFIGS' ) );
+	}
+
+	public function test_configure_merges_org_and_env_config(): void {
+		$vip_config_mock = $this->get_vip_config_mock( [
+			'org' => [
+				'status' => 'enabled',
+				'config' => [ 'ingestion_api_token' => 'org-token' ],
+			],
+			'env' => [
+				'status' => 'enabled',
+				'config' => [ 'ingestion_api_sync_all_posts' => true ],
+			],
+		] );
+
+		$agentforce_integration = new AgentforceIntegration( $this->slug );
+		$agentforce_integration->set_vip_config( $vip_config_mock );
+		$agentforce_integration->configure();
+
+		$configs = constant( 'VIP_AGENTFORCE_CONFIGS' );
+		$this->assertArrayHasKey( 'ingestion_api_token', $configs );
+		$this->assertArrayHasKey( 'ingestion_api_sync_all_posts', $configs );
+		$this->assertEquals( 'org-token', $configs['ingestion_api_token'] );
+		$this->assertTrue( $configs['ingestion_api_sync_all_posts'] );
+	}
+
+	public function test_configure_works_when_org_config_is_empty(): void {
+		$vip_config_mock = $this->get_vip_config_mock( [
+			'org' => [
+				'status' => 'enabled',
+			],
+			'env' => [
+				'status' => 'enabled',
+				'config' => [ 'env_key' => 'env-value' ],
+			],
+		] );
+
+		$agentforce_integration = new AgentforceIntegration( $this->slug );
+		$agentforce_integration->set_vip_config( $vip_config_mock );
+		$agentforce_integration->configure();
+
+		$configs = constant( 'VIP_AGENTFORCE_CONFIGS' );
+		$this->assertArrayHasKey( 'env_key', $configs );
+		$this->assertEquals( 'env-value', $configs['env_key'] );
+	}
+
+	/**
+	 * Get a mock IntegrationVipConfig.
+	 *
+	 * @param array $vip_config The config to return from the mock.
+	 * @return MockObject&IntegrationVipConfig
+	 */
+	private function get_vip_config_mock( array $vip_config ) {
+		$mock = $this->getMockBuilder( IntegrationVipConfig::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_vip_config_from_file' ] )
+			->getMock();
+
+		$mock->method( 'get_vip_config_from_file' )->willReturn( $vip_config );
+		$mock->__construct( $this->slug );
+
+		return $mock;
 	}
 
 	public function test_get_selected_version_folder_returns_latest_version_when_version_is_latest(): void {

--- a/tests/integrations/test-integration-vip-config.php
+++ b/tests/integrations/test-integration-vip-config.php
@@ -207,7 +207,7 @@ class VIP_Integration_Vip_Config_Test extends WP_UnitTestCase {
 	public function test__get_org_config_returns_value_from_organization_config(): void {
 		$mock = $this->get_mock( [
 			'org' => [
-				'status' => Org_Integration_Status::ENABLED,
+				'status' => 'enabled',
 				'config' => array( 'org-config' ),
 			],
 		] );
@@ -218,7 +218,7 @@ class VIP_Integration_Vip_Config_Test extends WP_UnitTestCase {
 	public function test__get_org_config_returns_empty_array_when_no_config(): void {
 		$mock = $this->get_mock( [
 			'org' => [
-				'status' => Org_Integration_Status::ENABLED,
+				'status' => 'enabled',
 			],
 		] );
 

--- a/tests/integrations/test-integration-vip-config.php
+++ b/tests/integrations/test-integration-vip-config.php
@@ -204,6 +204,27 @@ class VIP_Integration_Vip_Config_Test extends WP_UnitTestCase {
 		$this->assertEquals( array( 'env-config' ), $mock->get_env_config() );
 	}
 
+	public function test__get_org_config_returns_value_from_organization_config(): void {
+		$mock = $this->get_mock( [
+			'org' => [
+				'status' => Org_Integration_Status::ENABLED,
+				'config' => array( 'org-config' ),
+			],
+		] );
+
+		$this->assertEquals( array( 'org-config' ), $mock->get_org_config() );
+	}
+
+	public function test__get_org_config_returns_empty_array_when_no_config(): void {
+		$mock = $this->get_mock( [
+			'org' => [
+				'status' => Org_Integration_Status::ENABLED,
+			],
+		] );
+
+		$this->assertEquals( array(), $mock->get_org_config() );
+	}
+
 	public function test__get_env_config_returns_value_from_network_site_config(): void {
 		$mock = $this->get_mock( [
 			'env'           => [


### PR DESCRIPTION
## Description

The Agentforce WordPress plugin requires org-level configuration values (ingestion API credentials) to sync content to Salesforce's Data Cloud.

`VIP_AGENTFORCE_CONFIGS` only includes env-level config, so the plugin is missing the credentials it needs for data sync.

To do so, we're:
 - Addkn `get_org_config()` method to read org-level config from ConfigMaps
  - Update Agentforce integration to merge org config with env config into `VIP_AGENTFORCE_CONFIGS`

Relies on vip-go-api #6907.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Spin up VIP dev env
3. Test via `wp shell`. Make sure you see org-level config (ingestion credentials) as well:
```
vip dev-env exec -- wp shell
wp> var_dump( VIP_AGENTFORCE_CONFIGS );
array(5) {
  ["ingestion_api_instance_url"]=>
  string(27) "https://fake.salesforce.com"
  ["ingestion_api_token"]=>
  string(10) "fake-token"
  ["ingestion_api_source_name"]=>
  string(11) "test-source"
  ["ingestion_api_object_name"]=>
  string(11) "test-object"
  ["ingestion_api_sync_all_posts"]=>
  bool(true)
}
=> NULL
```
