### PR TITLE
fix: insecure deserialization of remote data

### DIFF
--- a/tests/vip-helpers/vip-utils/include-wpcom-vip-get-user-profile.php
+++ b/tests/vip-helpers/vip-utils/include-wpcom-vip-get-user-profile.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * A class with a __wakeup() side effect, used to test insecure deserialization protection.
+ */
+class VIP_Test_Deserialization_Class {
+	public static bool $wakeup_called = false;
+
+	public function __construct() {
+		self::$wakeup_called = false;
+	}
+
+	public function __wakeup(): void {
+		self::$wakeup_called = true;
+	}
+}

--- a/tests/vip-helpers/vip-utils/test-wpcom-vip-get-user-profile.php
+++ b/tests/vip-helpers/vip-utils/test-wpcom-vip-get-user-profile.php
@@ -1,0 +1,64 @@
+<?php
+
+require_once __DIR__ . '/include-wpcom-vip-get-user-profile.php';
+
+class WPCOM_VIP_Get_User_Profile_Test extends WP_UnitTestCase {
+
+	private function mock_profile_response( string $body ): void {
+		add_filter( 'pre_http_request', function () use ( $body ) {
+			return [
+				'headers'  => [],
+				'body'     => $body,
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		} );
+	}
+
+	/**
+	 * Test that __wakeup() is not triggered when the remote response contains
+	 * a serialized object (insecure deserialization protection via allowed_classes => false).
+	 */
+	public function test__wpcom_vip_get_user_profile__serialized_object_does_not_call_wakeup() {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$this->mock_profile_response( serialize( new VIP_Test_Deserialization_Class() ) );
+
+		$result = wpcom_vip_get_user_profile( 'test@example.com' );
+
+		self::assertFalse( VIP_Test_Deserialization_Class::$wakeup_called, '__wakeup() must not be called during deserialization' );
+		self::assertFalse( $result, 'Profile should be false when deserialized data is not a valid profile array' );
+	}
+
+	/**
+	 * Test that __wakeup() is not triggered when the remote response contains a
+	 * serialized object nested inside the entry array (insecure deserialization protection).
+	 */
+	public function test__wpcom_vip_get_user_profile__serialized_object_in_entry_does_not_call_wakeup() {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$this->mock_profile_response( serialize( [ 'entry' => [ new VIP_Test_Deserialization_Class() ] ] ) );
+
+		wpcom_vip_get_user_profile( 'nested@example.com' );
+
+		self::assertFalse( VIP_Test_Deserialization_Class::$wakeup_called, '__wakeup() must not be called during deserialization' );
+	}
+
+	/**
+	 * Test that a valid serialized profile array is returned correctly.
+	 */
+	public function test__wpcom_vip_get_user_profile__valid_profile_is_returned() {
+		$entry = [
+			'id'          => '12345',
+			'displayName' => 'Test User',
+		];
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$this->mock_profile_response( serialize( [ 'entry' => [ $entry ] ] ) );
+
+		$result = wpcom_vip_get_user_profile( 'valid@example.com' );
+
+		self::assertEquals( $entry, $result );
+	}
+}

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -958,7 +958,7 @@ function wpcom_vip_get_user_profile( $email_or_id ) {
 	$profile = wpcom_vip_file_get_contents( $profile_url, 1, 900 );
 	if ( $profile ) {
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
-		$profile = unserialize( $profile );
+		$profile = unserialize( $profile, [ 'allowed_classes' => false ] );
 
 		if ( is_array( $profile ) && ! empty( $profile['entry'] ) && is_array( $profile['entry'] ) ) {
 			$profile = $profile['entry'][0];


### PR DESCRIPTION
## Description

This pull request improves security for the `wpcom_vip_get_user_profile` function by updating how serialized data is unserialized. The change restricts the unserialize operation, preventing the instantiation of any PHP classes and reducing the risk of object injection vulnerabilities.

This is mainly defense-in-depth: to exploit this, either Gravatar needs to be compromised, or the attacker must be able to tamper with network traffic in Automattic data centers.

**Security hardening:**

* Updated the call to `unserialize` in `vip-helpers/vip-utils.php` to use the `['allowed_classes' => false]` option, which disallows PHP objects from being unserialized.

## Changelog Description

### Fixed
- Hardening: improve security of `wpcom_vip_get_user_profile()`

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

CI must pass.
