### PR TITLE
chore: add Copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,35 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      mysql:
+        image: mysql:8
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_ROOT_PASSWORD: wordpress
+          MYSQL_INITDB_SKIP_TZINFO: 1
+          MYSQL_USER: wordpress
+          MYSQL_PASSWORD: wordpress
+          MYSQL_DATABASE: wordpress_test
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Prepare source code
+        uses: ./.github/actions/prepare-source


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow called `Copilot Setup Steps`. The workflow is designed to automate environment setup for testing and development, including MySQL service configuration and code preparation steps.

Ref: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment
Ref: https://github.com/Automattic/vip-go-mu-plugins/pull/6799#issuecomment-3959215915