### PR TITLE
Move purge cache tool from widget to nav menu and implement better guard rails (require domain confirmation)

### DIFF
--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -154,6 +154,111 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 		$this->assertFalse( $this->cache_manager->purge_site_cache(), 'Subsequent site purge should return false for same request.' );
 	}
 
+	public function test_current_user_can_purge_cache_filter_receives_scope_and_user() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+
+		$captured_scope = null;
+		$captured_user  = null;
+
+		$callback = static function ( $can_purge_cache, $user, $scope ) use ( &$captured_scope, &$captured_user ) {
+			$captured_scope = $scope;
+			$captured_user  = $user;
+
+			return $can_purge_cache;
+		};
+
+		add_filter( 'vip_cache_manager_can_purge_cache', $callback, 10, 3 );
+
+		try {
+			$method = new \ReflectionMethod( WPCOM_VIP_Cache_Manager::class, 'current_user_can_purge_cache' );
+			$method->invoke( $this->cache_manager, 'url' );
+		} finally {
+			remove_filter( 'vip_cache_manager_can_purge_cache', $callback, 10 );
+		}
+
+		$this->assertSame( 'url', $captured_scope, 'Scope should be passed to the permission filter.' );
+		$this->assertInstanceOf( WP_User::class, $captured_user, 'Current user should be passed to the permission filter.' );
+		$this->assertSame( $user_id, $captured_user->ID, 'Permission filter should receive the current user ID.' );
+	}
+
+	public function test_current_user_can_purge_cache_filter_scope_defaults_to_null() {
+		$captured_scope = 'not-set';
+
+		$callback = static function ( $can_purge_cache, $user, $scope ) use ( &$captured_scope ) {
+			$captured_scope = $scope;
+
+			return $can_purge_cache;
+		};
+
+		add_filter( 'vip_cache_manager_can_purge_cache', $callback, 10, 3 );
+
+		try {
+			$method = new \ReflectionMethod( WPCOM_VIP_Cache_Manager::class, 'current_user_can_purge_cache' );
+			$method->invoke( $this->cache_manager );
+		} finally {
+			remove_filter( 'vip_cache_manager_can_purge_cache', $callback, 10 );
+		}
+
+		$this->assertNull( $captured_scope, 'Scope should default to null when no specific purge context is provided.' );
+	}
+
+	public function test_current_user_can_purge_cache_allows_scope_specific_permissions() {
+		$callback = static function ( $can_purge_cache, $user, $scope ) {
+			return 'url' === $scope;
+		};
+
+		add_filter( 'vip_cache_manager_can_purge_cache', $callback, 10, 3 );
+
+		try {
+			$method = new \ReflectionMethod( WPCOM_VIP_Cache_Manager::class, 'current_user_can_purge_cache' );
+			$this->assertTrue( $method->invoke( $this->cache_manager, 'url' ), 'URL scope should be allowed by the filter callback.' );
+			$this->assertFalse( $method->invoke( $this->cache_manager, 'site' ), 'Non-URL scope should be denied by the filter callback.' );
+		} finally {
+			remove_filter( 'vip_cache_manager_can_purge_cache', $callback, 10 );
+		}
+	}
+
+	public function test_available_manual_purge_actions_are_filtered_by_scope_permissions() {
+		$callback = static function ( $can_purge_cache, $user, $scope ) {
+			return in_array( $scope, [ 'url', 'origin' ], true );
+		};
+
+		add_filter( 'vip_cache_manager_can_purge_cache', $callback, 10, 3 );
+
+		try {
+			$method          = new \ReflectionMethod( WPCOM_VIP_Cache_Manager::class, 'get_available_manual_purge_actions_config' );
+			$visible_actions = $method->invoke( $this->cache_manager );
+		} finally {
+			remove_filter( 'vip_cache_manager_can_purge_cache', $callback, 10 );
+		}
+
+		$this->assertSame( [ 'url', 'origin' ], array_keys( $visible_actions ), 'Only allowed purge scopes should be returned for rendering.' );
+	}
+
+	public function test_render_dashboard_widget_dropdown_only_shows_allowed_scopes() {
+		$callback = static function ( $can_purge_cache, $user, $scope ) {
+			return in_array( $scope, [ 'url', 'origin' ], true );
+		};
+
+		add_filter( 'vip_cache_manager_can_purge_cache', $callback, 10, 3 );
+
+		try {
+			ob_start();
+			$this->cache_manager->render_dashboard_widget();
+			$widget_html = (string) ob_get_clean();
+		} finally {
+			remove_filter( 'vip_cache_manager_can_purge_cache', $callback, 10 );
+		}
+
+		$this->assertStringContainsString( 'value="url"', $widget_html, 'URL action should be visible when URL scope is allowed.' );
+		$this->assertStringContainsString( 'value="origin"', $widget_html, 'Origin action should be visible when origin scope is allowed.' );
+		$this->assertStringNotContainsString( 'value="site"', $widget_html, 'Site action should be hidden when site scope is denied.' );
+		$this->assertStringNotContainsString( 'value="uploads"', $widget_html, 'Uploads action should be hidden when uploads scope is denied.' );
+		$this->assertStringNotContainsString( 'value="static"', $widget_html, 'Static action should be hidden when static scope is denied.' );
+		$this->assertStringNotContainsString( 'value="private"', $widget_html, 'Private files action should be hidden when private scope is denied.' );
+	}
+
 	private function reset_cache_manager_state(): void {
 		$properties = [
 			'ban_urls'          => array(),

--- a/tests/test-vip-cache-manager.php
+++ b/tests/test-vip-cache-manager.php
@@ -259,6 +259,28 @@ class VIP_Go_Cache_Manager_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'value="private"', $widget_html, 'Private files action should be hidden when private scope is denied.' );
 	}
 
+	public function test_enqueue_dashboard_widget_assets_localizes_confirmation_guardrail_data() {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$this->cache_manager->enqueue_dashboard_widget_assets( 'vip_page_vip-purge-cache' );
+
+		$this->assertTrue( wp_script_is( 'vip-cache-manager-dashboard-widget', 'enqueued' ), 'Dashboard widget script should be enqueued.' );
+		$this->assertTrue( wp_style_is( 'wp-components', 'enqueued' ), 'WordPress component styles should be enqueued for modal rendering.' );
+		$this->assertTrue( wp_style_is( 'vip-cache-manager-dashboard-widget-style', 'enqueued' ), 'Dashboard widget modal styles should be enqueued.' );
+
+		global $wp_scripts;
+		$localized_data = $wp_scripts->get_data( 'vip-cache-manager-dashboard-widget', 'data' );
+
+		$this->assertIsString( $localized_data, 'Dashboard widget localized data should be available.' );
+		$this->assertSame( 1, preg_match( '/var VIPCacheManagerDashboard = (\{.*\});/s', $localized_data, $matches ), 'Dashboard localized data should be present.' );
+
+		$dashboard_data = json_decode( $matches[1], true );
+		$this->assertIsArray( $dashboard_data, 'Dashboard localized data should decode to an array.' );
+		$this->assertSame( home_url( '/' ), $dashboard_data['siteUrl'], 'Dashboard localized data should include the current site URL for confirmation matching.' );
+		$this->assertArrayHasKey( 'confirmationMismatchMessage', $dashboard_data, 'Dashboard localized data should include mismatch copy for the confirmation guardrail.' );
+	}
+
 	private function reset_cache_manager_state(): void {
 		$properties = [
 			'ban_urls'          => array(),

--- a/vip-cache-manager.php
+++ b/vip-cache-manager.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin name: VIP Cache Manager
-Description: Automatically clears the Varnish cache when necessary
+Description: Purge a specific URL from the VIP Platform page cache
 Author: Automattic
 Author URI: http://automattic.com/
 Version: 1.1

--- a/vip-cache-manager.php
+++ b/vip-cache-manager.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin name: VIP Cache Manager
-Description: Purge a specific URL from the VIP Platform page cache
+Description: Selectively purge the page cache for a VIP Platform site
 Author: Automattic
 Author URI: http://automattic.com/
 Version: 1.1

--- a/vip-cache-manager/css/dashboard-widget.css
+++ b/vip-cache-manager/css/dashboard-widget.css
@@ -1,0 +1,20 @@
+.vip-cache-manager-dashboard-form #vip-cache-manager-dashboard-url-wrap {
+	display: none;
+}
+
+.components-modal__frame.vip-cache-manager-confirmation-modal {
+	max-width: 400px;
+	width: calc( 100% - 32px );
+}
+
+.vip-cache-manager-confirmation-modal .vip-cache-manager-confirmation-modal__actions {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+	margin-top: 16px;
+	padding-top: 8px;
+}
+
+.vip-cache-manager-confirmation-modal .components-notice {
+	margin-top: 8px;
+}

--- a/vip-cache-manager/css/dashboard-widget.css
+++ b/vip-cache-manager/css/dashboard-widget.css
@@ -18,3 +18,7 @@
 .vip-cache-manager-confirmation-modal .components-notice {
 	margin-top: 8px;
 }
+
+.vip-cache-manager-dashboard-form {
+	max-width: 450px;
+}

--- a/vip-cache-manager/js/dashboard-widget.js
+++ b/vip-cache-manager/js/dashboard-widget.js
@@ -24,7 +24,7 @@
 
 	function updateUrlVisibility() {
 		const isUrl = select.value === cfg.urlKey;
-		urlWrap.style.display = isUrl ? 'block' : 'none';
+		urlWrap.style.display = isUrl ? '' : 'none';
 		urlInput.required = isUrl;
 		if ( ! isUrl ) {
 			urlInput.value = '';

--- a/vip-cache-manager/js/dashboard-widget.js
+++ b/vip-cache-manager/js/dashboard-widget.js
@@ -22,9 +22,144 @@
 		return;
 	}
 
+	function setResultNotice( message, isSuccess ) {
+		result.classList.remove( 'notice-success', 'notice-error' );
+		result.textContent = message;
+		result.classList.add( isSuccess ? 'notice-success' : 'notice-error' );
+		result.classList.add( 'notice' );
+	}
+
+	function normalizeUrlForComparison( value ) {
+		if ( 'string' !== typeof value || ! value.trim() ) {
+			return '';
+		}
+
+		try {
+			const parsed = new URL( value.trim() );
+			let port = parsed.port;
+			if ( ( 'https:' === parsed.protocol && '443' === parsed.port ) || ( 'http:' === parsed.protocol && '80' === parsed.port ) ) {
+				port = '';
+			}
+
+			const host = parsed.hostname.toLowerCase() + ( port ? ':' + port : '' );
+			const pathname = parsed.pathname.replace( /\/+$/, '' ) || '/';
+
+			return `${ parsed.protocol.toLowerCase() }//${ host }${ pathname }`;
+		} catch ( error ) {
+			return '';
+		}
+	}
+
+	function urlsMatchCurrentSite( candidateUrl ) {
+		return normalizeUrlForComparison( candidateUrl ) === normalizeUrlForComparison( cfg.siteUrl );
+	}
+
+	function openNonUrlConfirmationModal( selectedOption ) {
+		const optionTitle = selectedOption ? ( selectedOption.text || select.value ) : select.value;
+		const optionDescription = selectedOption && selectedOption.dataset ? ( selectedOption.dataset.description || '' ) : '';
+		const actionPrompt = optionDescription || optionTitle;
+		const expectedUrl = cfg.siteUrl || '';
+		const canUseWPModal = window.wp && window.wp.element && window.wp.components && typeof window.wp.element.render === 'function';
+
+		if ( ! canUseWPModal ) {
+			const enteredUrl = window.prompt(
+				`${ cfg.confirmationPrompt }\n\n${ expectedUrl }\n\n${ actionPrompt }`
+			);
+
+			if ( null === enteredUrl ) {
+				return Promise.resolve( false );
+			}
+
+			if ( urlsMatchCurrentSite( enteredUrl ) ) {
+				return Promise.resolve( true );
+			}
+
+			setResultNotice( cfg.confirmationMismatchMessage || 'The entered URL does not match this site URL.', false );
+			return Promise.resolve( false );
+		}
+
+		return new Promise( ( resolve ) => {
+			const modalRoot = document.createElement( 'div' );
+			document.body.appendChild( modalRoot );
+
+			const { createElement, useState } = window.wp.element;
+			const { Modal, TextControl, Button, Notice } = window.wp.components;
+
+			function closeModal( isConfirmed ) {
+				window.wp.element.render( null, modalRoot );
+				modalRoot.remove();
+				resolve( isConfirmed );
+			}
+
+			function ConfirmationModal() {
+				const [ enteredUrl, setEnteredUrl ] = useState( '' );
+				const [ hasMismatch, setHasMismatch ] = useState( false );
+
+				function onConfirm() {
+					if ( urlsMatchCurrentSite( enteredUrl ) ) {
+						closeModal( true );
+						return;
+					}
+
+					setHasMismatch( true );
+				}
+
+				function onUrlChange( value ) {
+					setEnteredUrl( value );
+					if ( hasMismatch ) {
+						setHasMismatch( false );
+					}
+				}
+
+				return createElement(
+					Modal,
+					{
+						title: cfg.confirmationTitle || 'Confirm cache purge',
+						className: 'vip-cache-manager-confirmation-modal',
+						onRequestClose: () => closeModal( false ),
+						shouldCloseOnClickOutside: false,
+					},
+					createElement( 'p', null, actionPrompt ),
+					createElement( 'p', null, '⚠️ This operation may result in temporary performance degradation.' ),
+					createElement( 'p', null, cfg.confirmationPrompt || 'Type the current site URL to confirm this cache purge action.' ),
+					createElement( 'p', null, createElement( 'strong', null, expectedUrl ) ),
+					createElement( TextControl, {
+						label: cfg.confirmationInputLabel || 'Site URL',
+						value: enteredUrl,
+						onChange: onUrlChange,
+						placeholder: expectedUrl,
+					} ),
+					hasMismatch && createElement( Notice, { status: 'error', isDismissible: false }, cfg.confirmationMismatchMessage || 'The entered URL does not match this site URL.' ),
+					createElement(
+						'div',
+						{ className: 'vip-cache-manager-confirmation-modal__actions' },
+						createElement(
+							Button,
+							{
+								variant: 'secondary',
+								onClick: () => closeModal( false ),
+							},
+							cfg.confirmationCancelLabel || 'Cancel'
+						),
+						createElement(
+							Button,
+							{
+								variant: 'primary',
+								onClick: onConfirm,
+							},
+							cfg.confirmationSubmitLabel || 'Confirm purge'
+						)
+					)
+				);
+			}
+
+			window.wp.element.render( createElement( ConfirmationModal ), modalRoot );
+		} );
+	}
+
 	function updateUrlVisibility() {
 		const isUrl = select.value === cfg.urlKey;
-		urlWrap.style.display = isUrl ? '' : 'none';
+		urlWrap.style.display = isUrl ? 'block' : 'none';
 		urlInput.required = isUrl;
 		if ( ! isUrl ) {
 			urlInput.value = '';
@@ -57,11 +192,8 @@
 		const selectedOption = select.options[ select.selectedIndex ];
 		const isUrlAction = select.value === cfg.urlKey;
 		if ( ! isUrlAction ) {
-			const title = selectedOption ? ( selectedOption.text || select.value ) : select.value;
-			const desc = selectedOption && selectedOption.dataset ? ( selectedOption.dataset.description || '' ) : '';
-			const message = desc ? `Confirm that you want to ${ desc.toLowerCase() }\n\nProceed?` : `${ title }\n\nProceed?`;
-
-			if ( ! window.confirm( message ) ) {
+			const confirmed = await openNonUrlConfirmationModal( selectedOption );
+			if ( ! confirmed ) {
 				return;
 			}
 		}
@@ -87,22 +219,10 @@
 			const isSuccess = response.ok && ( ! json || json.success !== false );
 			const message = hasMessage ? json.data.message : ( isSuccess ? 'Done.' : 'Request failed.' );
 
-			// Clear previous notice state before setting new one.
-			result.classList.remove( 'notice-success', 'notice-error' );
-
-			result.textContent = message;
-			if ( isSuccess ) {
-				result.classList.add( 'notice-success' );
-			} else {
-				result.classList.add( 'notice-error' );
-			}
-			result.classList.add( 'notice' );
+			setResultNotice( message, isSuccess );
 		} catch ( e ) {
 			// Network or unexpected error.
-			result.classList.remove( 'notice-success', 'notice-error' );
-			result.textContent = 'Request failed.';
-			result.classList.add( 'notice-error' );
-			result.classList.add( 'notice' );
+			setResultNotice( 'Request failed.', false );
 		} finally {
 			submit.disabled = false;
 		}

--- a/vip-cache-manager/js/dashboard-widget.js
+++ b/vip-cache-manager/js/dashboard-widget.js
@@ -24,7 +24,7 @@
 
 	function updateUrlVisibility() {
 		const isUrl = select.value === cfg.urlKey;
-		urlWrap.style.display = isUrl ? '' : 'none';
+		urlWrap.style.display = isUrl ? 'block' : 'none';
 		urlInput.required = isUrl;
 		if ( ! isUrl ) {
 			urlInput.value = '';
@@ -59,7 +59,7 @@
 		if ( ! isUrlAction ) {
 			const title = selectedOption ? ( selectedOption.text || select.value ) : select.value;
 			const desc = selectedOption && selectedOption.dataset ? ( selectedOption.dataset.description || '' ) : '';
-			const message = desc ? `Please confirm you want to ${ desc.toLowerCase() }\n\nProceed?` : `${ title }\n\nProceed?`;
+			const message = desc ? `Confirm that you want to ${ desc.toLowerCase() }\n\nProceed?` : `${ title }\n\nProceed?`;
 
 			if ( ! window.confirm( message ) ) {
 				return;

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -87,7 +87,7 @@ class WPCOM_VIP_Cache_Manager {
 	 * @return void
 	 */
 	public function admin_bar_callback( WP_Admin_Bar $admin_bar ) {
-		if ( ! is_admin() && $this->current_user_can_purge_cache() ) {
+		if ( ! is_admin() && $this->current_user_can_purge_cache( 'url' ) ) {
 			$admin_bar->add_menu(
 				[
 					'id'     => 'vip-purge-page',
@@ -109,7 +109,7 @@ class WPCOM_VIP_Cache_Manager {
 	 * @return void
 	 */
 	public function button_enqueue_scripts() {
-		if ( $this->current_user_can_purge_cache() ) {
+		if ( $this->current_user_can_purge_cache( 'url' ) ) {
 			wp_enqueue_script( 'purge-page-cache-btn', plugins_url( '/js/admin-bar.js', __FILE__ ), [], '1.2', true );
 			wp_localize_script( 'purge-page-cache-btn', 'VIPPagePurge', [
 				'nonce'   => wp_create_nonce( 'purge-page' ),
@@ -224,6 +224,18 @@ class WPCOM_VIP_Cache_Manager {
 		];
 	}
 
+	private function get_available_manual_purge_actions_config(): array {
+		$actions = $this->get_manual_purge_actions_config();
+
+		return array_filter(
+			$actions,
+			function ( $_config, $scope ) {
+				return $this->can_purge_cache( $scope );
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+	}
+
 
 	/**
 	 * AJAX callback that performs basic security checks and payload validation and queues urls for the purge.
@@ -241,7 +253,7 @@ class WPCOM_VIP_Cache_Manager {
 			wp_send_json_error( [ 'error' => 'Malformed payload' ], 400 );
 		}
 
-		if ( ! $this->current_user_can_purge_cache() ) {
+		if ( ! $this->current_user_can_purge_cache( 'url' ) ) {
 			\Automattic\VIP\Stats\send_pixel( [
 				'vip-cache-url-purge-status' => 'deny-permissions',
 			] );
@@ -287,7 +299,7 @@ class WPCOM_VIP_Cache_Manager {
 	}
 
 	public function vip_purge_cache_page() {
-		if ( ! $this->can_purge_cache() ) {
+		if ( empty( $this->get_available_manual_purge_actions_config() ) ) {
 			return;
 		}
 		add_submenu_page(
@@ -301,16 +313,16 @@ class WPCOM_VIP_Cache_Manager {
 	}
 
 	public function render_dashboard_widget() {
-		if ( ! $this->can_purge_cache() ) {
+		$actions = $this->get_available_manual_purge_actions_config();
+
+		if ( empty( $actions ) ) {
 			echo '<p>' . esc_html__( 'You do not have permission to manage the page cache.', 'vip-cache-manager' ) . '</p>';
 		} else {
-			$this->render_dashboard_widget_form();
+			$this->render_dashboard_widget_form( $actions );
 		}
 	}
 
-	private function render_dashboard_widget_form() {
-		$actions = $this->get_manual_purge_actions_config();
-
+	private function render_dashboard_widget_form( array $actions ) {
 		if ( empty( $actions ) ) {
 			return;
 		}
@@ -364,7 +376,7 @@ class WPCOM_VIP_Cache_Manager {
 
 
 	public function enqueue_dashboard_widget_assets( $hook_suffix ) {
-		if ( 'vip_page_vip-purge-cache' !== $hook_suffix || ! $this->can_purge_cache() ) {
+		if ( 'vip_page_vip-purge-cache' !== $hook_suffix || empty( $this->get_available_manual_purge_actions_config() ) ) {
 			return;
 		}
 
@@ -395,7 +407,10 @@ class WPCOM_VIP_Cache_Manager {
 			wp_send_json_error( array( 'message' => __( 'Malformed payload.', 'vip-cache-manager' ) ), 400 );
 		}
 
-		if ( ! $this->current_user_can_purge_cache() ) {
+		$action = isset( $req->purge_action ) ? sanitize_key( $req->purge_action ) : '';
+		$scope  = empty( $action ) ? 'dashboard' : $action;
+
+		if ( ! $this->current_user_can_purge_cache( $scope ) ) {
 			wp_send_json_error( array( 'message' => __( 'Unauthorized.', 'vip-cache-manager' ) ), 403 );
 		}
 
@@ -403,8 +418,7 @@ class WPCOM_VIP_Cache_Manager {
 			wp_send_json_error( array( 'message' => __( 'Unauthorized.', 'vip-cache-manager' ) ), 403 );
 		}
 
-		$action = isset( $req->purge_action ) ? sanitize_key( $req->purge_action ) : '';
-		$url    = isset( $req->url ) ? esc_url_raw( $req->url ) : '';
+		$url = isset( $req->url ) ? esc_url_raw( $req->url ) : '';
 
 		$actions = $this->get_manual_purge_actions_config();
 		if ( ! isset( $actions[ $action ] ) ) {
@@ -1149,12 +1163,12 @@ class WPCOM_VIP_Cache_Manager {
 		return wp_http_validate_url( $url );
 	}
 
-	private function can_purge_cache() {
-		return ( function_exists( 'is_proxied_automattician' ) && is_proxied_automattician() ) || $this->current_user_can_purge_cache();
+	private function can_purge_cache( ?string $scope = null ): bool {
+		return ( function_exists( 'is_proxied_automattician' ) && is_proxied_automattician() ) || $this->current_user_can_purge_cache( $scope );
 	}
 
-	private function current_user_can_purge_cache(): bool {
-		return apply_filters( 'vip_cache_manager_can_purge_cache', current_user_can( 'edit_others_posts' ), wp_get_current_user() );
+	private function current_user_can_purge_cache( ?string $scope = null ): bool {
+		return apply_filters( 'vip_cache_manager_can_purge_cache', current_user_can( 'edit_others_posts' ), wp_get_current_user(), $scope );
 	}
 }
 

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin name: Cache Manager
-Description: Automatically clears the edge cache when necessary
+Description: Purge a specific URL from the VIP Platform page cache
 Author: Automattic
 Author URI: http://automattic.com/
 Version: 1.1
@@ -63,7 +63,7 @@ class WPCOM_VIP_Cache_Manager {
 		add_action( 'switch_theme', array( $this, 'purge_site_cache' ) );
 		add_action( 'post_updated', array( $this, 'queue_old_permalink_purge' ), 10, 3 );
 
-		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
+		add_action( 'admin_menu', array( $this, 'vip_purge_cache_page' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_widget_assets' ) );
 
 		add_action( 'shutdown', array( $this, 'execute_purges' ) );
@@ -177,48 +177,48 @@ class WPCOM_VIP_Cache_Manager {
 	private function get_manual_purge_actions_config(): array {
 		return [
 			'site'    => [
-				'label'       => __( 'Purge entire site cache', 'vip-cache-manager' ),
-				'description' => __( 'Clear all origin responses, static files, uploads, and private file visibility metadata.', 'vip-cache-manager' ),
+				'label'       => __( 'Purge the cache for the entire site', 'vip-cache-manager' ),
+				'description' => __( 'Purge all WordPress responses from origin, deployed static asset files, site files uploaded to the VIP File System, and private file visibility metadata.', 'vip-cache-manager' ),
 				'callback'    => 'purge_site_cache',
-				'message'     => __( 'Site cache purge queued.', 'vip-cache-manager' ),
+				'message'     => __( 'Purge queued for entire site.', 'vip-cache-manager' ),
 				'stat'        => 'dashboard-site-purge',
 			],
 			'url'     => [
 				'type'        => 'url',
-				'label'       => __( 'Purge specific URL', 'vip-cache-manager' ),
+				'label'       => __( 'Purge a specific URL', 'vip-cache-manager' ),
 				'description' => __( 'Enter the full URL (including scheme) to purge a single page without affecting other cache content.', 'vip-cache-manager' ),
 				'placeholder' => home_url( '/' ),
 				'button'      => __( 'Purge URL', 'vip-cache-manager' ),
 				'callback'    => 'purge_single_url',
-				'message'     => __( 'URL purge queued.', 'vip-cache-manager' ),
+				'message'     => __( 'Purge queued for URL.', 'vip-cache-manager' ),
 				'stat'        => 'dashboard-url-purge',
 			],
 			'origin'  => [
-				'label'       => __( 'Purge WordPress responses', 'vip-cache-manager' ),
-				'description' => __( 'Clear cached WordPress responses without touching uploads or static files.', 'vip-cache-manager' ),
+				'label'       => __( 'Purge WordPress responses from origin', 'vip-cache-manager' ),
+				'description' => __( 'Purge the site\'s cached WordPress responses without affecting other cached files such as uploads or deployed static asset files.', 'vip-cache-manager' ),
 				'callback'    => 'purge_origin_cache',
-				'message'     => __( 'WordPress responses purge queued.', 'vip-cache-manager' ),
+				'message'     => __( 'Purge queued for origin responses.', 'vip-cache-manager' ),
 				'stat'        => 'dashboard-origin-purge',
 			],
 			'uploads' => [
-				'label'       => __( 'Purge uploads', 'vip-cache-manager' ),
-				'description' => __( 'Clear cached VIP File Service uploads.', 'vip-cache-manager' ),
+				'label'       => __( 'Purge files uploaded to the VIP File System for this site', 'vip-cache-manager' ),
+				'description' => __( 'Purge the cache for all files that were uploaded to the VIP File System for this site.', 'vip-cache-manager' ),
 				'callback'    => 'purge_uploads_cache',
-				'message'     => __( 'Uploads purge queued.', 'vip-cache-manager' ),
+				'message'     => __( 'Purge queued for uploaded files.', 'vip-cache-manager' ),
 				'stat'        => 'dashboard-uploads-purge',
 			],
 			'static'  => [
-				'label'       => __( 'Purge static files', 'vip-cache-manager' ),
-				'description' => __( 'Clear cached static assets such as theme and core CSS, JS, and images.', 'vip-cache-manager' ),
+				'label'       => __( 'Purge deployed static asset files', 'vip-cache-manager' ),
+				'description' => __( 'Purge all cached static asset files such as CSS, JS, and images that were deployed as part of WordPress Core or the site\'s theme or plugins.', 'vip-cache-manager' ),
 				'callback'    => 'purge_static_files_cache',
-				'message'     => __( 'Static files purge queued.', 'vip-cache-manager' ),
+				'message'     => __( 'Purge queued for static asset files.', 'vip-cache-manager' ),
 				'stat'        => 'dashboard-static-purge',
 			],
 			'private' => [
-				'label'       => __( 'Reset private file visibility', 'vip-cache-manager' ),
-				'description' => __( 'Clear cached visibility information for private files.', 'vip-cache-manager' ),
+				'label'       => __( 'Purge files that are protected by Access-controlled files', 'vip-cache-manager' ),
+				'description' => __( 'Purge the cache to reset the availability of files that are protected by Access-controlled files.', 'vip-cache-manager' ),
 				'callback'    => 'purge_private_files_cache',
-				'message'     => __( 'Private file visibility cache purge queued.', 'vip-cache-manager' ),
+				'message'     => __( 'Purge queued for Access-controlled files.', 'vip-cache-manager' ),
 				'stat'        => 'dashboard-private-files-purge',
 			],
 		];
@@ -286,21 +286,23 @@ class WPCOM_VIP_Cache_Manager {
 		);
 	}
 
-	public function register_dashboard_widget() {
+	public function vip_purge_cache_page() {
 		if ( ! $this->can_purge_cache() ) {
 			return;
 		}
-
-		wp_add_dashboard_widget(
-			'vip_cache_manager_purge',
-			__( 'Edge Cache Controls', 'vip-cache-manager' ),
+		add_submenu_page(
+			'vip-dashboard',
+			__( 'Purge the VIP Platform page cache', 'textdomain' ),
+			__( 'Purge Cache', 'textdomain' ),
+			'manage_options',
+			'vip-purge-cache',
 			array( $this, 'render_dashboard_widget' )
 		);
 	}
 
 	public function render_dashboard_widget() {
 		if ( ! $this->can_purge_cache() ) {
-			echo '<p>' . esc_html__( 'You do not have permission to manage page cache.', 'vip-cache-manager' ) . '</p>';
+			echo '<p>' . esc_html__( 'You do not have permission to manage the page cache.', 'vip-cache-manager' ) . '</p>';
 		} else {
 			$this->render_dashboard_widget_form();
 		}
@@ -351,7 +353,7 @@ class WPCOM_VIP_Cache_Manager {
 
 		printf(
 			'<p><button type="submit" class="button button-primary">%s</button></p>',
-			esc_html__( 'Purge cache', 'vip-cache-manager' )
+			esc_html__( 'Purge Cache', 'vip-cache-manager' )
 		);
 
 		echo '<p class="vip-cache-manager-dashboard-result" aria-live="polite"></p>';
@@ -362,7 +364,7 @@ class WPCOM_VIP_Cache_Manager {
 
 
 	public function enqueue_dashboard_widget_assets( $hook_suffix ) {
-		if ( 'index.php' !== $hook_suffix || ! $this->can_purge_cache() ) {
+		if ( 'vip_page_vip-purge-cache' !== $hook_suffix || ! $this->can_purge_cache() ) {
 			return;
 		}
 
@@ -412,7 +414,7 @@ class WPCOM_VIP_Cache_Manager {
 		$context = array();
 		if ( isset( $actions[ $action ]['type'] ) && 'url' === $actions[ $action ]['type'] ) {
 			if ( empty( $url ) ) {
-				wp_send_json_error( array( 'message' => __( 'Please enter a URL to purge.', 'vip-cache-manager' ) ), 400 );
+				wp_send_json_error( array( 'message' => __( 'Enter a URL to purge.', 'vip-cache-manager' ) ), 400 );
 			}
 			$context['url'] = $url;
 		}
@@ -1102,7 +1104,7 @@ class WPCOM_VIP_Cache_Manager {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( empty( $url ) || ! $this->is_valid_purge_url( $url ) ) {
-			return new \WP_Error( 'invalid_url', __( 'Please enter a valid URL to purge.', 'vip-cache-manager' ) );
+			return new \WP_Error( 'invalid_url', __( 'Enter a valid URL to purge.', 'vip-cache-manager' ) );
 		}
 
 		return $this->queue_purge_url( $url );

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -383,18 +383,32 @@ class WPCOM_VIP_Cache_Manager {
 		wp_enqueue_script(
 			'vip-cache-manager-dashboard-widget',
 			plugins_url( '/js/dashboard-widget.js', __FILE__ ),
-			array(),
-			'1.0',
+			array( 'wp-components', 'wp-element' ),
+			'1.1',
 			true
+		);
+		wp_enqueue_style( 'wp-components' );
+		wp_enqueue_style(
+			'vip-cache-manager-dashboard-widget-style',
+			plugins_url( '/css/dashboard-widget.css', __FILE__ ),
+			array( 'wp-components' ),
+			'1.0'
 		);
 
 		wp_localize_script(
 			'vip-cache-manager-dashboard-widget',
 			'VIPCacheManagerDashboard',
 			array(
-				'ajaxurl' => admin_url( 'admin-ajax.php' ),
-				'action'  => 'vip_cache_manager_dashboard_purge',
-				'urlKey'  => 'url',
+				'ajaxurl'                     => admin_url( 'admin-ajax.php' ),
+				'action'                      => 'vip_cache_manager_dashboard_purge',
+				'urlKey'                      => 'url',
+				'siteUrl'                     => home_url( '/' ),
+				'confirmationTitle'           => __( 'Confirm cache purge', 'vip-cache-manager' ),
+				'confirmationPrompt'          => __( 'Type the current site URL to confirm this cache purge action.', 'vip-cache-manager' ),
+				'confirmationInputLabel'      => __( 'Site URL', 'vip-cache-manager' ),
+				'confirmationMismatchMessage' => __( 'The entered URL does not match this site URL.', 'vip-cache-manager' ),
+				'confirmationCancelLabel'     => __( 'Cancel', 'vip-cache-manager' ),
+				'confirmationSubmitLabel'     => __( 'Confirm purge', 'vip-cache-manager' ),
 			)
 		);
 	}

--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -96,7 +96,7 @@ class WPCOM_VIP_Cache_Manager {
 					'title'  => 'Purge Page Cache',
 					'href'   => '#',
 					'meta'   => [
-						'title' => 'Purge Page cache for this page and its assets',
+						'title' => 'Purge page cache for this page and its assets',
 					],
 				]
 			);
@@ -215,8 +215,8 @@ class WPCOM_VIP_Cache_Manager {
 				'stat'        => 'dashboard-static-purge',
 			],
 			'private' => [
-				'label'       => __( 'Purge files that are protected by Access-controlled files', 'vip-cache-manager' ),
-				'description' => __( 'Purge the cache to reset the availability of files that are protected by Access-controlled files.', 'vip-cache-manager' ),
+				'label'       => __( 'Purge files that are protected by Access-Controlled Files', 'vip-cache-manager' ),
+				'description' => __( 'Purge the cache to reset the availability of files that are protected by Access-Controlled Files.', 'vip-cache-manager' ),
 				'callback'    => 'purge_private_files_cache',
 				'message'     => __( 'Purge queued for Access-controlled files.', 'vip-cache-manager' ),
 				'stat'        => 'dashboard-private-files-purge',


### PR DESCRIPTION
## Description

Change the location of the purge cache tool from the WP Admin Dashboard screen to the VIP-specific nav menu area where it can have a screen of its own. 

## Changelog Description

### Changed
- Moved the tooling for purging page cache from a widget to its own screen in the VIP navigation menu group and improved guardrails against accidental purges.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Go to WP Admin --> VIP --> Purge Cache
3. Review the updated text for all dropdown options and their descriptions. 
4. Test the functionality of each dropdown option.
