### PR TITLE
fix(qm-object-cache): PHP 8.4 implicit nullable parameter deprecation

### DIFF
--- a/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-ops.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-ops.php
@@ -207,7 +207,7 @@ class QM_Output_Html_Object_Cache_Ops extends QM_Output_Html {
 	 * @param string $value Value to be outputted in table cell
 	 * @param int|null $weight Weight by sorting priority
 	 */
-	public function output_table_cell( ?string $value, int $weight = null ) {
+	public function output_table_cell( ?string $value, ?int $weight = null ) {
 		if ( $weight ) {
 			$weight = ' data-qm-sort-weight="' . esc_attr( $weight ) . '"';
 		}

--- a/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-slow-ops.php
+++ b/qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-slow-ops.php
@@ -223,7 +223,7 @@ class QM_Output_Html_Object_Cache_Slow_Ops extends QM_Output_Html {
 	 * @param string $value Value to be outputted in table cell
 	 * @param int|null $weight Weight by sorting priority
 	 */
-	public function output_table_cell( ?string $value, int $weight = null ) {
+	public function output_table_cell( ?string $value, ?int $weight = null ) {
 		if ( $weight ) {
 			$weight = ' data-qm-sort-weight="' . esc_attr( $weight ) . '"';
 		}


### PR DESCRIPTION
## Summary

- Fixes PHP 8.4 deprecation warning in `QM_Output_Html_Object_Cache_Ops::output_table_cell()` by changing `int $weight = null` to `?int $weight = null`

## Details

PHP 8.4 [deprecated implicitly nullable parameter declarations](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). This one-line change makes the nullable type explicit.

```
PHP Deprecated: QM_Output_Html_Object_Cache_Ops::output_table_cell(): Implicitly marking parameter $weight as nullable is deprecated, the explicit nullable type must be used instead in .../qm-plugins/qm-object-cache/html/class-qm-output-html-object-cache-ops.php on line 210
```

Fixes #6827