### PR TITLE
feat(wp-cli): introduce `wp security unban` commands

### DIFF
--- a/wp-cli/class-user-unban-cli-command.php
+++ b/wp-cli/class-user-unban-cli-command.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Automattic\VIP\CLI;
+
+use WP_CLI;
+use WPCOM_VIP_CLI_Command;
+
+final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
+
+	public static function get_instance(): self {
+		static $instance = null;
+
+		if ( null === $instance ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	public static function register() {
+		$instance = self::get_instance();
+
+		WP_CLI::add_command(
+			'security unban ip',
+			[ $instance, 'unban_ip' ],
+			[
+				'shortdesc' => 'Unban an IP address.',
+				'synopsis'  => [
+					[
+						'type'        => 'positional',
+						'name'        => 'ip',
+						'description' => 'The IP address(es) to unban.',
+						'required'    => true,
+						'repeating'   => true,
+					],
+				],
+			],
+		);
+
+		WP_CLI::add_command(
+			'security unban user',
+			[ $instance, 'unban_user' ],
+			[
+				'shortdesc' => 'Unban a user.',
+				'synopsis'  => [
+					[
+						'type'        => 'positional',
+						'name'        => 'user',
+						'description' => 'The user to unban (ID, login, or email).',
+						'required'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'positional',
+						'name'        => 'ip',
+						'description' => 'The IP address(es) to unban.',
+						'required'    => false,
+						'repeating'   => true,
+					],
+				],
+			],
+		);
+	}
+
+	public function unban_ip( array $args ): void {
+		foreach ( $args as $ip ) {
+			if ( ! filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+				WP_CLI::warning( sprintf( 'Invalid IP address: %s', $ip ) );
+				continue;
+			}
+
+			wp_cache_delete( $ip, CACHE_GROUP_LOGIN_LIMIT );
+			wp_cache_delete( $ip, CACHE_GROUP_LOST_PASSWORD_LIMIT );
+			wp_cache_delete( CACHE_KEY_LOCK_PREFIX . $ip, CACHE_GROUP_LOGIN_LIMIT );
+			wp_cache_delete( CACHE_KEY_LOCK_PREFIX . $ip, CACHE_GROUP_LOST_PASSWORD_LIMIT );
+
+			WP_CLI::success( sprintf( 'Unbanned IP %s', $ip ) );
+		}
+	}
+
+	public function unban_user( array $args ): void {
+		$user_arg = $args[0];
+		$user     = null;
+
+		$user = get_user_by( 'login', $user_arg );
+
+		if ( ! $user && strpos( $user_arg, '@' ) !== false ) {
+			$user = get_user_by( 'email', $user_arg );
+		}
+
+		if ( ! $user && is_numeric( $user_arg ) ) {
+			$user = get_user_by( 'ID', (int) $user_arg );
+		}
+
+		if ( ! $user ) {
+			WP_CLI::error( sprintf( 'User not found: %s', $user_arg ) );
+			return;
+		}
+
+		$login = $user->user_login;
+
+		wp_cache_delete( $login, CACHE_GROUP_LOGIN_LIMIT );
+		wp_cache_delete( $login, CACHE_GROUP_LOST_PASSWORD_LIMIT );
+		wp_cache_delete( CACHE_KEY_LOCK_PREFIX . $login, CACHE_GROUP_LOGIN_LIMIT );
+		wp_cache_delete( CACHE_KEY_LOCK_PREFIX . $login, CACHE_GROUP_LOST_PASSWORD_LIMIT );
+
+		$num_args = count( $args );
+		for ( $i = 1; $i < $num_args; ++$i ) {
+			$ip = $args[ $i ];
+
+			if ( ! filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+				WP_CLI::warning( sprintf( 'Invalid IP address: %s', $ip ) );
+				continue;
+			}
+
+			$keys   = [ $ip, $ip . '|' . $login ];
+			$groups = [ CACHE_GROUP_LOGIN_LIMIT, CACHE_GROUP_LOST_PASSWORD_LIMIT ];
+
+			foreach ( $keys as $key ) {
+				foreach ( $groups as $group ) {
+					wp_cache_delete( $key, $group );
+					wp_cache_delete( CACHE_KEY_LOCK_PREFIX . $key, $group );
+				}
+			}
+
+			WP_CLI::success( sprintf( 'Unbanned user %s for IP %s', $login, $ip ) );
+		}
+
+		WP_CLI::success( sprintf( 'Unbanned user %s', $login ) );
+	}
+}
+
+User_Unban_CLI_Command::register();

--- a/wp-cli/class-user-unban-cli-command.php
+++ b/wp-cli/class-user-unban-cli-command.php
@@ -21,7 +21,7 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 		$instance = self::get_instance();
 
 		WP_CLI::add_command(
-			'security unban ip',
+			'vip security unban ip',
 			[ $instance, 'unban_ip' ],
 			[
 				'shortdesc' => 'Unban an IP address.',
@@ -30,7 +30,7 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 						'type'        => 'positional',
 						'name'        => 'ip',
 						'description' => 'The IP address(es) to unban.',
-						'required'    => true,
+						'optional'    => false,
 						'repeating'   => true,
 					],
 				],
@@ -38,7 +38,7 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 		);
 
 		WP_CLI::add_command(
-			'security unban user',
+			'vip security unban user',
 			[ $instance, 'unban_user' ],
 			[
 				'shortdesc' => 'Unban a user.',
@@ -47,14 +47,14 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 						'type'        => 'positional',
 						'name'        => 'user',
 						'description' => 'The user to unban (ID, login, or email).',
-						'required'    => true,
+						'optional'    => false,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'positional',
 						'name'        => 'ip',
 						'description' => 'The IP address(es) to unban.',
-						'required'    => false,
+						'optional'    => true,
 						'repeating'   => true,
 					],
 				],
@@ -62,7 +62,7 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 		);
 	}
 
-	public function unban_ip( array $args ): void {
+	public function unban_ip( array $args, array $_assoc ): void {
 		foreach ( $args as $ip ) {
 			if ( ! filter_var( $ip, FILTER_VALIDATE_IP ) ) {
 				WP_CLI::warning( sprintf( 'Invalid IP address: %s', $ip ) );
@@ -78,7 +78,7 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 		}
 	}
 
-	public function unban_user( array $args ): void {
+	public function unban_user( array $args, array $_assoc ): void {
 		$user_arg = $args[0];
 		$user     = null;
 


### PR DESCRIPTION
## Description

This PR introduces two WP CLI commands:
* `wp vip security unban ip <ip>...`
* `wp vip security unban user <user> [<ip>...]`

The first one unbans the IP address; the second unbans the user and, optionally, the user's associated IP addresses.

See PLTFRM-1598 for details.

## Changelog Description

### Added
- `wp vip security unban ip` and `wp vip security unban user` commands to allow for self-serve user unlock

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Manual testing in codespaces

<img width="1344" height="374" alt="Screenshot_20260307_034700" src="https://github.com/user-attachments/assets/f460ad9e-f887-40b5-900d-a6f50592d40f" />
