### PR TITLE
test: properly clean up `$_SERVER` vars

### DIFF
--- a/tests/lib/proxy/class-ip-forward-test-base.php
+++ b/tests/lib/proxy/class-ip-forward-test-base.php
@@ -26,10 +26,14 @@ abstract class IP_Forward_Test_Base extends TestCase {
 	public function tearDown(): void {
 		if ( $this->original_remote_addr ) {
 			$_SERVER['REMOTE_ADDR'] = $this->original_remote_addr;
+		} else {
+			unset( $_SERVER['REMOTE_ADDR'] );
 		}
 
 		if ( $this->original_x_forwarded_for ) {
 			$_SERVER['HTTP_X_FORWARDED_FOR'] = $this->original_x_forwarded_for;
+		} else {
+			unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
 		}
 	}
 }

--- a/tests/lib/proxy/class-ip-forward-test-base.php
+++ b/tests/lib/proxy/class-ip-forward-test-base.php
@@ -24,13 +24,13 @@ abstract class IP_Forward_Test_Base extends TestCase {
 	}
 
 	public function tearDown(): void {
-		if ( $this->original_remote_addr ) {
+		if ( null !== $this->original_remote_addr ) {
 			$_SERVER['REMOTE_ADDR'] = $this->original_remote_addr;
 		} else {
 			unset( $_SERVER['REMOTE_ADDR'] );
 		}
 
-		if ( $this->original_x_forwarded_for ) {
+		if ( null !== $this->original_x_forwarded_for ) {
 			$_SERVER['HTTP_X_FORWARDED_FOR'] = $this->original_x_forwarded_for;
 		} else {
 			unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );


### PR DESCRIPTION
This PR fixes flakiness in tests that rely upon `$_SERVER['HTTP_X_FORWARDED_FOR']` by properly restoring entries in the `$_SERVER` superglobal.

Fixes: #6829

Test: `./bin/test.sh --random-order-seed=1772804709 --order-by=random --stop-on-defect` must pass.
