### PR TITLE
feat(wp-cli): add logging to logstash for `unban` commands

### DIFF
--- a/wp-cli/class-user-unban-cli-command.php
+++ b/wp-cli/class-user-unban-cli-command.php
@@ -133,7 +133,7 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 
 	private static function log( string $message ): void {
 		WP_CLI::success( $message );
-		if ( function_exists( 'log2logstash' ) ) {
+		if ( function_exists( '\\Automattic\\VIP\\Logstash\\log2logstash' ) ) {
 			log2logstash( [
 				'severity' => 'notice',
 				'message'  => $message,

--- a/wp-cli/class-user-unban-cli-command.php
+++ b/wp-cli/class-user-unban-cli-command.php
@@ -5,6 +5,8 @@ namespace Automattic\VIP\CLI;
 use WP_CLI;
 use WPCOM_VIP_CLI_Command;
 
+use function Automattic\VIP\Logstash\log2logstash;
+
 final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 
 	public static function get_instance(): self {
@@ -74,7 +76,7 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 			wp_cache_delete( CACHE_KEY_LOCK_PREFIX . $ip, CACHE_GROUP_LOGIN_LIMIT );
 			wp_cache_delete( CACHE_KEY_LOCK_PREFIX . $ip, CACHE_GROUP_LOST_PASSWORD_LIMIT );
 
-			WP_CLI::success( sprintf( 'Unbanned IP %s', $ip ) );
+			self::log( sprintf( 'Unbanned IP %s', $ip ) );
 		}
 	}
 
@@ -123,10 +125,21 @@ final class User_Unban_CLI_Command extends WPCOM_VIP_CLI_Command {
 				}
 			}
 
-			WP_CLI::success( sprintf( 'Unbanned user %s for IP %s', $login, $ip ) );
+			self::log( sprintf( 'Unbanned user %s for IP %s', $login, $ip ) );
 		}
 
-		WP_CLI::success( sprintf( 'Unbanned user %s', $login ) );
+		self::log( sprintf( 'Unbanned user %s', $login ) );
+	}
+
+	private static function log( string $message ): void {
+		WP_CLI::success( $message );
+		if ( function_exists( 'log2logstash' ) ) {
+			log2logstash( [
+				'severity' => 'notice',
+				'message'  => $message,
+				'feature'  => 'security',
+			] );
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

This is a follow-up on #6831.

This PR adds logging to Logstash for all successful unbans. 

## Changelog Description

### Added
- Log all successful unbans (`wp vip security unban`) to Logstash

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See #6831 
