### PR TITLE
Add network-site specific config support for Agentforce

### DIFF
--- a/integrations/agentforce.php
+++ b/integrations/agentforce.php
@@ -26,7 +26,7 @@ class AgentforceIntegration extends Integration {
 	}
 
 	public function configure(): void {
-		$configs = $this->get_env_config();
+		$configs = is_multisite() ? $this->get_network_site_config() : $this->get_env_config();
 
 		if ( ! defined( 'VIP_AGENTFORCE_CONFIGS' ) ) {
 			define( 'VIP_AGENTFORCE_CONFIGS', $configs );

--- a/tests/integrations/test-agentforce.php
+++ b/tests/integrations/test-agentforce.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\VIP\Integrations;
 
+use Env_Integration_Status;
+use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 use Automattic\Test\Constant_Mocker;
 
@@ -54,6 +56,61 @@ class Agentforce_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( defined( 'VIP_AGENTFORCE_CONFIGS' ) );
 		$this->assertEquals( [], constant( 'VIP_AGENTFORCE_CONFIGS' ) );
+	}
+
+	public function test_configure_uses_network_site_config_for_multisite(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Only valid for multisite.' );
+		}
+
+		$blog_2_id = $this->factory()->blog->create_object( [ 'domain' => 'agentforce-test.site/2' ] );
+		switch_to_blog( $blog_2_id );
+
+		try {
+			/** @var IntegrationVipConfig&MockObject $config_mock */
+			$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )
+				->disableOriginalConstructor()
+				->onlyMethods( [ 'get_vip_config_from_file' ] )
+				->getMock();
+
+			$config_mock->method( 'get_vip_config_from_file' )->willReturn(
+				[
+					'env'           => [
+						'status' => Env_Integration_Status::ENABLED,
+						'config' => [ 'version' => '1.0' ],
+					],
+					'network_sites' => [
+						1          => [
+							'status' => Env_Integration_Status::ENABLED,
+							'config' => [ 'version' => '1.5' ],
+						],
+						$blog_2_id => [
+							'status' => Env_Integration_Status::ENABLED,
+							'config' => [
+								'version' => '2.0',
+								'api_key' => 'site-2-key',
+							],
+						],
+					],
+				]
+			);
+			$config_mock->__construct( $this->slug );
+
+			$agentforce_integration = new AgentforceIntegration( $this->slug );
+			$agentforce_integration->set_vip_config( $config_mock );
+			$agentforce_integration->configure();
+
+			$this->assertSame( '2.0', $agentforce_integration->version );
+			$this->assertEquals(
+				[
+					'version' => '2.0',
+					'api_key' => 'site-2-key',
+				],
+				constant( 'VIP_AGENTFORCE_CONFIGS' )
+			);
+		} finally {
+			restore_current_blog();
+		}
 	}
 
 	public function test_configure_does_not_redefine_constant(): void {


### PR DESCRIPTION
## Description
This updates the Agentforce integration config handling to support network-site specific configs on multisite, following the pattern already used by other VIP integrations.

It changes `AgentforceIntegration::configure()` to read the current network site's config when running on multisite, while preserving the existing env-level behavior for single-site installs.

## Changelog Description

### Fixed
- Agentforce: Respect network-site specific integration config on multisite when defining `VIP_AGENTFORCE_CONFIGS` and selecting the configured version.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out this branch on a multisite environment.
2. Configure Agentforce with different env-level and network-site-level config values.
3. Load the integration on a subsite and verify `VIP_AGENTFORCE_CONFIGS` contains the current site's config rather than the env-level config.
4. Verify the selected Agentforce version follows the current network site's `version` value.
5. Run `vendor/bin/phpcs integrations/agentforce.php tests/integrations/test-agentforce.php`.
6. Run `php -l integrations/agentforce.php`.
7. Run `php -l tests/integrations/test-agentforce.php`.
8. Optional: run `vendor/bin/phpunit -c phpunit-multisite.xml --filter Agentforce_Integration_Test tests/integrations/test-agentforce.php` once the WordPress test library is available at `/tmp/wordpress-tests-lib`.
