### PR TITLE
Release gutenberg-0.2-20260323 for RTC

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260317';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260323';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Description
Updates RTC to the latest `trunk` version of Gutenberg.

## Changelog Description

### Changed
- Updated the version of Gutenberg used by VIP Real-Time Collaboration to the latest `trunk` code as of https://github.com/WordPress/gutenberg/commit/29e8cdbf75a8515345d72ecc959dcf19ab10011b