### PR TITLE
Update the gutenberg version to load to be 0.2 instead

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260323';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Description

This is a companion PR to https://github.com/Automattic/vip-go-mu-plugins-ext/pull/117.

The intention is to load gutenberg-0.2 which'll be the version used in WordPress 7.0 by default. This'll only be updated once we begin supporting a managed Gutenberg integration.

## Changelog Description

### Changed

- Update the Gutenberg version used in RTC to be the same as WordPress 7.0

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 