### PR TITLE
Add and set wp-parsely 3.23 as the default version

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -23,6 +23,7 @@ use Parsely\Parsely;
  * The default version is the first entry in the SUPPORTED_VERSIONS list.
  */
 const SUPPORTED_VERSIONS = [
+	'3.23',
 	'3.22',
 	'3.21',
 	'3.20',


### PR DESCRIPTION
## Description

This PR adds and sets wp-parsely 3.23 as the default version in vip-go-mu-plugins. Any websites not pinned to a specific wp-parsely version will automatically be upgraded to 3.23.x when this PR takes effect.

## Changelog Description

### Changed
- Updated the default version of wp-parsely from 3.22 to 3.23.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Checkout the PR.
2. Enable wp-parsely (if needed):
```
add_filter( 'wpvip_parsely_load_mu', '__return_true' );
```
3. In wp-admin, go the plugin's settings (Parse.ly -> Settings). On the top of the page, you should be seeing the new default version number (3.23.x).