### PR TITLE
QM 4 compat in the compacted-header plugin

### DIFF
--- a/qm-plugins/qm-limited-header-php-errors/output/headers/php-errors.php
+++ b/qm-plugins/qm-limited-header-php-errors/output/headers/php-errors.php
@@ -34,33 +34,24 @@ class QM_Output_Headers_Limited_PHP_Errors extends QM_Output_Headers {
 
 		$count = 0;
 
-		foreach ( $data->errors as $type => $errors ) {
+		foreach ( $data->errors as $error ) {
+			++$count;
 
-			foreach ( $errors as $error_key => $error ) {
+			$stack     = isset( $error->trace ) ? $error->trace->get_stack() : array();
+			$component = isset( $error->trace ) ? $error->trace->get_component()->name : '';
+			$callsite  = isset( $error->trace ) ? $error->trace->get_callsite() : null;
 
-				// phpcs:ignore Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound
-				$count++;
+			$output_error = array(
+				'level'     => $error->level,
+				'message'   => $error->message,
+				'file'      => $callsite ? QM_Util::standard_dir( $callsite->file, '' ) : '',
+				'line'      => $callsite->line ?? null,
+				'stack'     => $stack,
+				'component' => $component,
+			);
 
-				$stack = array();
-
-				if ( ! empty( $error['filtered_trace'] ) ) {
-					$stack = array_column( $error['filtered_trace'], 'display' );
-				}
-
-				$output_error = array(
-					'key'       => $error_key,
-					'type'      => $error['type'],
-					'message'   => $error['message'],
-					'file'      => QM_Util::standard_dir( $error['file'], '' ),
-					'line'      => $error['line'],
-					'stack'     => $stack,
-					'component' => $error['component']->name,
-				);
-
-				$key             = sprintf( 'error-%d', $count );
-				$headers[ $key ] = json_encode( $output_error ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-
-			}
+			$key             = sprintf( 'error-%d', $count );
+			$headers[ $key ] = json_encode( $output_error ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 		}
 
 		// VIP: hack to avoid failed requests due to headers being too large
@@ -94,7 +85,7 @@ class QM_Output_Headers_Limited_PHP_Errors extends QM_Output_Headers {
 
 		return array_merge(
 			array(
-				'error-count' => $count,
+				'count' => $count,
 			),
 			$headers
 		);


### PR DESCRIPTION
## Description


This pull request refactors the way PHP errors are processed and output in the `get_output()` function of `php-errors.php`. The changes simplify the error iteration logic, improve how error details are extracted, and update the structure of the returned headers.

**Refactoring and Simplification:**

* Changed the error iteration from a nested loop (by error type and error) to a single loop over error objects, simplifying the logic and reducing complexity.

**Error Detail Extraction Improvements:**

* Updated how stack traces, component names, and callsite information are extracted from each error, using object properties and methods (`$error->trace->get_stack()`, etc.) instead of array access.
* Changed the error output structure to use the error's `level`, `message`, `file`, `line`, `stack`, and `component` properties, aligning with the new error object model.

**Header Output Structure Update:**

* Renamed the returned header key from `'error-count'` to `'count'` for consistency and clarity.

## Changelog Description

### Added
- Query Monitor 4 compatibility fixes.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->