### PR TITLE
ci: add test timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,4 @@ jobs:
           phpunit: ${{ matrix.config.phpunit }}
           coverage: ${{ matrix.config.coverage }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
+        timeout-minutes: 15

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -111,16 +111,20 @@ jobs:
           --verbose -c phpunit.xml.dist
           --filter "^\(?!.*test_wp_generate_attachment_metadata_png_thumbnail_smaller_than_original\).*\$"
         working-directory: wordpress
+        timeout-minutes: 15
 
       - name: Run AJAX tests
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group ajax
         working-directory: wordpress
+        timeout-minutes: 15
 
       - name: Run ms-files tests as a multisite install
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c tests/phpunit/multisite.xml --group ms-files
         working-directory: wordpress
+        timeout-minutes: 15
 
       - name: Run external HTTP tests
         run: |
           node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group external-http
         working-directory: wordpress
+        timeout-minutes: 15

--- a/.github/workflows/parsely.yml
+++ b/.github/workflows/parsely.yml
@@ -59,3 +59,4 @@ jobs:
         with:
           wordpress: ${{ matrix.config.wp }}
           php: ${{ matrix.config.php }}
+        timeout-minutes: 15


### PR DESCRIPTION
This PR adds timeouts to the test to ensure CI jobs terminate within a reasonable time.

This is important because there is a finite number of runners across the entire organization, and recently, GitHub runners have started freezing for no apparent reason (bailing out on the internal timeout of 6 to 10 hours).
