### PR TITLE
fix(wp-cli): correct --skip-confirm docblock format for vip cache purge

### DIFF
--- a/wp-cli/vip-cache.php
+++ b/wp-cli/vip-cache.php
@@ -20,7 +20,8 @@ class VIP_Cache_CLI extends WPCOM_VIP_CLI_Command {
 	 *   - private
 	 * ---
 	 *
-	 * [--skip-confirm] force purge without confirmation (site scope only).
+	 * [--skip-confirm]
+	 * : Force purge without confirmation (site scope only).
 	 */
 	public function purge( $args, $assoc_args ) {
 		if ( isset( $args[0] ) && wp_http_validate_url( $args[0] ) ) {


### PR DESCRIPTION
## Summary

- Fixes `unknown --skip-confirm parameter` error when running `wp vip cache purge --skip-confirm`
- The WP-CLI docblock had the flag description inline (`[--skip-confirm] description...`) instead of on a separate line prefixed with `: `, which caused WP-CLI's synopsis parser to not register the flag as valid

## Test plan

- [ ] Run `wp vip cache purge --skip-confirm` and confirm it no longer errors with `unknown parameter`
- [ ] Run `wp vip cache purge` (without `--skip-confirm`) and confirm the confirmation prompt still appears for site scope