### PR TITLE
fix(wp-cli): correct --skip-confirm docblock format for vip cache purge

### DIFF
--- a/wp-cli/vip-cache.php
+++ b/wp-cli/vip-cache.php
@@ -20,7 +20,8 @@ class VIP_Cache_CLI extends WPCOM_VIP_CLI_Command {
 	 *   - private
 	 * ---
 	 *
-	 * [--skip-confirm] force purge without confirmation (site scope only).
+	 * [--skip-confirm]
+	 * : Force purge without confirmation (site scope only).
 	 */
 	public function purge( $args, $assoc_args ) {
 		if ( isset( $args[0] ) && wp_http_validate_url( $args[0] ) ) {


### PR DESCRIPTION
## Description
Fixes `unknown --skip-confirm parameter` in the `wp vip cache purge` command.
WP-CLI requires option descriptions on a separate line prefixed with ': '. The inline format caused the flag to not be registered, resulting in an 'unknown parameter' error at runtime.


## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Fixed
- Fixed `unknown --skip-confirm parameter` in the `wp vip cache purge` command

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.