### PR TITLE
VIP_Request_Block: Only log once every 5 minutes for invalid IPs passed

### DIFF
--- a/lib/class-vip-request-block.php
+++ b/lib/class-vip-request-block.php
@@ -38,8 +38,11 @@ class VIP_Request_Block {
 		// Don't try to block if the passed value is not a valid IP.
 		if ( ! filter_var( $value, FILTER_VALIDATE_IP ) ) {
 			if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( 'VIP Request Block: The value passed is not a correct IP address: ' . $value );
+				$rate_key = 'vip_req_block_invalid_ip_' . md5( $value );
+				if ( ! function_exists( 'apcu_add' ) || apcu_add( $rate_key, 1, 300 ) ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'VIP Request Block: The value passed is not a correct IP address: ' . $value );
+				}
 			}
 
 			return false;


### PR DESCRIPTION

## Description
Rate limits the logging for invalid IPs being passed into VIP_Request_Block
## Changelog Description


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->