### PR TITLE
Helper function: Add vip_get_device_class

### DIFF
--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -319,6 +319,25 @@ function wpcom_vip_remove_livechat() {
 }
 
 /**
+ * Get the mobile device type from the X-Mobile-Class header set in the request.
+ *
+ * @return string|null One of 'desktop', 'smart', 'dumb', 'tablet', or null if the header is not set or contains unrecognized value.
+ */
+function vip_get_mobile(): ?string {
+	if ( ! isset( $_SERVER['HTTP_X_MOBILE_CLASS'] ) ) {
+		return null;
+	}
+
+	$type    = $_SERVER['HTTP_X_MOBILE_CLASS']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$allowed = [ 'desktop', 'smart', 'dumb', 'tablet' ];
+	if ( ! in_array( $type, $allowed, true ) ) {
+		return null;
+	}
+
+	return $type;
+}
+
+/**
 * Eliminates widows in strings by replace the breaking space that appears before the last word with a non-breaking space.
 *
 * This function is defined on WordPress.com and can be a common source of frustration for VIP devs.

--- a/vip-helpers/vip-utils.php
+++ b/vip-helpers/vip-utils.php
@@ -323,7 +323,7 @@ function wpcom_vip_remove_livechat() {
  *
  * @return string|null One of 'desktop', 'smart', 'dumb', 'tablet', or null if the header is not set or contains unrecognized value.
  */
-function vip_get_mobile(): ?string {
+function vip_get_device_class(): ?string {
 	if ( ! isset( $_SERVER['HTTP_X_MOBILE_CLASS'] ) ) {
 		return null;
 	}


### PR DESCRIPTION
## Description
This pull request introduces a new wrapper function to help determine the type of mobile device making a request based on a custom VIP HTTP header (https://docs.wpvip.com/caching/page-cache/http-headers/added-by-vip/). 
New utility for device detection:

## Changelog Description

### Added
- * Added the `vip_get_device_class()` to return the device type (`'desktop'`, `'smart'`, `'dumb'`, or `'tablet'`) based on the `X-Mobile-Class` HTTP header.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->