### PR TITLE
Update RTC to gutenberg-0.2-20260519

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260414';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260519';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Description

Updated the RTC integration to use the latest Gutenberg release added in https://github.com/Automattic/vip-go-mu-plugins-ext/pull/120

## Changelog Description

### Changed
- Updated RTC to use Gutenberg 23.1.1