### PR TITLE
Enterprise Search: Prevent site's index version leaking into cross-site ES queries

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -815,7 +815,18 @@ class Search {
 			$index_name .= sprintf( '-%s', $blog_id );
 		}
 
+		// get_versions() uses get_option(), which is blog-context-sensitive. Without switching,
+		// cross-site queries resolve the version from the calling site instead of the target site.
+		$switched = $blog_id && \is_multisite() && \get_current_blog_id() !== (int) $blog_id;
+		if ( $switched ) {
+			\switch_to_blog( $blog_id );
+		}
+
 		$current_version = $this->versioning->get_current_version_number( $indexable );
+
+		if ( $switched ) {
+			\restore_current_blog();
+		}
 
 		if ( is_int( $current_version ) && $current_version > 1 ) {
 			$index_name .= sprintf( '-v%d', $current_version );

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -331,7 +331,7 @@ class Search_Test extends WP_UnitTestCase {
 				],
 				2 => [
 					'number'         => 2,
-					'active'         => true, 
+					'active'         => true,
 					'created_time'   => time(),
 					'activated_time' => time(),
 				],

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -134,17 +134,17 @@ class Search_Test extends WP_UnitTestCase {
 				// Active index number
 				1,
 				// Blog id
-				2,
+				1,
 				// Expected index name
-				'vip-123-post-2',
+				'vip-123-post-1',
 			),
 			array(
 				// Active index number
 				2,
 				// Blog id
-				2,
+				1,
 				// Expected index name
-				'vip-123-post-2-v2',
+				'vip-123-post-1-v2',
 			),
 			array(
 				// Active index number
@@ -293,6 +293,73 @@ class Search_Test extends WP_UnitTestCase {
 		$index_name = apply_filters( 'ep_index_name', 'index-name', $blog_id, $indexable );
 
 		$this->assertEquals( $expected_index_name, $index_name );
+	}
+
+	/**
+	 * Test that index name version is resolved using the target blog's version data,
+	 * not the calling site's — i.e. cross-site searches use the correct index.
+	 *
+	 * Scenario (mirrors the real bug):
+	 *   - site A has active index version 2  → should produce vip-123-post-{A}-v2
+	 *   - site B has active index version 1  → should produce vip-123-post-{B}  (no suffix)
+	 * Before the fix, calling the filter from site A's context for site B produced
+	 * vip-123-post-{B}-v2 because get_option() ran against site A's DB row.
+	 *
+	 * @group ms-required
+	 */
+	public function test__vip_search_filter_ep_index_name_uses_target_blog_version() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Blog switching only applies on multisite.' );
+		}
+
+		Constant_Mocker::define( 'VIP_ORIGIN_DATACENTER', 'dfw' );
+		$this->init_es();
+		Constant_Mocker::define( 'FILES_CLIENT_SITE_ID', 123 );
+
+		$indexable = Indexables::factory()->get( 'post' );
+
+		$blog_id_a = self::factory()->blog->create();
+		$blog_id_b = self::factory()->blog->create();
+
+		$v2_versions = [
+			'post' => [
+				1 => [
+					'number'         => 1,
+					'active'         => false,
+					'created_time'   => null,
+					'activated_time' => null,
+				],
+				2 => [
+					'number'         => 2,
+					'active'         => true, 
+					'created_time'   => time(),
+					'activated_time' => time(),
+				],
+			],
+		];
+		switch_to_blog( $blog_id_a );
+		update_option( Versioning::INDEX_VERSIONS_OPTION, $v2_versions );
+		restore_current_blog();
+
+		switch_to_blog( $blog_id_a );
+		$index_name_b = apply_filters( 'ep_index_name', 'index-name', $blog_id_b, $indexable );
+		restore_current_blog();
+
+		$this->assertSame(
+			"vip-123-post-{$blog_id_b}",
+			$index_name_b,
+			'Cross-site query should use the target site\'s version (v1), not the calling site\'s (v2)'
+		);
+
+		switch_to_blog( $blog_id_a );
+		$index_name_a = apply_filters( 'ep_index_name', 'index-name', $blog_id_a, $indexable );
+		restore_current_blog();
+
+		$this->assertSame(
+			"vip-123-post-{$blog_id_a}-v2",
+			$index_name_a,
+			'Querying the site that has v2 active should still produce the -v2 suffix'
+		);
 	}
 
 	public function test__vip_search_filter_ep_index_name_with_overridden_version() {


### PR DESCRIPTION

## Description
This pull request addresses a bug in multisite environments where the search index name version could be incorrectly resolved from the calling site's context rather than the target site. The update ensures that cross-site queries use the correct version data for each site, and adds a test to verify this behavior.

## Changelog Description

### Fixed
- Enterprise Search: Prevent site's index version leaking into cross-site ES queries

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. On a MS, create 2 more subsites
2. On site 2, create an index version 2 and activate it
3. Add:
```
$query = new WP_Query(
	array(
		's' => 'carrot',
		'sites' => array( 2, 3 ), // Search only in site IDs 2 and 3 
		'ep_integrate' => true,
	)
);
```
4. In site 2 context, you should see in the QM API call list:
```
http://elasticsearch:9200/vip-200508-post-2-v2,vip-200508-post-3/_search
```