### PR TITLE
cherry-pick: Update RTC to gutenberg-0.2-20260519 (#6970)

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260414';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260519';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Description

Cherry-pick of #6970 from `staging` → `production`. 

Updates the `VIP_RTC_GUTENBERG_VERSION` constant in `integrations/real-time-collaboration.php` from `0.2-20260414` to `0.2-20260519`, pointing the Real-Time Collaboration integration at the May 19 Gutenberg build.



## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->