### PR TITLE
Fix RTC Gutenberg activation detection

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -47,13 +47,11 @@ class RealTimeCollaborationIntegration extends Integration {
 			return true;
 		}
 
-		$active_plugins = (array) get_option( 'active_plugins', [] );
-		if ( in_array( 'gutenberg/gutenberg.php', $active_plugins, true ) ) {
-			return true;
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$network_active_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
-		return isset( $network_active_plugins['gutenberg/gutenberg.php'] );
+		return \is_plugin_active( 'gutenberg/gutenberg.php' );
 	}
 
 	/**

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -48,16 +48,13 @@ class RealTimeCollaborationIntegration extends Integration {
 		}
 
 		$plugin_file = 'gutenberg/gutenberg.php';
-		if ( in_array( $plugin_file, (array) get_option( 'active_plugins', [] ), true ) ) {
-			return true;
+		$is_active   = in_array( $plugin_file, (array) get_option( 'active_plugins', [] ), true );
+		if ( ! $is_active && is_multisite() ) {
+			$network_active_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+			$is_active              = isset( $network_active_plugins[ $plugin_file ] );
 		}
 
-		if ( ! is_multisite() ) {
-			return false;
-		}
-
-		$network_active_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
-		return isset( $network_active_plugins[ $plugin_file ] );
+		return $is_active;
 	}
 
 	/**

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -47,11 +47,17 @@ class RealTimeCollaborationIntegration extends Integration {
 			return true;
 		}
 
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		$plugin_file = 'gutenberg/gutenberg.php';
+		if ( in_array( $plugin_file, (array) get_option( 'active_plugins', [] ), true ) ) {
+			return true;
 		}
 
-		return \is_plugin_active( 'gutenberg/gutenberg.php' );
+		if ( ! is_multisite() ) {
+			return false;
+		}
+
+		$network_active_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+		return isset( $network_active_plugins[ $plugin_file ] );
 	}
 
 	/**

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -43,7 +43,17 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Check if the Gutenberg plugin is active.
 	 */
 	private function is_gutenberg_plugin_active(): bool {
-		return defined( 'IS_GUTENBERG_PLUGIN' ) && constant( 'IS_GUTENBERG_PLUGIN' );
+		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && constant( 'IS_GUTENBERG_PLUGIN' ) ) {
+			return true;
+		}
+
+		$active_plugins = (array) get_option( 'active_plugins', [] );
+		if ( in_array( 'gutenberg/gutenberg.php', $active_plugins, true ) ) {
+			return true;
+		}
+
+		$network_active_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+		return isset( $network_active_plugins['gutenberg/gutenberg.php'] );
 	}
 
 	/**

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 use Automattic\Test\Constant_Mocker;
 
+use function Automattic\Test\Utils\get_class_method_as_public;
+
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
@@ -275,46 +277,30 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( $integration_mock->is_active() );
 	}
 
-	public function test_load_sets_inactive_when_gutenberg_plugin_activated(): void {
+	public function test_can_load_returns_false_when_gutenberg_plugin_activated(): void {
 		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
 		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
 		update_option( 'active_plugins', [ 'gutenberg/gutenberg.php' ] );
 
-		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
-		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
-			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded' ] )
-			->getMock();
+		$rtc_integration = new RealTimeCollaborationIntegration( $this->slug );
+		$can_load        = get_class_method_as_public( RealTimeCollaborationIntegration::class, 'can_load' );
 
-		$integration_mock->method( 'is_loaded' )->willReturn( false );
-
-		$integration_mock->load();
-
-		// Trigger the plugins_loaded action to execute the closure
-		do_action( 'plugins_loaded' );
-
-		$this->assertFalse( $integration_mock->is_active() );
+		$this->assertFalse( $can_load->invoke( $rtc_integration ) );
 	}
 
-	public function test_load_sets_inactive_when_gutenberg_plugin_network_activated(): void {
+	public function test_can_load_returns_false_when_gutenberg_plugin_network_activated(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Network activation is only available in multisite.' );
+		}
+
 		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
 		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
-		update_site_option( 'active_sitewide_plugins', [ 'gutenberg/gutenberg.php' => time() ] );
+		update_site_option( 'active_sitewide_plugins', [ 'gutenberg/gutenberg.php' => 1 ] );
 
-		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
-		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
-			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'is_loaded' ] )
-			->getMock();
+		$rtc_integration = new RealTimeCollaborationIntegration( $this->slug );
+		$can_load        = get_class_method_as_public( RealTimeCollaborationIntegration::class, 'can_load' );
 
-		$integration_mock->method( 'is_loaded' )->willReturn( false );
-
-		$integration_mock->load();
-
-		// Trigger the plugins_loaded action to execute the closure
-		do_action( 'plugins_loaded' );
-
-		$this->assertFalse( $integration_mock->is_active() );
+		$this->assertFalse( $can_load->invoke( $rtc_integration ) );
 	}
 
 	public function test_load_sets_inactive_when_gutenberg_file_missing(): void {

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -16,11 +16,23 @@ use Automattic\Test\Constant_Mocker;
 
 class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'real-time-collaboration';
+	private array $previous_active_plugins = [];
+	private array $previous_active_sitewide_plugins = [];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->previous_active_plugins = get_option( 'active_plugins', [] );
+		$this->previous_active_sitewide_plugins = get_site_option( 'active_sitewide_plugins', [] );
+
+		update_option( 'active_plugins', [] );
+		update_site_option( 'active_sitewide_plugins', [] );
+	}
 
 	public function tearDown(): void {
 		Constant_Mocker::clear();
-		update_option( 'active_plugins', [] );
-		update_site_option( 'active_sitewide_plugins', [] );
+		update_option( 'active_plugins', $this->previous_active_plugins );
+		update_site_option( 'active_sitewide_plugins', $this->previous_active_sitewide_plugins );
 
 		parent::tearDown();
 	}

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -15,14 +15,14 @@ use Automattic\Test\Constant_Mocker;
 // phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
-	private string $slug = 'real-time-collaboration';
-	private array $previous_active_plugins = [];
+	private string $slug                            = 'real-time-collaboration';
+	private array $previous_active_plugins          = [];
 	private array $previous_active_sitewide_plugins = [];
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->previous_active_plugins = get_option( 'active_plugins', [] );
+		$this->previous_active_plugins          = get_option( 'active_plugins', [] );
 		$this->previous_active_sitewide_plugins = get_site_option( 'active_sitewide_plugins', [] );
 
 		update_option( 'active_plugins', [] );

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -19,6 +19,8 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		Constant_Mocker::clear();
+		update_option( 'active_plugins', [] );
+		update_site_option( 'active_sitewide_plugins', [] );
 
 		parent::tearDown();
 	}
@@ -244,6 +246,48 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
 		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
 		Constant_Mocker::define( 'IS_GUTENBERG_PLUGIN', true );
+
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_load_sets_inactive_when_gutenberg_plugin_activated(): void {
+		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
+		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
+		update_option( 'active_plugins', [ 'gutenberg/gutenberg.php' ] );
+
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+
+		$integration_mock->load();
+
+		// Trigger the plugins_loaded action to execute the closure
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_load_sets_inactive_when_gutenberg_plugin_network_activated(): void {
+		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'test-secret' );
+		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://test.example.com' );
+		update_site_option( 'active_sitewide_plugins', [ 'gutenberg/gutenberg.php' => time() ] );
 
 		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )


### PR DESCRIPTION
## Summary
- Detect an already activated Gutenberg plugin via active_plugins before RTC loads its bundled Gutenberg copy
- Detect network-activated Gutenberg via active_sitewide_plugins on multisite
- Avoid loading wp-admin/includes/plugin.php in the RTC request path
- Add regression tests that directly verify the RTC load gate

## Testing
- npm run phplint
- npm run phpcs
- npm run test:smoke
- CI=1 ./bin/test.sh --filter Real_Time_Collaboration_Integration_Test
- CI=1 ./bin/test.sh --multisite 1 --filter Real_Time_Collaboration_Integration_Test
- CI=1 ./bin/test.sh