### PR TITLE
Tests: Remove WP 6.4 from matrix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,10 +101,10 @@ npm run lint  # Runs both phplint and phpcs
 All PRs to `develop` branch trigger these workflows:
 
 1. **CI Workflow** (`.github/workflows/ci.yml`):
-   - Runs PHPUnit tests across matrix of WP versions (6.4.x-nightly), PHP versions (8.1-8.4), multisite yes/no, Jetpack yes/no
+   - Runs PHPUnit tests across matrix of WP versions (6.5.x-nightly), PHP versions (8.2-8.5), multisite yes/no, Jetpack yes/no
    - Uses MySQL 8 service container
    - Takes about 10 minutes for full matrix
-   - Generates code coverage for latest WP + PHP 8.1
+   - Generates code coverage for latest WP + PHP 8.2
 
 2. **Lint Workflow** (`.github/workflows/lint.yml`):
    - Runs `npm run lint` (phplint + phpcs)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
       matrix:
         config:
         # PHP 8.2
-          - { wp: 6.4.x,   ms: 'no',  jp: 'yes', php: '8.2', phpunit: '' }
-          - { wp: 6.4.x,   ms: 'yes', jp: 'yes', php: '8.2', phpunit: '' }
           - { wp: 6.5.x,   ms: 'no',  jp: 'yes', php: '8.2', phpunit: '' }
           - { wp: 6.5.x,   ms: 'yes', jp: 'yes', php: '8.2', phpunit: '' }
           - { wp: 6.6.x,   ms: 'no',  jp: 'yes', php: '8.2', phpunit: '' }
@@ -46,8 +44,6 @@ jobs:
           - { wp: latest,  ms: 'no',  jp: 'no', php: '8.2', phpunit: '', coverage: 'yes' }
           - { wp: latest,  ms: 'yes', jp: 'no', php: '8.2', phpunit: '', coverage: 'yes' }
         # PHP 8.3
-          - { wp: 6.4.x,   ms: 'no',  jp: 'yes', php: '8.3', phpunit: '' }
-          - { wp: 6.4.x,   ms: 'yes', jp: 'yes', php: '8.3', phpunit: '' }
           - { wp: 6.5.x,   ms: 'no',  jp: 'yes', php: '8.3', phpunit: '' }
           - { wp: 6.5.x,   ms: 'yes', jp: 'yes', php: '8.3', phpunit: '' }
           - { wp: 6.6.x,   ms: 'no',  jp: 'yes', php: '8.3', phpunit: '' }


### PR DESCRIPTION
## Description
Removes WP 6.4 from CI test matrix.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->