### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260520';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260525';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary
- update `VIP_RTC_GUTENBERG_VERSION` to `0.2-20260525`
- keep `VIP_RTC_PLUGIN_VERSION` at `0.2` because latest VIP RTC release `v0.2.5` is already present in `vip-go-mu-plugins-ext`
- rebased onto latest `develop` on 2026-06-01; no newer stable Gutenberg or RTC release was available

## Dependency
- Requires Automattic/vip-go-mu-plugins-ext#123 to make `vip-integrations/gutenberg-0.2-20260525` available.

## Deployed-stage versions recorded before update
- develop: RTC `0.2`, Gutenberg `0.2-20260520`
- staging: RTC `0.2`, Gutenberg `0.2-20260520`
- production: RTC `0.2`, Gutenberg `0.2-20260519`

## Validation
- `git diff --check origin/develop...HEAD` passed
- `./bin/test.sh --test-suffix .php --filter Real_Time_Collaboration_Integration_Test tests/integrations` passed: 13 tests, 18 assertions
- `php -l integrations/real-time-collaboration.php` could not run because local `php` is not installed
