### PR TITLE
Add Safe Publish VIP integration loader

### DIFF
--- a/integrations/safe-publish.php
+++ b/integrations/safe-publish.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Integration: Safe Publish.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+/**
+ * Loads the Safe Publish integration.
+ *
+ * @private
+ */
+class SafePublishIntegration extends Integration {
+	/**
+	 * The version of Safe Publish to load, defaults to the latest version.
+	 *
+	 * @var string
+	 */
+	public string $version = 'latest';
+
+	/**
+	 * Enable Pendo tracking for this integration.
+	 *
+	 * @var bool
+	 */
+	protected bool $enable_pendo_tracking = true;
+
+	public function is_loaded(): bool {
+		return defined( 'SAFE_PUBLISH_LOADED' ) || defined( 'SAFE_PUBLISH_PLUGIN_FILE' );
+	}
+
+	public function configure(): void {
+		$configs = is_multisite() ? $this->get_network_site_config() : $this->get_env_config();
+
+		$this->define_config_constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL', $configs['connected_site_url'] ?? null );
+		$this->define_config_constant( 'SAFE_PUBLISH_SYNC_MODE', $configs['sync_mode'] ?? null );
+		$this->define_config_constant( 'SAFE_PUBLISH_SHARED_SECRET', $configs['shared_secret'] ?? null );
+		$this->define_config_constant( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME', $configs['basic_auth_username'] ?? null );
+		$this->define_config_constant( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD', $configs['basic_auth_password'] ?? null );
+
+		if ( isset( $configs['version'] ) && is_string( $configs['version'] ) && '' !== $configs['version'] ) {
+			$this->version = $configs['version'];
+		}
+	}
+
+	public function load(): void {
+		add_action( 'plugins_loaded', function () {
+			if ( $this->is_loaded() ) {
+				return;
+			}
+
+			$versions = $this->get_versions();
+
+			if ( empty( $versions ) ) {
+				$this->is_active = false;
+				return;
+			}
+
+			$selected_version_folder = $this->get_selected_version_folder( $versions );
+			$load_path               = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $selected_version_folder . '/safe-publish.php';
+
+			if ( file_exists( $load_path ) ) {
+				require_once $load_path;
+			} else {
+				$this->is_active = false;
+			}
+		}, 1 );
+	}
+
+	/**
+	 * Get the available versions of Safe Publish in descending order.
+	 *
+	 * @return array<string,string>
+	 */
+	public function get_versions(): array {
+		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'safe-publish', 'safe-publish.php' );
+	}
+
+	/**
+	 * Get the folder name for the selected version of the integration.
+	 *
+	 * @param array<string,string> $versions Available versions.
+	 * @return string The selected folder name.
+	 */
+	public function get_selected_version_folder( array $versions ): string {
+		if ( 'latest' === $this->version ) {
+			return array_key_first( $versions );
+		}
+
+		$desired_version = array_search( $this->version, $versions, true );
+
+		if ( false !== $desired_version ) {
+			return $desired_version;
+		}
+
+		return array_key_first( $versions );
+	}
+
+	/**
+	 * Define a Safe Publish configuration constant.
+	 *
+	 * @param string $constant_name Constant name.
+	 * @param mixed  $value         Constant value.
+	 */
+	private function define_config_constant( string $constant_name, mixed $value ): void {
+		if ( defined( $constant_name ) || ! is_string( $value ) || '' === $value ) {
+			return;
+		}
+
+		define( $constant_name, $value );
+	}
+}

--- a/tests/integrations/test-safe-publish.php
+++ b/tests/integrations/test-safe-publish.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Test: Safe Publish Integration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+use Automattic\Test\Constant_Mocker;
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_UnitTestCase;
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+class Safe_Publish_Integration_Test extends WP_UnitTestCase {
+	private string $slug = 'safe-publish';
+
+	public function tearDown(): void {
+		Constant_Mocker::clear();
+
+		parent::tearDown();
+	}
+
+	public function test_is_loaded_returns_false_when_not_loaded(): void {
+		$safe_publish_integration = new SafePublishIntegration( $this->slug );
+		$this->assertFalse( $safe_publish_integration->is_loaded() );
+	}
+
+	public function test_is_loaded_returns_true_when_loaded_constant_is_defined(): void {
+		Constant_Mocker::define( 'SAFE_PUBLISH_LOADED', true );
+
+		$safe_publish_integration = new SafePublishIntegration( $this->slug );
+		$this->assertTrue( $safe_publish_integration->is_loaded() );
+	}
+
+	public function test_is_loaded_returns_true_when_plugin_file_constant_is_defined(): void {
+		Constant_Mocker::define( 'SAFE_PUBLISH_PLUGIN_FILE', '/path/to/safe-publish.php' );
+
+		$safe_publish_integration = new SafePublishIntegration( $this->slug );
+		$this->assertTrue( $safe_publish_integration->is_loaded() );
+	}
+
+	public function test_configure_defines_safe_publish_constants_from_config(): void {
+		/** @var MockObject|SafePublishIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( SafePublishIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_env_config' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_env_config' )->willReturn( [
+			'connected_site_url'  => 'https://source.example.com',
+			'sync_mode'           => 'import',
+			'shared_secret'       => 'test-shared-secret',
+			'basic_auth_username' => 'publisher',
+			'basic_auth_password' => 'password',
+			'version'             => '1.0',
+		] );
+
+		$integration_mock->configure();
+
+		$this->assertSame( 'https://source.example.com', constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL' ) );
+		$this->assertSame( 'import', constant( 'SAFE_PUBLISH_SYNC_MODE' ) );
+		$this->assertSame( 'test-shared-secret', constant( 'SAFE_PUBLISH_SHARED_SECRET' ) );
+		$this->assertSame( 'publisher', constant( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME' ) );
+		$this->assertSame( 'password', constant( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD' ) );
+		$this->assertSame( '1.0', $integration_mock->version );
+	}
+
+	public function test_configure_does_not_redefine_existing_constants(): void {
+		Constant_Mocker::define( 'SAFE_PUBLISH_CONNECTED_SITE_URL', 'https://existing.example.com' );
+
+		/** @var MockObject|SafePublishIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( SafePublishIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_env_config' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_env_config' )->willReturn( [
+			'connected_site_url' => 'https://new.example.com',
+		] );
+
+		$integration_mock->configure();
+
+		$this->assertSame( 'https://existing.example.com', constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL' ) );
+	}
+
+	public function test_load_returns_early_if_plugin_already_loaded(): void {
+		/** @var MockObject|SafePublishIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( SafePublishIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+
+		$integration_mock->expects( $this->once() )
+			->method( 'is_loaded' )
+			->willReturn( true );
+
+		$integration_mock->load();
+
+		do_action( 'plugins_loaded' );
+	}
+
+	public function test_load_sets_inactive_when_no_versions_are_available(): void {
+		/** @var MockObject|SafePublishIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( SafePublishIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->activate();
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		$integration_mock->method( 'get_versions' )->willReturn( [] );
+
+		$integration_mock->load();
+
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_get_selected_version_folder_returns_latest_version_when_version_is_latest(): void {
+		$safe_publish_integration          = new SafePublishIntegration( $this->slug );
+		$safe_publish_integration->version = 'latest';
+		$versions                          = [
+			'safe-publish-2.5'  => '2.5',
+			'safe-publish-1.11' => '1.11',
+			'safe-publish-1.2'  => '1.2',
+		];
+
+		$this->assertSame( 'safe-publish-2.5', $safe_publish_integration->get_selected_version_folder( $versions ) );
+	}
+
+	public function test_get_selected_version_folder_returns_desired_version_when_version_is_specified(): void {
+		$safe_publish_integration          = new SafePublishIntegration( $this->slug );
+		$safe_publish_integration->version = '1.2';
+		$versions                          = [
+			'safe-publish-2.5'  => '2.5',
+			'safe-publish-1.11' => '1.11',
+			'safe-publish-1.2'  => '1.2',
+		];
+
+		$this->assertSame( 'safe-publish-1.2', $safe_publish_integration->get_selected_version_folder( $versions ) );
+	}
+
+	public function test_get_selected_version_folder_returns_latest_version_when_version_not_found(): void {
+		$safe_publish_integration          = new SafePublishIntegration( $this->slug );
+		$safe_publish_integration->version = '9.9';
+		$versions                          = [
+			'safe-publish-2.5'  => '2.5',
+			'safe-publish-1.11' => '1.11',
+			'safe-publish-1.2'  => '1.2',
+		];
+
+		$this->assertSame( 'safe-publish-2.5', $safe_publish_integration->get_selected_version_folder( $versions ) );
+	}
+}

--- a/tests/integrations/test-safe-publish.php
+++ b/tests/integrations/test-safe-publish.php
@@ -9,6 +9,7 @@
 namespace Automattic\VIP\Integrations;
 
 use Automattic\Test\Constant_Mocker;
+use Env_Integration_Status;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 
@@ -43,47 +44,110 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_configure_defines_safe_publish_constants_from_config(): void {
-		/** @var MockObject|SafePublishIntegration $integration_mock */
-		$integration_mock = $this->getMockBuilder( SafePublishIntegration::class )
-			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'get_env_config' ] )
-			->getMock();
-
-		$integration_mock->method( 'get_env_config' )->willReturn( [
-			'connected_site_url'  => 'https://source.example.com',
-			'sync_mode'           => 'import',
-			'shared_secret'       => 'test-shared-secret',
-			'basic_auth_username' => 'publisher',
-			'basic_auth_password' => 'password',
-			'version'             => '1.0',
-		] );
-
-		$integration_mock->configure();
+		$safe_publish_integration = new SafePublishIntegration( $this->slug );
+		$safe_publish_integration->activate(
+			[
+				'config' => [
+					'connected_site_url'  => 'https://source.example.com',
+					'sync_mode'           => 'import',
+					'shared_secret'       => 'test-shared-secret',
+					'basic_auth_username' => 'publisher',
+					'basic_auth_password' => 'password',
+					'version'             => '1.0',
+				],
+			]
+		);
+		$safe_publish_integration->configure();
 
 		$this->assertSame( 'https://source.example.com', constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL' ) );
 		$this->assertSame( 'import', constant( 'SAFE_PUBLISH_SYNC_MODE' ) );
 		$this->assertSame( 'test-shared-secret', constant( 'SAFE_PUBLISH_SHARED_SECRET' ) );
 		$this->assertSame( 'publisher', constant( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME' ) );
 		$this->assertSame( 'password', constant( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD' ) );
-		$this->assertSame( '1.0', $integration_mock->version );
+		$this->assertSame( '1.0', $safe_publish_integration->version );
 	}
 
 	public function test_configure_does_not_redefine_existing_constants(): void {
 		Constant_Mocker::define( 'SAFE_PUBLISH_CONNECTED_SITE_URL', 'https://existing.example.com' );
 
-		/** @var MockObject|SafePublishIntegration $integration_mock */
-		$integration_mock = $this->getMockBuilder( SafePublishIntegration::class )
-			->setConstructorArgs( [ $this->slug ] )
-			->onlyMethods( [ 'get_env_config' ] )
-			->getMock();
-
-		$integration_mock->method( 'get_env_config' )->willReturn( [
-			'connected_site_url' => 'https://new.example.com',
-		] );
-
-		$integration_mock->configure();
+		$safe_publish_integration = new SafePublishIntegration( $this->slug );
+		$safe_publish_integration->activate(
+			[
+				'config' => [
+					'connected_site_url' => 'https://new.example.com',
+				],
+			]
+		);
+		$safe_publish_integration->configure();
 
 		$this->assertSame( 'https://existing.example.com', constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL' ) );
+	}
+
+	public function test_configure_uses_network_site_config_for_multisite(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Only valid for multisite.' );
+		}
+
+		$blog_2_id = $this->factory()->blog->create_object( [ 'domain' => 'safe-publish-test.site/2' ] );
+		switch_to_blog( $blog_2_id );
+
+		try {
+			/** @var IntegrationVipConfig&MockObject $config_mock */
+			$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )
+				->disableOriginalConstructor()
+				->onlyMethods( [ 'get_vip_config_from_file' ] )
+				->getMock();
+
+			$config_mock->method( 'get_vip_config_from_file' )->willReturn(
+				[
+					'env'           => [
+						'status' => Env_Integration_Status::ENABLED,
+						'config' => [
+							'connected_site_url'  => 'https://env-source.example.com',
+							'sync_mode'           => 'import',
+							'shared_secret'       => 'env-shared-secret',
+							'basic_auth_username' => 'env-publisher',
+							'basic_auth_password' => 'env-password',
+							'version'             => '1.0',
+						],
+					],
+					'network_sites' => [
+						1          => [
+							'status' => Env_Integration_Status::ENABLED,
+							'config' => [
+								'connected_site_url' => 'https://site-one.example.com',
+								'version'            => '1.5',
+							],
+						],
+						$blog_2_id => [
+							'status' => Env_Integration_Status::ENABLED,
+							'config' => [
+								'connected_site_url'  => 'https://site-two.example.com',
+								'sync_mode'           => 'export',
+								'shared_secret'       => 'site-two-shared-secret',
+								'basic_auth_username' => 'site-two-publisher',
+								'basic_auth_password' => 'site-two-password',
+								'version'             => '2.0',
+							],
+						],
+					],
+				]
+			);
+			$config_mock->__construct( $this->slug );
+
+			$safe_publish_integration = new SafePublishIntegration( $this->slug );
+			$safe_publish_integration->set_vip_config( $config_mock );
+			$safe_publish_integration->configure();
+
+			$this->assertSame( 'https://site-two.example.com', constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL' ) );
+			$this->assertSame( 'export', constant( 'SAFE_PUBLISH_SYNC_MODE' ) );
+			$this->assertSame( 'site-two-shared-secret', constant( 'SAFE_PUBLISH_SHARED_SECRET' ) );
+			$this->assertSame( 'site-two-publisher', constant( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME' ) );
+			$this->assertSame( 'site-two-password', constant( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD' ) );
+			$this->assertSame( '2.0', $safe_publish_integration->version );
+		} finally {
+			restore_current_blog();
+		}
 	}
 
 	public function test_load_returns_early_if_plugin_already_loaded(): void {

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -42,6 +42,10 @@ if ( file_exists( __DIR__ . '/integrations/real-time-collaboration.php' ) ) {
 	require_once __DIR__ . '/integrations/real-time-collaboration.php';
 }
 
+if ( file_exists( __DIR__ . '/integrations/safe-publish.php' ) ) {
+	require_once __DIR__ . '/integrations/safe-publish.php';
+}
+
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
@@ -63,6 +67,10 @@ if ( class_exists( __NAMESPACE__ . '\\JetpackIntegration' ) ) {
 
 if ( class_exists( __NAMESPACE__ . '\\RealTimeCollaborationIntegration' ) ) {
 	IntegrationsSingleton::instance()->register( new RealTimeCollaborationIntegration( 'real-time-collaboration' ) );
+}
+
+if ( class_exists( __NAMESPACE__ . '\\SafePublishIntegration' ) ) {
+	IntegrationsSingleton::instance()->register( new SafePublishIntegration( 'safe-publish' ) );
 }
 
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
## Summary
- register a Safe Publish VIP integration loader
- map integration config values to Safe Publish constants
- load versioned Safe Publish artifacts from vip-integrations/safe-publish-*

## Dependencies
- Depends on the Safe Publish PR that adds constant-backed configuration support.
- Depends on vip-go-mu-plugins-ext ingesting Safe Publish release artifacts.