### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/run-wp-tests/action.yml
+++ b/.github/actions/run-wp-tests/action.yml
@@ -89,7 +89,7 @@ runs:
       uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
     - name: Set up WordPress and WordPress Test Library
-      uses: sjinks/setup-wordpress-test-library@v3.0.0
+      uses: sjinks/setup-wordpress-test-library@9726426f2a40656274560a0394718177f8adb424 # v3.0.0
       with:
         version: ${{ inputs.wordpress }}
 
@@ -137,7 +137,7 @@ runs:
         COVERAGE: ${{ steps.coverage.outputs.coverage }}
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v6.0.1
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         files: ${{ inputs.coverage-file }}
         flags: ${{ inputs.coverage-flags }}


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

Tracking: DEVPROD-1072

Changes:
- Pins 2 distinct third-party action refs to full commit SHAs with readable version comments.
- Updates: .github/actions/run-wp-tests/action.yml
- Dependabot GitHub Actions coverage: already_present (.github/dependabot.yml)

Verification commands:

```bash
# codecov/codecov-action # v6.0.1 -> e79a6962e0d4c0c17b229090214935d2e33f8354
gh api repos/codecov/codecov-action/commits/v6.0.1 --jq '.sha'
# expected: e79a6962e0d4c0c17b229090214935d2e33f8354

# sjinks/setup-wordpress-test-library # v3.0.0 -> 9726426f2a40656274560a0394718177f8adb424
gh api repos/sjinks/setup-wordpress-test-library/commits/v3.0.0 --jq '.sha'
# expected: 9726426f2a40656274560a0394718177f8adb424
```
