### PR TITLE
CI: Remove RELEASE_PR_TOKEN from scheduled mu release

### DIFF
--- a/.github/workflows/create-release-prs.yml
+++ b/.github/workflows/create-release-prs.yml
@@ -79,19 +79,12 @@ jobs:
       - name: Create selected release PRs
         if: steps.release.outputs.should_create == 'true'
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_PR_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
-          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_DATE: ${{ steps.release.outputs.date }}
           RELEASE_PR_TARGET: ${{ github.event.inputs.release_pr || 'scheduled' }}
         run: |
           set -euo pipefail
-
-          if [ "${EVENT_NAME}" = "schedule" ] && [ -z "${RELEASE_PR_TOKEN}" ]; then
-            echo "RELEASE_PR_TOKEN secret is required for scheduled runs so that the created PR will trigger CI workflows. Configure RELEASE_PR_TOKEN (PAT or GitHub App token) and rerun." >&2
-            exit 1
-          fi
 
           get_highest_existing_release_suffix() {
             local highest=-1

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,7 +23,7 @@ Manual runs are not limited to Tuesday at 11:00 MST. They use the current MST da
 
 The workflow skips PR creation when a matching open release PR already exists or when there are no commits to promote between the selected branches.
 
-The workflow uses `GITHUB_TOKEN` to create release PRs. Repository Actions settings must allow GitHub Actions to create pull requests, and CI workflows for the created PRs may need manual approval or reruns.
+The workflow uses `GITHUB_TOKEN` to create release PRs. Repository Actions settings must allow GitHub Actions to create pull requests, and workflows will not auto-run for PRs opened by `GITHUB_TOKEN` (trigger via `workflow_dispatch` if needed).
 
 ## Preflight checks
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,7 +23,7 @@ Manual runs are not limited to Tuesday at 11:00 MST. They use the current MST da
 
 The workflow skips PR creation when a matching open release PR already exists or when there are no commits to promote between the selected branches.
 
-Scheduled runs require the `RELEASE_PR_TOKEN` secret so that created PRs trigger CI workflows. Manual runs fall back to `GITHUB_TOKEN` when `RELEASE_PR_TOKEN` is not set.
+The workflow uses `GITHUB_TOKEN` to create release PRs. Repository Actions settings must allow GitHub Actions to create pull requests, and CI workflows for the created PRs may need manual approval or reruns.
 
 ## Preflight checks
 


### PR DESCRIPTION
## Description
Not gonna do the GitHub app thing for this

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->