### PR TITLE
WordPress MCP: Customize 2FA denial error

### DIFF
--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -286,15 +286,25 @@ class WordPressMcpIntegration extends Integration {
 			return false;
 		}
 
-		if ( ! function_exists( 'wpcom_vip_is_two_factor_forced' ) || ! \wpcom_vip_is_two_factor_forced() ) {
+		if ( ! $this->is_two_factor_forced_for_current_user() ) {
 			return false;
 		}
 
-		if ( ! is_callable( [ 'Two_Factor_Core', 'is_user_using_two_factor' ] ) ) {
-			return false;
-		}
+		return ! $this->is_user_using_two_factor( $user_id );
+	}
 
-		return ! \Two_Factor_Core::is_user_using_two_factor( $user_id );
+	/**
+	 * Check whether VIP two-factor enforcement applies to the current user.
+	 */
+	protected function is_two_factor_forced_for_current_user(): bool {
+		return function_exists( 'wpcom_vip_is_two_factor_forced' ) && \wpcom_vip_is_two_factor_forced();
+	}
+
+	/**
+	 * Check whether the user has two-factor authentication enabled.
+	 */
+	protected function is_user_using_two_factor( int $user_id ): bool {
+		return is_callable( [ 'Two_Factor_Core', 'is_user_using_two_factor' ] ) && \Two_Factor_Core::is_user_using_two_factor( $user_id );
 	}
 
 	/**

--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -37,6 +37,7 @@ class WordPressMcpIntegration extends Integration {
 		}
 
 		add_filter( 'determine_current_user', [ $this, 'authenticate_mcp_request' ], 19 );
+		add_filter( 'mcp_adapter_target_ability_permission_denied_message', [ $this, 'filter_target_ability_permission_denied_message' ], 10, 3 );
 
 		add_action( 'plugins_loaded', function () {
 			if ( $this->is_loaded() ) {
@@ -83,6 +84,25 @@ class WordPressMcpIntegration extends Integration {
 		}
 
 		return $config;
+	}
+
+	/**
+	 * Add VIP 2FA context to MCP target ability permission message.
+	 *
+	 * @param string $message Existing permission denied message.
+	 * @param string $ability_name Target ability name.
+	 * @param mixed  $_parameters Parameters passed to the target ability.
+	 * @return string Filtered permission denied message.
+	 */
+	public function filter_target_ability_permission_denied_message( string $message, string $ability_name, $_parameters = null ): string {
+		if ( ! $this->is_current_user_blocked_by_required_two_factor() ) {
+			return $message;
+		}
+
+		return sprintf(
+			'Unable to run ability "%s" because two-factor authentication is not enabled for the current user.',
+			$ability_name
+		);
 	}
 
 	/**
@@ -254,6 +274,27 @@ class WordPressMcpIntegration extends Integration {
 	 */
 	private function trigger_auth_warning( string $message ): void {
 		trigger_error( esc_html( 'VIP MCP Auth: ' . $message ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Check whether VIP two-factor enforcement downgraded the current user's capabilities.
+	 */
+	protected function is_current_user_blocked_by_required_two_factor(): bool {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'wpcom_vip_is_two_factor_forced' ) || ! \wpcom_vip_is_two_factor_forced() ) {
+			return false;
+		}
+
+		if ( ! is_callable( [ 'Two_Factor_Core', 'is_user_using_two_factor' ] ) ) {
+			return false;
+		}
+
+		return ! \Two_Factor_Core::is_user_using_two_factor( $user_id );
 	}
 
 	/**

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -113,9 +113,14 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 			PHP_INT_MAX,
 			has_filter( 'mcp_adapter_default_server_config', [ $wordpress_mcp_integration, 'filter_default_server_config' ] )
 		);
+		$this->assertSame(
+			10,
+			has_filter( 'mcp_adapter_target_ability_permission_denied_message', [ $wordpress_mcp_integration, 'filter_target_ability_permission_denied_message' ] )
+		);
 
 		remove_filter( 'mcp_adapter_default_server_config', [ $wordpress_mcp_integration, 'filter_default_server_config' ], PHP_INT_MAX );
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+		remove_filter( 'mcp_adapter_target_ability_permission_denied_message', [ $wordpress_mcp_integration, 'filter_target_ability_permission_denied_message' ], 10 );
 	}
 
 	public function test_load_does_not_register_default_server_config_filter_without_server_config(): void {
@@ -128,6 +133,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		);
 
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+		remove_filter( 'mcp_adapter_target_ability_permission_denied_message', [ $wordpress_mcp_integration, 'filter_target_ability_permission_denied_message' ], 10 );
 	}
 
 	public function test_load_sets_inactive_if_no_versions_found(): void {
@@ -145,8 +151,39 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		do_action( 'plugins_loaded' );
 		remove_filter( 'mcp_adapter_default_server_config', [ $integration_mock, 'filter_default_server_config' ], PHP_INT_MAX );
 		remove_filter( 'determine_current_user', [ $integration_mock, 'authenticate_mcp_request' ], 19 );
+		remove_filter( 'mcp_adapter_target_ability_permission_denied_message', [ $integration_mock, 'filter_target_ability_permission_denied_message' ], 10 );
 
 		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_filter_target_ability_permission_denied_message_keeps_default_without_two_factor_block(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+
+		$this->assertSame(
+			'Default permission denied.',
+			$wordpress_mcp_integration->filter_target_ability_permission_denied_message(
+				'Default permission denied.',
+				'core/get-environment-info',
+				[]
+			)
+		);
+	}
+
+	public function test_filter_target_ability_permission_denied_message_adds_two_factor_context(): void {
+		$wordpress_mcp_integration = new class( $this->slug ) extends WordPressMcpIntegration {
+			protected function is_current_user_blocked_by_required_two_factor(): bool {
+				return true;
+			}
+		};
+
+		$this->assertSame(
+			'Unable to run ability "core/get-environment-info" because two-factor authentication is not enabled for the current user.',
+			$wordpress_mcp_integration->filter_target_ability_permission_denied_message(
+				'Default permission denied.',
+				'core/get-environment-info',
+				[]
+			)
+		);
 	}
 
 	public function test_is_mcp_adapter_rest_request_returns_true_for_pretty_rest_url(): void {

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -186,6 +186,56 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_filter_target_ability_permission_denied_message_detects_current_user_without_two_factor(): void {
+		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		try {
+			$wordpress_mcp_integration = $this->get_integration_with_two_factor_state(
+				static function (): bool {
+					return current_user_can( apply_filters( 'wpcom_vip_two_factor_enforcement_cap', 'manage_options' ) );
+				},
+				false
+			);
+
+			$this->assertSame(
+				'Unable to run ability "core/get-environment-info" because two-factor authentication is not enabled for the current user.',
+				$wordpress_mcp_integration->filter_target_ability_permission_denied_message(
+					'Default permission denied.',
+					'core/get-environment-info',
+					[]
+				)
+			);
+		} finally {
+			wp_set_current_user( 0 );
+		}
+	}
+
+	public function test_filter_target_ability_permission_denied_message_keeps_default_for_non_admin_without_two_factor(): void {
+		$user_id = $this->factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+
+		try {
+			$wordpress_mcp_integration = $this->get_integration_with_two_factor_state(
+				static function (): bool {
+					return current_user_can( apply_filters( 'wpcom_vip_two_factor_enforcement_cap', 'manage_options' ) );
+				},
+				false
+			);
+
+			$this->assertSame(
+				'Default permission denied.',
+				$wordpress_mcp_integration->filter_target_ability_permission_denied_message(
+					'Default permission denied.',
+					'core/get-environment-info',
+					[]
+				)
+			);
+		} finally {
+			wp_set_current_user( 0 );
+		}
+	}
+
 	public function test_is_mcp_adapter_rest_request_returns_true_for_pretty_rest_url(): void {
 		Constant_Mocker::define( 'REST_REQUEST', true );
 
@@ -305,5 +355,27 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 
 		$this->assertFalse( $wordpress_mcp_integration->authenticate_mcp_request( false ) );
+	}
+
+	private function get_integration_with_two_factor_state( callable $is_two_factor_forced, bool $is_user_using_two_factor ): WordPressMcpIntegration {
+		return new class( $this->slug, $is_two_factor_forced, $is_user_using_two_factor ) extends WordPressMcpIntegration {
+			private $is_two_factor_forced;
+			private bool $is_user_using_two_factor;
+
+			public function __construct( string $slug, callable $is_two_factor_forced, bool $is_user_using_two_factor ) {
+				parent::__construct( $slug );
+
+				$this->is_two_factor_forced     = $is_two_factor_forced;
+				$this->is_user_using_two_factor = $is_user_using_two_factor;
+			}
+
+			protected function is_two_factor_forced_for_current_user(): bool {
+				return (bool) call_user_func( $this->is_two_factor_forced );
+			}
+
+			protected function is_user_using_two_factor( int $user_id ): bool {
+				return $this->is_user_using_two_factor;
+			}
+		};
 	}
 }


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
Customizes 2FA permissions message

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->