### PR TITLE
Always load latest Safe Publish artifact

### DIFF
--- a/integrations/safe-publish.php
+++ b/integrations/safe-publish.php
@@ -14,13 +14,6 @@ namespace Automattic\VIP\Integrations;
  */
 class SafePublishIntegration extends Integration {
 	/**
-	 * The version of Safe Publish to load, defaults to the latest version.
-	 *
-	 * @var string
-	 */
-	public string $version = 'latest';
-
-	/**
 	 * Enable Pendo tracking for this integration.
 	 *
 	 * @var bool
@@ -39,10 +32,6 @@ class SafePublishIntegration extends Integration {
 		$this->define_config_constant( 'SAFE_PUBLISH_SHARED_SECRET', $configs['shared_secret'] ?? null );
 		$this->define_config_constant( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME', $configs['basic_auth_username'] ?? null );
 		$this->define_config_constant( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD', $configs['basic_auth_password'] ?? null );
-
-		if ( isset( $configs['version'] ) && is_string( $configs['version'] ) && '' !== $configs['version'] ) {
-			$this->version = $configs['version'];
-		}
 	}
 
 	public function load(): void {
@@ -79,22 +68,12 @@ class SafePublishIntegration extends Integration {
 	}
 
 	/**
-	 * Get the folder name for the selected version of the integration.
+	 * Get the folder name for the latest version of the integration.
 	 *
 	 * @param array<string,string> $versions Available versions.
-	 * @return string The selected folder name.
+	 * @return string The latest version folder name.
 	 */
 	public function get_selected_version_folder( array $versions ): string {
-		if ( 'latest' === $this->version ) {
-			return array_key_first( $versions );
-		}
-
-		$desired_version = array_search( $this->version, $versions, true );
-
-		if ( false !== $desired_version ) {
-			return $desired_version;
-		}
-
 		return array_key_first( $versions );
 	}
 

--- a/tests/integrations/test-safe-publish.php
+++ b/tests/integrations/test-safe-publish.php
@@ -53,7 +53,6 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 					'shared_secret'       => 'test-shared-secret',
 					'basic_auth_username' => 'publisher',
 					'basic_auth_password' => 'password',
-					'version'             => '1.0',
 				],
 			]
 		);
@@ -64,7 +63,6 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( 'test-shared-secret', constant( 'SAFE_PUBLISH_SHARED_SECRET' ) );
 		$this->assertSame( 'publisher', constant( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME' ) );
 		$this->assertSame( 'password', constant( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD' ) );
-		$this->assertSame( '1.0', $safe_publish_integration->version );
 	}
 
 	public function test_configure_does_not_redefine_existing_constants(): void {
@@ -108,7 +106,6 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 							'shared_secret'       => 'env-shared-secret',
 							'basic_auth_username' => 'env-publisher',
 							'basic_auth_password' => 'env-password',
-							'version'             => '1.0',
 						],
 					],
 					'network_sites' => [
@@ -116,7 +113,6 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 							'status' => Env_Integration_Status::ENABLED,
 							'config' => [
 								'connected_site_url' => 'https://site-one.example.com',
-								'version'            => '1.5',
 							],
 						],
 						$blog_2_id => [
@@ -127,7 +123,6 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 								'shared_secret'       => 'site-two-shared-secret',
 								'basic_auth_username' => 'site-two-publisher',
 								'basic_auth_password' => 'site-two-password',
-								'version'             => '2.0',
 							],
 						],
 					],
@@ -144,7 +139,6 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 			$this->assertSame( 'site-two-shared-secret', constant( 'SAFE_PUBLISH_SHARED_SECRET' ) );
 			$this->assertSame( 'site-two-publisher', constant( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME' ) );
 			$this->assertSame( 'site-two-password', constant( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD' ) );
-			$this->assertSame( '2.0', $safe_publish_integration->version );
 		} finally {
 			restore_current_blog();
 		}
@@ -184,10 +178,9 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 		$this->assertFalse( $integration_mock->is_active() );
 	}
 
-	public function test_get_selected_version_folder_returns_latest_version_when_version_is_latest(): void {
-		$safe_publish_integration          = new SafePublishIntegration( $this->slug );
-		$safe_publish_integration->version = 'latest';
-		$versions                          = [
+	public function test_get_selected_version_folder_returns_latest_version(): void {
+		$safe_publish_integration = new SafePublishIntegration( $this->slug );
+		$versions                 = [
 			'safe-publish-2.5'  => '2.5',
 			'safe-publish-1.11' => '1.11',
 			'safe-publish-1.2'  => '1.2',
@@ -196,22 +189,17 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( 'safe-publish-2.5', $safe_publish_integration->get_selected_version_folder( $versions ) );
 	}
 
-	public function test_get_selected_version_folder_returns_desired_version_when_version_is_specified(): void {
-		$safe_publish_integration          = new SafePublishIntegration( $this->slug );
-		$safe_publish_integration->version = '1.2';
-		$versions                          = [
-			'safe-publish-2.5'  => '2.5',
-			'safe-publish-1.11' => '1.11',
-			'safe-publish-1.2'  => '1.2',
-		];
-
-		$this->assertSame( 'safe-publish-1.2', $safe_publish_integration->get_selected_version_folder( $versions ) );
-	}
-
-	public function test_get_selected_version_folder_returns_latest_version_when_version_not_found(): void {
-		$safe_publish_integration          = new SafePublishIntegration( $this->slug );
-		$safe_publish_integration->version = '9.9';
-		$versions                          = [
+	public function test_get_selected_version_folder_ignores_version_config(): void {
+		$safe_publish_integration = new SafePublishIntegration( $this->slug );
+		$safe_publish_integration->activate(
+			[
+				'config' => [
+					'version' => '1.2',
+				],
+			]
+		);
+		$safe_publish_integration->configure();
+		$versions = [
 			'safe-publish-2.5'  => '2.5',
 			'safe-publish-1.11' => '1.11',
 			'safe-publish-1.2'  => '1.2',


### PR DESCRIPTION
## Summary
- remove the Safe Publish loader version override
- always select the latest available Safe Publish artifact folder
- update Safe Publish integration tests so legacy version config is ignored

## Testing
- php -l integrations/safe-publish.php
- npm run phpcs -- integrations/safe-publish.php tests/integrations/test-safe-publish.php
- npm test -- --filter Safe_Publish_Integration_Test