### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260525';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260608';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary
- update `RealTimeCollaborationIntegration::VIP_RTC_GUTENBERG_VERSION` from `0.2-20260525` to `0.2-20260608`
- keep `RealTimeCollaborationIntegration::VIP_RTC_PLUGIN_VERSION` at `0.3`; latest VIP RTC release `v0.3.0` is already selected
- pair with Automattic/vip-go-mu-plugins-ext#123, which adds the `gutenberg-0.2-20260608` folder

## Deployed-stage versions checked
- develop: RTC `0.3`, Gutenberg `0.2-20260525`
- staging: RTC `0.2`, Gutenberg `0.2-20260525`
- production: RTC `0.2`, Gutenberg `0.2-20260520`

## Validation
- `npm run test -- --filter Real_Time_Collaboration_Integration_Test` passed: 13 tests, 18 assertions
- `git diff --check` passed

## Merge order
- Merge Automattic/vip-go-mu-plugins-ext#123 first so `gutenberg-0.2-20260608` exists in the bundled integrations repo.
