### PR TITLE
fix: Clarify "Purge Cache" terminology to "Purge Page Cache" in admin…

### DIFF
--- a/vip-cache-manager/vip-cache-manager.php
+++ b/vip-cache-manager/vip-cache-manager.php
@@ -305,7 +305,7 @@ class WPCOM_VIP_Cache_Manager {
 		add_submenu_page(
 			'vip-dashboard',
 			__( 'Purge the VIP Platform page cache', 'textdomain' ),
-			__( 'Purge Cache', 'textdomain' ),
+			__( 'Purge Page Cache', 'textdomain' ),
 			'manage_options',
 			'vip-purge-cache',
 			array( $this, 'render_dashboard_widget' )
@@ -315,11 +315,16 @@ class WPCOM_VIP_Cache_Manager {
 	public function render_dashboard_widget() {
 		$actions = $this->get_available_manual_purge_actions_config();
 
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Purge Page Cache', 'vip-cache-manager' ) . '</h1>';
+
 		if ( empty( $actions ) ) {
 			echo '<p>' . esc_html__( 'You do not have permission to manage the page cache.', 'vip-cache-manager' ) . '</p>';
 		} else {
 			$this->render_dashboard_widget_form( $actions );
 		}
+
+		echo '</div>';
 	}
 
 	private function render_dashboard_widget_form( array $actions ) {
@@ -365,7 +370,7 @@ class WPCOM_VIP_Cache_Manager {
 
 		printf(
 			'<p><button type="submit" class="button button-primary">%s</button></p>',
-			esc_html__( 'Purge Cache', 'vip-cache-manager' )
+			esc_html__( 'Purge Page Cache', 'vip-cache-manager' )
 		);
 
 		echo '<p class="vip-cache-manager-dashboard-result" aria-live="polite"></p>';


### PR DESCRIPTION
## Summary

Clarifies the **Purge Page Cache** admin screen (`/wp-admin/admin.php?page=vip-purge-cache`)
so customers don't confuse the **page cache** with the **object cache**, and adds the
page heading that was missing.

Previously the screen rendered without an `<h1>` or the standard `<div class="wrap">`
wrapper, and was labelled generically as "Purge Cache" — leaving customers unsure
which cache layer the actions affect.

Resolves [PLTFRM-2455](https://linear.app/a8c/issue/PLTFRM-2455/clarify-page-cache-in-vip-purge-cache-ui)

## Changes

All in `vip-cache-manager/vip-cache-manager.php`:

- **Added a page heading and wrapper.** `render_dashboard_widget()` now outputs
  `<div class="wrap"><h1>Purge Page Cache</h1>…</div>`, giving the screen the standard
  WordPress admin layout and a proper top-level heading (it had neither before).
- **Renamed "Purge Cache" → "Purge Page Cache"** in the sidebar submenu label and the
  submit button, so the wording is explicit and matches the existing admin-bar button
  (which already reads "Purge Page Cache").

## Why

- **Removes object-vs-page-cache ambiguity** — naming the action "Purge Page Cache"
  makes it clear these controls affect the edge/page cache, not the object cache.
- **Fixes a missing-heading accessibility gap** — WordPress admin pages are expected to
  have a single `<h1>` inside `<div class="wrap">`; this page had no heading at all.
- **Consistency** — the dashboard, sidebar, and toolbar now all use the same label.

## Testing

1. Visit **VIP Dashboard → Purge Page Cache** (`/wp-admin/admin.php?page=vip-purge-cache`).
2. Confirm the page renders an "Purge Page Cache" `<h1>` with standard admin spacing.
3. Confirm the sidebar menu item and the submit button both read "Purge Page Cache".
4. Confirm existing purge actions still function unchanged.

<img width="688" height="316" alt="Screenshot 2026-06-08 at 3 37 12 PM" src="https://github.com/user-attachments/assets/c8a8a250-df37-4847-b3de-685af1eaa1c9" />

