### PR TITLE
CI: Add Jetpack release PR creation

### DIFF
--- a/.github/scripts/update-jetpack-release.sh
+++ b/.github/scripts/update-jetpack-release.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+	echo "usage: $0 <jetpack-version>" >&2
+	exit 1
+fi
+
+new_version="${1#v}"
+
+if ! [[ "${new_version}" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+	echo "Jetpack version '${new_version}' is not a stable release tag." >&2
+	exit 1
+fi
+
+if ! git -C jetpack rev-parse -q --verify "refs/tags/${new_version}" >/dev/null; then
+	git -C jetpack fetch --depth=1 origin "refs/tags/${new_version}:refs/tags/${new_version}"
+fi
+
+git -C jetpack checkout --detach "${new_version}"
+
+requires_at_least="$(awk -F': ' '/^ \* Requires at least: / { print $2; exit }' jetpack/jetpack.php)"
+requires_php="$(awk -F': ' '/^ \* Requires PHP: / { print $2; exit }' jetpack/jetpack.php)"
+jetpack_sha="$(git -C jetpack rev-parse HEAD)"
+
+if [ -z "${requires_at_least}" ] || [ -z "${requires_php}" ]; then
+	echo "Could not read Jetpack header requirements from jetpack/jetpack.php." >&2
+	exit 1
+fi
+
+export NEW_VERSION="${new_version}"
+export REQUIRES_AT_LEAST="${requires_at_least}"
+export REQUIRES_PHP="${requires_php}"
+
+perl -0pi -e '
+	s/^ \* Version: .*/ * Version: $ENV{NEW_VERSION}/m;
+	s/^ \* Requires at least: .*/ * Requires at least: $ENV{REQUIRES_AT_LEAST}/m;
+	s/^ \* Requires PHP: .*/ * Requires PHP: $ENV{REQUIRES_PHP}/m;
+' jetpack.php
+
+perl <<'PERL'
+use strict;
+use warnings;
+
+my $new_version       = $ENV{NEW_VERSION};
+my $requires_at_least = $ENV{REQUIRES_AT_LEAST};
+
+sub version_minor {
+	my ( $version ) = @_;
+
+	die "Could not read a major.minor version from '${version}'.\n"
+		unless $version =~ /^([0-9]+\.[0-9]+)/;
+
+	return $1;
+}
+
+sub compare_versions {
+	my ( $left, $right ) = @_;
+	my @left_parts  = split /\./, $left;
+	my @right_parts = split /\./, $right;
+	my $length      = @left_parts > @right_parts ? @left_parts : @right_parts;
+
+	for my $index ( 0 .. $length - 1 ) {
+		my $left_part  = $left_parts[$index]  // 0;
+		my $right_part = $right_parts[$index] // 0;
+
+		return -1 if $left_part < $right_part;
+		return 1  if $left_part > $right_part;
+	}
+
+	return 0;
+}
+
+sub next_minor {
+	my ( $version ) = @_;
+	my ( $major, $minor ) = split /\./, $version;
+
+	return $major . '.' . ( $minor + 1 );
+}
+
+sub read_file {
+	my ( $path ) = @_;
+
+	open my $handle, '<', $path or die "Could not read ${path}: $!\n";
+	local $/;
+	my $content = <$handle>;
+	close $handle;
+
+	return $content;
+}
+
+sub write_file {
+	my ( $path, $content ) = @_;
+
+	open my $handle, '>', $path or die "Could not write ${path}: $!\n";
+	print {$handle} $content;
+	close $handle;
+}
+
+my $minimum_wordpress = version_minor( $requires_at_least );
+my $jetpack_php       = read_file( 'jetpack.php' );
+
+my ( $latest_wordpress, $previous_latest_version ) = $jetpack_php =~ m{\t\} else \{\n\t\t// WordPress ([0-9]+\.[0-9]+) and newer\.\n\t\treturn '([0-9]+(?:\.[0-9]+){1,2})';\n\t\}}
+	or die "Could not read latest WordPress branch from vip_default_jetpack_version().\n";
+
+if ( compare_versions( $minimum_wordpress, $latest_wordpress ) > 0 ) {
+	my $previous_comment = next_minor( $latest_wordpress ) eq $minimum_wordpress
+		? "WordPress ${latest_wordpress}.x"
+		: "WordPress ${latest_wordpress} and newer, before ${minimum_wordpress}.";
+
+	my $replacement = sprintf(
+		"\t} elseif ( version_compare( \$wp_version, '%s', '<' ) ) {\n\t\t// %s\n\t\treturn '%s';\n\t} else {\n\t\t// WordPress %s and newer.\n\t\treturn '%s';\n\t}",
+		$minimum_wordpress,
+		$previous_comment,
+		$previous_latest_version,
+		$minimum_wordpress,
+		$new_version
+	);
+
+	$jetpack_php =~ s{\t\} else \{\n\t\t// WordPress \Q$latest_wordpress\E and newer\.\n\t\treturn '\Q$previous_latest_version\E';\n\t\}}{$replacement}
+		or die "Could not split latest Jetpack compatibility branch.\n";
+} else {
+	$jetpack_php =~ s{(// WordPress [^\n]+ and newer\.\n\s*return ')[0-9]+(?:\.[0-9]+){1,2}(';)}{$1$new_version$2}s
+		or die "Could not update latest Jetpack compatibility branch.\n";
+}
+
+write_file( 'jetpack.php', $jetpack_php );
+
+my $test_php = read_file( 'tests/test-jetpack.php' );
+$test_php =~ s/(\$latest = ')[0-9]+(?:\.[0-9]+){1,2}(';)/$1$new_version$2/s
+	or die "Could not update latest Jetpack test version.\n";
+
+if ( compare_versions( $minimum_wordpress, $latest_wordpress ) > 0 ) {
+	$test_php =~ s{(\n\t\t\t'\Q$latest_wordpress\E' => )\$latest(,\n)}{$1'$previous_latest_version'$2}
+		or die "Could not pin previous latest Jetpack test row.\n";
+
+	if ( $test_php =~ m{^\t\t\t'\Q$minimum_wordpress\E' => }m ) {
+		$test_php =~ s{(^\t\t\t'\Q$minimum_wordpress\E' => ).*(,\n)}{$1\$latest$2}m
+			or die "Could not update new latest Jetpack test row.\n";
+	} else {
+		$test_php =~ s{(\n\t\t\t'\Q$latest_wordpress\E' => '\Q$previous_latest_version\E',\n)}{$1\t\t\t'$minimum_wordpress' => \$latest,\n}
+			or die "Could not add new latest Jetpack test row.\n";
+	}
+}
+
+write_file( 'tests/test-jetpack.php', $test_php );
+PERL
+
+grep -Fq " * Version: ${new_version}" jetpack.php
+grep -Fq " * Requires at least: ${requires_at_least}" jetpack.php
+grep -Fq " * Requires PHP: ${requires_php}" jetpack.php
+grep -Fq "return '${new_version}';" jetpack.php
+grep -Fq "\$latest = '${new_version}';" tests/test-jetpack.php
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+	{
+		echo "jetpack_sha=${jetpack_sha}"
+		echo "requires_at_least=${requires_at_least}"
+		echo "requires_php=${requires_php}"
+	} >> "${GITHUB_OUTPUT}"
+else
+	echo "Updated Jetpack to ${new_version} (${jetpack_sha})."
+	echo "Requires at least: ${requires_at_least}"
+	echo "Requires PHP: ${requires_php}"
+fi

--- a/.github/workflows/create-jetpack-release-pr.yml
+++ b/.github/workflows/create-jetpack-release-pr.yml
@@ -1,0 +1,148 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Create Jetpack Release PR
+
+on:
+  schedule:
+    # GitHub cron is UTC. 16:00 UTC is 9:00 MST.
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+    inputs:
+      jetpack_version:
+        description: 'Jetpack release tag to use. Leave blank for latest stable release.'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-jetpack-release-pr:
+    name: Create Jetpack Release PR
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Resolve Jetpack release
+        id: jetpack
+        env:
+          REQUESTED_VERSION: ${{ github.event.inputs.jetpack_version || '' }}
+        run: |
+          set -euo pipefail
+
+          current_version="$(awk -F': ' '/^ \* Version: / { print $2; exit }' jetpack.php)"
+          if [ -z "${current_version}" ]; then
+            echo "Could not read current Jetpack version from jetpack.php." >&2
+            exit 1
+          fi
+
+          if [ -n "${REQUESTED_VERSION}" ]; then
+            new_version="${REQUESTED_VERSION#v}"
+            release_url="https://github.com/Automattic/jetpack-production/releases/tag/${new_version}"
+          else
+            latest_release="$(gh api repos/Automattic/jetpack-production/releases/latest)"
+            new_version="$(jq -r '.tag_name' <<< "${latest_release}")"
+            release_url="$(jq -r '.html_url' <<< "${latest_release}")"
+            new_version="${new_version#v}"
+          fi
+
+          if ! [[ "${new_version}" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+            echo "Jetpack release tag '${new_version}' is not a stable release tag." >&2
+            exit 1
+          fi
+
+          should_create=true
+          highest_version="$(printf '%s\n%s\n' "${current_version}" "${new_version}" | sort -V | tail -n 1)"
+          if [ "${current_version}" = "${new_version}" ] || [ "${highest_version}" != "${new_version}" ]; then
+            should_create=false
+            echo "Jetpack ${current_version} is already at or ahead of ${new_version}." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          branch="update/jetpack-${new_version}"
+          existing_pr="$(gh pr list --state open --head "${GH_REPO%%/*}:${branch}" --base develop --json url --jq '.[0].url // ""')"
+          if [ -n "${existing_pr}" ]; then
+            should_create=false
+            echo "An open Jetpack ${new_version} PR already exists: ${existing_pr}" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          {
+            echo "current_version=${current_version}"
+            echo "new_version=${new_version}"
+            echo "release_url=${release_url}"
+            echo "branch=${branch}"
+            echo "should_create=${should_create}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Update Jetpack release files
+        if: steps.jetpack.outputs.should_create == 'true'
+        id: update
+        run: .github/scripts/update-jetpack-release.sh "${NEW_VERSION}"
+        env:
+          NEW_VERSION: ${{ steps.jetpack.outputs.new_version }}
+
+      - name: Create pull request
+        if: steps.jetpack.outputs.should_create == 'true'
+        env:
+          BRANCH: ${{ steps.jetpack.outputs.branch }}
+          NEW_VERSION: ${{ steps.jetpack.outputs.new_version }}
+          RELEASE_URL: ${{ steps.jetpack.outputs.release_url }}
+          JETPACK_SHA: ${{ steps.update.outputs.jetpack_sha }}
+          REQUIRES_AT_LEAST: ${{ steps.update.outputs.requires_at_least }}
+          REQUIRES_PHP: ${{ steps.update.outputs.requires_php }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- jetpack jetpack.php tests/test-jetpack.php; then
+            echo "No Jetpack changes detected after update." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          git config user.name "WordPress VIP Bot"
+          git config user.email no-reply@automattic.com
+          git switch -c "${BRANCH}"
+          git add jetpack jetpack.php tests/test-jetpack.php
+          git commit -m "Update Jetpack to ${NEW_VERSION}"
+          git push --force-with-lease origin "HEAD:${BRANCH}"
+
+          body_file="$(mktemp)"
+          cat > "${body_file}" << EOF
+          Automated Jetpack release PR.
+
+          Jetpack release: [${NEW_VERSION}](${RELEASE_URL})
+          Jetpack production commit: \`${JETPACK_SHA}\`
+
+          Changes:
+          - Updates the \`jetpack\` submodule to the \`${NEW_VERSION}\` production tag.
+          - Updates \`jetpack.php\` plugin header metadata from upstream.
+          - Updates the default latest Jetpack version and test fixture.
+          - Preserves older WordPress compatibility mappings.
+
+          Note: this PR was created with GitHub's built-in token, so CI may need to be started manually.
+
+          Review checklist:
+          - Confirm whether \`vip_default_jetpack_version()\` needs any new compatibility branch.
+          - Check upstream requirements: WordPress \`${REQUIRES_AT_LEAST}\`, PHP \`${REQUIRES_PHP}\`.
+          - Let required CI pass before merge.
+          EOF
+
+          pr_url="$(gh pr create \
+            --base develop \
+            --head "${GH_REPO%%/*}:${BRANCH}" \
+            --title "Update Jetpack to ${NEW_VERSION}" \
+            --body-file "${body_file}")"
+
+          rm -f "${body_file}"
+
+          echo "Created Jetpack ${NEW_VERSION} PR: ${pr_url}" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/create-jetpack-release-pr.yml
+++ b/.github/workflows/create-jetpack-release-pr.yml
@@ -6,12 +6,6 @@ on:
     # GitHub cron is UTC. 16:00 UTC is 9:00 MST.
     - cron: '0 16 * * *'
   workflow_dispatch:
-    inputs:
-      jetpack_version:
-        description: 'Jetpack release tag to use. Leave blank for latest stable release.'
-        required: false
-        default: ''
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -38,8 +32,6 @@ jobs:
 
       - name: Resolve Jetpack release
         id: jetpack
-        env:
-          REQUESTED_VERSION: ${{ github.event.inputs.jetpack_version || '' }}
         run: |
           set -euo pipefail
 
@@ -49,15 +41,10 @@ jobs:
             exit 1
           fi
 
-          if [ -n "${REQUESTED_VERSION}" ]; then
-            new_version="${REQUESTED_VERSION#v}"
-            release_url="https://github.com/Automattic/jetpack-production/releases/tag/${new_version}"
-          else
-            latest_release="$(gh api repos/Automattic/jetpack-production/releases/latest)"
-            new_version="$(jq -r '.tag_name' <<< "${latest_release}")"
-            release_url="$(jq -r '.html_url' <<< "${latest_release}")"
-            new_version="${new_version#v}"
-          fi
+          latest_release="$(gh api repos/Automattic/jetpack-production/releases/latest)"
+          new_version="$(jq -r '.tag_name' <<< "${latest_release}")"
+          release_url="$(jq -r '.html_url' <<< "${latest_release}")"
+          new_version="${new_version#v}"
 
           if ! [[ "${new_version}" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
             echo "Jetpack release tag '${new_version}' is not a stable release tag." >&2

--- a/.github/workflows/create-jetpack-release-pr.yml
+++ b/.github/workflows/create-jetpack-release-pr.yml
@@ -19,6 +19,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -141,6 +142,7 @@ jobs:
             --base develop \
             --head "${GH_REPO%%/*}:${BRANCH}" \
             --title "Update Jetpack to ${NEW_VERSION}" \
+            --label "[Status] Needs Review" \
             --body-file "${body_file}")"
 
           rm -f "${body_file}"


### PR DESCRIPTION
## Description

This pull request introduces full automation for updating the Jetpack plugin to the latest stable release via a scheduled GitHub Actions workflow. It adds a new workflow to automatically create pull requests for Jetpack updates and a supporting script to update all relevant files and metadata. This significantly reduces manual intervention and ensures the codebase stays up to date with upstream Jetpack releases.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->