### PR TITLE
CI: Remove release PR schedule time gate

### DIFF
--- a/.github/workflows/create-release-prs.yml
+++ b/.github/workflows/create-release-prs.yml
@@ -3,8 +3,8 @@ name: Release PRs
 
 on:
   schedule:
-    # GitHub cron is UTC. 16:20 UTC is 10:20 MDT.
-    - cron: '20 16 * * 2'
+    # GitHub cron is UTC. 15:20 UTC is 9:20 MDT.
+    - cron: '20 15 * * 2'
   workflow_dispatch:
     inputs:
       release_pr:

--- a/.github/workflows/create-release-prs.yml
+++ b/.github/workflows/create-release-prs.yml
@@ -33,46 +33,22 @@ jobs:
       - name: Resolve release date
         id: release
         env:
-          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TIMEZONE: MST7
-          RELEASE_TIMEZONE_LABEL: MST
         run: |
           set -euo pipefail
 
-          local_hour="$(TZ="${RELEASE_TIMEZONE}" date '+%H')"
-          local_day="$(TZ="${RELEASE_TIMEZONE}" date '+%u')"
           release_date="$(TZ="${RELEASE_TIMEZONE}" date '+%Y%m%d')"
-          should_create=true
-
-          # Manual workflow_dispatch runs are not date/time gated.
-          # Scheduled runs use Tuesday off-hour cron entries. 10:20 MDT resolves to 09:20 MST7.
-          if [ "${EVENT_NAME}" = "schedule" ]; then
-            case "${local_day}-${local_hour}" in
-              2-09)
-                ;;
-              *)
-                should_create=false
-                ;;
-            esac
-          fi
 
           {
             echo "date=${release_date}"
-            echo "should_create=${should_create}"
           } >> "${GITHUB_OUTPUT}"
 
-          if [ "${should_create}" = "false" ]; then
-            echo "Skipping release PR creation because this scheduled run is outside the configured Tuesday ${RELEASE_TIMEZONE_LABEL} window." >> "${GITHUB_STEP_SUMMARY}"
-          fi
-
       - name: Check out source code
-        if: steps.release.outputs.should_create == 'true'
         uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 
       - name: Fetch release branches and tags
-        if: steps.release.outputs.should_create == 'true'
         run: |
           set -euo pipefail
 
@@ -83,7 +59,6 @@ jobs:
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Create selected release PRs
-        if: steps.release.outputs.should_create == 'true'
         id: create_prs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Since it doesn't always run on time, we should remove that gate, so it runs

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->