### PR TITLE
feat(wordpress-mcp): support configurable auth_key via integration config

### DIFF
--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -155,7 +155,13 @@ class WordPressMcpIntegration extends Integration {
 			return $input_user;
 		}
 
-		$expected = hash_hmac( 'sha256', $email . $timestamp, constant( 'AUTH_KEY' ) );
+		$key              = constant( 'AUTH_KEY' ); // Deprecated in favor of integrations_key.
+		$integrations_key = $this->get_server_config_value( 'auth_key' );
+		if ( null !== $integrations_key ) {
+			$key = $integrations_key;
+		}
+
+		$expected = hash_hmac( 'sha256', $email . $timestamp, $key );
 
 		if ( ! hash_equals( $expected, $provided_hash ) ) {
 			$this->trigger_auth_warning( 'Authentication failed' );
@@ -267,7 +273,7 @@ class WordPressMcpIntegration extends Integration {
 	 * Emit an authentication warning without exposing raw user identity.
 	 */
 	private function trigger_auth_warning( string $message ): void {
-		trigger_error( esc_html( 'VIP MCP Auth: ' . $message ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		error_log( esc_html( 'VIP MCP Auth: ' . $message ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 	}
 
 	/**

--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -20,6 +20,8 @@ class WordPressMcpIntegration extends Integration {
 	private const DEFAULT_SERVER_NAMESPACE = 'mcp';
 	private const DEFAULT_SERVER_ROUTE     = 'mcp-adapter-default-server';
 
+	private const AUTH_KEY_CONFIG_KEY = 'auth_key';
+
 	/**
 	 * Enable Pendo tracking for this integration.
 	 *
@@ -114,10 +116,6 @@ class WordPressMcpIntegration extends Integration {
 			return $input_user;
 		}
 
-		if ( ! defined( 'AUTH_KEY' ) || '' === constant( 'AUTH_KEY' ) ) {
-			return $input_user;
-		}
-
 		$email         = $this->get_server_value( 'PHP_AUTH_USER' );
 		$provided_hash = $this->get_server_value( 'PHP_AUTH_PW' );
 		$auth_header   = $this->get_server_value( self::AUTH_HEADER_SERVER_KEY );
@@ -128,6 +126,13 @@ class WordPressMcpIntegration extends Integration {
 		}
 
 		if ( 'true' !== strtolower( $auth_header ) ) {
+			return $input_user;
+		}
+
+		$auth_key = $this->get_server_config_value( self::AUTH_KEY_CONFIG_KEY );
+		if ( ! $auth_key ) {
+			$this->trigger_auth_warning( 'Missing auth key' );
+
 			return $input_user;
 		}
 
@@ -155,13 +160,7 @@ class WordPressMcpIntegration extends Integration {
 			return $input_user;
 		}
 
-		$key              = constant( 'AUTH_KEY' ); // Deprecated in favor of integrations_key.
-		$integrations_key = $this->get_server_config_value( 'auth_key' );
-		if ( null !== $integrations_key ) {
-			$key = $integrations_key;
-		}
-
-		$expected = hash_hmac( 'sha256', $email . $timestamp, $key );
+		$expected = hash_hmac( 'sha256', $email . $timestamp, $auth_key );
 
 		if ( ! hash_equals( $expected, $provided_hash ) ) {
 			$this->trigger_auth_warning( 'Authentication failed' );
@@ -273,7 +272,7 @@ class WordPressMcpIntegration extends Integration {
 	 * Emit an authentication warning without exposing raw user identity.
 	 */
 	private function trigger_auth_warning( string $message ): void {
-		error_log( esc_html( 'VIP MCP Auth: ' . $message ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		error_log( esc_html( 'VIP MCP Auth: ' . $message ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 
 	/**

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -403,6 +403,66 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( $user_id, $wordpress_mcp_integration->authenticate_mcp_request( false ) );
 	}
 
+	public function test_authenticate_mcp_request_uses_integrations_key_when_configured(): void {
+		$auth_key         = 'legacy-auth-key';
+		$integrations_key = 'integrations-auth-key';
+		$email            = 'mcp-user-' . wp_generate_password( 8, false ) . '@example.com';
+		$timestamp        = (string) time();
+		$user_id          = $this->factory()->user->create( [ 'user_email' => $email ] );
+
+		Constant_Mocker::define( 'AUTH_KEY', $auth_key );
+		Constant_Mocker::define( 'REST_REQUEST', true );
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/mcp-adapter-default-server';
+		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
+		$_SERVER['PHP_AUTH_USER'] = $email;
+		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
+		$_SERVER['PHP_AUTH_PW']                   = hash_hmac( 'sha256', $email . $timestamp, $integrations_key );
+		$_SERVER['HTTP_X_VIP_MCP_AUTH']           = 'true';
+		$_SERVER['HTTP_X_VIP_MCP_AUTH_TIMESTAMP'] = $timestamp;
+
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $integrations_key ] ] );
+		$wordpress_mcp_integration->configure();
+		$wordpress_mcp_integration->load();
+
+		$result = apply_filters( 'determine_current_user', false );
+		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+
+		$this->assertSame( $user_id, $result );
+	}
+
+	public function test_authenticate_mcp_request_ignores_auth_key_constant_when_integrations_key_configured(): void {
+		$auth_key         = 'legacy-auth-key';
+		$integrations_key = 'integrations-auth-key';
+		$email            = 'mcp-user-' . wp_generate_password( 8, false ) . '@example.com';
+		$timestamp        = (string) time();
+		$this->factory()->user->create( [ 'user_email' => $email ] );
+
+		Constant_Mocker::define( 'AUTH_KEY', $auth_key );
+		Constant_Mocker::define( 'REST_REQUEST', true );
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/mcp-adapter-default-server';
+		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
+		$_SERVER['PHP_AUTH_USER'] = $email;
+		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
+		$_SERVER['PHP_AUTH_PW']                   = hash_hmac( 'sha256', $email . $timestamp, $auth_key );
+		$_SERVER['HTTP_X_VIP_MCP_AUTH']           = 'true';
+		$_SERVER['HTTP_X_VIP_MCP_AUTH_TIMESTAMP'] = $timestamp;
+
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $integrations_key ] ] );
+		$wordpress_mcp_integration->configure();
+		$wordpress_mcp_integration->load();
+
+		$result = apply_filters( 'determine_current_user', false );
+		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+
+		$this->assertFalse( $result );
+	}
+
 	public function test_authenticate_mcp_request_ignores_missing_hmac_headers(): void {
 		Constant_Mocker::define( 'AUTH_KEY', 'test-auth-key' );
 		Constant_Mocker::define( 'REST_REQUEST', true );

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -386,7 +386,6 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$timestamp = (string) time();
 		$user_id   = $this->factory()->user->create( [ 'user_email' => $email ] );
 
-		Constant_Mocker::define( 'AUTH_KEY', $auth_key );
 		Constant_Mocker::define( 'REST_REQUEST', true );
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
@@ -399,72 +398,12 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$_SERVER['HTTP_X_VIP_MCP_AUTH_TIMESTAMP'] = $timestamp;
 
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $auth_key ] ] );
 
 		$this->assertSame( $user_id, $wordpress_mcp_integration->authenticate_mcp_request( false ) );
 	}
 
-	public function test_authenticate_mcp_request_uses_integrations_key_when_configured(): void {
-		$auth_key         = 'legacy-auth-key';
-		$integrations_key = 'integrations-auth-key';
-		$email            = 'mcp-user-' . wp_generate_password( 8, false ) . '@example.com';
-		$timestamp        = (string) time();
-		$user_id          = $this->factory()->user->create( [ 'user_email' => $email ] );
-
-		Constant_Mocker::define( 'AUTH_KEY', $auth_key );
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/mcp-adapter-default-server';
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
-		$_SERVER['PHP_AUTH_USER'] = $email;
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
-		$_SERVER['PHP_AUTH_PW']                   = hash_hmac( 'sha256', $email . $timestamp, $integrations_key );
-		$_SERVER['HTTP_X_VIP_MCP_AUTH']           = 'true';
-		$_SERVER['HTTP_X_VIP_MCP_AUTH_TIMESTAMP'] = $timestamp;
-
-		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
-		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $integrations_key ] ] );
-		$wordpress_mcp_integration->configure();
-		$wordpress_mcp_integration->load();
-
-		$result = apply_filters( 'determine_current_user', false );
-		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
-
-		$this->assertSame( $user_id, $result );
-	}
-
-	public function test_authenticate_mcp_request_ignores_auth_key_constant_when_integrations_key_configured(): void {
-		$auth_key         = 'legacy-auth-key';
-		$integrations_key = 'integrations-auth-key';
-		$email            = 'mcp-user-' . wp_generate_password( 8, false ) . '@example.com';
-		$timestamp        = (string) time();
-		$this->factory()->user->create( [ 'user_email' => $email ] );
-
-		Constant_Mocker::define( 'AUTH_KEY', $auth_key );
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/mcp-adapter-default-server';
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
-		$_SERVER['PHP_AUTH_USER'] = $email;
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
-		$_SERVER['PHP_AUTH_PW']                   = hash_hmac( 'sha256', $email . $timestamp, $auth_key );
-		$_SERVER['HTTP_X_VIP_MCP_AUTH']           = 'true';
-		$_SERVER['HTTP_X_VIP_MCP_AUTH_TIMESTAMP'] = $timestamp;
-
-		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
-		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $integrations_key ] ] );
-		$wordpress_mcp_integration->configure();
-		$wordpress_mcp_integration->load();
-
-		$result = apply_filters( 'determine_current_user', false );
-		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
-
-		$this->assertFalse( $result );
-	}
-
 	public function test_authenticate_mcp_request_ignores_missing_hmac_headers(): void {
-		Constant_Mocker::define( 'AUTH_KEY', 'test-auth-key' );
 		Constant_Mocker::define( 'REST_REQUEST', true );
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';


### PR DESCRIPTION
## Description

  - Adds auth_key as an optional integration env config value that overrides the AUTH_KEY constant when computing HMAC signatures for MCP authentication                                                                                                                                                                                                                                                                   
  - AUTH_KEY remains as a fallback for backwards compatibility but is now deprecated for this purpose                                                                                                                                                                                                                                                                                                                      
  - Switches auth failure warnings from trigger_error to error_log                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                           
###  Why                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                           
  Using the global AUTH_KEY constant for MCP HMAC authentication doesn't allow per-environment key rotation without affecting the broader WordPress installation. The new auth_key config value lets the platform supply a dedicated key scoped to the MCP integration.                                                                                                                                                    
                                                               


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->