### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260608';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260617-pr79021';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary
- Updates the RTC integration Gutenberg folder constant to `0.2-20260617-pr79021`.
- This points VIP RTC at the custom Gutenberg artifact added in Automattic/vip-go-mu-plugins-ext#128.
- The selected Gutenberg base release is `v23.4.0`, but the shipped artifact is a custom build from `v23.4.0` plus WordPress/gutenberg#79021.
- Keeps `VIP_RTC_PLUGIN_VERSION` at `0.3`; Automattic/vip-go-mu-plugins-ext#128 now updates `vip-integrations/vip-real-time-collaboration-0.3` to VIP RTC release `v0.3.2`.

## Deployed-stage versions checked
- `develop`: Gutenberg `0.2-20260608`, RTC `0.3`
- `staging`: Gutenberg `0.2-20260608`, RTC `0.3`
- `production`: Gutenberg `0.2-20260608`, RTC `0.3`

## Validation
- `git diff --check` passed.
- `CI=1 ./bin/test.sh --filter Real_Time_Collaboration_Integration_Test` passed: 13 tests, 18 assertions.
- `npm run phplint` could not run on the host because `php` is not installed locally (`/bin/sh: php: command not found`).
