### PR TITLE
WordPress MCP: Add exposed_abilities config

### DIFF
--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -113,7 +113,7 @@ class WordPressMcpIntegration extends Integration {
 	 * @return array Filtered ability registration args.
 	 */
 	public function filter_exposed_abilities_args( array $args, string $ability_name ): array {
-		if ( in_array( $ability_name, $this->get_exposed_abilities_config(), true ) ) {
+		if ( $this->is_exposed_ability( $ability_name ) ) {
 			if ( ! isset( $args['meta'] ) || ! is_array( $args['meta'] ) ) {
 				$args['meta'] = [];
 			}
@@ -126,6 +126,37 @@ class WordPressMcpIntegration extends Integration {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Whether the ability matches the exposed abilities config.
+	 */
+	private function is_exposed_ability( string $ability_name ): bool {
+		foreach ( $this->get_exposed_abilities_config() as $exposed_ability ) {
+			if ( $ability_name === $exposed_ability || $this->matches_exposed_ability_pattern( $exposed_ability, $ability_name ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Match an ability name against a glob-style exposed ability pattern.
+	 */
+	private function matches_exposed_ability_pattern( string $pattern, string $ability_name ): bool {
+		if ( ! str_contains( $pattern, '*' ) || ! str_contains( $pattern, '/' ) ) {
+			return false;
+		}
+
+		[ $namespace ] = explode( '/', $pattern, 2 );
+		if ( str_contains( $namespace, '*' ) ) {
+			return false;
+		}
+
+		$regex = '/^' . str_replace( '\*', '.*', preg_quote( $pattern, '/' ) ) . '$/';
+
+		return 1 === preg_match( $regex, $ability_name );
 	}
 
 	/**

--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -53,7 +53,7 @@ class WordPressMcpIntegration extends Integration {
 		}
 
 		if ( ! empty( $this->get_exposed_abilities_config() ) ) {
-			add_filter( 'wp_register_ability_args', [ $this, 'filter_exposed_ability_args' ], 10, 2 );
+			add_filter( 'wp_register_ability_args', [ $this, 'filter_exposed_abilities_args' ], PHP_INT_MAX, 2 );
 		}
 
 		add_filter( 'determine_current_user', [ $this, 'authenticate_mcp_request' ], 19 );
@@ -112,7 +112,7 @@ class WordPressMcpIntegration extends Integration {
 	 * @param string $ability_name Ability name.
 	 * @return array Filtered ability registration args.
 	 */
-	public function filter_exposed_ability_args( array $args, string $ability_name ): array {
+	public function filter_exposed_abilities_args( array $args, string $ability_name ): array {
 		if ( in_array( $ability_name, $this->get_exposed_abilities_config(), true ) ) {
 			if ( ! isset( $args['meta'] ) || ! is_array( $args['meta'] ) ) {
 				$args['meta'] = [];

--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -52,6 +52,10 @@ class WordPressMcpIntegration extends Integration {
 			add_filter( 'mcp_adapter_default_server_config', [ $this, 'filter_default_server_config' ], PHP_INT_MAX );
 		}
 
+		if ( ! empty( $this->get_exposed_abilities_config() ) ) {
+			add_filter( 'wp_register_ability_args', [ $this, 'filter_exposed_ability_args' ], 10, 2 );
+		}
+
 		add_filter( 'determine_current_user', [ $this, 'authenticate_mcp_request' ], 19 );
 
 		add_action( 'plugins_loaded', function () {
@@ -99,6 +103,29 @@ class WordPressMcpIntegration extends Integration {
 		}
 
 		return $config;
+	}
+
+	/**
+	 * Mark configured abilities as public MCP tools.
+	 *
+	 * @param array  $args         Ability registration args.
+	 * @param string $ability_name Ability name.
+	 * @return array Filtered ability registration args.
+	 */
+	public function filter_exposed_ability_args( array $args, string $ability_name ): array {
+		if ( in_array( $ability_name, $this->get_exposed_abilities_config(), true ) ) {
+			if ( ! isset( $args['meta'] ) || ! is_array( $args['meta'] ) ) {
+				$args['meta'] = [];
+			}
+
+			if ( ! isset( $args['meta']['mcp'] ) || ! is_array( $args['meta']['mcp'] ) ) {
+				$args['meta']['mcp'] = [];
+			}
+
+			$args['meta']['mcp']['public'] = true;
+		}
+
+		return $args;
 	}
 
 	/**
@@ -228,6 +255,17 @@ class WordPressMcpIntegration extends Integration {
 	 */
 	private function has_server_config(): bool {
 		return null !== $this->get_server_config_value( 'server_namespace' ) || null !== $this->get_server_config_value( 'server_route' );
+	}
+
+	/**
+	 * Get configured ability names to expose through MCP.
+	 *
+	 * @return string[]
+	 */
+	private function get_exposed_abilities_config(): array {
+		$exposed_abilities = $this->get_env_config()['exposed_abilities'] ?? [];
+
+		return is_array( $exposed_abilities ) ? array_values( array_filter( $exposed_abilities, 'is_string' ) ) : [];
 	}
 
 	/**

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -139,6 +139,22 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
 	}
 
+	public function test_load_registers_exposed_ability_args_filter_when_configured(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
+		$wordpress_mcp_integration->configure();
+
+		$wordpress_mcp_integration->load();
+
+		$this->assertSame(
+			10,
+			has_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_ability_args' ] )
+		);
+
+		remove_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_ability_args' ], 10 );
+		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+	}
+
 	public function test_load_does_not_register_default_server_config_filter_without_server_config(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 
@@ -149,6 +165,79 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		);
 
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+	}
+
+	public function test_load_does_not_register_exposed_ability_args_filter_without_config(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+
+		$wordpress_mcp_integration->load();
+
+		$this->assertFalse(
+			has_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_ability_args' ] )
+		);
+
+		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+	}
+
+	public function test_filter_exposed_ability_args_marks_configured_ability_public(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
+		$wordpress_mcp_integration->configure();
+
+		$args = $wordpress_mcp_integration->filter_exposed_ability_args(
+			[
+				'meta' => [
+					'mcp'  => [
+						'description' => 'Existing MCP metadata',
+					],
+					'data' => 'preserved',
+				],
+			],
+			'core/get-site-info'
+		);
+
+		$this->assertTrue( $args['meta']['mcp']['public'] );
+		$this->assertSame( 'Existing MCP metadata', $args['meta']['mcp']['description'] );
+		$this->assertSame( 'preserved', $args['meta']['data'] );
+	}
+
+	public function test_filter_exposed_ability_args_handles_invalid_meta_shape(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
+		$wordpress_mcp_integration->configure();
+
+		$args = $wordpress_mcp_integration->filter_exposed_ability_args(
+			[ 'meta' => 'invalid' ],
+			'core/get-site-info'
+		);
+
+		$this->assertTrue( $args['meta']['mcp']['public'] );
+
+		$args = $wordpress_mcp_integration->filter_exposed_ability_args(
+			[ 'meta' => [ 'mcp' => 'invalid' ] ],
+			'core/get-site-info'
+		);
+
+		$this->assertTrue( $args['meta']['mcp']['public'] );
+	}
+
+	public function test_filter_exposed_ability_args_preserves_unconfigured_ability(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
+		$wordpress_mcp_integration->configure();
+
+		$args = [
+			'meta' => [
+				'mcp' => [
+					'public' => false,
+				],
+			],
+		];
+
+		$this->assertSame(
+			$args,
+			$wordpress_mcp_integration->filter_exposed_ability_args( $args, 'core/update-site' )
+		);
 	}
 
 	public function test_load_sets_inactive_if_no_versions_found(): void {

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -221,6 +221,23 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$this->assertTrue( $args['meta']['mcp']['public'] );
 	}
 
+	public function test_filter_exposed_abilities_args_matches_wildcards(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get*', 'core/*-info', 'vip/*' ] ] ] );
+		$wordpress_mcp_integration->configure();
+
+		$this->assertTrue( $wordpress_mcp_integration->filter_exposed_abilities_args( [], 'core/get-site-info' )['meta']['mcp']['public'] );
+		$this->assertTrue( $wordpress_mcp_integration->filter_exposed_abilities_args( [], 'core/site-info' )['meta']['mcp']['public'] );
+		$this->assertTrue( $wordpress_mcp_integration->filter_exposed_abilities_args( [], 'vip/update-site' )['meta']['mcp']['public'] );
+		$this->assertSame( [], $wordpress_mcp_integration->filter_exposed_abilities_args( [], 'other/delete-site' ) );
+
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ '*', '*/*', '*/delete-site' ] ] ] );
+		$wordpress_mcp_integration->configure();
+
+		$this->assertSame( [], $wordpress_mcp_integration->filter_exposed_abilities_args( [], 'vip/delete-site' ) );
+	}
+
 	public function test_filter_exposed_abilities_args_preserves_unconfigured_ability(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -139,7 +139,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
 	}
 
-	public function test_load_registers_exposed_ability_args_filter_when_configured(): void {
+	public function test_load_registers_exposed_abilities_args_filter_when_configured(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
 		$wordpress_mcp_integration->configure();
@@ -147,11 +147,11 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$wordpress_mcp_integration->load();
 
 		$this->assertSame(
-			10,
-			has_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_ability_args' ] )
+			PHP_INT_MAX,
+			has_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_abilities_args' ] )
 		);
 
-		remove_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_ability_args' ], 10 );
+		remove_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_abilities_args' ], PHP_INT_MAX );
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
 	}
 
@@ -167,24 +167,24 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
 	}
 
-	public function test_load_does_not_register_exposed_ability_args_filter_without_config(): void {
+	public function test_load_does_not_register_exposed_abilities_args_filter_without_config(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 
 		$wordpress_mcp_integration->load();
 
 		$this->assertFalse(
-			has_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_ability_args' ] )
+			has_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_abilities_args' ] )
 		);
 
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
 	}
 
-	public function test_filter_exposed_ability_args_marks_configured_ability_public(): void {
+	public function test_filter_exposed_abilities_args_marks_configured_ability_public(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
 		$wordpress_mcp_integration->configure();
 
-		$args = $wordpress_mcp_integration->filter_exposed_ability_args(
+		$args = $wordpress_mcp_integration->filter_exposed_abilities_args(
 			[
 				'meta' => [
 					'mcp'  => [
@@ -201,19 +201,19 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( 'preserved', $args['meta']['data'] );
 	}
 
-	public function test_filter_exposed_ability_args_handles_invalid_meta_shape(): void {
+	public function test_filter_exposed_abilities_args_handles_invalid_meta_shape(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
 		$wordpress_mcp_integration->configure();
 
-		$args = $wordpress_mcp_integration->filter_exposed_ability_args(
+		$args = $wordpress_mcp_integration->filter_exposed_abilities_args(
 			[ 'meta' => 'invalid' ],
 			'core/get-site-info'
 		);
 
 		$this->assertTrue( $args['meta']['mcp']['public'] );
 
-		$args = $wordpress_mcp_integration->filter_exposed_ability_args(
+		$args = $wordpress_mcp_integration->filter_exposed_abilities_args(
 			[ 'meta' => [ 'mcp' => 'invalid' ] ],
 			'core/get-site-info'
 		);
@@ -221,7 +221,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$this->assertTrue( $args['meta']['mcp']['public'] );
 	}
 
-	public function test_filter_exposed_ability_args_preserves_unconfigured_ability(): void {
+	public function test_filter_exposed_abilities_args_preserves_unconfigured_ability(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
 		$wordpress_mcp_integration->configure();
@@ -236,7 +236,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertSame(
 			$args,
-			$wordpress_mcp_integration->filter_exposed_ability_args( $args, 'core/update-site' )
+			$wordpress_mcp_integration->filter_exposed_abilities_args( $args, 'core/update-site' )
 		);
 	}
 


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
Adds `exposed_abilities` config key.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->