### PR TITLE
Merge Safe Publish site and network-site config

### DIFF
--- a/integrations/safe-publish.php
+++ b/integrations/safe-publish.php
@@ -32,7 +32,7 @@ class SafePublishIntegration extends Integration {
 	}
 
 	public function configure(): void {
-		$configs = is_multisite() ? $this->get_network_site_config() : $this->get_env_config();
+		$configs = $this->get_safe_publish_config();
 
 		$this->define_config_constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL', $configs['connected_site_url'] ?? null );
 		$this->define_config_constant( 'SAFE_PUBLISH_SYNC_MODE', $configs['sync_mode'] ?? null );
@@ -96,6 +96,25 @@ class SafePublishIntegration extends Integration {
 		}
 
 		return array_key_first( $versions );
+	}
+
+	/**
+	 * Get Safe Publish configuration for the current site context.
+	 *
+	 * On multisite, Safe Publish config is split across levels. Site-level
+	 * config holds shared values like Basic Auth and version, while
+	 * network-site config holds connection values like the connected site URL,
+	 * sync mode, and shared secret. Merge both levels so the current network
+	 * site gets a complete runtime config.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function get_safe_publish_config(): array {
+		if ( ! is_multisite() ) {
+			return $this->get_env_config();
+		}
+
+		return array_merge( $this->get_env_config(), $this->get_network_site_config() );
 	}
 
 	/**

--- a/tests/integrations/test-safe-publish.php
+++ b/tests/integrations/test-safe-publish.php
@@ -83,12 +83,74 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( 'https://existing.example.com', constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL' ) );
 	}
 
-	public function test_configure_uses_network_site_config_for_multisite(): void {
+	public function test_configure_merges_site_and_network_site_config_for_multisite(): void {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Only valid for multisite.' );
 		}
 
 		$blog_2_id = $this->factory()->blog->create_object( [ 'domain' => 'safe-publish-test.site/2' ] );
+		switch_to_blog( $blog_2_id );
+
+		try {
+			/** @var IntegrationVipConfig&MockObject $config_mock */
+			$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )
+				->disableOriginalConstructor()
+				->onlyMethods( [ 'get_vip_config_from_file' ] )
+				->getMock();
+
+			$config_mock->method( 'get_vip_config_from_file' )->willReturn(
+				[
+					'env'           => [
+						'status' => Env_Integration_Status::ENABLED,
+						'config' => [
+							'basic_auth_username' => 'env-publisher',
+							'basic_auth_password' => 'env-password',
+							'version'             => '1.0',
+						],
+					],
+					'network_sites' => [
+						1          => [
+							'status' => Env_Integration_Status::ENABLED,
+							'config' => [
+								'connected_site_url' => 'https://site-one.example.com',
+							],
+						],
+						$blog_2_id => [
+							'status' => Env_Integration_Status::ENABLED,
+							'config' => [
+								'connected_site_url' => 'https://site-two.example.com',
+								'sync_mode'          => 'export',
+								'shared_secret'      => 'site-two-shared-secret',
+							],
+						],
+					],
+				]
+			);
+			$config_mock->__construct( $this->slug );
+
+			$safe_publish_integration = new SafePublishIntegration( $this->slug );
+			$safe_publish_integration->set_vip_config( $config_mock );
+			$safe_publish_integration->configure();
+
+			$this->assertSame( 'https://site-two.example.com', constant( 'SAFE_PUBLISH_CONNECTED_SITE_URL' ) );
+			$this->assertSame( 'export', constant( 'SAFE_PUBLISH_SYNC_MODE' ) );
+			$this->assertSame( 'site-two-shared-secret', constant( 'SAFE_PUBLISH_SHARED_SECRET' ) );
+			$this->assertTrue( defined( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME' ) );
+			$this->assertTrue( defined( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD' ) );
+			$this->assertSame( 'env-publisher', constant( 'SAFE_PUBLISH_BASIC_AUTH_USERNAME' ) );
+			$this->assertSame( 'env-password', constant( 'SAFE_PUBLISH_BASIC_AUTH_PASSWORD' ) );
+			$this->assertSame( '1.0', $safe_publish_integration->version );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	public function test_configure_prefers_network_site_config_for_duplicate_multisite_keys(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Only valid for multisite.' );
+		}
+
+		$blog_2_id = $this->factory()->blog->create_object( [ 'domain' => 'safe-publish-duplicates-test.site/2' ] );
 		switch_to_blog( $blog_2_id );
 
 		try {
@@ -116,6 +178,8 @@ class Safe_Publish_Integration_Test extends WP_UnitTestCase {
 							'status' => Env_Integration_Status::ENABLED,
 							'config' => [
 								'connected_site_url' => 'https://site-one.example.com',
+								'sync_mode'          => 'import',
+								'shared_secret'      => 'site-one-shared-secret',
 								'version'            => '1.5',
 							],
 						],


### PR DESCRIPTION
## Description

Safe Publish multisite configuration is split across site-level and network-site-level config. The loader now merges both levels so shared values like Basic Auth and version are available alongside per-network-site values like connected site URL, sync mode, and shared secret.

Network-site config is still merged last so duplicate keys keep the per-network-site value.

## Changelog Description

### Fixed
- Fixed Safe Publish config loading on multisite so site-level and network-site-level settings are available together.

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation).

## Steps to Test

1. Run `CI=1 ./bin/test.sh --multisite 1 --filter 'test_configure_merges_site_and_network_site_config_for_multisite|test_configure_prefers_network_site_config_for_duplicate_multisite_keys'`.
1. Run `CI=1 ./bin/test.sh --multisite 1 --filter Safe_Publish_Integration_Test`.
1. Run `CI=1 ./bin/test.sh --filter Safe_Publish_Integration_Test`.
1. Run `npm run phplint`.
1. Run `npm run test:smoke`.
1. Run `vendor/bin/phpcs --cache -d memory_limit=512M integrations/safe-publish.php tests/integrations/test-safe-publish.php`.
