### PR TITLE
search: cap dynamic bulk request size and truncate oversized request logs

### DIFF
--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -173,6 +173,11 @@ class Search {
 	private const POST_SHARD_THRESHOLD = 1000000;
 	private const USER_SHARD_THRESHOLD = 2000000;
 
+	// Cap on the request body size copied into failed-request log entries. Bulk index
+	// payloads can be tens of MB, which is worthless to log in full and blows past the
+	// logstash `extra` size limit (262144 bytes), causing the whole entry to be dropped.
+	private const MAX_LOGGED_QUERY_BODY_BYTES = 2048;
+
 	public $healthcheck;
 	public $settings_healthcheck;
 	public $versioning_cleanup;
@@ -522,6 +527,13 @@ class Search {
 
 		// Override default per page value set in elasticpress/includes/classes/Indexable.php
 		add_filter( 'ep_bulk_items_per_page', [ $this, 'filter__ep_bulk_items_per_page' ], PHP_INT_MAX );
+
+		// Constrain dynamic bulk request sizes so each _bulk completes within the upstream
+		// 30s request timeout (throughput ~3 MB/s, degrades on large batches; ~40 MB lands
+		// around 13-15s, ~2x margin before the timeout/data loss).
+		add_filter( 'ep_dynamic_bulk_min_buffer_size', fn() => 20 * MB_IN_BYTES );
+		add_filter( 'ep_dynamic_bulk_incremental_step', fn() => 10 * MB_IN_BYTES );
+		add_filter( 'ep_dynamic_bulk_max_buffer_size', fn() => 40 * MB_IN_BYTES );
 
 		// Network layer replacement to use VIP helpers (that handle slow/down upstream server)
 		add_filter( 'ep_intercept_remote_request', '__return_true', 9999 );
@@ -1279,9 +1291,23 @@ class Search {
 		}
 
 		// Try to parse the body if possible to make it better readable in the log entry.
-		if ( isset( $query['args']['body'] ) ) {
-			$decoded_body          = json_decode( $query['args']['body'] );
-			$query['args']['body'] = ! json_last_error() ? $decoded_body : $query['args']['body'];
+		if ( isset( $query['args']['body'] ) && is_string( $query['args']['body'] ) ) {
+			$body        = $query['args']['body'];
+			$body_length = strlen( $body );
+
+			if ( $body_length > self::MAX_LOGGED_QUERY_BODY_BYTES ) {
+				// Large bodies (e.g. _bulk index payloads) are worthless to log in full
+				// and would exceed the logstash `extra` size limit. Keep a small preview
+				// plus the real byte size so failures remain diagnosable.
+				$query['args']['body'] = [
+					'truncated'  => true,
+					'body_bytes' => $body_length,
+					'preview'    => substr( $body, 0, self::MAX_LOGGED_QUERY_BODY_BYTES ),
+				];
+			} else {
+				$decoded_body          = json_decode( $body );
+				$query['args']['body'] = ! json_last_error() ? $decoded_body : $body;
+			}
 		}
 
 		return $query;


### PR DESCRIPTION
## Description

During a full CLI reindex (`wp vip-search index`), ElasticPress's dynamic bulk loop ramps each `_bulk` request up by byte size toward a 150 MB ceiling. On this cluster that's a problem: requests grow large enough to exceed the upstream **30s request timeout** before Elasticsearch finishes indexing them. Because that failure surfaces as a timeout / `504` (not a `413`), the dynamic shrink-and-retry never engages — the batch is recorded as failed and skipped, **silently dropping documents** from the index.

Empirically, indexing throughput on this cluster is ~3 MB/s and degrades on larger batches (a ~60 MB request took ~20s; ~65 MB blew past the 30s wall). The Elasticsearch node limit (`http.max_content_length` = 100 MB, `http.read_timeout` = 0) is *not* the constraint — the upstream request timeout is.

This PR makes two related changes:

### 1. Constrain dynamic bulk request size
Pin the dynamic buffer so each request reliably completes within the timeout window, with margin:
- `ep_dynamic_bulk_min_buffer_size` → 20 MB (start, skips slow warm-up)
- `ep_dynamic_bulk_incremental_step` → 10 MB (ramp 20 → 30 → 40)
- `ep_dynamic_bulk_max_buffer_size` → 40 MB (plateau ~13–15s/request, ~2x margin under 30s)

These filters are only consumed by the dynamic bulk path (`Indexable::send_bulk_index_request()`), so normal query traffic is unaffected.

### 2. Truncate oversized request bodies in failed-request logs
When a bulk request fails, `sanitize_ep_query_for_logging()` copied the **entire** request body into the logstash `extra` payload. For a bulk index that body is tens of MB, which exceeds the logstash `extra` limit (262144 bytes) and causes the **whole** error entry to be dropped (plus a PHP warning) — destroying the very log that would tell us why the request failed. We now keep a 2 KB preview plus the real byte size, so failures stay diagnosable without blowing the limit.

## How to test

1. Run a full index: `wp vip-search index --per-page=20000`
2. Observe the dynamic buffer logs — request body size should ramp 20 → 30 → 40 MB and **plateau at ~40 MB**, with each request completing well under 30s and no `cURL error 28` / `504` lines.
3. To exercise the logging fix, trigger a failed bulk request and confirm the `search_http_error` logstash entry is written (no "Invalid `extra` ... Must be 262144 bytes or less" warning) and contains a truncated body preview with `body_bytes`.