### PR TITLE
integrations: load vip-wordpress-abilities plugin in MCP integration

### DIFF
--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -48,6 +48,11 @@ class WordPressMcpIntegration extends Integration {
 	}
 
 	public function load(): void {
+		$vip_abilities_plugin = WPVIP_MU_PLUGIN_DIR . '/vip-wordpress-abilities/vip-wordpress-abilities.php';
+		if ( file_exists( $vip_abilities_plugin ) ) {
+			require_once $vip_abilities_plugin;
+		}
+
 		if ( $this->has_server_config() ) {
 			add_filter( 'mcp_adapter_default_server_config', [ $this, 'filter_default_server_config' ], PHP_INT_MAX );
 		}


### PR DESCRIPTION
## Description

Loads the `vip-wordpress-abilities` plugin during the WordPress MCP integration's `load()` step, if the plugin is present on the platform.

### Why

The plugin registers VIP-specific WordPress abilities that should be available to the MCP server. Requiring it early in `WordPressMcpIntegration::load()` ensures those abilities are registered before the MCP server config filters run.

### Technical details

- Builds the plugin path from `WPVIP_MU_PLUGIN_DIR`.
- Guards the `require_once` with a `file_exists()` check so environments without the plugin are unaffected — no fatal error when it's absent.
- Runs before the existing `mcp_adapter_default_server_config` filter registration.

### How to test locally

1. On an environment with `vip-wordpress-abilities/vip-wordpress-abilities.php` present, load the MCP integration and confirm the plugin's abilities are registered with the MCP server.
2. On an environment without the plugin, confirm the integration loads cleanly with no fatal error.