### PR TITLE
integrations: fix MCP auth error never reaching the REST response

### DIFF
--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -43,6 +43,13 @@ class WordPressMcpIntegration extends Integration {
 	 */
 	protected bool $parent_integration_requires_org_enabled = true;
 
+	/**
+	 * MCP authentication error to surface on the REST response.
+	 *
+	 * @var \WP_Error|null
+	 */
+	private ?\WP_Error $auth_error = null;
+
 	public function is_loaded(): bool {
 		return class_exists( '\WP\MCP\Plugin', false );
 	}
@@ -62,6 +69,9 @@ class WordPressMcpIntegration extends Integration {
 		}
 
 		add_filter( 'determine_current_user', [ $this, 'authenticate_mcp_request' ], 19 );
+		// Surfaces MCP auth errors; must run before core's app-password (90) and cookie (100)
+		// checks, which would otherwise settle the authentication result for the request.
+		add_filter( 'rest_authentication_errors', [ $this, 'report_auth_error' ] );
 
 		add_action( 'plugins_loaded', function () {
 			if ( $this->is_loaded() ) {
@@ -167,6 +177,12 @@ class WordPressMcpIntegration extends Integration {
 	/**
 	 * Authenticate MCP requests.
 	 *
+	 * Runs on determine_current_user, which cannot return errors — hard failures are
+	 * recorded in $this->auth_error and surfaced to the client by report_auth_error().
+	 * No user-resolving function (is_user_logged_in, rest_authorization_required_code,
+	 * current_user_can, ...) may be called in here: each one re-fires this filter and
+	 * recurses infinitely.
+	 *
 	 * @param int|false|null $input_user Existing authenticated user ID.
 	 * @return int|false|null Authenticated user ID, or the original input.
 	 */
@@ -233,26 +249,16 @@ class WordPressMcpIntegration extends Integration {
 
 		$user = get_user_by( 'email', $email );
 		if ( ! $user ) {
-			$this->trigger_auth_warning( 'User not found for email hash ' . hash( 'sha256', strtolower( $email ) ) );
+			$this->trigger_auth_warning( sprintf( 'No user was found with the email %s.', $email ) );
 
-			// Surface a hard 401 for the REST request instead of silently declining auth.
-			$rest_auth_error_callback = null;
-			$rest_auth_error_callback = function ( $errors ) use ( $email, &$rest_auth_error_callback ) {
-				// Ensure the filter is one-shot for this request.
-				remove_filter( 'rest_authentication_errors', $rest_auth_error_callback, 10 );
-
-				// Don't override an existing error or a successful authentication.
-				if ( null !== $errors ) {
-					return $errors;
-				}
-
-				return new \WP_Error(
-					'vip_mcp_user_not_found',
-					sprintf( 'No user was found with the email %s.', $email ),
-					[ 'status' => rest_authorization_required_code() ]
-				);
-			};
-			add_filter( 'rest_authentication_errors', $rest_auth_error_callback, 10, 1 );
+			// Hardcoded 401: rest_authorization_required_code() is a user-resolving
+			// function (see the method docblock), and 401 is what it returns for
+			// unauthenticated requests anyway.
+			$this->auth_error = new \WP_Error(
+				'vip_mcp_user_not_found',
+				sprintf( 'No user was found with the email %s.', $email ),
+				[ 'status' => 401 ]
+			);
 
 			return $input_user;
 		}
@@ -261,13 +267,23 @@ class WordPressMcpIntegration extends Integration {
 	}
 
 	/**
+	 * Surface a deferred MCP authentication error on the REST response.
+	 *
+	 * @param \WP_Error|null|true $errors Result of any previous REST authentication checks.
+	 * @return \WP_Error|null|true A WP_Error for failed MCP authentication, or the original value.
+	 */
+	public function report_auth_error( $errors ) {
+		return $errors ?? $this->auth_error;
+	}
+
+	/**
 	 * Check whether the current request targets the MCP adapter REST endpoint.
+	 *
+	 * Deliberately does not require REST_REQUEST: authentication runs on the
+	 * determine_current_user pass at $wp->init(), before the REST server defines
+	 * the constant, so the endpoint is matched on method and URL alone.
 	 */
 	public function is_mcp_adapter_rest_request(): bool {
-		if ( ! defined( 'REST_REQUEST' ) || ! constant( 'REST_REQUEST' ) ) {
-			return false;
-		}
-
 		if ( 'POST' !== $this->get_server_value( 'REQUEST_METHOD' ) ) {
 			return false;
 		}
@@ -365,7 +381,7 @@ class WordPressMcpIntegration extends Integration {
 	 * Emit an authentication warning without exposing raw user identity.
 	 */
 	private function trigger_auth_warning( string $message ): void {
-		error_log( esc_html( 'VIP MCP Auth: ' . $message ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( esc_html( 'VIP MCP Auth Error: ' . $message ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 
 	/**

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -137,6 +137,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 
 		remove_filter( 'mcp_adapter_default_server_config', [ $wordpress_mcp_integration, 'filter_default_server_config' ], PHP_INT_MAX );
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+		remove_filter( 'rest_authentication_errors', [ $wordpress_mcp_integration, 'report_auth_error' ] );
 	}
 
 	public function test_load_registers_exposed_abilities_args_filter_when_configured(): void {
@@ -153,6 +154,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 
 		remove_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_abilities_args' ], PHP_INT_MAX );
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+		remove_filter( 'rest_authentication_errors', [ $wordpress_mcp_integration, 'report_auth_error' ] );
 	}
 
 	public function test_load_does_not_register_default_server_config_filter_without_server_config(): void {
@@ -165,6 +167,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		);
 
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+		remove_filter( 'rest_authentication_errors', [ $wordpress_mcp_integration, 'report_auth_error' ] );
 	}
 
 	public function test_load_does_not_register_exposed_abilities_args_filter_without_config(): void {
@@ -177,6 +180,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		);
 
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
+		remove_filter( 'rest_authentication_errors', [ $wordpress_mcp_integration, 'report_auth_error' ] );
 	}
 
 	public function test_filter_exposed_abilities_args_marks_configured_ability_public(): void {
@@ -401,8 +405,6 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_mcp_adapter_rest_request_returns_true_for_pretty_rest_url(): void {
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/mcp-adapter-default-server';
 
@@ -412,8 +414,6 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_mcp_adapter_rest_request_returns_true_for_configured_rest_url(): void {
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/wp-json/vip-mcp/v1/vip-mcp-server';
 
@@ -432,8 +432,6 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_mcp_adapter_rest_request_uses_default_namespace_with_configured_server_route(): void {
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/vip-mcp-server';
 
@@ -445,8 +443,6 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_mcp_adapter_rest_request_uses_default_route_with_configured_namespace(): void {
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/wp-json/vip-mcp/v1/mcp-adapter-default-server';
 
@@ -458,8 +454,6 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_mcp_adapter_rest_request_returns_true_for_rest_route_query_arg(): void {
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/index.php?rest_route=/mcp/mcp-adapter-default-server';
 		$_GET['rest_route']        = '/mcp/mcp-adapter-default-server';
@@ -470,8 +464,6 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_mcp_adapter_rest_request_returns_false_for_other_rest_url(): void {
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/wp-json/wp/v2/posts';
 
@@ -486,32 +478,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( 123, $wordpress_mcp_integration->authenticate_mcp_request( 123 ) );
 	}
 
-	public function test_authenticate_mcp_request_maps_valid_hmac_to_user(): void {
-		$auth_key  = 'test-auth-key';
-		$email     = 'mcp-user-' . wp_generate_password( 8, false ) . '@example.com';
-		$timestamp = (string) time();
-		$user_id   = $this->factory()->user->create( [ 'user_email' => $email ] );
-
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/mcp-adapter-default-server';
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
-		$_SERVER['PHP_AUTH_USER'] = $email;
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
-		$_SERVER['PHP_AUTH_PW']                   = hash_hmac( 'sha256', $email . $timestamp, $auth_key );
-		$_SERVER['HTTP_X_VIP_MCP_AUTH']           = 'true';
-		$_SERVER['HTTP_X_VIP_MCP_AUTH_TIMESTAMP'] = $timestamp;
-
-		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
-		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $auth_key ] ] );
-
-		$this->assertSame( $user_id, $wordpress_mcp_integration->authenticate_mcp_request( false ) );
-	}
-
 	public function test_authenticate_mcp_request_ignores_missing_hmac_headers(): void {
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/mcp-adapter-default-server';
 
@@ -526,8 +493,6 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 	private function sign_mcp_request( string $email, string $auth_key ): void {
 		$timestamp = (string) time();
 
-		Constant_Mocker::define( 'REST_REQUEST', true );
-
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/wp-json/mcp/mcp-adapter-default-server';
 		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- Test fixture for MCP Basic auth bridge.
@@ -536,9 +501,24 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$_SERVER['PHP_AUTH_PW']                   = hash_hmac( 'sha256', $email . $timestamp, $auth_key );
 		$_SERVER['HTTP_X_VIP_MCP_AUTH']           = 'true';
 		$_SERVER['HTTP_X_VIP_MCP_AUTH_TIMESTAMP'] = $timestamp;
+
+		wp_set_current_user( 0 );
 	}
 
-	public function test_authenticate_mcp_request_declines_when_user_not_found(): void {
+	public function test_authenticate_mcp_request_maps_valid_hmac_to_user(): void {
+		$auth_key = 'test-auth-key';
+		$email    = 'mcp-user-' . wp_generate_password( 8, false ) . '@example.com';
+		$user_id  = $this->factory()->user->create( [ 'user_email' => $email ] );
+
+		$this->sign_mcp_request( $email, $auth_key );
+
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $auth_key ] ] );
+
+		$this->assertSame( $user_id, $wordpress_mcp_integration->authenticate_mcp_request( false ) );
+	}
+
+	public function test_report_auth_error_surfaces_rest_error_when_user_not_found(): void {
 		$auth_key = 'test-auth-key';
 		$email    = 'missing-' . wp_generate_password( 8, false ) . '@example.com';
 
@@ -547,62 +527,19 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $auth_key ] ] );
 
-		// A valid signature for an unknown user must not resolve to a user ID; the input is preserved.
+		// A valid signature for an unknown user must not resolve to a user ID; the
+		// input is preserved and the hard failure is recorded for the REST layer.
 		$this->assertFalse( $wordpress_mcp_integration->authenticate_mcp_request( false ) );
 
-		$callback = $this->get_registered_rest_auth_error_closure();
-		if ( $callback instanceof \Closure ) {
-			remove_filter( 'rest_authentication_errors', $callback, 10 );
-		}
-	}
-
-	/**
-	 * Return the one-shot closure the integration registers on rest_authentication_errors, if any.
-	 *
-	 * The closure is isolated from the environment's own rest_authentication_errors callbacks so it
-	 * can be asserted on directly, rather than running the whole (contaminated) filter chain.
-	 */
-	private function get_registered_rest_auth_error_closure(): ?\Closure {
-		$hook = $GLOBALS['wp_filter']['rest_authentication_errors'] ?? null;
-		if ( null === $hook ) {
-			return null;
-		}
-
-		$found = null;
-		foreach ( ( $hook->callbacks[10] ?? [] ) as $callback ) {
-			if ( $callback['function'] instanceof \Closure ) {
-				$found = $callback['function'];
-			}
-		}
-
-		return $found;
-	}
-
-	public function test_authenticate_mcp_request_surfaces_rest_auth_error_when_user_not_found(): void {
-		$auth_key = 'test-auth-key';
-		$email    = 'missing-' . wp_generate_password( 8, false ) . '@example.com';
-
-		$this->sign_mcp_request( $email, $auth_key );
-
-		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
-		$wordpress_mcp_integration->activate( [ 'config' => [ 'auth_key' => $auth_key ] ] );
-
-		$wordpress_mcp_integration->authenticate_mcp_request( false );
-
-		$callback = $this->get_registered_rest_auth_error_closure();
-		$this->assertNotNull( $callback, 'A rest_authentication_errors closure should be registered.' );
-
-		$error = $callback( null );
+		$error = $wordpress_mcp_integration->report_auth_error( null );
 
 		$this->assertInstanceOf( \WP_Error::class, $error );
 		$this->assertSame( 'vip_mcp_user_not_found', $error->get_error_code() );
 		$this->assertStringContainsString( $email, $error->get_error_message() );
-		$this->assertSame( rest_authorization_required_code(), $error->get_error_data()['status'] );
-
-		remove_filter( 'rest_authentication_errors', $callback, 10 );
+		$this->assertSame( 401, $error->get_error_data()['status'] );
 	}
 
-	public function test_user_not_found_rest_auth_error_preserves_existing_result(): void {
+	public function test_report_auth_error_preserves_existing_result(): void {
 		$auth_key = 'test-auth-key';
 		$email    = 'missing-' . wp_generate_password( 8, false ) . '@example.com';
 
@@ -613,20 +550,15 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 
 		$wordpress_mcp_integration->authenticate_mcp_request( false );
 
-		$callback = $this->get_registered_rest_auth_error_closure();
-		$this->assertNotNull( $callback, 'A rest_authentication_errors closure should be registered.' );
-
 		// A prior successful authentication (true) must pass through untouched.
-		$this->assertTrue( $callback( true ) );
+		$this->assertTrue( $wordpress_mcp_integration->report_auth_error( true ) );
 
 		// An error set by another handler must not be overridden.
 		$existing = new \WP_Error( 'existing_error', 'Existing error' );
-		$this->assertSame( $existing, $callback( $existing ) );
-
-		remove_filter( 'rest_authentication_errors', $callback, 10 );
+		$this->assertSame( $existing, $wordpress_mcp_integration->report_auth_error( $existing ) );
 	}
 
-	public function test_authenticate_mcp_request_does_not_register_rest_auth_error_for_valid_user(): void {
+	public function test_report_auth_error_returns_null_for_valid_user(): void {
 		$auth_key = 'test-auth-key';
 		$email    = 'mcp-user-' . wp_generate_password( 8, false ) . '@example.com';
 		$user_id  = $this->factory()->user->create( [ 'user_email' => $email ] );
@@ -638,7 +570,13 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $user_id, $wordpress_mcp_integration->authenticate_mcp_request( false ) );
 
-		// A successful auth must not register a hard error for the REST layer.
-		$this->assertNull( $this->get_registered_rest_auth_error_closure() );
+		// A successful auth must not surface a hard error for the REST layer.
+		$this->assertNull( $wordpress_mcp_integration->report_auth_error( null ) );
+	}
+
+	public function test_report_auth_error_returns_null_without_recorded_error(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+
+		$this->assertNull( $wordpress_mcp_integration->report_auth_error( null ) );
 	}
 }


### PR DESCRIPTION
## Description

MCP requests signed for an email with no matching WordPress user were supposed to receive a descriptive `vip_mcp_user_not_found` 401, but clients got the generic `rest_forbidden` ("Sorry, you are not allowed to do that.") instead. This PR fixes the error delivery and simplifies the auth flow in the process.

### Why it was broken

The 401 was registered as a one-shot closure on `rest_authentication_errors` from inside `authenticate_mcp_request`. Because endpoint detection required the `REST_REQUEST` constant, authentication could only run on the *lazy* `determine_current_user` pass — which core triggers from `rest_cookie_check_errors`, at priority 100 of the very same `rest_authentication_errors` chain. `WP_Hook` never rewinds to earlier priorities mid-run, so the closure (priority 10) was registered into a chain that had already passed it and never executed. The cookie check then returned `true` for the nonce-less request, and the REST API proceeded anonymously to the permission callback's generic error.

### The fix

- `is_mcp_adapter_rest_request()` no longer requires `REST_REQUEST`; it matches the MCP endpoint on request method + URL (pretty permalinks and `?rest_route=`). This lets authentication run to completion on the early `determine_current_user` pass at `$wp->init()`, before the REST filter chain starts — the same timing core's Application Passwords use. The HMAC signature remains the actual authentication gate.
- On user-not-found, the `WP_Error` is recorded in a property instead of registering a closure, and a `report_auth_error()` callback — registered up front on `rest_authentication_errors`, ahead of core's app-password (90) and cookie (100) checks — surfaces it to the client.
- The error status is hardcoded to 401: `rest_authorization_required_code()` resolves the current user and must not be called inside a `determine_current_user` callback (infinite recursion). The docblock now warns about this class of bug.

