### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260617-pr79021';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260706-pr79021';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary
- Updates `RealTimeCollaborationIntegration::VIP_RTC_GUTENBERG_VERSION` to `0.2-20260706-pr79021`.
- Leaves `VIP_RTC_PLUGIN_VERSION` at `0.3`; VIP RTC latest release `v0.3.2` is already present in the `vip-real-time-collaboration-0.3` loader folder.
- Pairs with Automattic/vip-go-mu-plugins-ext#130, which adds the new custom Gutenberg folder.

## Deployed-stage versions recorded before change
- `develop`: Gutenberg `0.2-20260617-pr79021`, RTC `0.3`
- `staging`: Gutenberg `0.2-20260617-pr79021`, RTC `0.3`
- `production`: Gutenberg `0.2-20260617-pr79021`, RTC `0.3`

## Validation
- `php -l integrations/real-time-collaboration.php` passed.
- `vendor/bin/phpcs --cache integrations/real-time-collaboration.php` passed, with existing repo-level deprecated-sniff warnings only.
- `composer validate --no-check-publish` passed, with the existing no-license warning.
- Confirmed `vip-go-mu-plugins-ext` PR #130 contains `vip-integrations/gutenberg-0.2-20260706-pr79021` and preserves deployed-stage folders.
