### PR TITLE
Remove unused e2e Babel decorators plugin

### DIFF
--- a/__tests__/e2e/package-lock.json
+++ b/__tests__/e2e/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "devDependencies": {
         "@automattic/eslint-plugin-wpvip": "^1.2.1",
-        "@babel/plugin-syntax-decorators": "^7.28.6",
         "@playwright/test": "^1.59.1",
         "@types/node": "^26.0.1",
         "asana-phrase": "^0.0.8",
@@ -216,16 +215,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -284,22 +273,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
-      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/template": {

--- a/__tests__/e2e/package.json
+++ b/__tests__/e2e/package.json
@@ -15,7 +15,6 @@
   "author": "Automattic",
   "devDependencies": {
     "@automattic/eslint-plugin-wpvip": "^1.2.1",
-    "@babel/plugin-syntax-decorators": "^7.28.6",
     "@playwright/test": "^1.59.1",
     "@types/node": "^26.0.1",
     "asana-phrase": "^0.0.8",


### PR DESCRIPTION
## Description
Removes the unused `@babel/plugin-syntax-decorators` dependency from the E2E test package.

The package is only listed in `__tests__/e2e/package.json` / lockfile and is not referenced by Babel, ESLint, TypeScript config, or E2E source files. Removing it also avoids the Babel 8 peer dependency conflict from Dependabot PR #7054 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->