### PR TITLE
[PLTFRM-1061] Respect theme.json layout widths for image resize

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -205,6 +205,32 @@ class A8C_Files {
 		return false;
 	}
 
+	/**
+	 * Gets a numeric pixel width from theme.json layout settings.
+	 *
+	 * @param string[] $layout_settings Ordered layout settings to check.
+	 * @return int Width in pixels, or 0 when unavailable.
+	 */
+	private function get_theme_json_layout_width( $layout_settings ) {
+		if ( ! function_exists( 'wp_get_global_settings' ) || ! function_exists( 'wp_theme_has_theme_json' ) || ! wp_theme_has_theme_json() ) {
+			return 0;
+		}
+
+		foreach ( $layout_settings as $layout_setting ) {
+			$value = wp_get_global_settings( array( 'layout', $layout_setting ) );
+
+			if ( is_numeric( $value ) ) {
+				return max( 0, (int) $value );
+			}
+
+			if ( is_string( $value ) && preg_match( '/^(\d+(?:\.\d+)?)px$/i', trim( $value ), $matches ) ) {
+				return max( 0, (int) round( (float) $matches[1] ) );
+			}
+		}
+
+		return 0;
+	}
+
 	public function upload_url_path( $upload_url_path ) {
 		// No modifications needed outside multisite
 		if ( false !== is_multisite() ) {
@@ -235,9 +261,11 @@ class A8C_Files {
 			return false;
 		}
 
-		$content_width = isset( $GLOBALS['content_width'] ) ? $GLOBALS['content_width'] : null;
-		$crop          = false;
-		$args          = array();
+		$content_width                = isset( $GLOBALS['content_width'] ) ? max( 0, (int) $GLOBALS['content_width'] ) : 0;
+		$content_width_for_constraint = $content_width ?: $this->get_theme_json_layout_width( array( 'contentSize' ) );
+		$max_image_width              = $content_width ?: $this->get_theme_json_layout_width( array( 'wideSize', 'contentSize' ) );
+		$crop                         = false;
+		$args                         = array();
 
 		// For resize requests coming from an image's attachment page, override
 		// the supplied $size and use the user-defined $content_width if the
@@ -285,8 +313,8 @@ class A8C_Files {
 			$w      = $_max_w;
 			$h      = $_max_h;
 			$crop   = $_wp_additional_image_sizes[ $size ]['crop'];
-		} elseif ( $content_width > 0 ) {
-			$_max_w = $content_width;
+		} elseif ( $max_image_width > 0 ) {
+			$_max_w = $max_image_width;
 			$_max_h = 0;
 		} else {
 			$_max_w = 1024;
@@ -294,8 +322,8 @@ class A8C_Files {
 		}
 
 		// Constrain default image sizes to the theme's content width, if available.
-		if ( $content_width > 0 && in_array( $size, array( 'thumbnail', 'medium', 'large' ) ) ) {
-			$_max_w = min( $_max_w, $content_width );
+		if ( $content_width_for_constraint > 0 && in_array( $size, array( 'thumbnail', 'medium', 'medium_large', 'large' ) ) ) {
+			$_max_w = min( $_max_w, $content_width_for_constraint );
 		}
 
 		$resized = false;

--- a/tests/files/test-a8c-files-image-resize.php
+++ b/tests/files/test-a8c-files-image-resize.php
@@ -1,9 +1,15 @@
 <?php
 
 class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
+	private const MISSING_OPTION = '__vip_go_missing_option__';
+
 	private $original_content_width;
+	private $original_large_size_h;
+	private $original_large_size_w;
 	private $original_stylesheet;
+	private $original_template;
 	private $attachment_id;
+	private $theme_directory;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -15,9 +21,14 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 		$this->original_content_width = $GLOBALS['content_width'] ?? null;
 		unset( $GLOBALS['content_width'] );
 
-		$this->original_stylesheet = get_stylesheet();
+		$this->original_large_size_w = get_option( 'large_size_w', self::MISSING_OPTION );
+		$this->original_large_size_h = get_option( 'large_size_h', self::MISSING_OPTION );
 
-		register_theme_directory( VIP_GO_MUPLUGINS_TESTS__DIR__ . '/fixtures/themes' );
+		$this->original_stylesheet = get_stylesheet();
+		$this->original_template   = get_template();
+		$this->theme_directory     = VIP_GO_MUPLUGINS_TESTS__DIR__ . '/fixtures/themes';
+
+		register_theme_directory( $this->theme_directory );
 		wp_clean_themes_cache();
 		switch_theme( 'vip-theme-json-layout' );
 		$this->clean_theme_json_cache();
@@ -45,15 +56,20 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		if ( $this->original_stylesheet ) {
-			switch_theme( $this->original_stylesheet );
+			switch_theme( $this->original_template, $this->original_stylesheet );
 			$this->clean_theme_json_cache();
 		}
+
+		$this->unregister_theme_directory();
 
 		if ( null === $this->original_content_width ) {
 			unset( $GLOBALS['content_width'] );
 		} else {
 			$GLOBALS['content_width'] = $this->original_content_width;
 		}
+
+		$this->restore_option( 'large_size_w', $this->original_large_size_w );
+		$this->restore_option( 'large_size_h', $this->original_large_size_h );
 
 		parent::tearDown();
 	}
@@ -102,6 +118,22 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 	private function clean_theme_json_cache() {
 		if ( class_exists( 'WP_Theme_JSON_Resolver' ) ) {
 			WP_Theme_JSON_Resolver::clean_cached_data();
+		}
+	}
+
+	private function restore_option( $option, $value ) {
+		if ( self::MISSING_OPTION === $value ) {
+			delete_option( $option );
+			return;
+		}
+
+		update_option( $option, $value );
+	}
+
+	private function unregister_theme_directory() {
+		if ( $this->theme_directory && function_exists( 'unregister_theme_directory' ) ) {
+			unregister_theme_directory( $this->theme_directory );
+			wp_clean_themes_cache();
 		}
 	}
 }

--- a/tests/files/test-a8c-files-image-resize.php
+++ b/tests/files/test-a8c-files-image-resize.php
@@ -1,0 +1,107 @@
+<?php
+
+class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
+	private $original_content_width;
+	private $original_stylesheet;
+	private $attachment_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
+			$this->markTestSkipped( 'Test requires theme.json support.' );
+		}
+
+		$this->original_content_width = $GLOBALS['content_width'] ?? null;
+		unset( $GLOBALS['content_width'] );
+
+		$this->original_stylesheet = get_stylesheet();
+
+		register_theme_directory( VIP_GO_MUPLUGINS_TESTS__DIR__ . '/fixtures/themes' );
+		wp_clean_themes_cache();
+		switch_theme( 'vip-theme-json-layout' );
+		$this->clean_theme_json_cache();
+
+		$this->attachment_id = self::factory()->attachment->create_object(
+			VIP_GO_MUPLUGINS_TESTS__DIR__ . '/fixtures/image.jpg',
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			)
+		);
+
+		update_post_meta( $this->attachment_id, '_wp_attached_file', 'image.jpg' );
+		wp_update_attachment_metadata(
+			$this->attachment_id,
+			array(
+				'width'  => 5472,
+				'height' => 3080,
+				'file'   => 'image.jpg',
+				'sizes'  => array(),
+			)
+		);
+	}
+
+	public function tearDown(): void {
+		if ( $this->original_stylesheet ) {
+			switch_theme( $this->original_stylesheet );
+			$this->clean_theme_json_cache();
+		}
+
+		if ( null === $this->original_content_width ) {
+			unset( $GLOBALS['content_width'] );
+		} else {
+			$GLOBALS['content_width'] = $this->original_content_width;
+		}
+
+		parent::tearDown();
+	}
+
+	public function test__image_resize__uses_theme_json_wide_size_for_unknown_size_when_content_width_missing() {
+		$result = $this->resize_image( 'vip_unknown_size' );
+
+		$this->assertSame( 1600, $result[1] );
+		$this->assertUrlQueryArgSame( '1600', 'w', $result[0] );
+	}
+
+	public function test__image_resize__uses_theme_json_content_size_to_constrain_default_sizes() {
+		update_option( 'large_size_w', 2000 );
+		update_option( 'large_size_h', 2000 );
+
+		$result = $this->resize_image( 'large' );
+
+		$this->assertSame( 720, $result[1] );
+		$this->assertUrlQueryArgSame( '720', 'w', $result[0] );
+	}
+
+	public function test__image_resize__prefers_global_content_width_over_theme_json_layout_widths() {
+		$GLOBALS['content_width'] = 900;
+
+		$result = $this->resize_image( 'vip_unknown_size' );
+
+		$this->assertSame( 900, $result[1] );
+		$this->assertUrlQueryArgSame( '900', 'w', $result[0] );
+	}
+
+	private function resize_image( $size ) {
+		$reflection = new ReflectionClass( A8C_Files::class );
+		$files      = $reflection->newInstanceWithoutConstructor();
+
+		return $files->image_resize( false, $this->attachment_id, $size );
+	}
+
+	private function assertUrlQueryArgSame( $expected, $arg, $url ) {
+		$query_args = array();
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
+
+		$this->assertArrayHasKey( $arg, $query_args );
+		$this->assertSame( $expected, $query_args[ $arg ] );
+	}
+
+	private function clean_theme_json_cache() {
+		if ( class_exists( 'WP_Theme_JSON_Resolver' ) ) {
+			WP_Theme_JSON_Resolver::clean_cached_data();
+		}
+	}
+}

--- a/tests/fixtures/themes/vip-theme-json-layout/style.css
+++ b/tests/fixtures/themes/vip-theme-json-layout/style.css
@@ -1,0 +1,3 @@
+/*
+Theme Name: VIP Theme JSON Layout Test
+*/

--- a/tests/fixtures/themes/vip-theme-json-layout/theme.json
+++ b/tests/fixtures/themes/vip-theme-json-layout/theme.json
@@ -1,0 +1,9 @@
+{
+	"version": 2,
+	"settings": {
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1600px"
+		}
+	}
+}


### PR DESCRIPTION
## Description
Fixes #5339 

## Changelog Description

### Changed
- VIP Image Resize: Respect theme.json layout contentSize and wideSize when determining resize widths for block themes without $content_width.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->