### PR TITLE
fix: check the meta property exists before trying to use it

### DIFF
--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -69,6 +69,9 @@ function wpcom_vip_render_vip_featured_plugins() {
 		<div class="plugins-grid">
 		<?php
 		foreach ( $plugins as $plugin ) {
+			if ( ! property_exists( $plugin, 'meta' ) ) {
+				continue;
+			}
 			?>
 			<div class="plugin">
 				<a class="fp-content" href="<?php echo esc_url( $plugin->permalink ?? $plugin->meta->plugin_url ); ?>" target="_blank">

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -53,6 +53,16 @@ function wpcom_vip_render_vip_featured_plugins() {
 	}
 
 	$plugins = wpcom_vip_fetch_vip_featured_plugins();
+	$plugins = is_array( $plugins ) ? array_filter(
+		$plugins,
+		static function ( $plugin ) {
+			return ! empty( $plugin->meta ) &&
+				( ! empty( $plugin->permalink ) || ! empty( $plugin->meta->plugin_url ) ) &&
+				! empty( $plugin->meta->listing_logo ) &&
+				! empty( $plugin->post_title ) &&
+				! empty( $plugin->meta->listing_description );
+		}
+	) : array();
 
 	if ( empty( $plugins ) ) {
 		?>
@@ -69,18 +79,7 @@ function wpcom_vip_render_vip_featured_plugins() {
 		<div class="plugins-grid">
 		<?php
 		foreach ( $plugins as $plugin ) {
-			// Make sure all the required data exists before proceeding.
-			if (
-				empty( $plugin->meta ) ||
-				( empty( $plugin->permalink ) && empty( $plugin->meta->plugin_url ) ) ||
-				empty( $plugin->meta->listing_logo ) ||
-				empty( $plugin->post_title ) ||
-				empty( $plugin->meta->listing_description )
-			) {
-				continue;
-			}
-
-			$plugin_url = $plugin->permalink ?? $plugin->meta->plugin_url;
+			$plugin_url = ! empty( $plugin->permalink ) ? $plugin->permalink : $plugin->meta->plugin_url;
 			?>
 			<div class="plugin">
 				<a class="fp-content" href="<?php echo esc_url( $plugin_url ); ?>" target="_blank">

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -69,17 +69,26 @@ function wpcom_vip_render_vip_featured_plugins() {
 		<div class="plugins-grid">
 		<?php
 		foreach ( $plugins as $plugin ) {
-			if ( ! property_exists( $plugin, 'meta' ) ) {
+			// Make sure all the required data exists before proceeding.
+			if (
+				empty( $plugin->meta ) ||
+				( empty( $plugin->permalink ) && empty( $plugin->meta->plugin_url ) ) ||
+				empty( $plugin->meta->listing_logo ) ||
+				empty( $plugin->post_title ) ||
+				empty( $plugin->meta->listing_description )
+			) {
 				continue;
 			}
+
+			$plugin_url = $plugin->permalink ?? $plugin->meta->plugin_url;
 			?>
 			<div class="plugin">
-				<a class="fp-content" href="<?php echo esc_url( $plugin->permalink ?? $plugin->meta->plugin_url ); ?>" target="_blank">
+				<a class="fp-content" href="<?php echo esc_url( $plugin_url ); ?>" target="_blank">
 					<img src="<?php echo esc_url( $plugin->meta->listing_logo ); ?>" alt="<?php echo esc_attr( $plugin->post_title ); ?>" />
 					<h4><?php echo esc_html( $plugin->post_title ); ?></h4>
 					<p><?php echo esc_html( $plugin->meta->listing_description ); ?></p>
 				</a>
-				<a class="fp-overlay" href="<?php echo esc_url( $plugin->permalink ?? $plugin->meta->plugin_url ); ?>" target="_blank">
+				<a class="fp-overlay" href="<?php echo esc_url( $plugin_url ); ?>" target="_blank">
 					<div class="fp-overlay-inner">
 						<div class="fp-overlay-cell">
 							<span>

--- a/vip-plugins/vip-plugins.php
+++ b/vip-plugins/vip-plugins.php
@@ -88,7 +88,7 @@ function wpcom_vip_render_vip_featured_plugins() {
 					<h4><?php echo esc_html( $plugin->post_title ); ?></h4>
 					<p><?php echo esc_html( $plugin->meta->listing_description ); ?></p>
 				</a>
-				<a class="fp-overlay" href="<?php echo esc_url( $plugin_url ); ?>" target="_blank">
+				<a class="fp-overlay" href="<?php echo esc_url( $plugin_url ); ?>" target="_blank" rel="noopener noreferrer">
 					<div class="fp-overlay-inner">
 						<div class="fp-overlay-cell">
 							<span>


### PR DESCRIPTION
## Description

The following PHP Warning is appearing on VIP Sites:

> Attempt to read property "plugin_url" on null
>     in wpcom_vip_render_vip_featured_plugins called at /var/www/wp-includes/class-wp-hook.php (341)
>                    in WP_Hook::apply_filters called at /var/www/wp-includes/class-wp-hook.php (365)
>                               in WP_Hook::do_action called at /var/www/wp-includes/plugin.php (522)
>                                     in do_action called at /var/www/wp-admin/admin-header.php (313)
>                                       in require_once called at /var/www/wp-admin/plugins.php (637)

## Changelog Description

Fixes the above PHP Warning by skipping any plugins that do not have the `meta` property and therefore can't output a link and image.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Navigate to WP Admin > Plugins on any VIP site
2. Check the runtime logs for the above Warning
3. Apply the fix and refresh the plugins page
4. Confirm the Warning no longer appears in the log