### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260706-pr79021';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260720-pr79021';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary
- Updates `RealTimeCollaborationIntegration::VIP_RTC_GUTENBERG_VERSION` from `0.2-20260706-pr79021` to `0.2-20260720-pr79021`.
- The selected Gutenberg artifact is built from current Gutenberg `trunk` at `38f10b39e9b08a1a265a0ea84413a9ff4bc5c703` (plugin version `23.6.0-rc.1`), with WordPress/gutenberg#79021 cherry-picked on top.
- Leaves `VIP_RTC_PLUGIN_VERSION` at `0.3`; VIP RTC release `v0.3.2` remains present in the loader folder.
- Pairs with Automattic/vip-go-mu-plugins-ext#133. Although this PR changes only integration constants, activating the new constant deploys the Gutenberg/RTC runtime changes described below.

## Changelog Description

### Changed

- Real-Time Collaboration: Updated the bundled Gutenberg integration from the `0.2-20260706-pr79021` build based on Gutenberg 23.5.0 to the `0.2-20260720-pr79021` build based on the July 20 Gutenberg trunk snapshot. The VIP RTC plugin remains at v0.3.2.
- Real-Time Collaboration: Added independent controls for collaborator join, leave, and post-update notifications, and avoided synchronous CRDT updates while editing alone to reduce typing latency outside active collaboration.

### Fixed

- Real-Time Collaboration: Preserved collaborators' unsaved content and post meta when another user saves, prevented redundant empty autosave revisions, and restored undo and redo when plugins with incompatible meta boxes disable collaboration.
- Real-Time Collaboration: Disabled Quick Edit for posts with active collaborative sessions and improved remote cursor and selection positioning while resizing the browser window.

## Deployed-stage versions recorded before change
- develop: Gutenberg `0.2-20260706-pr79021`, RTC `0.3`
- staging: Gutenberg `0.2-20260706-pr79021`, RTC `0.3`
- production: Gutenberg `0.2-20260706-pr79021`, RTC `0.3`

## Release-note sources
- Runtime artifact and version delta: Automattic/vip-go-mu-plugins-ext#133
- Granular collaboration controls: WordPress/gutenberg#79184
- Undo/redo with incompatible meta boxes: WordPress/gutenberg#79510
- Empty autosave handling: WordPress/gutenberg#79591 and WordPress/gutenberg#79911
- Solo-editing CRDT performance: WordPress/gutenberg#79991
- Preserve unsaved collaborator edits and post meta: WordPress/gutenberg#79936
- Quick Edit collaboration locking: WordPress/gutenberg#80016
- Cursor and selection resize redraws: WordPress/gutenberg#79685

## Validation
- `php -l integrations/real-time-collaboration.php` passed.
- `vendor/bin/phpcs --cache integrations/real-time-collaboration.php` passed, with existing deprecated-sniff warnings only.
- `composer validate --no-check-publish` passed, with the existing no-license warning.
- Confirmed vip-go-mu-plugins-ext#133 contains `gutenberg-0.2-20260720-pr79021` and preserves every deployed-stage folder.
