### PR TITLE
fix(sandbox): rewrite admin_url for sandboxes

### DIFF
--- a/vip-helpers/sandbox.php
+++ b/vip-helpers/sandbox.php
@@ -70,13 +70,13 @@ add_action( 'admin_footer', 'wpcom_do_sandbox_bar', 100 );
 add_filter( 'wpcom_show_sandbox_bar', '__return_true' );
 
 /**
- * Filters plugin URLs to use sandboxed hostnames.
+ * Filters URLs to use sandboxed hostnames.
  *
- * @param string $url The complete URL to the plugins directory including scheme and path.
+ * @param string $url The complete URL including scheme and path.
  *
  * @return string Filtered URL using sandboxed hostname.
  */
-function wpvip_filter_sandbox_plugins_url( $url ) {
+function wpvip_filter_sandbox_url( $url ) {
 	/** @var array<string,string> */
 	global $sandbox_vhosts;
 	$host = $_SERVER['HTTP_HOST'] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -101,4 +101,5 @@ function wpvip_filter_sandbox_plugins_url( $url ) {
 
 	return $url;
 }
-add_filter( 'plugins_url', 'wpvip_filter_sandbox_plugins_url', 1000 );
+add_filter( 'plugins_url', 'wpvip_filter_sandbox_url', 1000 );
+add_filter( 'admin_url', 'wpvip_filter_sandbox_url', 1000 );


### PR DESCRIPTION
## Description

`admin_url()` output resolves to the production hostname on sandboxes, so requests built from it, such as the `admin-ajax.php` endpoint many plugins use for AJAX, hit the production host instead of the sandbox. On a sandbox this surfaces as cross-origin (CORS) request failures.

The `plugins_url` filter already rewrites plugin asset URLs back to the sandbox host. This PR reuses that same host-rewrite filter for `admin_url`, so admin URLs behave consistently on sandboxes. The existing callback only rewrites the host portion of the URL and is therefore URL-agnostic, so no logic changes were needed; it is simply registered on the additional hook. The function was renamed from `wpvip_filter_sandbox_plugins_url()` to `wpvip_filter_sandbox_url()` since it is no longer plugins-specific. The filter remains scoped to sandboxes only (`WPCOM_SANDBOXED`).

## Changelog Description

### Fixed

- Fixed `admin_url()` resolving to the production hostname on sandboxes, which caused cross-origin request failures for AJAX calls using `admin-ajax.php`.

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease deployment (if applicable, especially for large-scale actions that require writes).
- [ ] This change has relevant documentation additions/updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out the PR on a sandbox.
2. Load a front-end page that makes an AJAX call built from `admin_url( 'admin-ajax.php' )`
3. Hard-refresh or bust the page cache, as a cached render may still contain the pre-filter URL baked into the page's inline JS.
4. Open the browser Network tab, filter for `admin-ajax.php`, and trigger the AJAX action.
5. Verify the Request URL host is the sandbox hostname (not the production/mapped domain) and the request is same-origin (200 OK, no CORS error).
6. Confirm plugin asset URLs (`plugins_url`) still resolve to the sandbox host as before (no regression).