### PR TITLE
Remove WordPress 6.4 compatibility cruft

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ npm run phpcs
 - Uses WordPress VIP coding standards (see `phpcs.xml.dist`)
 - Scans incrementally via lint-staged on pre-commit (see `.husky/pre-commit` and `.lintstagedrc`)
 - Full scan takes 30-60 seconds
-- Configuration: PHP 8.2+ compatibility, WordPress 6.4+ support
+- Configuration: PHP 8.2+ compatibility, WordPress 6.5+ support
 - Excludes: vendor/, submodules (advanced-post-cache, cron-control, http-concat, jetpack, etc.), __tests__/, bin/
 
 To fix auto-fixable issues:
@@ -192,7 +192,7 @@ Submodules and third-party code are excluded (see `phpcs.xml.dist` lines 14-41).
 
 1. **PHP Version Support:** Code must work on PHP 8.2+. Avoid syntax/features for older PHP versions.
 
-2. **WordPress Compatibility:** Minimum WordPress 6.4.
+2. **WordPress Compatibility:** Minimum WordPress 6.5.
 
 3. **No Breaking Changes to Public APIs:** This code runs on thousands of WordPress sites. Breaking changes to public functions/filters/actions require careful consideration, and if not possible to avoid, deprecation period and graceful fallbacks need to be implemented.
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -19,10 +19,7 @@
 function vip_default_jetpack_version() {
 	global $wp_version;
 
-	if ( version_compare( $wp_version, '6.5', '<' ) ) {
-		// WordPress 6.4.x
-		return '13.6';
-	} elseif ( version_compare( $wp_version, '6.6', '<' ) ) {
+	if ( version_compare( $wp_version, '6.6', '<' ) ) {
 		// WordPress 6.5.x
 		return '14.0';
 	} elseif ( version_compare( $wp_version, '6.7', '<' ) ) {

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -11,7 +11,6 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 
 		$versions_map = [
 			// WordPress version => Jetpack version
-			'6.4' => '13.6',
 			'6.5' => '14.0',
 			'6.6' => '14.5',
 			'6.7' => '15.4',


### PR DESCRIPTION
## What changed

- remove the WordPress 6.4 Jetpack 13.6 compatibility branch
- remove the corresponding WordPress 6.4 unit-test case
- update contributor guidance to state WordPress 6.5 as the minimum supported version

## Why

WordPress 6.4 is no longer supported. Keeping its Jetpack pin and documented compatibility baseline leaves dead compatibility code and stale guidance.

## Impact

WordPress 6.5 remains mapped to Jetpack 14.0. Supported WordPress versions are otherwise unchanged.

## Validation

- `CI=1 ./bin/test.sh --filter VIP_Go__Core__Default_VIP_Jetpack_Version`
- `npm run test:smoke`
- pre-commit PHP lint and staged-file PHPCS
- `git diff --check`

Full-repository PHPCS still reports the existing unrelated `finfo_close()` deprecation in `files/class-api-client.php:190`.
