### PR TITLE
Revert "Remove WordPress 6.4 compatibility cruft"

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ npm run phpcs
 - Uses WordPress VIP coding standards (see `phpcs.xml.dist`)
 - Scans incrementally via lint-staged on pre-commit (see `.husky/pre-commit` and `.lintstagedrc`)
 - Full scan takes 30-60 seconds
-- Configuration: PHP 8.2+ compatibility, WordPress 6.5+ support
+- Configuration: PHP 8.2+ compatibility, WordPress 6.4+ support
 - Excludes: vendor/, submodules (advanced-post-cache, cron-control, http-concat, jetpack, etc.), __tests__/, bin/
 
 To fix auto-fixable issues:
@@ -192,7 +192,7 @@ Submodules and third-party code are excluded (see `phpcs.xml.dist` lines 14-41).
 
 1. **PHP Version Support:** Code must work on PHP 8.2+. Avoid syntax/features for older PHP versions.
 
-2. **WordPress Compatibility:** Minimum WordPress 6.5.
+2. **WordPress Compatibility:** Minimum WordPress 6.4.
 
 3. **No Breaking Changes to Public APIs:** This code runs on thousands of WordPress sites. Breaking changes to public functions/filters/actions require careful consideration, and if not possible to avoid, deprecation period and graceful fallbacks need to be implemented.
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -19,7 +19,10 @@
 function vip_default_jetpack_version() {
 	global $wp_version;
 
-	if ( version_compare( $wp_version, '6.6', '<' ) ) {
+	if ( version_compare( $wp_version, '6.5', '<' ) ) {
+		// WordPress 6.4.x
+		return '13.6';
+	} elseif ( version_compare( $wp_version, '6.6', '<' ) ) {
 		// WordPress 6.5.x
 		return '14.0';
 	} elseif ( version_compare( $wp_version, '6.7', '<' ) ) {

--- a/tests/test-jetpack.php
+++ b/tests/test-jetpack.php
@@ -11,6 +11,7 @@ class VIP_Go__Core__Default_VIP_Jetpack_Version extends WP_UnitTestCase {
 
 		$versions_map = [
 			// WordPress version => Jetpack version
+			'6.4' => '13.6',
 			'6.5' => '14.0',
 			'6.6' => '14.5',
 			'6.7' => '15.4',


### PR DESCRIPTION
Reverts Automattic/vip-go-mu-plugins#7111