### PR TITLE
Add throttled VIP Search query observability

### DIFF
--- a/search/includes/classes/class-query-classifier.php
+++ b/search/includes/classes/class-query-classifier.php
@@ -17,10 +17,45 @@ final class Query_Classifier {
 		'timeout',
 	];
 
-	private const STRUCTURAL_VALUE_KEYS = [
-		'field',
-		'fields',
-		'path',
+	private const CLAUSE_CONTAINER_KEYS = [
+		'filter',
+		'must',
+		'must_not',
+		'negative',
+		'positive',
+		'queries',
+		'query',
+		'should',
+	];
+
+	private const ORDER_INSENSITIVE_LIST_KEYS = [
+		'filter',
+		'must',
+		'must_not',
+		'queries',
+		'should',
+	];
+
+	private const STRUCTURAL_OPTIONS_BY_OPERATOR = [
+		'bool'                => [ 'minimum_should_match' ],
+		'dis_max'             => [ 'tie_breaker' ],
+		'exists'              => [ 'field' ],
+		'function_score'      => [ 'boost_mode', 'max_boost', 'min_score', 'score_mode' ],
+		'fuzzy'               => [ 'fuzziness', 'max_expansions', 'prefix_length', 'rewrite', 'transpositions' ],
+		'has_child'           => [ 'ignore_unmapped', 'max_children', 'min_children', 'score_mode', 'type' ],
+		'has_parent'          => [ 'ignore_unmapped', 'parent_type', 'score' ],
+		'match'               => [ 'analyzer', 'auto_generate_synonyms_phrase_query', 'fuzziness', 'fuzzy_transpositions', 'lenient', 'max_expansions', 'minimum_should_match', 'operator', 'prefix_length', 'zero_terms_query' ],
+		'match_bool_prefix'   => [ 'analyzer', 'fuzziness', 'fuzzy_transpositions', 'max_expansions', 'minimum_should_match', 'operator', 'prefix_length' ],
+		'match_phrase'        => [ 'analyzer', 'slop', 'zero_terms_query' ],
+		'match_phrase_prefix' => [ 'analyzer', 'max_expansions', 'slop', 'zero_terms_query' ],
+		'multi_match'         => [ 'analyzer', 'auto_generate_synonyms_phrase_query', 'fields', 'fuzziness', 'fuzzy_rewrite', 'fuzzy_transpositions', 'lenient', 'max_expansions', 'minimum_should_match', 'operator', 'prefix_length', 'slop', 'tie_breaker', 'type', 'zero_terms_query' ],
+		'nested'              => [ 'ignore_unmapped', 'path', 'score_mode' ],
+		'prefix'              => [ 'case_insensitive', 'rewrite' ],
+		'query_string'        => [ 'analyzer', 'analyze_wildcard', 'default_field', 'default_operator', 'fields', 'fuzziness', 'fuzzy_max_expansions', 'fuzzy_prefix_length', 'lenient', 'minimum_should_match', 'phrase_slop', 'quote_analyzer', 'quote_field_suffix', 'rewrite', 'time_zone', 'type' ],
+		'range'               => [ 'format', 'relation', 'time_zone' ],
+		'regexp'              => [ 'case_insensitive', 'flags', 'max_determinized_states', 'rewrite' ],
+		'simple_query_string' => [ 'analyzer', 'analyze_wildcard', 'auto_generate_synonyms_phrase_query', 'default_operator', 'fields', 'flags', 'fuzzy_max_expansions', 'fuzzy_prefix_length', 'fuzzy_transpositions', 'lenient', 'minimum_should_match', 'quote_field_suffix' ],
+		'wildcard'            => [ 'case_insensitive', 'rewrite' ],
 	];
 
 	/**
@@ -37,14 +72,21 @@ final class Query_Classifier {
 			];
 		}
 
-		$scope = ! array_key_exists( 'query', $body ) || ! $this->has_effective_clause( $body['query'] )
-			? self::SCOPE_UNBOUNDED
-			: self::SCOPE_BOUNDED;
-
 		return [
-			'scope'     => $scope,
+			'scope'     => $this->scope_from_body( $body ),
 			'structure' => $this->normalize( $body ),
 		];
+	}
+
+	/**
+	 * Classify query scope without building the family-identity structure.
+	 *
+	 * @param array|string $request_body Elasticsearch request body.
+	 */
+	public function scope( $request_body ): string {
+		$body = $this->decode_body( $request_body );
+
+		return null === $body ? self::SCOPE_UNKNOWN : $this->scope_from_body( $body );
 	}
 
 	/**
@@ -63,6 +105,12 @@ final class Query_Classifier {
 		$decoded = json_decode( $request_body, true );
 
 		return is_array( $decoded ) ? $decoded : null;
+	}
+
+	private function scope_from_body( array $body ): string {
+		return ! array_key_exists( 'query', $body ) || ! $this->has_effective_clause( $body['query'] )
+			? self::SCOPE_UNBOUNDED
+			: self::SCOPE_BOUNDED;
 	}
 
 	/**
@@ -131,13 +179,15 @@ final class Query_Classifier {
 	/**
 	 * @param mixed  $value Value to normalize.
 	 * @param string $parent_key Parent key.
+	 * @param string $active_operator Active query operator.
+	 * @param array  $path Path from the request-body root.
 	 * @param int    $depth Current depth.
 	 * @return mixed
 	 */
-	private function normalize( $value, string $parent_key = '', int $depth = 0 ) {
+	private function normalize( $value, string $parent_key = '', string $active_operator = '', array $path = [], int $depth = 0 ) {
 		if ( is_array( $value ) ) {
 			if ( array_is_list( $value ) ) {
-				return $this->normalize_list( $value, $parent_key, $depth );
+				return $this->normalize_list( $value, $parent_key, $active_operator, $path, $depth );
 			}
 
 			$normalized = [];
@@ -149,14 +199,17 @@ final class Query_Classifier {
 					continue;
 				}
 
-				$normalized[ $key ] = $this->normalize( $value[ $key ], (string) $key, $depth + 1 );
+				$child_operator = in_array( $parent_key, self::CLAUSE_CONTAINER_KEYS, true ) ? (string) $key : $active_operator;
+				$child_path     = array_merge( $path, [ (string) $key ] );
+
+				$normalized[ $key ] = $this->normalize( $value[ $key ], (string) $key, $child_operator, $child_path, $depth + 1 );
 			}
 
 			return $normalized;
 		}
 
-		if ( in_array( $parent_key, self::STRUCTURAL_VALUE_KEYS, true ) && is_scalar( $value ) ) {
-			return sanitize_key( (string) $value );
+		if ( $this->is_structural_value( $parent_key, $active_operator, $path ) && is_scalar( $value ) ) {
+			return $value;
 		}
 
 		if ( is_bool( $value ) ) {
@@ -177,24 +230,29 @@ final class Query_Classifier {
 	/**
 	 * @param array  $values List values.
 	 * @param string $parent_key Parent key.
+	 * @param string $active_operator Active query operator.
+	 * @param array  $path Path from the request-body root.
 	 * @param int    $depth Current depth.
 	 * @return array
 	 */
-	private function normalize_list( array $values, string $parent_key, int $depth ): array {
-		if ( 'fields' === $parent_key ) {
-			$fields = array_map( static fn( $field ): string => sanitize_key( (string) $field ), $values );
-			$fields = array_values( array_unique( $fields ) );
-			sort( $fields, SORT_STRING );
+	private function normalize_list( array $values, string $parent_key, string $active_operator, array $path, int $depth ): array {
+		$all_scalar = [] === array_filter( $values, static fn( $value ): bool => ! is_scalar( $value ) && null !== $value );
+
+		if ( $all_scalar && $this->is_structural_value( $parent_key, $active_operator, $path ) ) {
+			$items = array_values( array_unique( $values, SORT_REGULAR ) );
+
+			if ( 'fields' === $parent_key ) {
+				sort( $items, SORT_STRING );
+			}
 
 			return [
 				'_count' => $this->count_bucket( count( $values ) ),
-				'_items' => $fields,
+				'_items' => $items,
 			];
 		}
 
-		$all_scalar = [] === array_filter( $values, static fn( $value ): bool => ! is_scalar( $value ) && null !== $value );
 		if ( $all_scalar ) {
-			$types = array_map( fn( $value ) => $this->normalize( $value, $parent_key, $depth + 1 ), $values );
+			$types = array_map( fn( $value ) => $this->normalize( $value, $parent_key, $active_operator, $path, $depth + 1 ), $values );
 			$types = array_values( array_unique( $types ) );
 			sort( $types, SORT_STRING );
 
@@ -204,13 +262,31 @@ final class Query_Classifier {
 			];
 		}
 
-		$items = array_map( fn( $value ) => $this->normalize( $value, $parent_key, $depth + 1 ), $values );
-		usort( $items, static fn( $left, $right ): int => strcmp( wp_json_encode( $left ), wp_json_encode( $right ) ) );
+		$item_path = array_merge( $path, [ '[]' ] );
+		$items     = array_map( fn( $value ) => $this->normalize( $value, $parent_key, $active_operator, $item_path, $depth + 1 ), $values );
+
+		if ( in_array( $parent_key, self::ORDER_INSENSITIVE_LIST_KEYS, true ) ) {
+			$unique_items = [];
+			foreach ( $items as $item ) {
+				$unique_items[ wp_json_encode( $item ) ] = $item;
+			}
+
+			ksort( $unique_items, SORT_STRING );
+			$items = array_values( $unique_items );
+		}
 
 		return [
 			'_count' => $this->count_bucket( count( $values ) ),
 			'_items' => $items,
 		];
+	}
+
+	private function is_structural_value( string $parent_key, string $active_operator, array $path ): bool {
+		if ( isset( self::STRUCTURAL_OPTIONS_BY_OPERATOR[ $active_operator ] ) && in_array( $parent_key, self::STRUCTURAL_OPTIONS_BY_OPERATOR[ $active_operator ], true ) ) {
+			return true;
+		}
+
+		return isset( $path[0] ) && 'sort' === $path[0];
 	}
 
 	private function count_bucket( int $count ): string {

--- a/search/includes/classes/class-query-classifier.php
+++ b/search/includes/classes/class-query-classifier.php
@@ -36,6 +36,22 @@ final class Query_Classifier {
 		'should',
 	];
 
+	private const SORT_STRUCTURAL_VALUE_KEYS = [
+		'distance_type',
+		'format',
+		'ignore_unmapped',
+		'max_children',
+		'missing',
+		'mode',
+		'numeric_type',
+		'order',
+		'path',
+		'type',
+		'unit',
+		'unmapped_type',
+		'validation_method',
+	];
+
 	private const STRUCTURAL_OPTIONS_BY_OPERATOR = [
 		'bool'                => [ 'minimum_should_match' ],
 		'dis_max'             => [ 'tie_breaker' ],
@@ -286,7 +302,15 @@ final class Query_Classifier {
 			return true;
 		}
 
-		return isset( $path[0] ) && 'sort' === $path[0];
+		if ( ! isset( $path[0] ) || 'sort' !== $path[0] ) {
+			return false;
+		}
+
+		if ( 'sort' === $parent_key || in_array( $parent_key, self::SORT_STRUCTURAL_VALUE_KEYS, true ) ) {
+			return true;
+		}
+
+		return 2 === count( $path ) || ( 3 === count( $path ) && '[]' === $path[1] );
 	}
 
 	private function count_bucket( int $count ): string {

--- a/search/includes/classes/class-query-classifier.php
+++ b/search/includes/classes/class-query-classifier.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+final class Query_Classifier {
+	public const SCOPE_BOUNDED   = 'bounded';
+	public const SCOPE_UNBOUNDED = 'unbounded';
+	public const SCOPE_UNKNOWN   = 'unknown';
+
+	private const TOP_LEVEL_VOLATILE_KEYS = [
+		'from',
+		'preference',
+		'routing',
+		'search_after',
+		'size',
+		'terminate_after',
+		'timeout',
+	];
+
+	private const STRUCTURAL_VALUE_KEYS = [
+		'field',
+		'fields',
+		'path',
+	];
+
+	/**
+	 * @param array|string $request_body Elasticsearch request body.
+	 * @return array{scope:string,structure:array}
+	 */
+	public function classify( $request_body ): array {
+		$body = $this->decode_body( $request_body );
+
+		if ( null === $body ) {
+			return [
+				'scope'     => self::SCOPE_UNKNOWN,
+				'structure' => [ '_body' => 'invalid' ],
+			];
+		}
+
+		$scope = ! array_key_exists( 'query', $body ) || ! $this->has_effective_clause( $body['query'] )
+			? self::SCOPE_UNBOUNDED
+			: self::SCOPE_BOUNDED;
+
+		return [
+			'scope'     => $scope,
+			'structure' => $this->normalize( $body ),
+		];
+	}
+
+	/**
+	 * @param array|string $request_body Elasticsearch request body.
+	 * @return array|null
+	 */
+	private function decode_body( $request_body ): ?array {
+		if ( is_array( $request_body ) ) {
+			return $request_body;
+		}
+
+		if ( ! is_string( $request_body ) || '' === trim( $request_body ) ) {
+			return null;
+		}
+
+		$decoded = json_decode( $request_body, true );
+
+		return is_array( $decoded ) ? $decoded : null;
+	}
+
+	/**
+	 * @param mixed $clause Query clause.
+	 */
+	private function has_effective_clause( $clause ): bool {
+		if ( ! is_array( $clause ) || [] === $clause ) {
+			return false;
+		}
+
+		if ( array_is_list( $clause ) ) {
+			foreach ( $clause as $item ) {
+				if ( $this->has_effective_clause( $item ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		foreach ( $clause as $operator => $definition ) {
+			if ( in_array( $operator, [ 'match_all', 'match_none' ], true ) ) {
+				return true;
+			}
+
+			if ( 'bool' === $operator ) {
+				if ( is_array( $definition ) ) {
+					foreach ( [ 'filter', 'must', 'must_not', 'should' ] as $bool_key ) {
+						if ( isset( $definition[ $bool_key ] ) && $this->has_effective_clause( $definition[ $bool_key ] ) ) {
+							return true;
+						}
+					}
+				}
+
+				continue;
+			}
+
+			if ( 'function_score' === $operator ) {
+				return is_array( $definition ) && isset( $definition['query'] ) && $this->has_effective_clause( $definition['query'] );
+			}
+
+			if ( in_array( $operator, [ 'has_child', 'has_parent', 'nested', 'script_score' ], true ) ) {
+				return is_array( $definition ) && isset( $definition['query'] ) && $this->has_effective_clause( $definition['query'] );
+			}
+
+			if ( 'constant_score' === $operator ) {
+				return is_array( $definition ) && isset( $definition['filter'] ) && $this->has_effective_clause( $definition['filter'] );
+			}
+
+			if ( 'boosting' === $operator ) {
+				return is_array( $definition ) && isset( $definition['positive'] ) && $this->has_effective_clause( $definition['positive'] );
+			}
+
+			if ( 'dis_max' === $operator ) {
+				return is_array( $definition ) && isset( $definition['queries'] ) && $this->has_effective_clause( $definition['queries'] );
+			}
+
+			if ( null !== $definition && '' !== $definition && [] !== $definition ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param mixed  $value Value to normalize.
+	 * @param string $parent_key Parent key.
+	 * @param int    $depth Current depth.
+	 * @return mixed
+	 */
+	private function normalize( $value, string $parent_key = '', int $depth = 0 ) {
+		if ( is_array( $value ) ) {
+			if ( array_is_list( $value ) ) {
+				return $this->normalize_list( $value, $parent_key, $depth );
+			}
+
+			$normalized = [];
+			$keys       = array_keys( $value );
+			sort( $keys, SORT_STRING );
+
+			foreach ( $keys as $key ) {
+				if ( 0 === $depth && in_array( $key, self::TOP_LEVEL_VOLATILE_KEYS, true ) ) {
+					continue;
+				}
+
+				$normalized[ $key ] = $this->normalize( $value[ $key ], (string) $key, $depth + 1 );
+			}
+
+			return $normalized;
+		}
+
+		if ( in_array( $parent_key, self::STRUCTURAL_VALUE_KEYS, true ) && is_scalar( $value ) ) {
+			return sanitize_key( (string) $value );
+		}
+
+		if ( is_bool( $value ) ) {
+			return '_bool';
+		}
+
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return '_number';
+		}
+
+		if ( is_string( $value ) ) {
+			return '_string';
+		}
+
+		return '_null';
+	}
+
+	/**
+	 * @param array  $values List values.
+	 * @param string $parent_key Parent key.
+	 * @param int    $depth Current depth.
+	 * @return array
+	 */
+	private function normalize_list( array $values, string $parent_key, int $depth ): array {
+		if ( 'fields' === $parent_key ) {
+			$fields = array_map( static fn( $field ): string => sanitize_key( (string) $field ), $values );
+			$fields = array_values( array_unique( $fields ) );
+			sort( $fields, SORT_STRING );
+
+			return [
+				'_count' => $this->count_bucket( count( $values ) ),
+				'_items' => $fields,
+			];
+		}
+
+		$all_scalar = [] === array_filter( $values, static fn( $value ): bool => ! is_scalar( $value ) && null !== $value );
+		if ( $all_scalar ) {
+			$types = array_map( fn( $value ) => $this->normalize( $value, $parent_key, $depth + 1 ), $values );
+			$types = array_values( array_unique( $types ) );
+			sort( $types, SORT_STRING );
+
+			return [
+				'_count' => $this->count_bucket( count( $values ) ),
+				'_types' => $types,
+			];
+		}
+
+		$items = array_map( fn( $value ) => $this->normalize( $value, $parent_key, $depth + 1 ), $values );
+		usort( $items, static fn( $left, $right ): int => strcmp( wp_json_encode( $left ), wp_json_encode( $right ) ) );
+
+		return [
+			'_count' => $this->count_bucket( count( $values ) ),
+			'_items' => $items,
+		];
+	}
+
+	private function count_bucket( int $count ): string {
+		if ( 0 === $count ) {
+			return '0';
+		}
+
+		if ( 1 === $count ) {
+			return '1';
+		}
+
+		if ( $count <= 5 ) {
+			return '2-5';
+		}
+
+		if ( $count <= 20 ) {
+			return '6-20';
+		}
+
+		return '21+';
+	}
+}

--- a/search/includes/classes/class-query-classifier.php
+++ b/search/includes/classes/class-query-classifier.php
@@ -148,8 +148,12 @@ final class Query_Classifier {
 		}
 
 		foreach ( $clause as $operator => $definition ) {
-			if ( in_array( $operator, [ 'match_all', 'match_none' ], true ) ) {
+			if ( 'match_none' === $operator ) {
 				return true;
+			}
+
+			if ( 'match_all' === $operator ) {
+				continue;
 			}
 
 			if ( 'bool' === $operator ) {

--- a/search/includes/classes/class-query-warning.php
+++ b/search/includes/classes/class-query-warning.php
@@ -57,9 +57,10 @@ class Query_Warning {
 			 *
 			 * @param int $budget Maximum logical pairs.
 			 */
-			$budget = $this->bounded_int( apply_filters( 'vip_search_query_warning_budget', self::DEFAULT_BUDGET ), self::DEFAULT_BUDGET, self::MIN_BUDGET, self::MAX_BUDGET );
-			$scope  = $this->classifier->scope( $request_body );
-			$types  = [];
+			$budget  = $this->bounded_int( apply_filters( 'vip_search_query_warning_budget', self::DEFAULT_BUDGET ), self::DEFAULT_BUDGET, self::MIN_BUDGET, self::MAX_BUDGET );
+			$decoded = $this->decode_body( $request_body );
+			$scope   = null === $decoded ? Query_Classifier::SCOPE_UNKNOWN : $this->classifier->scope( $decoded );
+			$types   = [];
 
 			if ( $request_ms > $threshold ) {
 				$types[] = 'slow_query';
@@ -78,8 +79,12 @@ class Query_Warning {
 			}
 
 			sort( $types, SORT_STRING );
-			$classified = $this->classifier->classify( $request_body );
-			$decoded    = $this->decode_body( $request_body );
+			$classified = null === $decoded
+				? [
+					'scope'     => Query_Classifier::SCOPE_UNKNOWN,
+					'structure' => [ '_body' => 'invalid' ],
+				]
+				: $this->classifier->classify( $decoded );
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Arguments are excluded and only customer-relative paths are retained.
 			$origin      = $this->origin( $backtrace ?? debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ) );
 			$source      = $this->request_source();
@@ -128,14 +133,14 @@ class Query_Warning {
 	}
 
 	/** @param array|string $request_body Elasticsearch request body. */
-	private function decode_body( $request_body ): array {
+	private function decode_body( $request_body ): ?array {
 		if ( is_array( $request_body ) ) {
 			return $request_body;
 		}
 
 		$decoded = is_string( $request_body ) ? json_decode( $request_body, true ) : null;
 
-		return is_array( $decoded ) ? $decoded : [];
+		return is_array( $decoded ) ? $decoded : null;
 	}
 
 	private function total_hits( array $response_body ): ?int {

--- a/search/includes/classes/class-query-warning.php
+++ b/search/includes/classes/class-query-warning.php
@@ -21,9 +21,13 @@ class Query_Warning {
 	/** @var callable */
 	private $clock;
 
-	public function __construct( ?Query_Classifier $classifier = null, ?callable $clock = null ) {
-		$this->classifier = $classifier ?? new Query_Classifier();
-		$this->clock      = $clock ?? 'time';
+	/** @var callable */
+	private $persistent_cache;
+
+	public function __construct( ?Query_Classifier $classifier = null, ?callable $clock = null, ?callable $persistent_cache = null ) {
+		$this->classifier       = $classifier ?? new Query_Classifier();
+		$this->clock            = $clock ?? 'time';
+		$this->persistent_cache = $persistent_cache ?? 'wp_using_ext_object_cache';
 	}
 
 	/**
@@ -53,15 +57,15 @@ class Query_Warning {
 			 *
 			 * @param int $budget Maximum logical pairs.
 			 */
-			$budget     = $this->bounded_int( apply_filters( 'vip_search_query_warning_budget', self::DEFAULT_BUDGET ), self::DEFAULT_BUDGET, self::MIN_BUDGET, self::MAX_BUDGET );
-			$classified = $this->classifier->classify( $request_body );
-			$types      = [];
+			$budget = $this->bounded_int( apply_filters( 'vip_search_query_warning_budget', self::DEFAULT_BUDGET ), self::DEFAULT_BUDGET, self::MIN_BUDGET, self::MAX_BUDGET );
+			$scope  = $this->classifier->scope( $request_body );
+			$types  = [];
 
 			if ( $request_ms > $threshold ) {
 				$types[] = 'slow_query';
 			}
 
-			if ( Query_Classifier::SCOPE_UNBOUNDED === $classified['scope'] ) {
+			if ( Query_Classifier::SCOPE_UNBOUNDED === $scope ) {
 				$types[] = 'unbounded_query';
 			}
 
@@ -69,13 +73,18 @@ class Query_Warning {
 				return false;
 			}
 
+			if ( true !== call_user_func( $this->persistent_cache ) ) {
+				return false;
+			}
+
 			sort( $types, SORT_STRING );
-			$decoded = $this->decode_body( $request_body );
+			$classified = $this->classifier->classify( $request_body );
+			$decoded    = $this->decode_body( $request_body );
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Arguments are excluded and only customer-relative paths are retained.
-			$origin     = $this->origin( $backtrace ?? debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ) );
-			$source     = $this->request_source();
-			$context    = [
-				'request_ms'       => (int) round( $request_ms ),
+			$origin      = $this->origin( $backtrace ?? debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ) );
+			$source      = $this->request_source();
+			$context     = [
+				'request_ms'       => (int) ceil( $request_ms ),
 				'request_limit_ms' => $threshold,
 				'engine_ms'        => isset( $response_body['took'] ) && is_numeric( $response_body['took'] ) ? (int) round( $response_body['took'] ) : null,
 				'requested'        => isset( $decoded['size'] ) && is_numeric( $decoded['size'] ) ? (int) $decoded['size'] : null,
@@ -86,9 +95,10 @@ class Query_Warning {
 				'source'           => $source['source'],
 				'origin'           => $origin['display'],
 			];
-			$warning_id = $this->warning_id( $classified, $origin['key'] );
+			$family_hash = $this->family_hash( $classified, $origin['key'] );
+			$warning_id  = 'VSQ-' . strtoupper( substr( $family_hash, 0, 8 ) );
 
-			if ( ! $this->should_emit( $warning_id, $types, $window, $budget ) ) {
+			if ( ! $this->should_emit( $family_hash, $types, $window, $budget ) ) {
 				return false;
 			}
 
@@ -140,6 +150,20 @@ class Query_Warning {
 
 	/** @return array{url:?string,source:?string} */
 	private function request_source(): array {
+		if ( defined( 'WP_CLI' ) && true === constant( 'WP_CLI' ) ) {
+			return [
+				'url'    => null,
+				'source' => 'wp_cli',
+			];
+		}
+
+		if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
+			return [
+				'url'    => null,
+				'source' => 'wp_cron',
+			];
+		}
+
 		if ( isset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Both values are constrained immediately below.
 			$host = preg_replace( '/[^A-Za-z0-9.\-:\[\]]/', '', wp_unslash( (string) $_SERVER['HTTP_HOST'] ) );
@@ -153,20 +177,6 @@ class Query_Warning {
 					'source' => null,
 				];
 			}
-		}
-
-		if ( defined( 'WP_CLI' ) && true === constant( 'WP_CLI' ) ) {
-			return [
-				'url'    => null,
-				'source' => 'wp_cli',
-			];
-		}
-
-		if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
-			return [
-				'url'    => null,
-				'source' => 'wp_cron',
-			];
 		}
 
 		return [
@@ -207,7 +217,7 @@ class Query_Warning {
 		];
 	}
 
-	private function warning_id( array $classified, string $origin_key ): string {
+	protected function family_hash( array $classified, string $origin_key ): string {
 		$identity = [
 			'application_id' => defined( 'FILES_CLIENT_SITE_ID' ) ? (string) constant( 'FILES_CLIENT_SITE_ID' ) : 'unknown',
 			'blog_id'        => (string) get_current_blog_id(),
@@ -216,11 +226,11 @@ class Query_Warning {
 			'structure'      => $classified['structure'],
 		];
 
-		return 'VSQ-' . strtoupper( substr( hash( 'sha256', wp_json_encode( $identity ) ), 0, 8 ) );
+		return hash( 'sha256', wp_json_encode( $identity ) );
 	}
 
-	private function should_emit( string $warning_id, array $types, int $window, int $budget ): bool {
-		$signature  = hash( 'sha256', $warning_id . '|' . implode( ',', $types ) );
+	private function should_emit( string $family_hash, array $types, int $window, int $budget ): bool {
+		$signature  = hash( 'sha256', $family_hash . '|' . implode( ',', $types ) );
 		$dedupe_key = 'query_warning_dedupe:' . $signature;
 
 		if ( true !== $this->cache_add( $dedupe_key, 1, $window ) ) {

--- a/search/includes/classes/class-query-warning.php
+++ b/search/includes/classes/class-query-warning.php
@@ -96,7 +96,7 @@ class Query_Warning {
 				'returned'         => isset( $response_body['hits']['hits'] ) && is_array( $response_body['hits']['hits'] ) ? count( $response_body['hits']['hits'] ) : null,
 				'total_hits'       => $this->total_hits( $response_body ),
 				'query_scope'      => $classified['scope'],
-				'url'              => $source['url'],
+				'url'              => substr( $source['url'], 0, 500 ),
 				'source'           => $source['source'],
 				'origin'           => $origin['display'],
 			];

--- a/search/includes/classes/class-query-warning.php
+++ b/search/includes/classes/class-query-warning.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+class Query_Warning {
+	public const DEFAULT_SLOW_THRESHOLD_MS = 200;
+	public const DEFAULT_DEDUPE_WINDOW_S   = 300;
+	public const DEFAULT_BUDGET            = 5;
+
+	private const MIN_SLOW_THRESHOLD_MS = 1;
+	private const MAX_SLOW_THRESHOLD_MS = 5000;
+	private const MIN_DEDUPE_WINDOW_S   = 60;
+	private const MAX_DEDUPE_WINDOW_S   = 3600;
+	private const MIN_BUDGET            = 1;
+	private const MAX_BUDGET            = 100;
+	private const CACHE_GROUP           = 'vip_search';
+
+	/** @var Query_Classifier */
+	private $classifier;
+
+	/** @var callable */
+	private $clock;
+
+	public function __construct( ?Query_Classifier $classifier = null, ?callable $clock = null ) {
+		$this->classifier = $classifier ?? new Query_Classifier();
+		$this->clock      = $clock ?? 'time';
+	}
+
+	/**
+	 * @param array|string $request_body Elasticsearch request body.
+	 * @param array        $response_body Decoded Elasticsearch response.
+	 * @param float        $request_ms Total Elasticsearch HTTP duration.
+	 * @param array|null   $backtrace Optional backtrace for deterministic tests.
+	 */
+	public function maybe_emit( $request_body, array $response_body, float $request_ms, ?array $backtrace = null ): bool {
+		try {
+			/**
+			 * Filters the total Elasticsearch HTTP duration that triggers a slow-query warning.
+			 *
+			 * @param int $threshold Duration in milliseconds.
+			 */
+			$threshold = $this->bounded_int( apply_filters( 'vip_search_slow_query_threshold_ms', self::DEFAULT_SLOW_THRESHOLD_MS ), self::DEFAULT_SLOW_THRESHOLD_MS, self::MIN_SLOW_THRESHOLD_MS, self::MAX_SLOW_THRESHOLD_MS );
+
+			/**
+			 * Filters how long identical query-family violations are deduplicated.
+			 *
+			 * @param int $window Duration in seconds.
+			 */
+			$window = $this->bounded_int( apply_filters( 'vip_search_query_warning_dedupe_window_s', self::DEFAULT_DEDUPE_WINDOW_S ), self::DEFAULT_DEDUPE_WINDOW_S, self::MIN_DEDUPE_WINDOW_S, self::MAX_DEDUPE_WINDOW_S );
+
+			/**
+			 * Filters the number of logical warning pairs admitted per application/blog and window.
+			 *
+			 * @param int $budget Maximum logical pairs.
+			 */
+			$budget     = $this->bounded_int( apply_filters( 'vip_search_query_warning_budget', self::DEFAULT_BUDGET ), self::DEFAULT_BUDGET, self::MIN_BUDGET, self::MAX_BUDGET );
+			$classified = $this->classifier->classify( $request_body );
+			$types      = [];
+
+			if ( $request_ms > $threshold ) {
+				$types[] = 'slow_query';
+			}
+
+			if ( Query_Classifier::SCOPE_UNBOUNDED === $classified['scope'] ) {
+				$types[] = 'unbounded_query';
+			}
+
+			if ( [] === $types ) {
+				return false;
+			}
+
+			sort( $types, SORT_STRING );
+			$decoded = $this->decode_body( $request_body );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Arguments are excluded and only customer-relative paths are retained.
+			$origin     = $this->origin( $backtrace ?? debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ) );
+			$source     = $this->request_source();
+			$context    = [
+				'request_ms'       => (int) round( $request_ms ),
+				'request_limit_ms' => $threshold,
+				'engine_ms'        => isset( $response_body['took'] ) && is_numeric( $response_body['took'] ) ? (int) round( $response_body['took'] ) : null,
+				'requested'        => isset( $decoded['size'] ) && is_numeric( $decoded['size'] ) ? (int) $decoded['size'] : null,
+				'returned'         => isset( $response_body['hits']['hits'] ) && is_array( $response_body['hits']['hits'] ) ? count( $response_body['hits']['hits'] ) : null,
+				'total_hits'       => $this->total_hits( $response_body ),
+				'query_scope'      => $classified['scope'],
+				'url'              => $source['url'],
+				'source'           => $source['source'],
+				'origin'           => $origin['display'],
+			];
+			$warning_id = $this->warning_id( $classified, $origin['key'] );
+
+			if ( ! $this->should_emit( $warning_id, $types, $window, $budget ) ) {
+				return false;
+			}
+
+			$technical = $this->technical_message( $warning_id, $types, $context, $window );
+			$human     = $this->human_message( $warning_id, $types, $context, $window );
+
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional customer-visible plain-text warning; dynamic values are sanitized during formatting.
+			trigger_error( $technical, E_USER_WARNING );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional customer-visible plain-text warning; dynamic values are sanitized during formatting.
+			trigger_error( $human, E_USER_WARNING );
+
+			return true;
+		} catch ( \Throwable $throwable ) {
+			return false;
+		}
+	}
+
+	/** @param mixed $value Filtered value. */
+	private function bounded_int( $value, int $default, int $minimum, int $maximum ): int {
+		$validated = filter_var( $value, FILTER_VALIDATE_INT );
+
+		if ( false === $validated || $validated < $minimum || $validated > $maximum ) {
+			return $default;
+		}
+
+		return $validated;
+	}
+
+	/** @param array|string $request_body Elasticsearch request body. */
+	private function decode_body( $request_body ): array {
+		if ( is_array( $request_body ) ) {
+			return $request_body;
+		}
+
+		$decoded = is_string( $request_body ) ? json_decode( $request_body, true ) : null;
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	private function total_hits( array $response_body ): ?int {
+		$total = $response_body['hits']['total'] ?? null;
+
+		if ( is_array( $total ) ) {
+			$total = $total['value'] ?? null;
+		}
+
+		return is_numeric( $total ) ? (int) $total : null;
+	}
+
+	/** @return array{url:?string,source:?string} */
+	private function request_source(): array {
+		if ( isset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Both values are constrained immediately below.
+			$host = preg_replace( '/[^A-Za-z0-9.\-:\[\]]/', '', wp_unslash( (string) $_SERVER['HTTP_HOST'] ) );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Control characters are removed before esc_url_raw().
+			$uri = preg_replace( '/[\x00-\x1F\x7F]/', '', wp_unslash( (string) $_SERVER['REQUEST_URI'] ) );
+			$url = esc_url_raw( ( is_ssl() ? 'https' : 'http' ) . '://' . $host . $uri, [ 'http', 'https' ] );
+
+			if ( '' !== $url ) {
+				return [
+					'url'    => $url,
+					'source' => null,
+				];
+			}
+		}
+
+		if ( defined( 'WP_CLI' ) && true === constant( 'WP_CLI' ) ) {
+			return [
+				'url'    => null,
+				'source' => 'wp_cli',
+			];
+		}
+
+		if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
+			return [
+				'url'    => null,
+				'source' => 'wp_cron',
+			];
+		}
+
+		return [
+			'url'    => null,
+			'source' => 'unknown',
+		];
+	}
+
+	/** @return array{display:?string,key:string} */
+	private function origin( array $backtrace ): array {
+		foreach ( $backtrace as $frame ) {
+			if ( empty( $frame['file'] ) ) {
+				continue;
+			}
+
+			$file = str_replace( '\\', '/', (string) $frame['file'] );
+			if ( str_contains( $file, '/vendor/' ) || str_contains( $file, '/wp-content/mu-plugins/' ) ) {
+				continue;
+			}
+
+			if ( ! preg_match( '#/(wp-content/(?:client-mu-plugins|plugins|themes)/.+)$#', $file, $matches ) ) {
+				continue;
+			}
+
+			$relative = sanitize_text_field( $matches[1] );
+			$line     = isset( $frame['line'] ) ? max( 0, (int) $frame['line'] ) : 0;
+			$callable = ( $frame['class'] ?? '' ) . ( $frame['type'] ?? '' ) . ( $frame['function'] ?? '' );
+
+			return [
+				'display' => $relative . ( $line > 0 ? ':' . $line : '' ),
+				'key'     => $relative . '|' . sanitize_text_field( $callable ) . '|' . $line,
+			];
+		}
+
+		return [
+			'display' => null,
+			'key'     => 'unknown',
+		];
+	}
+
+	private function warning_id( array $classified, string $origin_key ): string {
+		$identity = [
+			'application_id' => defined( 'FILES_CLIENT_SITE_ID' ) ? (string) constant( 'FILES_CLIENT_SITE_ID' ) : 'unknown',
+			'blog_id'        => (string) get_current_blog_id(),
+			'origin'         => $origin_key,
+			'query_scope'    => $classified['scope'],
+			'structure'      => $classified['structure'],
+		];
+
+		return 'VSQ-' . strtoupper( substr( hash( 'sha256', wp_json_encode( $identity ) ), 0, 8 ) );
+	}
+
+	private function should_emit( string $warning_id, array $types, int $window, int $budget ): bool {
+		$signature  = hash( 'sha256', $warning_id . '|' . implode( ',', $types ) );
+		$dedupe_key = 'query_warning_dedupe:' . $signature;
+
+		if ( true !== $this->cache_add( $dedupe_key, 1, $window ) ) {
+			return false;
+		}
+
+		$bucket     = (int) floor( call_user_func( $this->clock ) / $window );
+		$scope      = ( defined( 'FILES_CLIENT_SITE_ID' ) ? (string) constant( 'FILES_CLIENT_SITE_ID' ) : 'unknown' ) . '|' . get_current_blog_id();
+		$budget_key = 'query_warning_budget:' . hash( 'sha256', $scope . '|' . $bucket );
+
+		if ( true === $this->cache_add( $budget_key, 1, $window + 1 ) ) {
+			return true;
+		}
+
+		$count = $this->cache_incr( $budget_key );
+
+		return is_int( $count ) && $count <= $budget;
+	}
+
+	protected function cache_add( string $key, int $value, int $ttl ): bool {
+		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined -- The validated warning window is intentionally passed as the TTL.
+		return wp_cache_add( $key, $value, self::CACHE_GROUP, $ttl );
+	}
+
+	/** @return int|false */
+	protected function cache_incr( string $key ) {
+		return wp_cache_incr( $key, 1, self::CACHE_GROUP );
+	}
+
+	private function technical_message( string $warning_id, array $types, array $context, int $window ): string {
+		$location = null !== $context['url']
+			? 'url="' . $this->quoted_value( $context['url'] ) . '"'
+			: 'source="' . $this->quoted_value( $context['source'] ) . '"';
+
+		return sprintf(
+			'VIP_SEARCH_QUERY_WARNING v=1 warning_id=%s types=%s request_ms=%s request_limit_ms=%s engine_ms=%s requested=%s returned=%s total_hits=%s query_scope=%s %s deduplicated=true dedupe_window_s=%d',
+			$warning_id,
+			implode( ',', $types ),
+			$this->numeric_value( $context['request_ms'] ),
+			$this->numeric_value( $context['request_limit_ms'] ),
+			$this->numeric_value( $context['engine_ms'] ),
+			$this->numeric_value( $context['requested'] ),
+			$this->numeric_value( $context['returned'] ),
+			$this->numeric_value( $context['total_hits'] ),
+			$context['query_scope'],
+			$location,
+			$window
+		);
+	}
+
+	private function human_message( string $warning_id, array $types, array $context, int $window ): string {
+		$subject = null !== $context['url']
+			? 'A request to ' . $context['url']
+			: $this->source_subject( $context['source'] );
+		$origin  = null !== $context['origin']
+			? ' originating from ' . $context['origin'] . '.'
+			: ' during this request.';
+		$repeat  = sprintf(
+			'Similar occurrences are deduplicated for %s, so this warning may represent repeated requests. Warning ID: %s.',
+			$this->window_phrase( $window ),
+			$warning_id
+		);
+
+		if ( [ 'slow_query', 'unbounded_query' ] === $types ) {
+			return sprintf(
+				'%s triggered a potentially expensive VIP Search query%s The query took %d ms, above the configured warning threshold of %d ms, and did not contain a limiting search condition. An unbounded query may search the entire index and become more expensive as the site grows. Review the query and add an appropriate search term or filter. %s',
+				$subject,
+				$origin,
+				$context['request_ms'],
+				$context['request_limit_ms'],
+				$repeat
+			);
+		}
+
+		if ( [ 'slow_query' ] === $types ) {
+			return sprintf(
+				'%s triggered a slow VIP Search query%s The query took %d ms, above the configured warning threshold of %d ms. Review how this query is constructed and whether it runs more often than necessary. %s',
+				$subject,
+				$origin,
+				$context['request_ms'],
+				$context['request_limit_ms'],
+				$repeat
+			);
+		}
+
+		return sprintf(
+			'%s triggered an unbounded VIP Search query%s The query did not contain a limiting search condition and may search the entire index, becoming more expensive as the site grows. Review the query and add an appropriate search term or filter. %s',
+			$subject,
+			$origin,
+			$repeat
+		);
+	}
+
+	/** @param int|null $value Numeric value. */
+	private function numeric_value( $value ): string {
+		return null === $value ? 'unknown' : (string) $value;
+	}
+
+	private function quoted_value( string $value ): string {
+		return str_replace( [ '\\', '"', "\r", "\n" ], [ '\\\\', '\\"', '', '' ], $value );
+	}
+
+	private function source_subject( string $source ): string {
+		if ( 'wp_cli' === $source ) {
+			return 'A WP-CLI process';
+		}
+
+		if ( 'wp_cron' === $source ) {
+			return 'A scheduled WordPress task';
+		}
+
+		return 'A non-HTTP WordPress process';
+	}
+
+	private function window_phrase( int $window ): string {
+		if ( 0 === $window % MINUTE_IN_SECONDS ) {
+			$minutes = (int) ( $window / MINUTE_IN_SECONDS );
+			$words   = [
+				1  => 'one',
+				2  => 'two',
+				3  => 'three',
+				4  => 'four',
+				5  => 'five',
+				6  => 'six',
+				7  => 'seven',
+				8  => 'eight',
+				9  => 'nine',
+				10 => 'ten',
+			];
+			$number  = $words[ $minutes ] ?? (string) $minutes;
+
+			return $number . ( 1 === $minutes ? ' minute' : ' minutes' );
+		}
+
+		return $window . ' seconds';
+	}
+}

--- a/search/includes/classes/class-query-warning.php
+++ b/search/includes/classes/class-query-warning.php
@@ -96,7 +96,7 @@ class Query_Warning {
 				'returned'         => isset( $response_body['hits']['hits'] ) && is_array( $response_body['hits']['hits'] ) ? count( $response_body['hits']['hits'] ) : null,
 				'total_hits'       => $this->total_hits( $response_body ),
 				'query_scope'      => $classified['scope'],
-				'url'              => substr( $source['url'], 0, 500 ),
+				'url'              => $source['url'] ? substr( $source['url'], 0, 500 ) : null,
 				'source'           => $source['source'],
 				'origin'           => $origin['display'],
 			];

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -314,10 +314,6 @@ class Search {
 			$this->concurrency_limiter = new Concurrency_Limiter();
 		}
 
-		if ( ! $this->query_warning ) {
-			$this->query_warning = new Query_Warning();
-		}
-
 		/**
 		 * Load CLI commands
 		 */

--- a/search/includes/classes/class-search.php
+++ b/search/includes/classes/class-search.php
@@ -196,6 +196,8 @@ class Search {
 	public static $stat_sampling_drop_value = 5; // Value to compare >= against rand( 1, 10 ). 5 should result in roughly half being true.
 	/** @var Cache */
 	public $cache;
+	/** @var Query_Warning|null */
+	public $query_warning;
 
 	/**
 	 * Maximum number of queries before rate-limiting kicks in.
@@ -310,6 +312,10 @@ class Search {
 
 		if ( ! $this->concurrency_limiter ) {
 			$this->concurrency_limiter = new Concurrency_Limiter();
+		}
+
+		if ( ! $this->query_warning ) {
+			$this->query_warning = new Query_Warning();
 		}
 
 		/**
@@ -1016,6 +1022,22 @@ class Search {
 			// Record engine time (have to parse JSON to get it)
 			$response_body_json = wp_remote_retrieve_body( $response );
 			$response_body      = json_decode( $response_body_json, true );
+
+			if ( 'query' === $type && isset( $query['url'] ) && is_string( $query['url'] ) && preg_match( '#/_search(?:[/?]|$)#', $query['url'] ) ) {
+				try {
+					if ( ! $this->query_warning ) {
+						$this->query_warning = new Query_Warning();
+					}
+
+					$this->query_warning->maybe_emit(
+						$args['body'] ?? '',
+						is_array( $response_body ) ? $response_body : [],
+						(float) $duration
+					);
+				} catch ( \Throwable $throwable ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Query diagnostics must never affect the Elasticsearch response.
+					// Query diagnostics must never affect the Elasticsearch response.
+				}
+			}
 
 			if ( $response_body && isset( $response_body['took'] ) && is_int( $response_body['took'] ) ) {
 				if ( class_exists( Prometheus_Collector::class ) ) {

--- a/search/search.php
+++ b/search/search.php
@@ -24,6 +24,8 @@ if ( defined( 'VIP_ELASTICSEARCH_DISABLED' ) && true === constant( 'VIP_ELASTICS
 }
 
 require_once __DIR__ . '/includes/functions/utils.php';
+require_once __DIR__ . '/includes/classes/class-query-classifier.php';
+require_once __DIR__ . '/includes/classes/class-query-warning.php';
 require_once __DIR__ . '/includes/classes/class-search.php';
 
 if ( \Automattic\VIP\Search\Search::are_es_constants_defined() && ! wp_installing() ) {

--- a/tests/search/includes/classes/test-class-query-classifier.php
+++ b/tests/search/includes/classes/test-class-query-classifier.php
@@ -15,10 +15,11 @@ class Query_Classifier_Test extends WP_UnitTestCase {
 		$this->classifier = new Query_Classifier();
 	}
 
-	public function empty_query_data(): array {
+	public function unbounded_query_data(): array {
 		return [
 			'missing query'        => [ wp_json_encode( [ 'size' => 10 ] ) ],
 			'empty query'          => [ wp_json_encode( [ 'query' => [] ] ) ],
+			'explicit match all'   => [ wp_json_encode( [ 'query' => [ 'match_all' => [] ] ] ) ],
 			'empty bool'           => [ wp_json_encode( [ 'query' => [ 'bool' => [] ] ] ) ],
 			'empty bool arrays'    => [
 				wp_json_encode( [
@@ -45,9 +46,9 @@ class Query_Classifier_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider empty_query_data
+	 * @dataProvider unbounded_query_data
 	 */
-	public function test_classifies_missing_and_empty_query_clauses_as_unbounded( string $body ): void {
+	public function test_classifies_queries_without_a_limiting_clause_as_unbounded( string $body ): void {
 		$result = $this->classifier->classify( $body );
 
 		$this->assertSame( Query_Classifier::SCOPE_UNBOUNDED, $result['scope'] );
@@ -55,10 +56,10 @@ class Query_Classifier_Test extends WP_UnitTestCase {
 
 	public function bounded_query_data(): array {
 		return [
-			'explicit match all' => [ [ 'query' => [ 'match_all' => [] ] ] ],
-			'term query'         => [ [ 'query' => [ 'term' => [ 'post_status' => 'publish' ] ] ] ],
-			'bool filter'        => [ [ 'query' => [ 'bool' => [ 'filter' => [ [ 'term' => [ 'post_type' => 'post' ] ] ] ] ] ] ],
-			'function score'     => [ [ 'query' => [ 'function_score' => [ 'query' => [ 'match' => [ 'post_title' => 'events' ] ] ] ] ] ],
+			'match none'     => [ [ 'query' => [ 'match_none' => [] ] ] ],
+			'term query'     => [ [ 'query' => [ 'term' => [ 'post_status' => 'publish' ] ] ] ],
+			'bool filter'    => [ [ 'query' => [ 'bool' => [ 'filter' => [ [ 'term' => [ 'post_type' => 'post' ] ] ] ] ] ] ],
+			'function score' => [ [ 'query' => [ 'function_score' => [ 'query' => [ 'match' => [ 'post_title' => 'events' ] ] ] ] ] ],
 		];
 	}
 

--- a/tests/search/includes/classes/test-class-query-classifier.php
+++ b/tests/search/includes/classes/test-class-query-classifier.php
@@ -78,6 +78,12 @@ class Query_Classifier_Test extends WP_UnitTestCase {
 		$this->assertSame( [ '_body' => 'invalid' ], $result['structure'] );
 	}
 
+	public function test_scope_can_be_classified_without_building_a_family_structure(): void {
+		$this->assertSame( Query_Classifier::SCOPE_UNKNOWN, $this->classifier->scope( '{not-json' ) );
+		$this->assertSame( Query_Classifier::SCOPE_UNBOUNDED, $this->classifier->scope( [ 'size' => 10 ] ) );
+		$this->assertSame( Query_Classifier::SCOPE_BOUNDED, $this->classifier->scope( [ 'query' => [ 'term' => [ 'post_status' => 'publish' ] ] ] ) );
+	}
+
 	public function test_volatile_values_and_pagination_produce_the_same_structure(): void {
 		$first  = $this->classifier->classify( [
 			'from'  => 0,
@@ -123,6 +129,94 @@ class Query_Classifier_Test extends WP_UnitTestCase {
 				'multi_match' => [
 					'query'  => 'a different term',
 					'fields' => [ 'post_content', 'post_title' ],
+				],
+			],
+		] );
+
+		$this->assertSame( $first['structure'], $second['structure'] );
+	}
+
+	public function test_reserved_looking_document_field_values_remain_volatile(): void {
+		foreach ( [ 'field', 'fields', 'path' ] as $document_field ) {
+			$first  = $this->classifier->classify( [ 'query' => [ 'term' => [ $document_field => 'first runtime value' ] ] ] );
+			$second = $this->classifier->classify( [ 'query' => [ 'term' => [ $document_field => 'second runtime value' ] ] ] );
+
+			$this->assertSame( $first['structure'], $second['structure'], 'Runtime values for document field ' . $document_field . ' must not change the family.' );
+		}
+	}
+
+	public function test_structural_query_options_change_the_structure(): void {
+		$one_required = $this->classifier->classify( [
+			'query' => [
+				'bool' => [
+					'minimum_should_match' => 1,
+					'should'               => [
+						[ 'term' => [ 'post_type' => 'post' ] ],
+						[ 'term' => [ 'post_status' => 'publish' ] ],
+					],
+				],
+			],
+		] );
+		$two_required = $this->classifier->classify( [
+			'query' => [
+				'bool' => [
+					'minimum_should_match' => 2,
+					'should'               => [
+						[ 'term' => [ 'post_type' => 'post' ] ],
+						[ 'term' => [ 'post_status' => 'publish' ] ],
+					],
+				],
+			],
+		] );
+
+		$this->assertNotSame( $one_required['structure'], $two_required['structure'] );
+	}
+
+	public function test_sort_order_and_direction_change_the_structure(): void {
+		$date_then_title = $this->classifier->classify( [
+			'query' => [ 'match_all' => [] ],
+			'sort'  => [
+				[ 'post_date' => [ 'order' => 'desc' ] ],
+				[ 'post_title.keyword' => [ 'order' => 'asc' ] ],
+			],
+		] );
+		$title_then_date = $this->classifier->classify( [
+			'query' => [ 'match_all' => [] ],
+			'sort'  => [
+				[ 'post_title.keyword' => [ 'order' => 'asc' ] ],
+				[ 'post_date' => [ 'order' => 'desc' ] ],
+			],
+		] );
+		$ascending_date  = $this->classifier->classify( [
+			'query' => [ 'match_all' => [] ],
+			'sort'  => [
+				[ 'post_date' => [ 'order' => 'asc' ] ],
+				[ 'post_title.keyword' => [ 'order' => 'asc' ] ],
+			],
+		] );
+
+		$this->assertNotSame( $date_then_title['structure'], $title_then_date['structure'] );
+		$this->assertNotSame( $date_then_title['structure'], $ascending_date['structure'] );
+	}
+
+	public function test_order_insensitive_bool_clauses_are_canonicalized(): void {
+		$first  = $this->classifier->classify( [
+			'query' => [
+				'bool' => [
+					'filter' => [
+						[ 'term' => [ 'post_type' => 'post' ] ],
+						[ 'term' => [ 'post_status' => 'publish' ] ],
+					],
+				],
+			],
+		] );
+		$second = $this->classifier->classify( [
+			'query' => [
+				'bool' => [
+					'filter' => [
+						[ 'term' => [ 'post_status' => 'private' ] ],
+						[ 'term' => [ 'post_type' => 'page' ] ],
+					],
 				],
 			],
 		] );

--- a/tests/search/includes/classes/test-class-query-classifier.php
+++ b/tests/search/includes/classes/test-class-query-classifier.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/../../../../search/includes/classes/class-query-classifier.php';
+
+class Query_Classifier_Test extends WP_UnitTestCase {
+	/** @var Query_Classifier */
+	private $classifier;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->classifier = new Query_Classifier();
+	}
+
+	public function empty_query_data(): array {
+		return [
+			'missing query'        => [ wp_json_encode( [ 'size' => 10 ] ) ],
+			'empty query'          => [ wp_json_encode( [ 'query' => [] ] ) ],
+			'empty bool'           => [ wp_json_encode( [ 'query' => [ 'bool' => [] ] ] ) ],
+			'empty bool arrays'    => [
+				wp_json_encode( [
+					'query' => [
+						'bool' => [
+							'must'   => [],
+							'filter' => [],
+						],
+					],
+				] ),
+			],
+			'empty function score' => [ wp_json_encode( [ 'query' => [ 'function_score' => [ 'functions' => [ [ 'weight' => 2 ] ] ] ] ] ) ],
+			'empty nested wrapper' => [
+				wp_json_encode( [
+					'query' => [
+						'nested' => [
+							'path'  => 'author',
+							'query' => [],
+						],
+					],
+				] ),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider empty_query_data
+	 */
+	public function test_classifies_missing_and_empty_query_clauses_as_unbounded( string $body ): void {
+		$result = $this->classifier->classify( $body );
+
+		$this->assertSame( Query_Classifier::SCOPE_UNBOUNDED, $result['scope'] );
+	}
+
+	public function bounded_query_data(): array {
+		return [
+			'explicit match all' => [ [ 'query' => [ 'match_all' => [] ] ] ],
+			'term query'         => [ [ 'query' => [ 'term' => [ 'post_status' => 'publish' ] ] ] ],
+			'bool filter'        => [ [ 'query' => [ 'bool' => [ 'filter' => [ [ 'term' => [ 'post_type' => 'post' ] ] ] ] ] ] ],
+			'function score'     => [ [ 'query' => [ 'function_score' => [ 'query' => [ 'match' => [ 'post_title' => 'events' ] ] ] ] ] ],
+		];
+	}
+
+	/**
+	 * @dataProvider bounded_query_data
+	 */
+	public function test_classifies_effective_queries_as_bounded( array $body ): void {
+		$result = $this->classifier->classify( $body );
+
+		$this->assertSame( Query_Classifier::SCOPE_BOUNDED, $result['scope'] );
+	}
+
+	public function test_invalid_body_has_unknown_scope(): void {
+		$result = $this->classifier->classify( '{not-json' );
+
+		$this->assertSame( Query_Classifier::SCOPE_UNKNOWN, $result['scope'] );
+		$this->assertSame( [ '_body' => 'invalid' ], $result['structure'] );
+	}
+
+	public function test_volatile_values_and_pagination_produce_the_same_structure(): void {
+		$first  = $this->classifier->classify( [
+			'from'  => 0,
+			'size'  => 10,
+			'query' => [ 'term' => [ 'post_author' => 123 ] ],
+		] );
+		$second = $this->classifier->classify( [
+			'from'  => 9000,
+			'size'  => 100,
+			'query' => [ 'term' => [ 'post_author' => 987654 ] ],
+		] );
+
+		$this->assertSame( $first['structure'], $second['structure'] );
+	}
+
+	public function test_scalar_list_values_use_type_and_count_buckets(): void {
+		$first  = $this->classifier->classify( [ 'query' => [ 'terms' => [ 'post_author' => [ 1, 2, 3 ] ] ] ] );
+		$second = $this->classifier->classify( [ 'query' => [ 'terms' => [ 'post_author' => [ 7, 8, 9, 10, 11 ] ] ] ] );
+
+		$this->assertSame( $first['structure'], $second['structure'] );
+	}
+
+	public function test_field_names_and_operators_change_the_structure(): void {
+		$title   = $this->classifier->classify( [ 'query' => [ 'match' => [ 'post_title' => 'events' ] ] ] );
+		$content = $this->classifier->classify( [ 'query' => [ 'match' => [ 'post_content' => 'events' ] ] ] );
+		$term    = $this->classifier->classify( [ 'query' => [ 'term' => [ 'post_title' => 'events' ] ] ] );
+
+		$this->assertNotSame( $title['structure'], $content['structure'] );
+		$this->assertNotSame( $title['structure'], $term['structure'] );
+	}
+
+	public function test_multi_match_fields_are_preserved_but_query_text_is_not(): void {
+		$first  = $this->classifier->classify( [
+			'query' => [
+				'multi_match' => [
+					'query'  => 'events',
+					'fields' => [ 'post_title', 'post_content' ],
+				],
+			],
+		] );
+		$second = $this->classifier->classify( [
+			'query' => [
+				'multi_match' => [
+					'query'  => 'a different term',
+					'fields' => [ 'post_content', 'post_title' ],
+				],
+			],
+		] );
+
+		$this->assertSame( $first['structure'], $second['structure'] );
+	}
+}

--- a/tests/search/includes/classes/test-class-query-classifier.php
+++ b/tests/search/includes/classes/test-class-query-classifier.php
@@ -199,6 +199,39 @@ class Query_Classifier_Test extends WP_UnitTestCase {
 		$this->assertNotSame( $date_then_title['structure'], $ascending_date['structure'] );
 	}
 
+	public function test_nested_sort_filter_values_remain_volatile(): void {
+		$first  = $this->classifier->classify( [
+			'query' => [ 'match_all' => [] ],
+			'sort'  => [
+				[
+					'offer.price' => [
+						'order'  => 'asc',
+						'nested' => [
+							'path'   => 'offer',
+							'filter' => [ 'term' => [ 'offer.color' => 'blue' ] ],
+						],
+					],
+				],
+			],
+		] );
+		$second = $this->classifier->classify( [
+			'query' => [ 'match_all' => [] ],
+			'sort'  => [
+				[
+					'offer.price' => [
+						'order'  => 'asc',
+						'nested' => [
+							'path'   => 'offer',
+							'filter' => [ 'term' => [ 'offer.color' => 'red' ] ],
+						],
+					],
+				],
+			],
+		] );
+
+		$this->assertSame( $first['structure'], $second['structure'] );
+	}
+
 	public function test_order_insensitive_bool_clauses_are_canonicalized(): void {
 		$first  = $this->classifier->classify( [
 			'query' => [

--- a/tests/search/includes/classes/test-class-query-warning.php
+++ b/tests/search/includes/classes/test-class-query-warning.php
@@ -24,6 +24,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 			'vip_search_slow_query_threshold_ms',
 			'vip_search_query_warning_dedupe_window_s',
 			'vip_search_query_warning_budget',
+			'wp_doing_cron',
 		] as $filter ) {
 			remove_all_filters( $filter );
 		}
@@ -47,7 +48,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_200_ms_does_not_warn_and_201_ms_does(): void {
-		$warning  = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning  = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$body     = [
 			'query' => [ 'term' => [ 'post_status' => 'publish' ] ],
 			'size'  => 10,
@@ -61,7 +62,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 
 	public function test_invalid_filter_values_fall_back_and_valid_threshold_is_used(): void {
 		add_filter( 'vip_search_slow_query_threshold_ms', static fn() => 'invalid' );
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 
 		$this->assertFalse( $warning->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 1, 0, 0 ), 200.0, $this->customer_backtrace() ) );
 
@@ -72,7 +73,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 
 	public function test_tuned_dedupe_window_is_exposed_in_both_messages(): void {
 		add_filter( 'vip_search_query_warning_dedupe_window_s', static fn(): int => 120 );
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit( [], $this->response( 10, 0, 0 ), 50.0, $this->customer_backtrace() );
 
 		$this->assertStringContainsString( 'dedupe_window_s=120', $this->warnings[0] );
@@ -80,7 +81,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_exact_combined_message_contract_and_order(): void {
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit( [ 'size' => 10 ], $this->response( 493, 0, 0 ), 527.0, $this->customer_backtrace() );
 
 		$this->assertCount( 2, $this->warnings );
@@ -99,21 +100,21 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_slow_only_and_unbounded_only_select_different_human_copy(): void {
-		$slow = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$slow = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$slow->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() );
 		$this->assertStringContainsString( 'triggered a slow VIP Search query', $this->warnings[1] );
 		$this->assertStringNotContainsString( 'unbounded', strtolower( $this->warnings[1] ) );
 
 		$this->warnings = [];
 		wp_cache_flush();
-		$unbounded = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$unbounded = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$unbounded->maybe_emit( [], $this->response( 10, 2, 2 ), 50.0, $this->customer_backtrace() );
 		$this->assertStringContainsString( 'triggered an unbounded VIP Search query', $this->warnings[1] );
 		$this->assertStringNotContainsString( 'above the configured warning threshold', $this->warnings[1] );
 	}
 
 	public function test_volatile_query_values_share_warning_id_and_are_deduplicated(): void {
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit( [ 'query' => [ 'term' => [ 'post_author' => 1 ] ] ], $this->response( 250, 1, 1 ), 251.0, $this->customer_backtrace() );
 		$warning->maybe_emit( [ 'query' => [ 'term' => [ 'post_author' => 9999 ] ] ], $this->response( 250, 1, 1 ), 251.0, $this->customer_backtrace() );
 
@@ -121,7 +122,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_new_violation_set_emits_with_same_warning_id_inside_window(): void {
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit( [], $this->response( 10, 1, 1 ), 50.0, $this->customer_backtrace() );
 		$warning->maybe_emit( [], $this->response( 250, 1, 1 ), 251.0, $this->customer_backtrace() );
 
@@ -132,7 +133,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_different_customer_origins_receive_different_warning_ids(): void {
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() );
 		$warning->maybe_emit(
 			[ 'query' => [ 'match_all' => [] ] ],
@@ -153,7 +154,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_site_budget_counts_pairs_and_suppresses_the_sixth_family(): void {
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 
 		for ( $index = 1; $index <= 6; $index++ ) {
 			$warning->maybe_emit(
@@ -168,7 +169,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_cache_failure_suppresses_warning(): void {
-		$warning = new class( new Query_Classifier(), static fn(): int => 1000 ) extends Query_Warning {
+		$warning = new class( new Query_Classifier(), static fn(): int => 1000, '__return_true' ) extends Query_Warning {
 			protected function cache_add( string $key, int $value, int $ttl ): bool {
 				return false;
 			}
@@ -179,7 +180,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_invalid_body_can_slow_warn_without_unbounded_label(): void {
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit( '{invalid', $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() );
 
 		$this->assertStringContainsString( 'types=slow_query', $this->warnings[0] );
@@ -189,7 +190,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 
 	public function test_messages_are_single_line_and_do_not_copy_request_body_or_absolute_path(): void {
 		$_SERVER['REQUEST_URI'] = "/search/?s=visible\nInjected";
-		$warning                = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning                = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit(
 			[ 'query' => [ 'match' => [ 'post_content' => 'secret-body-term' ] ] ],
 			$this->response( 250, 0, 0 ),
@@ -206,7 +207,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	}
 
 	public function test_missing_customer_frame_uses_safe_origin_fallback(): void {
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit( [], $this->response( 10, 0, 0 ), 50.0, [
 			[
 				'file' => '/srv/www/wp-content/mu-plugins/search.php',
@@ -220,13 +221,76 @@ class Query_Warning_Test extends WP_UnitTestCase {
 
 	public function test_non_http_context_uses_an_explicit_allowlisted_source(): void {
 		unset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] );
-		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
 		$warning->maybe_emit( [], $this->response( 10, 0, 0 ), 50.0, $this->customer_backtrace() );
 		$_SERVER['HTTP_HOST']   = 'example.com';
 		$_SERVER['REQUEST_URI'] = '/search/?category=events';
 
 		$this->assertStringContainsString( 'source="unknown"', $this->warnings[0] );
 		$this->assertStringContainsString( 'A non-HTTP WordPress process triggered', $this->warnings[1] );
+	}
+
+	public function test_fractional_slow_duration_is_reported_above_the_threshold(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
+		$warning->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 200, 0, 0 ), 200.1, $this->customer_backtrace() );
+
+		$this->assertStringContainsString( 'request_ms=201 request_limit_ms=200', $this->warnings[0] );
+		$this->assertStringContainsString( 'took 201 ms, above the configured warning threshold of 200 ms', $this->warnings[1] );
+	}
+
+	public function test_non_persistent_cache_suppresses_warning(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_false' );
+
+		$this->assertFalse( $warning->maybe_emit( [], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() ) );
+		$this->assertSame( [], $this->warnings );
+	}
+
+	public function test_budget_counter_failure_suppresses_warning(): void {
+		$warning = new class( new Query_Classifier(), static fn(): int => 1000, '__return_true' ) extends Query_Warning {
+			private $add_calls = 0;
+
+			protected function cache_add( string $key, int $value, int $ttl ): bool {
+				++$this->add_calls;
+
+				return 1 === $this->add_calls;
+			}
+
+			protected function cache_incr( string $key ) {
+				return false;
+			}
+		};
+
+		$this->assertFalse( $warning->maybe_emit( [], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() ) );
+		$this->assertSame( [], $this->warnings );
+	}
+
+	public function test_full_family_hash_is_used_for_deduplication(): void {
+		$warning = new class( new Query_Classifier(), static fn(): int => 1000, '__return_true' ) extends Query_Warning {
+			private $family_count = 0;
+
+			protected function family_hash( array $classified, string $origin_key ): string {
+				++$this->family_count;
+
+				return 'abcdef12' . str_repeat( (string) $this->family_count, 56 );
+			}
+		};
+
+		$warning->maybe_emit( [ 'query' => [ 'term' => [ 'post_type' => 'post' ] ] ], $this->response( 250, 1, 1 ), 251.0, $this->customer_backtrace() );
+		$warning->maybe_emit( [ 'query' => [ 'match' => [ 'post_title' => 'events' ] ] ], $this->response( 250, 1, 1 ), 251.0, $this->customer_backtrace() );
+
+		$this->assertCount( 4, $this->warnings );
+		$this->assertStringContainsString( 'warning_id=VSQ-ABCDEF12', $this->warnings[0] );
+		$this->assertStringContainsString( 'warning_id=VSQ-ABCDEF12', $this->warnings[2] );
+	}
+
+	public function test_cron_source_takes_precedence_over_http_request_variables(): void {
+		add_filter( 'wp_doing_cron', '__return_true' );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
+		$warning->maybe_emit( [], $this->response( 10, 0, 0 ), 50.0, $this->customer_backtrace() );
+
+		$this->assertStringContainsString( 'source="wp_cron"', $this->warnings[0] );
+		$this->assertStringNotContainsString( 'url=', $this->warnings[0] );
+		$this->assertStringContainsString( 'A scheduled WordPress task triggered', $this->warnings[1] );
 	}
 
 	private function response( int $engine_ms, int $returned, int $total_hits ): array {

--- a/tests/search/includes/classes/test-class-query-warning.php
+++ b/tests/search/includes/classes/test-class-query-warning.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/../../../../search/includes/classes/class-query-classifier.php';
+require_once __DIR__ . '/../../../../search/includes/classes/class-query-warning.php';
+
+class Query_Warning_Test extends WP_UnitTestCase {
+	/** @var string[] */
+	private $warnings = [];
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->warnings         = [];
+		$_SERVER['HTTPS']       = 'on';
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/search/?category=events';
+
+		wp_cache_flush();
+
+		foreach ( [
+			'vip_search_slow_query_threshold_ms',
+			'vip_search_query_warning_dedupe_window_s',
+			'vip_search_query_warning_budget',
+		] as $filter ) {
+			remove_all_filters( $filter );
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		set_error_handler( function ( int $errno, string $message ): bool {
+			if ( E_USER_WARNING === $errno ) {
+				$this->warnings[] = $message;
+				return true;
+			}
+
+			return false;
+		}, E_USER_WARNING );
+	}
+
+	public function tearDown(): void {
+		restore_error_handler();
+		unset( $_SERVER['HTTPS'], $_SERVER['HTTP_HOST'] );
+		$_SERVER['REQUEST_URI'] = '/';
+		parent::tearDown();
+	}
+
+	public function test_200_ms_does_not_warn_and_201_ms_does(): void {
+		$warning  = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$body     = [
+			'query' => [ 'term' => [ 'post_status' => 'publish' ] ],
+			'size'  => 10,
+		];
+		$response = $this->response( 12, 1, 1 );
+
+		$this->assertFalse( $warning->maybe_emit( $body, $response, 200.0, $this->customer_backtrace() ) );
+		$this->assertTrue( $warning->maybe_emit( $body, $response, 201.0, $this->customer_backtrace() ) );
+		$this->assertCount( 2, $this->warnings );
+	}
+
+	public function test_invalid_filter_values_fall_back_and_valid_threshold_is_used(): void {
+		add_filter( 'vip_search_slow_query_threshold_ms', static fn() => 'invalid' );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+
+		$this->assertFalse( $warning->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 1, 0, 0 ), 200.0, $this->customer_backtrace() ) );
+
+		remove_all_filters( 'vip_search_slow_query_threshold_ms' );
+		add_filter( 'vip_search_slow_query_threshold_ms', static fn(): int => 50 );
+		$this->assertTrue( $warning->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 1, 0, 0 ), 51.0, $this->customer_backtrace() ) );
+	}
+
+	public function test_tuned_dedupe_window_is_exposed_in_both_messages(): void {
+		add_filter( 'vip_search_query_warning_dedupe_window_s', static fn(): int => 120 );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit( [], $this->response( 10, 0, 0 ), 50.0, $this->customer_backtrace() );
+
+		$this->assertStringContainsString( 'dedupe_window_s=120', $this->warnings[0] );
+		$this->assertStringContainsString( 'deduplicated for two minutes', $this->warnings[1] );
+	}
+
+	public function test_exact_combined_message_contract_and_order(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit( [ 'size' => 10 ], $this->response( 493, 0, 0 ), 527.0, $this->customer_backtrace() );
+
+		$this->assertCount( 2, $this->warnings );
+		preg_match( '/warning_id=(VSQ-[A-F0-9]{8})/', $this->warnings[0], $matches );
+		$this->assertArrayHasKey( 1, $matches );
+		$id = $matches[1];
+
+		$this->assertSame(
+			'VIP_SEARCH_QUERY_WARNING v=1 warning_id=VSQ-TEST000 types=slow_query,unbounded_query request_ms=527 request_limit_ms=200 engine_ms=493 requested=10 returned=0 total_hits=0 query_scope=unbounded url="https://example.com/search/?category=events" deduplicated=true dedupe_window_s=300',
+			str_replace( $id, 'VSQ-TEST000', $this->warnings[0] )
+		);
+		$this->assertSame(
+			'A request to https://example.com/search/?category=events triggered a potentially expensive VIP Search query originating from wp-content/plugins/acme/search.php:81. The query took 527 ms, above the configured warning threshold of 200 ms, and did not contain a limiting search condition. An unbounded query may search the entire index and become more expensive as the site grows. Review the query and add an appropriate search term or filter. Similar occurrences are deduplicated for five minutes, so this warning may represent repeated requests. Warning ID: VSQ-TEST000.',
+			str_replace( $id, 'VSQ-TEST000', $this->warnings[1] )
+		);
+	}
+
+	public function test_slow_only_and_unbounded_only_select_different_human_copy(): void {
+		$slow = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$slow->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() );
+		$this->assertStringContainsString( 'triggered a slow VIP Search query', $this->warnings[1] );
+		$this->assertStringNotContainsString( 'unbounded', strtolower( $this->warnings[1] ) );
+
+		$this->warnings = [];
+		wp_cache_flush();
+		$unbounded = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$unbounded->maybe_emit( [], $this->response( 10, 2, 2 ), 50.0, $this->customer_backtrace() );
+		$this->assertStringContainsString( 'triggered an unbounded VIP Search query', $this->warnings[1] );
+		$this->assertStringNotContainsString( 'above the configured warning threshold', $this->warnings[1] );
+	}
+
+	public function test_volatile_query_values_share_warning_id_and_are_deduplicated(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit( [ 'query' => [ 'term' => [ 'post_author' => 1 ] ] ], $this->response( 250, 1, 1 ), 251.0, $this->customer_backtrace() );
+		$warning->maybe_emit( [ 'query' => [ 'term' => [ 'post_author' => 9999 ] ] ], $this->response( 250, 1, 1 ), 251.0, $this->customer_backtrace() );
+
+		$this->assertCount( 2, $this->warnings );
+	}
+
+	public function test_new_violation_set_emits_with_same_warning_id_inside_window(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit( [], $this->response( 10, 1, 1 ), 50.0, $this->customer_backtrace() );
+		$warning->maybe_emit( [], $this->response( 250, 1, 1 ), 251.0, $this->customer_backtrace() );
+
+		$this->assertCount( 4, $this->warnings );
+		preg_match( '/warning_id=(VSQ-[A-F0-9]{8})/', $this->warnings[0], $first );
+		preg_match( '/warning_id=(VSQ-[A-F0-9]{8})/', $this->warnings[2], $second );
+		$this->assertSame( $first[1], $second[1] );
+	}
+
+	public function test_different_customer_origins_receive_different_warning_ids(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() );
+		$warning->maybe_emit(
+			[ 'query' => [ 'match_all' => [] ] ],
+			$this->response( 250, 0, 0 ),
+			251.0,
+			[
+				[
+					'file'     => '/srv/www/wp-content/themes/beta/search.php',
+					'line'     => 12,
+					'function' => 'run',
+				],
+			]
+		);
+
+		preg_match( '/warning_id=(VSQ-[A-F0-9]{8})/', $this->warnings[0], $first );
+		preg_match( '/warning_id=(VSQ-[A-F0-9]{8})/', $this->warnings[2], $second );
+		$this->assertNotSame( $first[1], $second[1] );
+	}
+
+	public function test_site_budget_counts_pairs_and_suppresses_the_sixth_family(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+
+		for ( $index = 1; $index <= 6; $index++ ) {
+			$warning->maybe_emit(
+				[ 'query' => [ 'term' => [ 'field_' . $index => 'value' ] ] ],
+				$this->response( 250, 1, 1 ),
+				251.0,
+				$this->customer_backtrace()
+			);
+		}
+
+		$this->assertCount( 10, $this->warnings );
+	}
+
+	public function test_cache_failure_suppresses_warning(): void {
+		$warning = new class( new Query_Classifier(), static fn(): int => 1000 ) extends Query_Warning {
+			protected function cache_add( string $key, int $value, int $ttl ): bool {
+				return false;
+			}
+		};
+
+		$this->assertFalse( $warning->maybe_emit( [], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() ) );
+		$this->assertSame( [], $this->warnings );
+	}
+
+	public function test_invalid_body_can_slow_warn_without_unbounded_label(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit( '{invalid', $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() );
+
+		$this->assertStringContainsString( 'types=slow_query', $this->warnings[0] );
+		$this->assertStringContainsString( 'query_scope=unknown', $this->warnings[0] );
+		$this->assertStringNotContainsString( 'unbounded_query', $this->warnings[0] );
+	}
+
+	public function test_messages_are_single_line_and_do_not_copy_request_body_or_absolute_path(): void {
+		$_SERVER['REQUEST_URI'] = "/search/?s=visible\nInjected";
+		$warning                = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit(
+			[ 'query' => [ 'match' => [ 'post_content' => 'secret-body-term' ] ] ],
+			$this->response( 250, 0, 0 ),
+			251.0,
+			$this->customer_backtrace()
+		);
+
+		$this->assertCount( 2, $this->warnings );
+		foreach ( $this->warnings as $message ) {
+			$this->assertStringNotContainsString( "\n", $message );
+			$this->assertStringNotContainsString( 'secret-body-term', $message );
+			$this->assertStringNotContainsString( '/srv/www/', $message );
+		}
+	}
+
+	public function test_missing_customer_frame_uses_safe_origin_fallback(): void {
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit( [], $this->response( 10, 0, 0 ), 50.0, [
+			[
+				'file' => '/srv/www/wp-content/mu-plugins/search.php',
+				'line' => 10,
+			],
+		] );
+
+		$this->assertStringContainsString( 'during this request.', $this->warnings[1] );
+		$this->assertStringNotContainsString( 'mu-plugins/search.php', $this->warnings[1] );
+	}
+
+	public function test_non_http_context_uses_an_explicit_allowlisted_source(): void {
+		unset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] );
+		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000 );
+		$warning->maybe_emit( [], $this->response( 10, 0, 0 ), 50.0, $this->customer_backtrace() );
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/search/?category=events';
+
+		$this->assertStringContainsString( 'source="unknown"', $this->warnings[0] );
+		$this->assertStringContainsString( 'A non-HTTP WordPress process triggered', $this->warnings[1] );
+	}
+
+	private function response( int $engine_ms, int $returned, int $total_hits ): array {
+		return [
+			'took' => $engine_ms,
+			'hits' => [
+				'total' => [ 'value' => $total_hits ],
+				'hits'  => array_fill( 0, $returned, [ '_id' => '1' ] ),
+			],
+		];
+	}
+
+	private function customer_backtrace(): array {
+		return [
+			[
+				'file'     => '/srv/www/wp-content/plugins/acme/search.php',
+				'line'     => 81,
+				'class'    => 'Acme\\Search',
+				'type'     => '->',
+				'function' => 'run',
+			],
+		];
+	}
+}

--- a/tests/search/includes/classes/test-class-query-warning.php
+++ b/tests/search/includes/classes/test-class-query-warning.php
@@ -66,12 +66,13 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	public function test_invalid_filter_values_fall_back_and_valid_threshold_is_used(): void {
 		add_filter( 'vip_search_slow_query_threshold_ms', static fn() => 'invalid' );
 		$warning = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
+		$body    = [ 'query' => [ 'term' => [ 'post_status' => 'publish' ] ] ];
 
-		$this->assertFalse( $warning->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 1, 0, 0 ), 200.0, $this->customer_backtrace() ) );
+		$this->assertFalse( $warning->maybe_emit( $body, $this->response( 1, 0, 0 ), 200.0, $this->customer_backtrace() ) );
 
 		remove_all_filters( 'vip_search_slow_query_threshold_ms' );
 		add_filter( 'vip_search_slow_query_threshold_ms', static fn(): int => 50 );
-		$this->assertTrue( $warning->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 1, 0, 0 ), 51.0, $this->customer_backtrace() ) );
+		$this->assertTrue( $warning->maybe_emit( $body, $this->response( 1, 0, 0 ), 51.0, $this->customer_backtrace() ) );
 	}
 
 	public function test_tuned_dedupe_window_is_exposed_in_both_messages(): void {
@@ -104,7 +105,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 
 	public function test_slow_only_and_unbounded_only_select_different_human_copy(): void {
 		$slow = new Query_Warning( new Query_Classifier(), static fn(): int => 1000, '__return_true' );
-		$slow->maybe_emit( [ 'query' => [ 'match_all' => [] ] ], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() );
+		$slow->maybe_emit( [ 'query' => [ 'term' => [ 'post_status' => 'publish' ] ] ], $this->response( 250, 0, 0 ), 251.0, $this->customer_backtrace() );
 		$this->assertStringContainsString( 'triggered a slow VIP Search query', $this->warnings[1] );
 		$this->assertStringNotContainsString( 'unbounded', strtolower( $this->warnings[1] ) );
 

--- a/tests/search/includes/classes/test-class-query-warning.php
+++ b/tests/search/includes/classes/test-class-query-warning.php
@@ -11,8 +11,12 @@ class Query_Warning_Test extends WP_UnitTestCase {
 	/** @var string[] */
 	private $warnings = [];
 
+	/** @var array */
+	private $original_server = [];
+
 	public function setUp(): void {
 		parent::setUp();
+		$this->original_server  = $_SERVER;
 		$this->warnings         = [];
 		$_SERVER['HTTPS']       = 'on';
 		$_SERVER['HTTP_HOST']   = 'example.com';
@@ -42,8 +46,7 @@ class Query_Warning_Test extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		restore_error_handler();
-		unset( $_SERVER['HTTPS'], $_SERVER['HTTP_HOST'] );
-		$_SERVER['REQUEST_URI'] = '/';
+		$_SERVER = $this->original_server;
 		parent::tearDown();
 	}
 

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -2979,6 +2979,12 @@ class Search_Test extends WP_UnitTestCase {
 		$this->assertSame( $response, $result );
 	}
 
+	public function test__vip_search_query_warning_is_not_initialized_during_search_setup(): void {
+		$this->init_es();
+
+		$this->assertNull( $this->search_instance->query_warning );
+	}
+
 	public function test__vip_search_query_warning_is_not_called_for_failed_search_response(): void {
 		wp_cache_flush();
 		$this->init_es();

--- a/tests/search/includes/classes/test-class-search.php
+++ b/tests/search/includes/classes/test-class-search.php
@@ -15,6 +15,8 @@ use WP_Error;
 use WP_Post;
 
 require_once __DIR__ . '/mock-header.php';
+require_once __DIR__ . '/../../../../search/includes/classes/class-query-classifier.php';
+require_once __DIR__ . '/../../../../search/includes/classes/class-query-warning.php';
 require_once __DIR__ . '/../../../../search/search.php';
 require_once __DIR__ . '/../../../../search/includes/classes/class-versioning.php';
 require_once __DIR__ . '/../../../../search/elasticpress/elasticpress.php';
@@ -2926,6 +2928,189 @@ class Search_Test extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'my_custom_analyzer', $filtered['settings']['analysis']['analyzer'], 'Custom analyzer referencing removed ngram filter should be removed' );
 		$this->assertArrayHasKey( 'default', $filtered['settings']['analysis']['analyzer'], 'default analyzer should be kept' );
+	}
+
+	public function test__vip_search_query_warning_observes_successful_search_response(): void {
+		wp_cache_flush();
+		$this->init_es();
+		$body          = wp_json_encode( [
+			'query' => [ 'match_all' => [] ],
+			'size'  => 10,
+		] );
+		$response_body = [
+			'took' => 21,
+			'hits' => [
+				'total' => [ 'value' => 2 ],
+				'hits'  => [ [ '_id' => '1' ], [ '_id' => '2' ] ],
+			],
+		];
+		$response      = [
+			'response' => [ 'code' => 200 ],
+			'headers'  => [],
+			'body'     => wp_json_encode( $response_body ),
+		];
+
+		self::$mock_global_functions->expects( $this->once() )
+			->method( 'mock_vip_safe_wp_remote_request' )
+			->willReturn( $response );
+
+		$warning = $this->createMock( Query_Warning::class );
+		$warning->expects( $this->once() )
+			->method( 'maybe_emit' )
+			->with(
+				$body,
+				$response_body,
+				$this->callback( static fn( $duration ): bool => is_float( $duration ) && $duration >= 0.0 )
+			)
+			->willReturn( true );
+		$this->search_instance->query_warning = $warning;
+
+		$result = $this->search_instance->filter__ep_do_intercept_request(
+			[],
+			[ 'url' => '/vip-123-post-1/_search' ],
+			[
+				'method' => 'POST',
+				'body'   => $body,
+			],
+			0,
+			'query'
+		);
+
+		$this->assertSame( $response, $result );
+	}
+
+	public function test__vip_search_query_warning_is_not_called_for_failed_search_response(): void {
+		wp_cache_flush();
+		$this->init_es();
+		$response = [
+			'response' => [
+				'code'    => 500,
+				'message' => 'Internal Server Error',
+			],
+			'headers'  => [],
+			'body'     => '{}',
+		];
+		self::$mock_global_functions->expects( $this->once() )
+			->method( 'mock_vip_safe_wp_remote_request' )
+			->willReturn( $response );
+
+		$warning = $this->createMock( Query_Warning::class );
+		$warning->expects( $this->never() )->method( 'maybe_emit' );
+		$this->search_instance->query_warning = $warning;
+
+		$result = $this->search_instance->filter__ep_do_intercept_request(
+			[],
+			[ 'url' => '/vip-123-post-1/_search' ],
+			[
+				'method' => 'POST',
+				'body'   => '{}',
+			],
+			0,
+			'query'
+		);
+
+		$this->assertSame( $response, $result );
+	}
+
+	public function test__vip_search_query_warning_is_not_called_for_non_search_query_type(): void {
+		wp_cache_flush();
+		$this->init_es();
+		$response = [
+			'response' => [ 'code' => 200 ],
+			'headers'  => [],
+			'body'     => '{}',
+		];
+		self::$mock_global_functions->expects( $this->once() )
+			->method( 'mock_vip_safe_wp_remote_request' )
+			->willReturn( $response );
+
+		$warning = $this->createMock( Query_Warning::class );
+		$warning->expects( $this->never() )->method( 'maybe_emit' );
+		$this->search_instance->query_warning = $warning;
+
+		$result = $this->search_instance->filter__ep_do_intercept_request(
+			[],
+			[ 'url' => '/vip-123-post-1/_mget' ],
+			[
+				'method' => 'POST',
+				'body'   => '{}',
+			],
+			0,
+			'query'
+		);
+
+		$this->assertSame( $response, $result );
+	}
+
+	public function test__vip_search_query_warning_is_not_called_for_cache_hit(): void {
+		wp_cache_flush();
+		$this->init_es();
+		$query     = [ 'url' => '/vip-123-post-1/_search' ];
+		$body      = wp_json_encode( [ 'query' => [ 'match_all' => [] ] ] );
+		$response  = [
+			'response' => [ 'code' => 200 ],
+			'headers'  => [],
+			'body'     => '{}',
+		];
+		$cache_key = 'es_query_cache:' . md5( $query['url'] . $body ) . ':' . wp_cache_get_last_changed( Search::SEARCH_CACHE_GROUP );
+		wp_cache_set( $cache_key, $response, Search::SEARCH_CACHE_GROUP, 300 );
+
+		self::$mock_global_functions->expects( $this->never() )->method( 'mock_vip_safe_wp_remote_request' );
+		$warning = $this->createMock( Query_Warning::class );
+		$warning->expects( $this->never() )->method( 'maybe_emit' );
+		$this->search_instance->query_warning = $warning;
+
+		$result = $this->search_instance->filter__ep_do_intercept_request(
+			[],
+			$query,
+			[
+				'method' => 'POST',
+				'body'   => $body,
+			],
+			0,
+			'query'
+		);
+
+		$this->assertSame( $response, $result );
+	}
+
+	public function test__vip_search_query_warning_failure_does_not_change_response(): void {
+		wp_cache_flush();
+		$this->init_es();
+		$response_body = [
+			'took' => 21,
+			'hits' => [
+				'total' => [ 'value' => 0 ],
+				'hits'  => [],
+			],
+		];
+		$response      = [
+			'response' => [ 'code' => 200 ],
+			'headers'  => [],
+			'body'     => wp_json_encode( $response_body ),
+		];
+		self::$mock_global_functions->expects( $this->once() )
+			->method( 'mock_vip_safe_wp_remote_request' )
+			->willReturn( $response );
+
+		$warning = $this->createMock( Query_Warning::class );
+		$warning->expects( $this->once() )
+			->method( 'maybe_emit' )
+			->willThrowException( new \RuntimeException( 'diagnostic failure' ) );
+		$this->search_instance->query_warning = $warning;
+
+		$result = $this->search_instance->filter__ep_do_intercept_request(
+			[],
+			[ 'url' => '/vip-123-post-1/_search' ],
+			[
+				'method' => 'POST',
+				'body'   => '{}',
+			],
+			0,
+			'query'
+		);
+
+		$this->assertSame( $response, $result );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Surface customer-visible warnings for slow and unbounded VIP Search queries after successful backend search requests.
- Emit a stable machine-readable warning followed by a human-readable explanation with sanitized URL or process source and customer-code origin.
- Deduplicate using the full normalized query-family hash and violation set, with configurable threshold, window, and site budget plus fail-closed persistent-cache throttling.
- Keep runtime values out of family identity while preserving query operators, searched fields, structural options, and ordered sort behavior.

## Changelog description

Enterprise Search now emits throttled, customer-visible warnings after successful Elasticsearch requests when a query takes longer than 200 ms or does not contain a limiting condition. Each occurrence produces a stable machine-readable entry and a human-readable explanation containing the originating URL and customer-code location. Similar query families are deduplicated for five minutes, with up to five warning pairs emitted per site during that window.

The defaults can be adjusted with these filters:

```php
add_filter( 'vip_search_slow_query_threshold_ms', static fn(): int => 300 );
add_filter( 'vip_search_query_warning_dedupe_window_s', static fn(): int => 600 );
add_filter( 'vip_search_query_warning_budget', static fn(): int => 10 );
```

- `vip_search_slow_query_threshold_ms`: defaults to `200`; accepts `1`–`5000`.
- `vip_search_query_warning_dedupe_window_s`: defaults to `300`; accepts `60`–`3600`.
- `vip_search_query_warning_budget`: defaults to `5`; accepts `1`–`100`.

Invalid or out-of-range values fall back to their defaults. Warnings require a persistent object cache so throttling can be enforced safely.

## Testing

- `CI=1 ./bin/test.sh --filter '/Query_Classifier_Test|Query_Warning_Test|test__vip_search_query_warning/'` — 45 tests, 91 assertions
- `CI=1 ./bin/test.sh --filter Search_Test` — 196 tests, 272 assertions, one existing skip
- `npm run test:smoke`
- `npm run phplint`
- PHPCS on all changed PHP files

## Notes

Repository-wide `npm run phpcs` still reports the existing `finfo_close()` deprecation in `files/class-api-client.php` and its existing `.claude/worktrees` copy. Neither file is changed by this PR.
