### PR TITLE
Add Safe Publish Mirror integration loader

### DIFF
--- a/integrations/integration-utils.php
+++ b/integrations/integration-utils.php
@@ -60,3 +60,29 @@ function get_latest_version( string $dir, string $folder_prefix, string $entry_f
 	// Return the latest version.
 	return array_key_first( $versions );
 }
+
+/**
+ * Resolve which version folder to load for an integration.
+ *
+ * Returns the folder for the requested version, falling back to the latest
+ * available when the request is 'latest' or the requested version is not
+ * present. Returns an empty string when no versions are available.
+ *
+ * @param array<string,string> $versions Available version folders (folder => version), in descending order.
+ * @param string               $version  The requested version, or 'latest'.
+ * @return string The folder to load, or an empty string when none are available.
+ */
+function get_version_folder_to_load( array $versions, string $version ): string {
+	if ( empty( $versions ) ) {
+		return '';
+	}
+
+	if ( 'latest' !== $version ) {
+		$requested_folder = array_search( $version, $versions, true );
+		if ( false !== $requested_folder ) {
+			return (string) $requested_folder;
+		}
+	}
+
+	return (string) array_key_first( $versions );
+}

--- a/integrations/safe-publish-mirror.php
+++ b/integrations/safe-publish-mirror.php
@@ -58,21 +58,19 @@ class SafePublishMirrorIntegration extends Integration {
 				return;
 			}
 
-			$versions = $this->get_versions();
-
-			if ( empty( $versions ) ) {
+			$version_folder = $this->get_selected_version_folder( $this->get_versions() );
+			if ( '' === $version_folder ) {
 				$this->is_active = false;
 				return;
 			}
 
-			$selected_version_folder = $this->get_selected_version_folder( $versions );
-			$load_path               = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $selected_version_folder . '/safe-publish-mirror.php';
-
-			if ( file_exists( $load_path ) ) {
-				require_once $load_path;
-			} else {
+			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $version_folder . '/safe-publish-mirror.php';
+			if ( ! file_exists( $load_path ) ) {
 				$this->is_active = false;
+				return;
 			}
+
+			require_once $load_path;
 		}, 1 );
 	}
 
@@ -89,20 +87,10 @@ class SafePublishMirrorIntegration extends Integration {
 	 * Get the folder name for the selected version of the integration.
 	 *
 	 * @param array<string,string> $versions Available versions.
-	 * @return string The selected folder name.
+	 * @return string The selected folder name, or an empty string when none are available.
 	 */
 	public function get_selected_version_folder( array $versions ): string {
-		if ( 'latest' === $this->version ) {
-			return array_key_first( $versions );
-		}
-
-		$desired_version = array_search( $this->version, $versions, true );
-
-		if ( false !== $desired_version ) {
-			return $desired_version;
-		}
-
-		return array_key_first( $versions );
+		return get_version_folder_to_load( $versions, $this->version );
 	}
 
 	/**

--- a/integrations/safe-publish-mirror.php
+++ b/integrations/safe-publish-mirror.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Integration: Safe Publish Mirror.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+/**
+ * Loads the Safe Publish Mirror integration.
+ *
+ * Unlike the original Safe Publish integration, which exposes each value as its
+ * own scalar constant, Safe Publish Mirror reads a single associative-array
+ * constant, VIP_SAFE_PUBLISH_MIRROR_CONFIG, as declared in the partner handoff
+ * manifest. The constant is always defined when the integration is active so the
+ * plugin's config reader can report incomplete setups gracefully instead of
+ * fataling on a missing constant.
+ *
+ * @private
+ */
+class SafePublishMirrorIntegration extends Integration {
+	/**
+	 * The version of Safe Publish Mirror to load, defaults to the latest version.
+	 *
+	 * @var string
+	 */
+	public string $version = 'latest';
+
+	public function is_loaded(): bool {
+		return defined( 'SAFE_PUBLISH_MIRROR_LOADED' ) || defined( 'SAFE_PUBLISH_MIRROR_PLUGIN_FILE' );
+	}
+
+	public function configure(): void {
+		if ( defined( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' ) ) {
+			return;
+		}
+
+		$configs = $this->get_mirror_config();
+
+		if ( isset( $configs['version'] ) && is_string( $configs['version'] ) && '' !== $configs['version'] ) {
+			$this->version = $configs['version'];
+		}
+
+		// Always define the constant so the plugin's config reader can detect and
+		// report missing required fields rather than fataling on an undefined
+		// constant. Absent values are passed through as null.
+		define( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG', [
+			'connected_site_url' => $configs['connected_site_url'] ?? null,
+			'sync_mode'          => $configs['sync_mode'] ?? null,
+			'shared_secret'      => $configs['shared_secret'] ?? null,
+		] );
+	}
+
+	public function load(): void {
+		add_action( 'plugins_loaded', function () {
+			if ( $this->is_loaded() ) {
+				return;
+			}
+
+			$versions = $this->get_versions();
+
+			if ( empty( $versions ) ) {
+				$this->is_active = false;
+				return;
+			}
+
+			$selected_version_folder = $this->get_selected_version_folder( $versions );
+			$load_path               = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $selected_version_folder . '/safe-publish-mirror.php';
+
+			if ( file_exists( $load_path ) ) {
+				require_once $load_path;
+			} else {
+				$this->is_active = false;
+			}
+		}, 1 );
+	}
+
+	/**
+	 * Get the available versions of Safe Publish Mirror in descending order.
+	 *
+	 * @return array<string,string>
+	 */
+	public function get_versions(): array {
+		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'safe-publish-mirror', 'safe-publish-mirror.php' );
+	}
+
+	/**
+	 * Get the folder name for the selected version of the integration.
+	 *
+	 * @param array<string,string> $versions Available versions.
+	 * @return string The selected folder name.
+	 */
+	public function get_selected_version_folder( array $versions ): string {
+		if ( 'latest' === $this->version ) {
+			return array_key_first( $versions );
+		}
+
+		$desired_version = array_search( $this->version, $versions, true );
+
+		if ( false !== $desired_version ) {
+			return $desired_version;
+		}
+
+		return array_key_first( $versions );
+	}
+
+	/**
+	 * Get Safe Publish Mirror configuration for the current site context.
+	 *
+	 * On multisite the connection values (connected site URL, sync mode, shared
+	 * secret) are set per network site, so merge the network-site config over the
+	 * environment config to build a complete runtime config for the current site.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function get_mirror_config(): array {
+		if ( ! is_multisite() ) {
+			return $this->get_env_config();
+		}
+
+		return array_merge( $this->get_env_config(), $this->get_network_site_config() );
+	}
+}

--- a/integrations/safe-publish-mirror.php
+++ b/integrations/safe-publish-mirror.php
@@ -32,14 +32,17 @@ class SafePublishMirrorIntegration extends Integration {
 	}
 
 	public function configure(): void {
-		if ( defined( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' ) ) {
-			return;
-		}
-
 		$configs = $this->get_mirror_config();
 
+		// Resolve the version before the constant guard below: version selection is
+		// independent of the config constant, so a site that pre-defines the config
+		// (e.g. a local override) must still honor a pinned version.
 		if ( isset( $configs['version'] ) && is_string( $configs['version'] ) && '' !== $configs['version'] ) {
 			$this->version = $configs['version'];
+		}
+
+		if ( defined( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' ) ) {
+			return;
 		}
 
 		// Always define the constant so the plugin's config reader can detect and

--- a/integrations/safe-publish-mirror.php
+++ b/integrations/safe-publish-mirror.php
@@ -47,12 +47,31 @@ class SafePublishMirrorIntegration extends Integration {
 
 		// Always define the constant so the plugin's config reader can detect and
 		// report missing required fields rather than fataling on an undefined
-		// constant. Absent values are passed through as null.
+		// constant. Non-string or absent values are normalized to null so the
+		// constant matches the manifest's string contract.
 		define( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG', [
-			'connected_site_url' => $configs['connected_site_url'] ?? null,
-			'sync_mode'          => $configs['sync_mode'] ?? null,
-			'shared_secret'      => $configs['shared_secret'] ?? null,
+			'connected_site_url' => $this->normalize_config_value( $configs['connected_site_url'] ?? null ),
+			'sync_mode'          => $this->normalize_config_value( $configs['sync_mode'] ?? null ),
+			'shared_secret'      => $this->normalize_config_value( $configs['shared_secret'] ?? null ),
 		] );
+	}
+
+	/**
+	 * Normalize a manifest config value to a non-empty string, or null.
+	 *
+	 * Manifest values are expected to be strings; anything else (an array from a
+	 * malformed manifest, an int, an empty string) is treated as absent so the
+	 * config constant stays aligned with the manifest's string|null contract.
+	 *
+	 * @param mixed $value Raw config value.
+	 * @return string|null
+	 */
+	private function normalize_config_value( mixed $value ): ?string {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+
+		return $value;
 	}
 
 	public function load(): void {

--- a/tests/integrations/test-safe-publish-mirror.php
+++ b/tests/integrations/test-safe-publish-mirror.php
@@ -115,6 +115,31 @@ class Safe_Publish_Mirror_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( '1.0', $integration->version );
 	}
 
+	public function test_configure_normalizes_non_string_config_values_to_null(): void {
+		$integration = new SafePublishMirrorIntegration( $this->slug );
+		$integration->activate(
+			[
+				'config' => [
+					'connected_site_url' => 'https://source.example.com',
+					'sync_mode'          => [ 'unexpected', 'array' ],
+					'shared_secret'      => 12345,
+				],
+			]
+		);
+		$integration->configure();
+
+		// Non-string manifest values are treated as absent so the constant stays
+		// aligned with the manifest's string|null contract.
+		$this->assertSame(
+			[
+				'connected_site_url' => 'https://source.example.com',
+				'sync_mode'          => null,
+				'shared_secret'      => null,
+			],
+			constant( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' )
+		);
+	}
+
 	public function test_configure_merges_site_and_network_site_config_for_multisite(): void {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Only valid for multisite.' );

--- a/tests/integrations/test-safe-publish-mirror.php
+++ b/tests/integrations/test-safe-publish-mirror.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * Test: Safe Publish Mirror Integration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+use Automattic\Test\Constant_Mocker;
+use Env_Integration_Status;
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_UnitTestCase;
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+class Safe_Publish_Mirror_Integration_Test extends WP_UnitTestCase {
+	private string $slug = 'safe-publish-mirror';
+
+	public function tearDown(): void {
+		Constant_Mocker::clear();
+
+		parent::tearDown();
+	}
+
+	public function test_is_loaded_returns_false_when_not_loaded(): void {
+		$integration = new SafePublishMirrorIntegration( $this->slug );
+		$this->assertFalse( $integration->is_loaded() );
+	}
+
+	public function test_is_loaded_returns_true_when_loaded_constant_is_defined(): void {
+		Constant_Mocker::define( 'SAFE_PUBLISH_MIRROR_LOADED', true );
+
+		$integration = new SafePublishMirrorIntegration( $this->slug );
+		$this->assertTrue( $integration->is_loaded() );
+	}
+
+	public function test_is_loaded_returns_true_when_plugin_file_constant_is_defined(): void {
+		Constant_Mocker::define( 'SAFE_PUBLISH_MIRROR_PLUGIN_FILE', '/path/to/safe-publish-mirror.php' );
+
+		$integration = new SafePublishMirrorIntegration( $this->slug );
+		$this->assertTrue( $integration->is_loaded() );
+	}
+
+	public function test_configure_defines_single_config_constant_from_config(): void {
+		$integration = new SafePublishMirrorIntegration( $this->slug );
+		$integration->activate(
+			[
+				'config' => [
+					'connected_site_url' => 'https://source.example.com',
+					'sync_mode'          => 'import',
+					'shared_secret'      => 'test-shared-secret',
+					'version'            => '1.0',
+				],
+			]
+		);
+		$integration->configure();
+
+		$this->assertSame(
+			[
+				'connected_site_url' => 'https://source.example.com',
+				'sync_mode'          => 'import',
+				'shared_secret'      => 'test-shared-secret',
+			],
+			constant( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' )
+		);
+		$this->assertSame( '1.0', $integration->version );
+	}
+
+	public function test_configure_defines_constant_with_nulls_for_incomplete_config(): void {
+		$integration = new SafePublishMirrorIntegration( $this->slug );
+		$integration->activate(
+			[
+				'config' => [
+					'connected_site_url' => 'https://source.example.com',
+					'sync_mode'          => 'import',
+				],
+			]
+		);
+		$integration->configure();
+
+		// The constant is always defined (even when required fields are missing) so
+		// the plugin's config reader can report the incomplete setup gracefully.
+		$this->assertSame(
+			[
+				'connected_site_url' => 'https://source.example.com',
+				'sync_mode'          => 'import',
+				'shared_secret'      => null,
+			],
+			constant( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' )
+		);
+	}
+
+	public function test_configure_does_not_redefine_existing_constant(): void {
+		Constant_Mocker::define( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG', [ 'connected_site_url' => 'https://existing.example.com' ] );
+
+		$integration = new SafePublishMirrorIntegration( $this->slug );
+		$integration->activate(
+			[
+				'config' => [
+					'connected_site_url' => 'https://new.example.com',
+				],
+			]
+		);
+		$integration->configure();
+
+		$this->assertSame(
+			[ 'connected_site_url' => 'https://existing.example.com' ],
+			constant( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' )
+		);
+	}
+
+	public function test_configure_merges_site_and_network_site_config_for_multisite(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Only valid for multisite.' );
+		}
+
+		$blog_2_id = $this->factory()->blog->create_object( [ 'domain' => 'safe-publish-mirror-test.site/2' ] );
+		switch_to_blog( $blog_2_id );
+
+		try {
+			/** @var IntegrationVipConfig&MockObject $config_mock */
+			$config_mock = $this->getMockBuilder( IntegrationVipConfig::class )
+				->disableOriginalConstructor()
+				->onlyMethods( [ 'get_vip_config_from_file' ] )
+				->getMock();
+
+			$config_mock->method( 'get_vip_config_from_file' )->willReturn(
+				[
+					'env'           => [
+						'status' => Env_Integration_Status::ENABLED,
+						'config' => [
+							'version' => '1.0',
+						],
+					],
+					'network_sites' => [
+						1          => [
+							'status' => Env_Integration_Status::ENABLED,
+							'config' => [
+								'connected_site_url' => 'https://site-one.example.com',
+							],
+						],
+						$blog_2_id => [
+							'status' => Env_Integration_Status::ENABLED,
+							'config' => [
+								'connected_site_url' => 'https://site-two.example.com',
+								'sync_mode'          => 'export',
+								'shared_secret'      => 'site-two-shared-secret',
+							],
+						],
+					],
+				]
+			);
+			$config_mock->__construct( $this->slug );
+
+			$integration = new SafePublishMirrorIntegration( $this->slug );
+			$integration->set_vip_config( $config_mock );
+			$integration->configure();
+
+			$this->assertSame(
+				[
+					'connected_site_url' => 'https://site-two.example.com',
+					'sync_mode'          => 'export',
+					'shared_secret'      => 'site-two-shared-secret',
+				],
+				constant( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' )
+			);
+			$this->assertSame( '1.0', $integration->version );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	public function test_load_returns_early_if_plugin_already_loaded(): void {
+		/** @var MockObject|SafePublishMirrorIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( SafePublishMirrorIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+
+		$integration_mock->expects( $this->once() )
+			->method( 'is_loaded' )
+			->willReturn( true );
+
+		$integration_mock->load();
+
+		do_action( 'plugins_loaded' );
+	}
+
+	public function test_load_sets_inactive_when_no_versions_are_available(): void {
+		/** @var MockObject|SafePublishMirrorIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( SafePublishMirrorIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration_mock->activate();
+		$integration_mock->method( 'is_loaded' )->willReturn( false );
+		$integration_mock->method( 'get_versions' )->willReturn( [] );
+
+		$integration_mock->load();
+
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration_mock->is_active() );
+	}
+
+	public function test_get_selected_version_folder_returns_latest_version_when_version_is_latest(): void {
+		$integration          = new SafePublishMirrorIntegration( $this->slug );
+		$integration->version = 'latest';
+		$versions             = [
+			'safe-publish-mirror-2.5'  => '2.5',
+			'safe-publish-mirror-1.11' => '1.11',
+			'safe-publish-mirror-1.2'  => '1.2',
+		];
+
+		$this->assertSame( 'safe-publish-mirror-2.5', $integration->get_selected_version_folder( $versions ) );
+	}
+
+	public function test_get_selected_version_folder_returns_desired_version_when_version_is_specified(): void {
+		$integration          = new SafePublishMirrorIntegration( $this->slug );
+		$integration->version = '1.2';
+		$versions             = [
+			'safe-publish-mirror-2.5'  => '2.5',
+			'safe-publish-mirror-1.11' => '1.11',
+			'safe-publish-mirror-1.2'  => '1.2',
+		];
+
+		$this->assertSame( 'safe-publish-mirror-1.2', $integration->get_selected_version_folder( $versions ) );
+	}
+
+	public function test_get_selected_version_folder_returns_latest_version_when_version_not_found(): void {
+		$integration          = new SafePublishMirrorIntegration( $this->slug );
+		$integration->version = '9.9';
+		$versions             = [
+			'safe-publish-mirror-2.5'  => '2.5',
+			'safe-publish-mirror-1.11' => '1.11',
+			'safe-publish-mirror-1.2'  => '1.2',
+		];
+
+		$this->assertSame( 'safe-publish-mirror-2.5', $integration->get_selected_version_folder( $versions ) );
+	}
+}

--- a/tests/integrations/test-safe-publish-mirror.php
+++ b/tests/integrations/test-safe-publish-mirror.php
@@ -100,6 +100,7 @@ class Safe_Publish_Mirror_Integration_Test extends WP_UnitTestCase {
 			[
 				'config' => [
 					'connected_site_url' => 'https://new.example.com',
+					'version'            => '1.0',
 				],
 			]
 		);
@@ -109,6 +110,9 @@ class Safe_Publish_Mirror_Integration_Test extends WP_UnitTestCase {
 			[ 'connected_site_url' => 'https://existing.example.com' ],
 			constant( 'VIP_SAFE_PUBLISH_MIRROR_CONFIG' )
 		);
+		// Version selection is independent of the config constant, so a pinned
+		// version must still be applied even when the constant is pre-defined.
+		$this->assertSame( '1.0', $integration->version );
 	}
 
 	public function test_configure_merges_site_and_network_site_config_for_multisite(): void {

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -50,6 +50,10 @@ if ( file_exists( __DIR__ . '/integrations/safe-publish.php' ) ) {
 	require_once __DIR__ . '/integrations/safe-publish.php';
 }
 
+if ( file_exists( __DIR__ . '/integrations/safe-publish-mirror.php' ) ) {
+	require_once __DIR__ . '/integrations/safe-publish-mirror.php';
+}
+
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
@@ -79,6 +83,10 @@ if ( class_exists( __NAMESPACE__ . '\\RealTimeCollaborationIntegration' ) ) {
 
 if ( class_exists( __NAMESPACE__ . '\\SafePublishIntegration' ) ) {
 	IntegrationsSingleton::instance()->register( new SafePublishIntegration( 'safe-publish' ) );
+}
+
+if ( class_exists( __NAMESPACE__ . '\\SafePublishMirrorIntegration' ) ) {
+	IntegrationsSingleton::instance()->register( new SafePublishMirrorIntegration( 'safe-publish-mirror' ) );
 }
 
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
## Description

Adds the platform loader for the [safe-publish-mirror](https://github.com/automattic/safe-publish-mirror/) integration. When the integration is active for a site, it loads the plugin from the `vip-integrations` drop directory and defines a single associative-array constant, `VIP_SAFE_PUBLISH_MIRROR_CONFIG`, from the platform-provided config — matching the fields in the partner handoff manifest (`connected_site_url`, `sync_mode`, `shared_secret`).

The constant is always defined while the integration is active, so the plugin can detect and report an incomplete configuration gracefully instead of fataling on a missing constant.

The `safe-publish-mirror` integration is a mirror of the existing `safe-publish` integration, but developed differently as a PoC of the VIP Integrations SDK project. This is an experimentation on whether VIP can build VIP's end of a partner-built integration, from a manifest file that we receive from the partner.