### PR TITLE
Allow opting out of theme.json image widths

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -263,20 +263,22 @@ class A8C_Files {
 
 		$content_width = isset( $GLOBALS['content_width'] ) ? max( 0, (int) $GLOBALS['content_width'] ) : 0;
 
-		/**
-		 * Filters whether theme.json layout widths are used when $content_width is unavailable.
-		 *
-		 * @param bool         $use_theme_json_layout_widths Whether to use theme.json layout widths.
-		 * @param int          $id                           Attachment ID.
-		 * @param array|string $size                         Requested image size.
-		 */
-		$use_theme_json_layout_widths = (bool) apply_filters( 'vip_image_resize_use_theme_json_layout_widths', true, $id, $size );
-
 		$content_width_for_constraint = $content_width;
 		$max_image_width              = $content_width;
-		if ( 0 === $content_width && $use_theme_json_layout_widths ) {
-			$content_width_for_constraint = $this->get_theme_json_layout_width( array( 'contentSize' ) );
-			$max_image_width              = $this->get_theme_json_layout_width( array( 'wideSize', 'contentSize' ) );
+		if ( 0 === $content_width ) {
+			/**
+			 * Filters whether theme.json layout widths are used when $content_width is unavailable.
+			 *
+			 * @param bool         $use_theme_json_layout_widths Whether to use theme.json layout widths.
+			 * @param int          $id                           Attachment ID.
+			 * @param array|string $size                         Requested image size.
+			 */
+			$use_theme_json_layout_widths = (bool) apply_filters( 'vip_image_resize_use_theme_json_layout_widths', true, $id, $size );
+
+			if ( $use_theme_json_layout_widths ) {
+				$content_width_for_constraint = $this->get_theme_json_layout_width( array( 'contentSize' ) );
+				$max_image_width              = $this->get_theme_json_layout_width( array( 'wideSize', 'contentSize' ) );
+			}
 		}
 
 		$crop = false;

--- a/a8c-files.php
+++ b/a8c-files.php
@@ -261,11 +261,26 @@ class A8C_Files {
 			return false;
 		}
 
-		$content_width                = isset( $GLOBALS['content_width'] ) ? max( 0, (int) $GLOBALS['content_width'] ) : 0;
-		$content_width_for_constraint = $content_width ?: $this->get_theme_json_layout_width( array( 'contentSize' ) );
-		$max_image_width              = $content_width ?: $this->get_theme_json_layout_width( array( 'wideSize', 'contentSize' ) );
-		$crop                         = false;
-		$args                         = array();
+		$content_width = isset( $GLOBALS['content_width'] ) ? max( 0, (int) $GLOBALS['content_width'] ) : 0;
+
+		/**
+		 * Filters whether theme.json layout widths are used when $content_width is unavailable.
+		 *
+		 * @param bool         $use_theme_json_layout_widths Whether to use theme.json layout widths.
+		 * @param int          $id                           Attachment ID.
+		 * @param array|string $size                         Requested image size.
+		 */
+		$use_theme_json_layout_widths = (bool) apply_filters( 'vip_image_resize_use_theme_json_layout_widths', true, $id, $size );
+
+		$content_width_for_constraint = $content_width;
+		$max_image_width              = $content_width;
+		if ( 0 === $content_width && $use_theme_json_layout_widths ) {
+			$content_width_for_constraint = $this->get_theme_json_layout_width( array( 'contentSize' ) );
+			$max_image_width              = $this->get_theme_json_layout_width( array( 'wideSize', 'contentSize' ) );
+		}
+
+		$crop = false;
+		$args = array();
 
 		// For resize requests coming from an image's attachment page, override
 		// the supplied $size and use the user-defined $content_width if the

--- a/tests/files/test-a8c-files-image-resize.php
+++ b/tests/files/test-a8c-files-image-resize.php
@@ -115,7 +115,7 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 		$this->assertUrlQueryArgSame( '1024', 'w', $result[0] );
 	}
 
-	public function count_theme_json_layout_width_filter_calls( $enabled ) {
+	public function count_theme_json_layout_width_filter_calls( $enabled, $attachment_id, $size ) {
 		++$this->theme_json_layout_width_filter_calls;
 
 		return $enabled;

--- a/tests/files/test-a8c-files-image-resize.php
+++ b/tests/files/test-a8c-files-image-resize.php
@@ -55,6 +55,8 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
+		remove_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_false' );
+
 		if ( $this->original_stylesheet ) {
 			switch_theme( $this->original_template, $this->original_stylesheet );
 			$this->clean_theme_json_cache();
@@ -98,6 +100,15 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 900, $result[1] );
 		$this->assertUrlQueryArgSame( '900', 'w', $result[0] );
+	}
+
+	public function test__image_resize__allows_theme_json_layout_widths_to_be_disabled() {
+		add_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_false' );
+
+		$result = $this->resize_image( 'vip_unknown_size' );
+
+		$this->assertSame( 1024, $result[1] );
+		$this->assertUrlQueryArgSame( '1024', 'w', $result[0] );
 	}
 
 	private function resize_image( $size ) {

--- a/tests/files/test-a8c-files-image-resize.php
+++ b/tests/files/test-a8c-files-image-resize.php
@@ -10,6 +10,7 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 	private $original_template;
 	private $attachment_id;
 	private $theme_directory;
+	private $theme_json_layout_width_filter_calls = 0;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -56,6 +57,7 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		remove_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_false' );
+		remove_filter( 'vip_image_resize_use_theme_json_layout_widths', array( $this, 'count_theme_json_layout_width_filter_calls' ) );
 
 		if ( $this->original_stylesheet ) {
 			switch_theme( $this->original_template, $this->original_stylesheet );
@@ -95,11 +97,13 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 
 	public function test__image_resize__prefers_global_content_width_over_theme_json_layout_widths() {
 		$GLOBALS['content_width'] = 900;
+		add_filter( 'vip_image_resize_use_theme_json_layout_widths', array( $this, 'count_theme_json_layout_width_filter_calls' ), 10, 3 );
 
 		$result = $this->resize_image( 'vip_unknown_size' );
 
 		$this->assertSame( 900, $result[1] );
 		$this->assertUrlQueryArgSame( '900', 'w', $result[0] );
+		$this->assertSame( 0, $this->theme_json_layout_width_filter_calls );
 	}
 
 	public function test__image_resize__allows_theme_json_layout_widths_to_be_disabled() {
@@ -109,6 +113,12 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 1024, $result[1] );
 		$this->assertUrlQueryArgSame( '1024', 'w', $result[0] );
+	}
+
+	public function count_theme_json_layout_width_filter_calls( $enabled ) {
+		++$this->theme_json_layout_width_filter_calls;
+
+		return $enabled;
 	}
 
 	private function resize_image( $size ) {


### PR DESCRIPTION
## Description

Adds a default-on filter around the `theme.json` image-width behavior introduced in #7093:

```php
vip_image_resize_use_theme_json_layout_widths
```

Returning `false` restores the previous fallback behavior when `$content_width` is unavailable. The filter receives the attachment ID and requested image size, allowing either global or selective opt-out.

## Why

Using `theme.json` layout widths by default changed the dimensions returned by image APIs for customers whose processes relied on the prior behavior. Keeping the new behavior enabled by default preserves the fix for #5339, while the filter provides a compatibility path for affected applications.

Explicit `$content_width` behavior remains unchanged.

## Changelog Description

### Changed
- VIP Image Resize: Add the vip_image_resize_use_theme_json_layout_widths filter to opt out of using theme.json layout widths.

## Testing

- `CI=1 ./bin/test.sh --filter VIP_Go_A8C_Files_Image_Resize_Test`
- `vendor/bin/phpcs --cache a8c-files.php tests/files/test-a8c-files-image-resize.php`
- PHP syntax checks for both changed files
- `git diff --check`
