### PR TITLE
Tighten search index validation

### DIFF
--- a/search/search-dev-tools/search-dev-tools.php
+++ b/search/search-dev-tools/search-dev-tools.php
@@ -126,11 +126,12 @@ function rest_endpoint_url_validate_callback( $value, $request, $param ) {
 		return $error;
 	}
 
-	$index_part = strtok( $path, '/' );
+	$index_part   = strtok( $path, '/' );
+	$index_prefix = 'vip-' . FILES_CLIENT_SITE_ID . '-';
 
 	// Check for the allowed index names.
 	foreach ( explode( ',', $index_part ) as $idx ) {
-		if ( ! str_starts_with( $idx, 'vip-' . FILES_CLIENT_SITE_ID ) ) {
+		if ( ! str_starts_with( $idx, $index_prefix ) ) {
 			return $error;
 		}
 	}


### PR DESCRIPTION
## Summary

Require the complete site-specific prefix when validating Search Dev Tools index names.

This prevents similarly prefixed indexes from being accepted as belonging to the current site.

## Validation

- PHP lint
- PHPCS
- Existing Search Dev Tools URL validation tests
