### PR TITLE
Default theme.json image width filter to false

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -269,11 +269,14 @@ class A8C_Files {
 			/**
 			 * Filters whether theme.json layout widths are used when $content_width is unavailable.
 			 *
+			 * Defaults to false to preserve core's default full-size image behaviour. Set to true
+			 * to constrain default image sizes to the theme.json layout widths.
+			 *
 			 * @param bool         $use_theme_json_layout_widths Whether to use theme.json layout widths.
 			 * @param int          $id                           Attachment ID.
 			 * @param array|string $size                         Requested image size.
 			 */
-			$use_theme_json_layout_widths = (bool) apply_filters( 'vip_image_resize_use_theme_json_layout_widths', true, $id, $size );
+			$use_theme_json_layout_widths = (bool) apply_filters( 'vip_image_resize_use_theme_json_layout_widths', false, $id, $size );
 
 			if ( $use_theme_json_layout_widths ) {
 				$content_width_for_constraint = $this->get_theme_json_layout_width( array( 'contentSize' ) );

--- a/tests/files/test-a8c-files-image-resize.php
+++ b/tests/files/test-a8c-files-image-resize.php
@@ -56,6 +56,7 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
+		remove_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_true' );
 		remove_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_false' );
 		remove_filter( 'vip_image_resize_use_theme_json_layout_widths', array( $this, 'count_theme_json_layout_width_filter_calls' ) );
 
@@ -79,6 +80,8 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 	}
 
 	public function test__image_resize__uses_theme_json_wide_size_for_unknown_size_when_content_width_missing() {
+		add_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_true' );
+
 		$result = $this->resize_image( 'vip_unknown_size' );
 
 		$this->assertSame( 1600, $result[1] );
@@ -86,6 +89,8 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 	}
 
 	public function test__image_resize__uses_theme_json_content_size_to_constrain_default_sizes() {
+		add_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_true' );
+
 		update_option( 'large_size_w', 2000 );
 		update_option( 'large_size_h', 2000 );
 
@@ -106,13 +111,20 @@ class VIP_Go_A8C_Files_Image_Resize_Test extends WP_UnitTestCase {
 		$this->assertSame( 0, $this->theme_json_layout_width_filter_calls );
 	}
 
-	public function test__image_resize__allows_theme_json_layout_widths_to_be_disabled() {
-		add_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_false' );
-
+	public function test__image_resize__does_not_use_theme_json_layout_widths_by_default() {
 		$result = $this->resize_image( 'vip_unknown_size' );
 
 		$this->assertSame( 1024, $result[1] );
 		$this->assertUrlQueryArgSame( '1024', 'w', $result[0] );
+	}
+
+	public function test__image_resize__allows_theme_json_layout_widths_to_be_enabled() {
+		add_filter( 'vip_image_resize_use_theme_json_layout_widths', '__return_true' );
+
+		$result = $this->resize_image( 'vip_unknown_size' );
+
+		$this->assertSame( 1600, $result[1] );
+		$this->assertUrlQueryArgSame( '1600', 'w', $result[0] );
 	}
 
 	public function count_theme_json_layout_width_filter_calls( $enabled, $attachment_id, $size ) {


### PR DESCRIPTION
## Description

PR #7093 changed the meaning of the `full` image size by constraining default image sizes to theme.json layout widths platform-wide. PR #7128 added the `vip_image_resize_use_theme_json_layout_widths` filter to allow opting out, but it still defaults to `true` — meaning core WordPress behaviour for what a "full" size image is remains altered across all sites unless they explicitly opt out.

Core behaviour should not be changed platform-wide. This PR flips the filter default to `false`, restoring core's default full-size image behaviour. Sites that want the theme.json layout width constraints can opt in by returning `true` from the filter.

## Changes

- `a8c-files.php`: default `vip_image_resize_use_theme_json_layout_widths` to `false` and update the docblock to reflect the opt-in behaviour.
- `tests/files/test-a8c-files-image-resize.php`: theme.json layout width tests now opt in via the filter; added a test asserting the default (opt-out) behaviour uses the core `1024` fallback width.

## Related

- #7093 (introduced the behaviour change)
- #7128 (added the opt-out filter)