### PR TITLE
Fix full image size handling

### DIFF
--- a/a8c-files.php
+++ b/a8c-files.php
@@ -261,6 +261,12 @@ class A8C_Files {
 			return false;
 		}
 
+		// The full size is the original attachment, not an intermediate image size.
+		// Fall through to core so it can return the original URL and dimensions.
+		if ( 'full' === $size ) {
+			return false;
+		}
+
 		$content_width = isset( $GLOBALS['content_width'] ) ? max( 0, (int) $GLOBALS['content_width'] ) : 0;
 
 		$content_width_for_constraint = $content_width;


### PR DESCRIPTION
## Description

Restore WordPress core behavior for `full` image-size requests.

The theme.json layout-width behavior introduced in #7093 was applied through the generic image-size fallback. Because `full` is a WordPress keyword rather than a registered intermediate size, it reached that fallback and returned dimensions constrained by `wideSize`.

This change returns `false` from the VIP `image_downsize` callback for `full`, allowing WordPress core to return the original attachment URL and dimensions. Theme-aware `wideSize` behavior remains unchanged for other fallback requests, and the opt-out filter added in #7128 remains available.

## Changelog Description

### Fixed
- VIP Image Resize: Fixed full-size image requests returning theme-constrained dimensions instead of the original attachment dimensions.

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes). N/A: the change restores core behavior for one reserved size keyword.
- [x] This change has relevant documentation additions / updates (if applicable). N/A: no public configuration or API was added.
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards. N/A: no alerts changed.

## Steps to Test

1. Use an attachment whose original width exceeds the active theme's `settings.layout.wideSize`.
2. Run `wp eval 'var_export( wp_get_attachment_image_src( ATTACHMENT_ID, "full" ) );'`, replacing `ATTACHMENT_ID`.
3. Confirm the returned URL and dimensions match the original attachment and the resized flag is `false`.
4. Request an unknown image-size name and confirm theme.json `wideSize` behavior remains unchanged.
