### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260720-pr79021';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260727-pr79021';
 
 	/**
 	 * Enable Pendo tracking for this integration.

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260727-pr79021';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260803-pr79021';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Description

- Updates `RealTimeCollaborationIntegration::VIP_RTC_GUTENBERG_VERSION` from the develop-stage baseline `0.2-20260720-pr79021` to `0.2-20260803-pr79021`.
- The selected artifact is built from Gutenberg `trunk` at `226fd44b7c157f62f1c200a9bda10f8f60019a84` (plugin version `23.7.0-rc.1`), with the current consolidated changes from WordPress/gutenberg#79021 applied on top.
- Leaves `VIP_RTC_PLUGIN_VERSION` at `0.3`; the VIP RTC plugin version is explicitly unchanged at release `v0.3.2`.
- Pairs with Automattic/vip-go-mu-plugins-ext#135. Although this PR changes only the integration constant, activating it deploys the Gutenberg/RTC runtime changes described below.

## Changelog Description

### Changed

- Real-Time Collaboration: Avoids showing a newer-autosave warning when the autosaved content is already confirmed in the shared document, while retaining the warning when content may be missing because a user edited alone or the collaboration backend was unavailable. See WordPress/gutenberg#80539.
- Real-Time Collaboration: Compacts the CRDT snapshot when serializing it for persistence, preventing deleted editing history from continually inflating post meta without removing the live session's undo history. See WordPress/gutenberg#80707.
- Real-Time Collaboration: Retains the inner-template synchronization fix from WordPress/gutenberg#79021. The VIP RTC plugin version is unchanged at `v0.3.2`.

### Fixed

- Real-Time Collaboration: Prevents derived updates from controlled blocks such as Navigation from intercepting a collaborator's first undo or clearing redo. See WordPress/gutenberg#80503.
- Post Preview: When RTC is disabled, uses WordPress Core's autosave handling so reverting a title to its published value does not leave Preview showing stale autosave content. See WordPress/gutenberg#80769.

## Deployed-stage versions recorded before change

- develop: Gutenberg `0.2-20260720-pr79021`, RTC `0.3`
- staging: Gutenberg `0.2-20260720-pr79021`, RTC `0.3`
- production: Gutenberg `0.2-20260706-pr79021`, RTC `0.3`

## Release-note sources

- Runtime artifact and changelog delta: Automattic/vip-go-mu-plugins-ext#135
- RTC inner-template synchronization carried forward: WordPress/gutenberg#79021
- Autosave notice suppression when shared content is current: WordPress/gutenberg#80539
- CRDT snapshot compaction: WordPress/gutenberg#80707
- Controlled-block undo behavior: WordPress/gutenberg#80503
- Core autosave handling when RTC is disabled: WordPress/gutenberg#80769

## Validation

- `php -l integrations/real-time-collaboration.php` passed.
- `vendor/bin/phpcs --cache integrations/real-time-collaboration.php` passed, with existing deprecated-sniff warnings only.
- `composer validate --no-check-publish` passed, with the existing no-license warning.
- `git diff --check` passed.
- Confirmed Automattic/vip-go-mu-plugins-ext#135 contains `gutenberg-0.2-20260803-pr79021`, preserves every deployed-stage folder, and removes only stale undeployed `gutenberg-0.2-20260727-pr79021`.

## Steps to Test

1. Check out this branch with Automattic/vip-go-mu-plugins-ext#135 available.
2. Enable the Real-Time Collaboration integration.
3. Confirm the integration loads `gutenberg-0.2-20260803-pr79021` and `vip-real-time-collaboration-0.3`.
