### PR TITLE
Add RTC multiplexing configuration support

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -18,7 +18,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Version of the vip-real-time-collaboration plugin to load.
 	 * Used to control staged rollouts (e.g., staging gets new version first).
 	 */
-	const VIP_RTC_PLUGIN_VERSION = '0.3';
+	const VIP_RTC_PLUGIN_VERSION = '0.4';
 
 	/**
 	 * Version of the Gutenberg plugin to load.

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -160,5 +160,10 @@ class RealTimeCollaborationIntegration extends Integration {
 		if ( isset( $env_config['web_socket_url'] ) && ! defined( 'VIP_RTC_WS_URL' ) ) {
 			define( 'VIP_RTC_WS_URL', $env_config['web_socket_url'] );
 		}
+
+		// Set up WebSocket multiplexing constant
+		if ( isset( $env_config['web_socket_multiplexing_enabled'] ) && ! defined( 'VIP_RTC_WS_MULTIPLEXING_ENABLED' ) ) {
+			define( 'VIP_RTC_WS_MULTIPLEXING_ENABLED', $env_config['web_socket_multiplexing_enabled'] );
+		}
 	}
 }

--- a/tests/integrations/test-real-time-collaboration.php
+++ b/tests/integrations/test-real-time-collaboration.php
@@ -114,9 +114,37 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'wss://test.example.com/_ws', constant( 'VIP_RTC_WS_URL' ) );
 	}
 
+	/**
+	 * @dataProvider websocket_multiplexing_enabled_provider
+	 */
+	public function test_configure_defines_websocket_multiplexing_enabled_constant( bool $enabled ): void {
+		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
+		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'get_env_config' ] )
+			->getMock();
+
+		$integration_mock->method( 'get_env_config' )->willReturn( [
+			'web_socket_multiplexing_enabled' => $enabled,
+		] );
+
+		$integration_mock->configure();
+
+		$this->assertTrue( defined( 'VIP_RTC_WS_MULTIPLEXING_ENABLED' ) );
+		$this->assertSame( $enabled, constant( 'VIP_RTC_WS_MULTIPLEXING_ENABLED' ) );
+	}
+
+	public static function websocket_multiplexing_enabled_provider(): array {
+		return [
+			'enabled'  => [ true ],
+			'disabled' => [ false ],
+		];
+	}
+
 	public function test_configure_does_not_redefine_existing_constants(): void {
 		Constant_Mocker::define( 'VIP_RTC_WS_AUTH_SECRET', 'existing-secret' );
 		Constant_Mocker::define( 'VIP_RTC_WS_URL', 'wss://existing.example.com/_ws' );
+		Constant_Mocker::define( 'VIP_RTC_WS_MULTIPLEXING_ENABLED', false );
 
 		/** @var MockObject|RealTimeCollaborationIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( RealTimeCollaborationIntegration::class )
@@ -125,14 +153,16 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 			->getMock();
 
 		$integration_mock->method( 'get_env_config' )->willReturn( [
-			'web_socket_auth_secret' => 'new-secret',
-			'web_socket_url'         => 'wss://new.example.com/_ws',
+			'web_socket_auth_secret'          => 'new-secret',
+			'web_socket_url'                  => 'wss://new.example.com/_ws',
+			'web_socket_multiplexing_enabled' => true,
 		] );
 
 		$integration_mock->configure();
 
 		$this->assertEquals( 'existing-secret', constant( 'VIP_RTC_WS_AUTH_SECRET' ) );
 		$this->assertEquals( 'wss://existing.example.com/_ws', constant( 'VIP_RTC_WS_URL' ) );
+		$this->assertFalse( constant( 'VIP_RTC_WS_MULTIPLEXING_ENABLED' ) );
 	}
 
 	public function test_configure_handles_missing_config_values(): void {
@@ -148,6 +178,7 @@ class Real_Time_Collaboration_Integration_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( defined( 'VIP_RTC_WS_AUTH_SECRET' ) );
 		$this->assertFalse( defined( 'VIP_RTC_WS_URL' ) );
+		$this->assertFalse( defined( 'VIP_RTC_WS_MULTIPLEXING_ENABLED' ) );
 	}
 
 	public function test_load_sets_inactive_when_ws_auth_secret_missing(): void {


### PR DESCRIPTION
## Description

Adds support for defining `VIP_RTC_WS_MULTIPLEXING_ENABLED` from the RTC environment configuration. This connects the feature flag introduced in [Automattic/vip-real-time-collaboration#208](https://github.com/Automattic/vip-real-time-collaboration/pull/208) to the integration loader.

When the config is absent, the constant remains undefined and the plugin continues to use the legacy transport. Explicit `true` and `false` values are passed through unchanged.
## Changelog Description

### Added

- RTC: Added configuration support for the multiplexed WebSocket transport.

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change works and has been tested on a sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [x] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation).

## Steps to Test

1. Run `CI=1 ./bin/test.sh --filter Real_Time_Collaboration_Integration_Test`.
1. Verify that all 15 tests and 24 assertions pass.
1. Run `npm run phplint`.
1. Run `npm run phpcs -- integrations/real-time-collaboration.php tests/integrations/test-real-time-collaboration.php`.
1. Run `npm run test:smoke`.
