### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260803-pr79021';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260810-pr79021';
 
 	/**
 	 * Enable Pendo tracking for this integration.

--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260810-pr79021';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260810';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary

- Updates the RTC integration loader to select `vip-integrations/gutenberg-0.2-20260810` from Automattic/vip-go-mu-plugins-ext#136.
- Keeps VIP RTC on `vip-integrations/vip-real-time-collaboration-0.4`; VIP RTC is unchanged at release `v0.4.0`.
- The selected Gutenberg artifact was built directly from WordPress/gutenberg trunk commit `ab730b2236cc956d06aaa340a0cf809c5125b924` with no additional cherry-pick.

## Changelog Description

### Changed

- Real-Time Collaboration: Created block templates synchronously during insertion so connected peers received a single complete block without duplicate template contents.

### Fixed

- Real-Time Collaboration: Displayed collaborator selections that spanned mixed text and non-text blocks, whole-block keyboard selections, and entire posts.
- Real-Time Collaboration: Cleared the post's dirty state after successfully saving edited post metadata.
- Real-Time Collaboration: Wrapped long usernames and mentions in the notes sidebar so the text remained readable.

## Deployed-stage versions before this change

- develop: Gutenberg `0.2-20260803-pr79021`, RTC `0.4`
- staging: Gutenberg `0.2-20260803-pr79021`, RTC `0.4`
- production: Gutenberg `0.2-20260803-pr79021`, RTC `0.3`

The changelog baseline is the artifact currently referenced by develop: Gutenberg `0.2-20260803-pr79021` and VIP RTC `0.4`.

## Release-note sources

- Extension artifacts: https://github.com/Automattic/vip-go-mu-plugins-ext/pull/136
- Static block templates / RTC duplicate prevention: https://github.com/WordPress/gutenberg/pull/80027
- Mixed-block collaborator selection awareness: https://github.com/WordPress/gutenberg/pull/79836
- Post-meta save dirty-state fix: https://github.com/WordPress/gutenberg/pull/81392
- Long username wrapping in collaboration notes: https://github.com/WordPress/gutenberg/pull/81406

## Validation

- `php -l integrations/real-time-collaboration.php` passed.
- PHPCS passed for `integrations/real-time-collaboration.php` using the repository standard (deprecation notices only).
- `composer validate --no-check-publish` passed with the repository's existing missing-license warning.
- `git diff --check` passed.
- Confirmed the referenced Gutenberg and RTC folders are present in the extension PR.

VIP RTC is unchanged at `v0.4.0`; this PR refreshes only the Gutenberg runtime artifact.
