### PR TITLE
Align MCP behavior across WordPress versions

### DIFF
--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -66,9 +66,7 @@ class WordPressMcpIntegration extends Integration {
 			add_filter( 'mcp_adapter_default_server_config', [ $this, 'filter_default_server_config' ], PHP_INT_MAX );
 		}
 
-		if ( ! empty( $this->get_exposed_abilities_config() ) ) {
-			add_filter( 'wp_register_ability_args', [ $this, 'filter_exposed_abilities_args' ], PHP_INT_MAX, 2 );
-		}
+		add_filter( 'wp_register_ability_args', [ $this, 'filter_exposed_abilities_args' ], PHP_INT_MAX, 2 );
 
 		add_filter( 'determine_current_user', [ $this, 'authenticate_mcp_request' ], 19 );
 		// Surfaces MCP auth errors; must run before core's app-password (90) and cookie (100)
@@ -128,7 +126,7 @@ class WordPressMcpIntegration extends Integration {
 	}
 
 	/**
-	 * Mark configured abilities as public MCP tools.
+	 * Apply MCP 0.6 ability exposure semantics to every adapter version.
 	 *
 	 * @param array  $args         Ability registration args.
 	 * @param string $ability_name Ability name.
@@ -144,6 +142,22 @@ class WordPressMcpIntegration extends Integration {
 				$args['meta']['mcp'] = [];
 			}
 
+			$args['meta']['mcp']['public'] = true;
+
+			return $args;
+		}
+
+		if ( ! isset( $args['meta'] ) || ! is_array( $args['meta'] ) || true !== ( $args['meta']['public'] ?? false ) ) {
+			return $args;
+		}
+
+		$mcp_meta = $args['meta']['mcp'] ?? [];
+		if ( ! is_array( $mcp_meta ) ) {
+			return $args;
+		}
+
+		if ( ! isset( $mcp_meta['public'] ) ) {
+			$args['meta']['mcp']           = $mcp_meta;
 			$args['meta']['mcp']['public'] = true;
 		}
 

--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -126,8 +126,12 @@ class WordPressMcpIntegration extends Integration {
 	}
 
 	/**
-	 * Apply MCP 0.6 ability exposure semantics to every adapter version.
+	 * Expose configured abilities and inherit `meta.public` when MCP-specific exposure is not set.
 	 *
+	 * MCP Adapter 0.6.0 inherits `meta.public` automatically. Copy the inherited value to
+	 * `meta.mcp.public` so MCP Adapter 0.5 exposes the same abilities.
+	 *
+	 * @see https://github.com/WordPress/mcp-adapter/releases/tag/v0.6.0
 	 * @param array  $args         Ability registration args.
 	 * @param string $ability_name Ability name.
 	 * @return array Filtered ability registration args.

--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -13,9 +13,11 @@ namespace Automattic\VIP\Integrations;
  * @private
  */
 class WordPressMcpIntegration extends Integration {
-	private const AUTH_HEADER_SERVER_KEY      = 'HTTP_X_VIP_MCP_AUTH';
-	private const TIMESTAMP_HEADER_SERVER_KEY = 'HTTP_X_VIP_MCP_AUTH_TIMESTAMP';
-	private const DEFAULT_TIMESTAMP_MAX_AGE   = 120;
+	private const LATEST_MINIMUM_WORDPRESS_VERSION = '6.9';
+	private const OLDEST_COMPATIBLE_VERSION        = '0.5';
+	private const AUTH_HEADER_SERVER_KEY           = 'HTTP_X_VIP_MCP_AUTH';
+	private const TIMESTAMP_HEADER_SERVER_KEY      = 'HTTP_X_VIP_MCP_AUTH_TIMESTAMP';
+	private const DEFAULT_TIMESTAMP_MAX_AGE        = 120;
 	// Mirrors mcp-adapter defaults for auth route detection before the config filter runs.
 	private const DEFAULT_SERVER_NAMESPACE = 'mcp';
 	private const DEFAULT_SERVER_ROUTE     = 'mcp-adapter-default-server';
@@ -85,8 +87,13 @@ class WordPressMcpIntegration extends Integration {
 				return;
 			}
 
-			$selected_version_folder = array_key_first( $versions );
-			$load_path               = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $selected_version_folder . '/mcp-adapter.php';
+			$selected_version_folder = $this->get_selected_version_folder( $versions );
+			if ( null === $selected_version_folder ) {
+				$this->is_active = false;
+				return;
+			}
+
+			$load_path = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $selected_version_folder . '/mcp-adapter.php';
 
 			if ( file_exists( $load_path ) ) {
 				require_once $load_path;
@@ -391,5 +398,22 @@ class WordPressMcpIntegration extends Integration {
 	 */
 	public function get_versions(): array {
 		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'wordpress-mcp', 'mcp-adapter.php' );
+	}
+
+	/**
+	 * Get the adapter folder compatible with the current WordPress version.
+	 *
+	 * @param array<string,string> $versions Available versions in descending order.
+	 */
+	public function get_selected_version_folder( array $versions ): ?string {
+		global $wp_version;
+
+		if ( version_compare( $wp_version, self::LATEST_MINIMUM_WORDPRESS_VERSION, '>=' ) ) {
+			return array_key_first( $versions );
+		}
+
+		$legacy_version_folder = array_search( self::OLDEST_COMPATIBLE_VERSION, $versions, true );
+
+		return false === $legacy_version_folder ? null : $legacy_version_folder;
 	}
 }

--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -146,7 +146,9 @@ class WordPressMcpIntegration extends Integration {
 				$args['meta']['mcp'] = [];
 			}
 
-			$args['meta']['mcp']['public'] = true;
+			if ( ! array_key_exists( 'public', $args['meta']['mcp'] ) ) {
+				$args['meta']['mcp']['public'] = true;
+			}
 
 			return $args;
 		}

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -269,6 +269,25 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_filter_exposed_abilities_args_preserves_configured_ability_mcp_opt_out(): void {
+		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
+		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
+		$wordpress_mcp_integration->configure();
+
+		$args = [
+			'meta' => [
+				'mcp' => [
+					'public' => false,
+				],
+			],
+		];
+
+		$this->assertSame(
+			$args,
+			$wordpress_mcp_integration->filter_exposed_abilities_args( $args, 'core/get-site-info' )
+		);
+	}
+
 	public function test_load_sets_inactive_if_no_versions_found(): void {
 		/** @var MockObject&WordPressMcpIntegration $integration_mock */
 		$integration_mock = $this->getMockBuilder( WordPressMcpIntegration::class )

--- a/tests/integrations/test-wordpress-mcp.php
+++ b/tests/integrations/test-wordpress-mcp.php
@@ -170,15 +170,17 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		remove_filter( 'rest_authentication_errors', [ $wordpress_mcp_integration, 'report_auth_error' ] );
 	}
 
-	public function test_load_does_not_register_exposed_abilities_args_filter_without_config(): void {
+	public function test_load_registers_exposed_abilities_args_filter_without_config(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 
 		$wordpress_mcp_integration->load();
 
-		$this->assertFalse(
+		$this->assertSame(
+			PHP_INT_MAX,
 			has_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_abilities_args' ] )
 		);
 
+		remove_filter( 'wp_register_ability_args', [ $wordpress_mcp_integration, 'filter_exposed_abilities_args' ], PHP_INT_MAX );
 		remove_filter( 'determine_current_user', [ $wordpress_mcp_integration, 'authenticate_mcp_request' ], 19 );
 		remove_filter( 'rest_authentication_errors', [ $wordpress_mcp_integration, 'report_auth_error' ] );
 	}
@@ -242,7 +244,7 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( [], $wordpress_mcp_integration->filter_exposed_abilities_args( [], 'vip/delete-site' ) );
 	}
 
-	public function test_filter_exposed_abilities_args_preserves_unconfigured_ability(): void {
+	public function test_filter_exposed_abilities_args_inherits_public_and_preserves_explicit_mcp_opt_out(): void {
 		$wordpress_mcp_integration = new WordPressMcpIntegration( $this->slug );
 		$wordpress_mcp_integration->activate( [ 'config' => [ 'exposed_abilities' => [ 'core/get-site-info' ] ] ] );
 		$wordpress_mcp_integration->configure();
@@ -258,6 +260,12 @@ class WordPress_Mcp_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			$args,
 			$wordpress_mcp_integration->filter_exposed_abilities_args( $args, 'core/update-site' )
+		);
+
+		$args = [ 'meta' => [ 'public' => true ] ];
+
+		$this->assertTrue(
+			$wordpress_mcp_integration->filter_exposed_abilities_args( $args, 'jetpack/get-stats' )['meta']['mcp']['public']
 		);
 	}
 


### PR DESCRIPTION
## What changed

- Select the newest bundled MCP Adapter on WordPress 6.9 and newer.
- Select MCP Adapter 0.5 on older WordPress versions.
- For abilities without an explicit MCP exposure setting, copy `meta.public=true` into `meta.mcp.public` so MCP Adapter 0.5 exposes the same abilities as 0.6.
- Continue exposing abilities selected by VIP configuration while preserving any explicit `meta.mcp.public` setting.

## Why

MCP Adapter 0.6+ requires WordPress 6.9. It also automatically inherits `meta.public` when `meta.mcp.public` is not set, while adapter 0.5 only reads the MCP-specific value. Without this compatibility layer, VIP sites would select an unsupported adapter on older WordPress versions and could expose different ability sets between adapter 0.5 and 0.6.

## Impact

- WordPress 6.9+ tracks the newest bundled adapter.
- Older WordPress versions use adapter 0.5.
- Adapter 0.5 now matches 0.6 when an ability declares `meta.public=true` without an MCP-specific setting.
- Explicit `meta.mcp.public` values always take precedence, including configured abilities that set `meta.mcp.public=false`.

## Validation

- Targeted PHPCS passed.
- Focused exposure tests: 5 tests, 13 assertions passed.