### PR TITLE
feat: configure AI connectors with `vip config envvar`

### DIFF
--- a/000-vip-init.php
+++ b/000-vip-init.php
@@ -228,6 +228,9 @@ require_once __DIR__ . '/vip-helpers/vip-syndication-cache.php';
 require_once __DIR__ . '/vip-helpers/vip-migrations.php';
 require_once __DIR__ . '/vip-helpers/class-user-cleanup.php';
 require_once __DIR__ . '/vip-helpers/class-wpcomvip-restrictions.php';
+if ( file_exists( __DIR__ . '/vip-helpers/vip-connectors.php' ) ) {
+	require_once __DIR__ . '/vip-helpers/vip-connectors.php';
+}
 
 // Load the Telemetry files
 require_once __DIR__ . '/telemetry/class-telemetry-system.php';

--- a/vip-helpers/vip-connectors.php
+++ b/vip-helpers/vip-connectors.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Automattic\VIP\Helpers;
+
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+
+function update_ai_connectors(): void {
+	if ( ! function_exists( 'wp_get_connectors' ) || ! function_exists( 'vip_get_env_var' ) || ! class_exists( AiClient::class ) ) {
+		return;
+	}
+
+	$registry   = AiClient::defaultRegistry();
+	$connectors = array_filter(
+		wp_get_connectors(),
+		fn ( $connector ) => 
+			isset( $connector['authentication']['method'] )
+			&& 'api_key' === $connector['authentication']['method']
+			&& ! empty( $connector['authentication']['env_var_name'] )
+			&& false === getenv( $connector['authentication']['env_var_name'] )
+	);
+
+	foreach ( $connectors as $id => $connector ) {
+		$env_var_name = $connector['authentication']['env_var_name'];
+		$value        = vip_get_env_var( $env_var_name );
+		if ( is_string( $value ) && ! empty( $value ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
+			putenv( sprintf( '%s=%s', $env_var_name, $value ) );
+			$registry->setProviderRequestAuthentication(
+				$id,
+				new ApiKeyRequestAuthentication( $value )
+			);
+		}
+	}
+}
+
+if ( defined( 'ABSPATH' ) ) {
+	add_action( 'init', __NAMESPACE__ . '\\update_ai_connectors', 16 );
+}

--- a/vip-helpers/vip-connectors.php
+++ b/vip-helpers/vip-connectors.php
@@ -13,7 +13,7 @@ function update_ai_connectors(): void {
 	$registry   = AiClient::defaultRegistry();
 	$connectors = array_filter(
 		wp_get_connectors(),
-		fn ( $connector ) => 
+		fn ( $connector ) =>
 			isset( $connector['authentication']['method'] )
 			&& 'api_key' === $connector['authentication']['method']
 			&& ! empty( $connector['authentication']['env_var_name'] )


### PR DESCRIPTION
## Description

Allow using `vip config envvar set` to configure AI Connectors.

## Changelog Description

### Added
- It is possible to use `vip config envvar set` to configure AI Connectors in WordPress

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

See PLTFRM-2681.
