### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260810';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260817';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary

- Updates the RTC integration loader to select `vip-integrations/gutenberg-0.2-20260817` from Automattic/vip-go-mu-plugins-ext#137.
- Keeps VIP RTC on `vip-integrations/vip-real-time-collaboration-0.4`; VIP RTC is unchanged at release `v0.4.1`.
- The selected Gutenberg artifact was built directly from WordPress/gutenberg trunk commit `4849c664c38421c747542015ae5fc7bd4634e06a`.

## Changelog Description

### Changed

- Real-Time Collaboration: Rendered empty editors and containers with their actual default block so its client ID, DOM element, and caret persisted when editing began, without saving the placeholder before entry.

## Deployed-stage versions before this change

- develop: Gutenberg `0.2-20260810`, RTC `0.4`
- staging: Gutenberg `0.2-20260810`, RTC `0.4`
- production: Gutenberg `0.2-20260803-pr79021`, RTC `0.3`

The changelog baseline is the artifact currently referenced by develop: Gutenberg `0.2-20260810` and VIP RTC `0.4` (release `v0.4.1`).

## Release-note sources

- Extension artifacts: https://github.com/Automattic/vip-go-mu-plugins-ext/pull/137
- Default block rendering and identity preservation: https://github.com/WordPress/gutenberg/pull/81231

## Validation

- `php -l integrations/real-time-collaboration.php` passed.
- PHPCS passed for `integrations/real-time-collaboration.php` using the repository standard (deprecation notices only).
- `composer validate --no-check-publish` passed with the repository's existing missing-license warning.
- `git diff --check` passed.
- Confirmed the referenced Gutenberg and RTC folders are present in the extension PR.

VIP RTC is unchanged at `v0.4.1`; this PR refreshes only the Gutenberg runtime artifact.
