### PR TITLE
Integrations: Prevent duplicate MCP adapter loading

### DIFF
--- a/integrations/wordpress-mcp.php
+++ b/integrations/wordpress-mcp.php
@@ -53,7 +53,7 @@ class WordPressMcpIntegration extends Integration {
 	private ?\WP_Error $auth_error = null;
 
 	public function is_loaded(): bool {
-		return class_exists( '\WP\MCP\Plugin', false );
+		return function_exists( 'WP\MCP\constants' ) || class_exists( '\WP\MCP\Plugin', false );
 	}
 
 	public function load(): void {


### PR DESCRIPTION
## Summary

Prevent the VIP WordPress MCP integration from loading its bundled MCP Adapter when another copy has already declared the adapter bootstrap function.

## Root cause

The integration only checked for `WP\MCP\Plugin`. MCP Adapter declares `WP\MCP\constants()` before its autoloader exposes that class, so another adapter copy could be present while the class check still returned false. Loading VIP's bundled copy then caused a fatal `Cannot redeclare WP\MCP\constants()` error.

## Impact

Sites with both the standalone MCP Adapter plugin and VIP's WordPress MCP integration avoid the duplicate function declaration fatal. Existing class-based detection remains as a fallback.

## Testing

- `CI=1 ./bin/test.sh --filter WordPress_Mcp_Integration_Test` (31 tests, 52 assertions)
- `npm run test:smoke`
- PHP lint and PHPCS for the changed file
