### PR TITLE
Tighten multisite upload path matching

### DIFF
--- a/files/acl/acl.php
+++ b/files/acl/acl.php
@@ -85,7 +85,7 @@ function is_valid_path_for_site( $file_path ) {
 			$is_valid = ! str_starts_with( $file_path, 'sites/' );
 		} else {
 			// Check if the file path matches the current site ID's directory.
-			$base_path = sprintf( 'sites/%d', get_current_blog_id() );
+			$base_path = sprintf( 'sites/%d/', get_current_blog_id() );
 			$is_valid  = str_starts_with( $file_path, $base_path );
 		}
 	}


### PR DESCRIPTION
## Summary

Align multisite upload path comparison with directory-boundary semantics.

## Why

The existing prefix omitted its terminating separator, so similarly prefixed directory names could be treated as equivalent. Including the separator keeps matching scoped to the intended directory.

## Impact

Valid upload paths continue to match as before. Paths outside the exact directory boundary no longer match.

## Validation

- PHP lint via commit hook
- PHPCS via commit hook
