### PR TITLE
Skip connectors whose provider isn't registered

### DIFF
--- a/vip-helpers/vip-connectors.php
+++ b/vip-helpers/vip-connectors.php
@@ -21,6 +21,9 @@ function update_ai_connectors(): void {
 	);
 
 	foreach ( $connectors as $id => $connector ) {
+		if ( ! $registry->hasProvider( $id ) ) {
+			continue;
+		}
 		$env_var_name = $connector['authentication']['env_var_name'];
 		$value        = vip_get_env_var( $env_var_name );
 		if ( is_string( $value ) && ! empty( $value ) ) {


### PR DESCRIPTION
## Description
Guards against an error when a connector's provider plugin isn't installed. 

`$connectors` is a list of all registered connectors, whether or not their implementation plugin is present. This change confirms the connector has a provider before setting the request authentication instance.

## Changelog Description

### Fixed
- Fixed a bug in the configuration of AI Connectors in WordPress.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [x] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out PR.
1. Add a env var for a provider
1. Verify no error
