### PR TITLE
fix(vip-helpers): fatal error when an AI provider is not set

### DIFF
--- a/vip-helpers/vip-connectors.php
+++ b/vip-helpers/vip-connectors.php
@@ -13,11 +13,13 @@ function update_ai_connectors(): void {
 	$registry   = AiClient::defaultRegistry();
 	$connectors = array_filter(
 		wp_get_connectors(),
-		fn ( $connector ) =>
-			isset( $connector['authentication']['method'] )
+		fn ( $connector, $id ) =>
+			$registry->hasProvider( $id )
+			&& isset( $connector['authentication']['method'] )
 			&& 'api_key' === $connector['authentication']['method']
 			&& ! empty( $connector['authentication']['env_var_name'] )
-			&& false === getenv( $connector['authentication']['env_var_name'] )
+			&& false === getenv( $connector['authentication']['env_var_name'] ),
+		ARRAY_FILTER_USE_BOTH
 	);
 
 	foreach ( $connectors as $id => $connector ) {


### PR DESCRIPTION
## Description

This PR fixes a fatal error caused by #7177 when the matching AI connector is not registered.

## Changelog Description

### Fixed
- Fatal error during configuration of AI Connectors

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change works and has been tested on a sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change uses a rollout method to ease with deployment (if applicable - especially for large scale actions that require writes).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Run the following command (provided that the OpenAI connector is not installed); env var value can be any:

```sh
vip @app.env config envvar set OPENAI_API_KEY
```

Then wait for the changes to propagate and test the affected site without and with this PR.
