### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260817';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260824';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary

- Updates the RTC integration loader to select `vip-integrations/gutenberg-0.2-20260824` from Automattic/vip-go-mu-plugins-ext#138.
- Keeps VIP RTC on `vip-integrations/vip-real-time-collaboration-0.4`; VIP RTC is unchanged at release `v0.4.1`.
- The selected Gutenberg artifact was built directly from WordPress/gutenberg trunk commit `cb20a4361e4cc500d3530cf261d95b56df94240a`.

## Changelog Description

### Added

- Real-Time Collaboration: Added session-scoped Anonymous User identities so authorized collaborators could continue editing when WordPress user profiles were unavailable.

### Changed

- Real-Time Collaboration: Moved collaboration and its bundled HTTP polling provider behind one opt-in Gutenberg experiment, disabled by default, while allowing plugins to replace the default provider.

### Fixed

- Real-Time Collaboration: Prevented misplaced collaborator cursors, selections, and highlights inside collapsed content, showed presence on the nearest visible container, and revealed collapsed Details content when navigating to a collaborator.

## Deployed-stage versions before this change

- develop: Gutenberg `0.2-20260817`, RTC `0.4`
- staging: Gutenberg `0.2-20260817`, RTC `0.4`
- production: Gutenberg `0.2-20260810`, RTC `0.4`

The changelog baseline is the artifact currently referenced by develop: Gutenberg `0.2-20260817` and VIP RTC `0.4` (release `v0.4.1`).

## Release-note sources

- Extension artifacts: https://github.com/Automattic/vip-go-mu-plugins-ext/pull/138
- Anonymous collaborator fallback identities: https://github.com/WordPress/gutenberg/pull/81408
- Real-Time Collaboration experiment and provider selection: https://github.com/WordPress/gutenberg/pull/80658
- Collaborator presence and navigation in collapsed content: https://github.com/WordPress/gutenberg/pull/81322

## Validation

- `php -l integrations/real-time-collaboration.php` passed.
- PHPCS passed for `integrations/real-time-collaboration.php` using the repository standard (deprecation notices only).
- `composer validate --no-check-publish` passed with the repository's existing missing-license warning.
- `git diff --check` passed.
- Confirmed the referenced Gutenberg and RTC folders are present in the extension PR.

VIP RTC is unchanged at `v0.4.1`; this PR refreshes only the Gutenberg runtime artifact.
