### PR TITLE
Update VIP RTC integration to v0.5.0

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -18,7 +18,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Version of the vip-real-time-collaboration plugin to load.
 	 * Used to control staged rollouts (e.g., staging gets new version first).
 	 */
-	const VIP_RTC_PLUGIN_VERSION = '0.4';
+	const VIP_RTC_PLUGIN_VERSION = '0.5';
 
 	/**
 	 * Version of the Gutenberg plugin to load.


### PR DESCRIPTION
## Summary

- Updates the RTC integration loader to select `vip-integrations/vip-real-time-collaboration-0.5` from Automattic/vip-go-mu-plugins-ext#138.
- Keeps Gutenberg on `vip-integrations/gutenberg-0.2-20260824`, which was merged through #7197.
- Selects VIP RTC release `v0.5.0`, built from the merged default branch after Automattic/vip-real-time-collaboration#225.

## Changelog Description

### Added

- Real-Time Collaboration: Added an emergency fallback setting that disabled collaboration and the VIP WebSocket provider together.
- Real-Time Collaboration: Added an admin notice when the installed Gutenberg version was older than the required `23.8.0`.

### Changed

- Real-Time Collaboration: Enabled Gutenberg's unified real-time collaboration experiment by default and moved its control from Gutenberg's Experiments page to the VIP Real-Time Collaboration settings page.

## Deployed-stage versions before this change

- develop: Gutenberg `0.2-20260824`, RTC `0.4` (`v0.4.1`)
- staging: Gutenberg `0.2-20260817`, RTC `0.4` (`v0.4.1`)
- production: Gutenberg `0.2-20260810`, RTC `0.4` (`v0.4.1`)

The changelog baseline is current `develop`: Gutenberg `0.2-20260824` and VIP RTC `0.4` (`v0.4.1`).

## Release-note sources

- Extension artifacts: https://github.com/Automattic/vip-go-mu-plugins-ext/pull/138
- VIP RTC v0.5.0: https://github.com/Automattic/vip-real-time-collaboration/releases/tag/v0.5.0
- Unified experiment and emergency fallback control: https://github.com/Automattic/vip-real-time-collaboration/pull/225
- Earlier weekly Gutenberg constants update: https://github.com/Automattic/vip-go-mu-plugins/pull/7197

## Validation

- `php -l integrations/real-time-collaboration.php` passed.
- PHPCS passed for `integrations/real-time-collaboration.php` using the repository standard (deprecation notices only).
- `composer validate --no-check-publish` passed with the repository's existing missing-license warning.
- `git diff --check` passed.
- Confirmed `vip-integrations/vip-real-time-collaboration-0.5` and `vip-integrations/gutenberg-0.2-20260824` are present in the extension PR.
