### PR TITLE
docs: fix typo compatability -> compatibility

### DIFF
--- a/drop-ins/wp-memcached/readme.md
+++ b/drop-ins/wp-memcached/readme.md
@@ -13,7 +13,7 @@ This is a fork of https://github.com/Automattic/wp-memcached, but may end up mer
 1. Install this plugin somewhere in your codebase.
 2. Create a file at `wp-content/object-cache.php`, with the contents being just `require_once DIR . '/path/to/wp-cache-memcached/object-cache.php`.
 
-This plugin aims to have full compatability with the wp-memcached plugin, and you can do those first two steps and call it a day. It will work seemlessly as a replacement. Will even keep using the same cache keys/values that are already stored.
+This plugin aims to have full compatibility with the wp-memcached plugin, and you can do those first two steps and call it a day. It will work seemlessly as a replacement. Will even keep using the same cache keys/values that are already stored.
 
 To additionally start using the Memcached php extension instead:
 


### PR DESCRIPTION
One-word typo fix in `drop-ins/wp-memcached/readme.md:16`: "This plugin aims to have full compatability" → "compatibility".
