### PR TITLE
Update VIP RTC integration to v0.5.1

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -15,7 +15,8 @@ namespace Automattic\VIP\Integrations;
  */
 class RealTimeCollaborationIntegration extends Integration {
 	/**
-	 * Version of the vip-real-time-collaboration plugin to load.
+	 * Minor-version artifact of the vip-real-time-collaboration plugin to load.
+	 * The 0.5 artifact currently contains upstream release v0.5.1.
 	 * Used to control staged rollouts (e.g., staging gets new version first).
 	 */
 	const VIP_RTC_PLUGIN_VERSION = '0.5';


### PR DESCRIPTION
## Summary

- Records that the RTC integration selector `VIP_RTC_PLUGIN_VERSION = '0.5'` now resolves to upstream VIP RTC release `v0.5.1` in Automattic/vip-go-mu-plugins-ext#139.
- Keeps the selector at `0.5` because established patch releases replace the matching minor-version artifact in place.
- Keeps `VIP_RTC_GUTENBERG_VERSION` unchanged at `0.2-20260824`.

## Changelog Description

### Fixed

- Real-Time Collaboration: Prevented fatal errors during settings registration when another plugin passed legacy non-array setting arguments.

## Deployed-stage versions before this change

- develop: Gutenberg `0.2-20260824`, RTC `0.5` (`v0.5.0` before the extension artifact update)
- staging: Gutenberg `0.2-20260824`, RTC `0.5` (`v0.5.0` before the extension artifact update)
- production: Gutenberg `0.2-20260817`, RTC `0.4` (`v0.4.1`)

The changelog baseline is current `develop`: Gutenberg `0.2-20260824` and VIP RTC `0.5` (`v0.5.0`).

## Release-note sources

- Extension artifact: https://github.com/Automattic/vip-go-mu-plugins-ext/pull/139
- VIP RTC v0.5.1: https://github.com/Automattic/vip-real-time-collaboration/releases/tag/v0.5.1
- Runtime fix: https://github.com/Automattic/vip-real-time-collaboration/pull/229

## Validation

- `php -l integrations/real-time-collaboration.php` passed.
- PHPCS passed for `integrations/real-time-collaboration.php` using the repository standard (deprecation notices only).
- `composer validate --no-check-publish` passed with the repository's existing missing-license warning.
- `git diff --check` passed.
- Confirmed `VIP_RTC_PLUGIN_VERSION = '0.5'` points to `vip-integrations/vip-real-time-collaboration-0.5` in extension PR #139, whose plugin header and runtime constant report `0.5.1`.
- Confirmed `VIP_RTC_GUTENBERG_VERSION` and all Gutenberg artifacts were unchanged.

