### PR TITLE
[PLTFRM-2576] Send plugin Update URI metadata to SDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Development repository for WordPress VIP Go MU plugins.
 
 - `000-vip-init.php`, `001-core.php`, `z-client-mu-plugins.php`: main MU bootstrap/load path.
 - `001-core/`, `lib/`, `cache/`, `security/`, `vip-helpers/`, `wp-cli/`: platform feature modules.
+- [`config/`](config/README.md): site details metadata sent to SDS.
 - `tests/`: PHPUnit test suite for root MU code.
 - `__tests__/e2e/`: Playwright e2e suite.
 - `ci/`, `.github/workflows/`: automation, CI, release/deploy workflows.

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,13 @@
+# Site details metadata
+
+`Site_Details_Index` includes every installed plugin in the SDS payload. The optional
+plugin header `Update URI` is sent as `plugins[].update_uri`, taken directly from
+WordPress plugin metadata rather than the update transient. Values such as the string
+`"false"`, empty strings, and external URIs are preserved; missing metadata is `null`.
+This does not filter plugins or change their slug, marketplace, or download URL.
+
+Deploy [SDS #1348](https://github.com/Automattic/vip-site-details/pull/1348), including
+its schema changes, before this producer change. SDS exposes the value as `updateUri`
+for CCM to interpret during vulnerability scans.
+
+Context: [PLTFRM-2576](https://linear.app/a8c/issue/PLTFRM-2576).

--- a/config/class-site-details-index.php
+++ b/config/class-site-details-index.php
@@ -119,6 +119,7 @@ class Site_Details_Index {
 				'path'          => $plugin_path,
 				'name'          => $plugin_data['Name'],
 				'version'       => $plugin_data['Version'],
+				'update_uri'    => $plugin_data['UpdateURI'] ?? null,
 				'active'        => null !== $activated_by,
 				'activated_by'  => $activated_by,
 				'wporg_slug'    => isset( $update_data[ $plugin_path ] ) ? $update_data[ $plugin_path ]['slug'] : null, // legacy, can be later removed.

--- a/tests/config/test-site-details-index.php
+++ b/tests/config/test-site-details-index.php
@@ -53,10 +53,10 @@ class Site_Details_Index_Test extends WP_UnitTestCase {
 		global $wp_version;
 
 		$test_plugins = [
-			'hello.php' => [ 'Name' => 'Hello Tests', 'Version' => '4.5', 'UpdateURI' => '' ],
+			'hello.php' => [ 'Name' => 'Hello Tests', 'Version' => '4.5', 'UpdateURI' => 'https://wordpress.org/plugins/hello-wporg-slug/' ],
 			'world.php' => [ 'Name' => 'Test Plugin', 'Version' => '1.2', 'UpdateURI' => '' ],
-			'woocommerce-subscriptions/woocommerce-subscriptions.php' => [ 'Name' => 'WooCommerce Subscriptions', 'Version' => '4.1.0', 'UpdateURI' => '' ],
-			'custom.php' => [ 'Name' => 'Custom Plugin', 'Version' => '8.6', 'UpdateURI' => '' ],
+			'woocommerce-subscriptions/woocommerce-subscriptions.php' => [ 'Name' => 'WooCommerce Subscriptions', 'Version' => '4.1.0', 'UpdateURI' => 'https://woocommerce.com/products/woocommerce-subscriptions/' ],
+			'custom.php' => [ 'Name' => 'Custom Plugin', 'Version' => '8.6', 'UpdateURI' => 'false' ],
 		];
 
 		// Mock the list of plugins, setting which are active and which have available updates.
@@ -83,6 +83,7 @@ class Site_Details_Index_Test extends WP_UnitTestCase {
 					'path'          => 'hello.php',
 					'name'          => 'Hello Tests',
 					'version'       => '4.5',
+					'update_uri'    => 'https://wordpress.org/plugins/hello-wporg-slug/',
 					'active'        => true,
 					'activated_by'  => 'option',
 					'wporg_slug'    => 'hello-wporg-slug',
@@ -96,6 +97,7 @@ class Site_Details_Index_Test extends WP_UnitTestCase {
 					'path'          => 'world.php',
 					'name'          => 'Test Plugin',
 					'version'       => '1.2',
+					'update_uri'    => '',
 					'active'        => false,
 					'activated_by'  => null,
 					'wporg_slug'    => 'test-wporg-slug',
@@ -109,6 +111,7 @@ class Site_Details_Index_Test extends WP_UnitTestCase {
 					'path'         => 'woocommerce-subscriptions/woocommerce-subscriptions.php',
 					'name'         => 'WooCommerce Subscriptions',
 					'version'      => '4.1.0',
+					'update_uri'    => 'https://woocommerce.com/products/woocommerce-subscriptions/',
 					'active'       => false,
 					'activated_by' => null,
 					'wporg_slug'    => 'woocommerce-com-woocommerce-subscriptions',
@@ -122,6 +125,7 @@ class Site_Details_Index_Test extends WP_UnitTestCase {
 					'path'          => 'custom.php',
 					'name'          => 'Custom Plugin',
 					'version'       => '8.6',
+					'update_uri'    => 'false',
 					'active'        => false,
 					'activated_by'  => null,
 					'wporg_slug'    => null,
@@ -135,6 +139,44 @@ class Site_Details_Index_Test extends WP_UnitTestCase {
 		);
 
 		remove_filter( 'pre_site_transient_update_plugins', [ $this, 'mock_update_plugins_transient' ], 999 );
+	}
+
+	/**
+	 * @dataProvider plugin_update_uri_provider
+	 */
+	public function test__plugin_update_uri_is_preserved_without_update_metadata( array $headers, ?string $expected, bool $active ) {
+		$test_plugin = array_merge( [ 'Name' => 'Custom Plugin', 'Version' => '1.0' ], $headers );
+		wp_cache_set( 'plugins', [ '' => [ 'custom.php' => $test_plugin ] ], 'plugins' );
+		update_option( 'active_plugins', $active ? [ 'custom.php' ] : [] );
+		add_filter( 'pre_site_transient_update_plugins', static function () {
+			return (object) [
+				'last_checked' => time(),
+				'checked' => [ 'custom.php' => '1.0' ],
+				'response' => [],
+				'no_update' => [],
+			];
+		}, 999 );
+
+		$plugins = ( new Site_Details_Index() )->get_plugin_info();
+
+		$this->assertCount( 1, $plugins );
+		$this->assertArrayHasKey( 'update_uri', $plugins[0] );
+		$this->assertSame( $expected, $plugins[0]['update_uri'] );
+		$this->assertSame( $active, $plugins[0]['active'] );
+		$this->assertNull( $plugins[0]['slug'] );
+		$this->assertNull( $plugins[0]['download_link'] );
+		$this->assertSame( $expected, json_decode( wp_json_encode( $plugins ), true )[0]['update_uri'] );
+	}
+
+	public static function plugin_update_uri_provider() {
+		return [
+			'missing header' => [ [], null, false ],
+			'null header' => [ [ 'UpdateURI' => null ], null, false ],
+			'empty header' => [ [ 'UpdateURI' => '' ], '', false ],
+			'inactive opt-out' => [ [ 'UpdateURI' => 'false' ], 'false', false ],
+			'active opt-out' => [ [ 'UpdateURI' => 'false' ], 'false', true ],
+			'custom Unicode URI' => [ [ 'UpdateURI' => 'https://vendor.example/plugins/🔌/' ], 'https://vendor.example/plugins/🔌/', false ],
+		];
 	}
 
 	public function mock_update_plugins_transient() {


### PR DESCRIPTION
## Description

Send the WordPress plugin `Update URI` header to the Site Details Service so downstream consumers can distinguish custom update sources from WordPress.org plugins.

`Site_Details_Index::get_plugin_info()` now includes `plugins[].update_uri`, taken directly from WordPress plugin metadata. This works even when the plugin has no entry in the update transient. The producer preserves the string `"false"`, empty strings, external/WordPress.org URIs, and Unicode; missing metadata is `null`.

All installed plugins remain in the payload, including inactive plugins. This change does not filter plugins, interpret the header as a download URL, or change slug, marketplace, activation, download, or theme behavior.

## Companion PRs and rollout

- [CCM scanner exclusions: Automattic/vip-customer-codebase-manager#963](https://github.com/Automattic/vip-customer-codebase-manager/pull/963)
- [SDS metadata persistence/API prerequisite: Automattic/vip-site-details#1348](https://github.com/Automattic/vip-site-details/pull/1348)

Deploy the SDS schema migrations and API support before this producer. SDS exposes the field as `updateUri`; the companion scanner change interprets it. This producer alone does not change vulnerability results. No production changes were made during testing.

## Changelog Description

### Added

- Include plugin Update URI metadata in site details sent to the platform.

## Verification

- `CI=1 ./bin/test.sh`: **1,895 tests, 3,317 assertions, 64 skips, no failures**.
- `CI=1 ./bin/test.sh --filter 'Site_Details_Index_Test|Sync_Test'`: 13 passed, one expected multisite-only skip.
- `CI=1 ./bin/test.sh --multisite 1 --filter 'Site_Details_Index_Test|Sync_Test'`: 14 passed, 69 assertions.
- `npm run test:smoke`: passed.
- `npm run phplint`: passed.
- `vendor/bin/phpcs --no-cache config/class-site-details-index.php tests/config/test-site-details-index.php`: passed (installed PHPCS dependencies emit PHP deprecation notices).
- Full `npm run phpcs` still reports existing errors in `files/class-api-client.php:190`, `tests/security/test-login-error.php:53`, and `tests/test-large-media-upload-warning.php:162`, plus a duplicate from a local worktree. All three errors were reproduced from unchanged HEAD versions; no unrelated fixes included.
- Tests use WordPress 6.9.4 / PHP 8.3.30 in the disposable Docker test runner. The new payload regressions failed before the implementation and passed afterward. Independent review found no remaining actionable issues.

## Pre-review checklist

- [x] Tested locally with disposable test databases.
- [ ] Tested on a sandbox.
- [x] Relevant unit tests added for raw header transport, JSON types, missing metadata, active/inactive plugins, and Unicode.
- [x] Rollout prerequisite documented.
- [x] Documentation updated.
- [x] Changelog description added.

## Pre-deploy checklist

- [ ] CI checks pass on the published branch.
- [ ] SDS schema/API support is deployed before this producer.
- No alerts added or changed.

## Steps to Test

1. Run the focused config tests in single-site and multisite modes using the commands above.
2. Inspect `vip_site_details_index_data` for plugins with an absent/empty header, `Update URI: false`, a WordPress.org URI, and a custom URI. Verify `update_uri` preserves the raw string, including `"false"` as a string rather than a boolean.
3. Confirm the header remains present for inactive plugins and plugins missing from the update transient. Slug and download fields should remain unchanged.
4. After the SDS prerequisite is deployed to a test environment, sync the payload and confirm the site plugin response includes the corresponding `updateUri` value.
