### PR TITLE
Update RTC integration version constants

### DIFF
--- a/integrations/real-time-collaboration.php
+++ b/integrations/real-time-collaboration.php
@@ -25,7 +25,7 @@ class RealTimeCollaborationIntegration extends Integration {
 	 * Empty string means load from the unversioned 'gutenberg' folder.
 	 * A version number (e.g., '1.0') loads from 'gutenberg-1.0' folder.
 	 */
-	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260824';
+	const VIP_RTC_GUTENBERG_VERSION = '0.2-20260831';
 
 	/**
 	 * Enable Pendo tracking for this integration.


### PR DESCRIPTION
## Summary

- Updates the RTC integration loader to select `vip-integrations/gutenberg-0.2-20260831` from Automattic/vip-go-mu-plugins-ext#141.
- Keeps VIP RTC on `vip-integrations/vip-real-time-collaboration-0.5`; VIP RTC is unchanged at release `v0.5.1`.
- The selected Gutenberg artifact was built directly from WordPress/gutenberg trunk commit `d377a13511b6f09a9c8ea6afa4b9492c7fd6c871`.

## Changelog Description

### Fixed

- Real-Time Collaboration: Prevented stale collaboration state from overwriting newer saved content by disabling collaboration for post types that could not persist its CRDT document.

## Deployed-stage versions before this change

- develop: Gutenberg `0.2-20260824`, RTC `0.5`
- staging: Gutenberg `0.2-20260824`, RTC `0.5`
- production: Gutenberg `0.2-20260817`, RTC `0.4`

The changelog baseline is the artifact currently referenced by develop: Gutenberg `0.2-20260824` and VIP RTC `0.5` (release `v0.5.1`).

## Release-note sources

- Extension artifact: https://github.com/Automattic/vip-go-mu-plugins-ext/pull/141
- Prevent stale RTC overwrites for post types without custom fields: https://github.com/WordPress/gutenberg/pull/81946

## Validation

- `php -l integrations/real-time-collaboration.php` passed.
- PHPCS passed for `integrations/real-time-collaboration.php` using the repository standard (deprecation notices only).
- `composer validate --no-check-publish` passed with the repository existing missing-license warning.
- `git diff --check` passed.
- Confirmed the referenced Gutenberg and RTC folders are present in the extension PR.

VIP RTC is unchanged at `v0.5.1`; this PR refreshes only the Gutenberg runtime artifact.
