### PR TITLE
Add VIP Workflows integration loader

### DIFF
--- a/integrations/vip-workflows.php
+++ b/integrations/vip-workflows.php
@@ -32,27 +32,34 @@ class VipWorkflowsIntegration extends Integration {
 	}
 
 	public function load(): void {
-		add_action( 'plugins_loaded', function () {
-			if ( $this->is_loaded() ) {
-				return;
-			}
-
-			$versions = $this->get_versions();
-
-			if ( empty( $versions ) ) {
-				$this->is_active = false;
-				return;
-			}
-
-			$selected_version_folder = $this->get_selected_version_folder( $versions );
-			$load_path               = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $selected_version_folder . '/vip-workflows.php';
-
-			if ( file_exists( $load_path ) ) {
-				require_once $load_path;
-			} else {
-				$this->is_active = false;
-			}
+		add_action( 'plugins_loaded', function (): void {
+			$this->load_plugin();
 		}, 1 );
+	}
+
+	/**
+	 * Load the selected bundled plugin file when it is available.
+	 */
+	private function load_plugin(): void {
+		if ( $this->is_loaded() ) {
+			return;
+		}
+
+		$versions = $this->get_versions();
+		if ( [] === $versions ) {
+			$this->is_active = false;
+			return;
+		}
+
+		$folder    = $this->get_selected_version_folder( $versions );
+		$main_file = sprintf( '%s/vip-integrations/%s/vip-workflows.php', WPVIP_MU_PLUGIN_DIR, $folder );
+
+		if ( ! file_exists( $main_file ) ) {
+			$this->is_active = false;
+			return;
+		}
+
+		require_once $main_file;
 	}
 
 	/**
@@ -71,16 +78,10 @@ class VipWorkflowsIntegration extends Integration {
 	 * @return string The selected folder name.
 	 */
 	public function get_selected_version_folder( array $versions ): string {
-		if ( 'latest' === $this->version ) {
-			return array_key_first( $versions );
-		}
+		$desired_folder = 'latest' === $this->version
+			? false
+			: array_search( $this->version, $versions, true );
 
-		$desired_version = array_search( $this->version, $versions, true );
-
-		if ( false !== $desired_version ) {
-			return $desired_version;
-		}
-
-		return array_key_first( $versions );
+		return false !== $desired_folder ? $desired_folder : array_key_first( $versions );
 	}
 }

--- a/integrations/vip-workflows.php
+++ b/integrations/vip-workflows.php
@@ -27,6 +27,14 @@ class VipWorkflowsIntegration extends Integration {
 	 */
 	protected bool $enable_pendo_tracking = true;
 
+public function configure(): void {
+		$configs = is_multisite() ? $this->get_network_site_config() : $this->get_env_config();
+
+		if ( isset( $configs['version'] ) && is_string( $configs['version'] ) && '' !== $configs['version'] ) {
+			$this->version = $configs['version'];
+		}
+	}
+
 	public function is_loaded(): bool {
 		return defined( 'VIP_WORKFLOWS_LOADED' ) || defined( 'VIP_WORKFLOWS_PLUGIN_FILE' );
 	}

--- a/integrations/vip-workflows.php
+++ b/integrations/vip-workflows.php
@@ -27,7 +27,7 @@ class VipWorkflowsIntegration extends Integration {
 	 */
 	protected bool $enable_pendo_tracking = true;
 
-public function configure(): void {
+	public function configure(): void {
 		$configs = is_multisite() ? $this->get_network_site_config() : $this->get_env_config();
 
 		if ( isset( $configs['version'] ) && is_string( $configs['version'] ) && '' !== $configs['version'] ) {

--- a/integrations/vip-workflows.php
+++ b/integrations/vip-workflows.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Integration: VIP Workflows.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+/**
+ * Loads the VIP Workflows integration.
+ *
+ * @private
+ */
+class VipWorkflowsIntegration extends Integration {
+	/**
+	 * The version of VIP Workflows to load, defaults to the latest version.
+	 *
+	 * @var string
+	 */
+	public string $version = 'latest';
+
+	/**
+	 * Enable Pendo tracking for this integration.
+	 *
+	 * @var bool
+	 */
+	protected bool $enable_pendo_tracking = true;
+
+	public function is_loaded(): bool {
+		return defined( 'VIP_WORKFLOWS_LOADED' ) || defined( 'VIP_WORKFLOWS_PLUGIN_FILE' );
+	}
+
+	public function load(): void {
+		add_action( 'plugins_loaded', function () {
+			if ( $this->is_loaded() ) {
+				return;
+			}
+
+			$versions = $this->get_versions();
+
+			if ( empty( $versions ) ) {
+				$this->is_active = false;
+				return;
+			}
+
+			$selected_version_folder = $this->get_selected_version_folder( $versions );
+			$load_path               = WPVIP_MU_PLUGIN_DIR . '/vip-integrations/' . $selected_version_folder . '/vip-workflows.php';
+
+			if ( file_exists( $load_path ) ) {
+				require_once $load_path;
+			} else {
+				$this->is_active = false;
+			}
+		}, 1 );
+	}
+
+	/**
+	 * Get the available versions of VIP Workflows in descending order.
+	 *
+	 * @return array<string,string>
+	 */
+	public function get_versions(): array {
+		return get_available_versions( WPVIP_MU_PLUGIN_DIR . '/vip-integrations/', 'vip-workflows', 'vip-workflows.php' );
+	}
+
+	/**
+	 * Get the folder name for the selected version of the integration.
+	 *
+	 * @param array<string,string> $versions Available versions.
+	 * @return string The selected folder name.
+	 */
+	public function get_selected_version_folder( array $versions ): string {
+		if ( 'latest' === $this->version ) {
+			return array_key_first( $versions );
+		}
+
+		$desired_version = array_search( $this->version, $versions, true );
+
+		if ( false !== $desired_version ) {
+			return $desired_version;
+		}
+
+		return array_key_first( $versions );
+	}
+}

--- a/tests/integrations/test-vip-workflows.php
+++ b/tests/integrations/test-vip-workflows.php
@@ -12,7 +12,7 @@ use Automattic\Test\Constant_Mocker;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTestCase;
 
-// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
 
 class VIP_Workflows_Integration_Test extends WP_UnitTestCase {
 	private string $slug = 'vip-workflows';

--- a/tests/integrations/test-vip-workflows.php
+++ b/tests/integrations/test-vip-workflows.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Test: VIP Workflows Integration.
+ *
+ * @package Automattic\VIP\Integrations
+ */
+
+namespace Automattic\VIP\Integrations;
+
+use Automattic\Test\Constant_Mocker;
+use PHPUnit\Framework\MockObject\MockObject;
+use WP_UnitTestCase;
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing
+
+class VIP_Workflows_Integration_Test extends WP_UnitTestCase {
+	private string $slug = 'vip-workflows';
+
+	public function tearDown(): void {
+		Constant_Mocker::clear();
+
+		parent::tearDown();
+	}
+
+	public function test_is_loaded_returns_false_when_not_loaded(): void {
+		$integration = new VipWorkflowsIntegration( $this->slug );
+		$this->assertFalse( $integration->is_loaded() );
+	}
+
+	public function test_is_loaded_returns_true_when_loaded_constant_is_defined(): void {
+		Constant_Mocker::define( 'VIP_WORKFLOWS_LOADED', true );
+
+		$integration = new VipWorkflowsIntegration( $this->slug );
+		$this->assertTrue( $integration->is_loaded() );
+	}
+
+	public function test_is_loaded_returns_true_when_plugin_file_constant_is_defined(): void {
+		Constant_Mocker::define( 'VIP_WORKFLOWS_PLUGIN_FILE', '/path/to/vip-workflows.php' );
+
+		$integration = new VipWorkflowsIntegration( $this->slug );
+		$this->assertTrue( $integration->is_loaded() );
+	}
+
+	public function test_load_returns_early_if_plugin_already_loaded(): void {
+		/** @var MockObject|VipWorkflowsIntegration $integration */
+		$integration = $this->getMockBuilder( VipWorkflowsIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded' ] )
+			->getMock();
+
+		$integration->expects( $this->once() )
+			->method( 'is_loaded' )
+			->willReturn( true );
+
+		$integration->load();
+		do_action( 'plugins_loaded' );
+	}
+
+	public function test_load_sets_inactive_when_no_versions_are_available(): void {
+		/** @var MockObject|VipWorkflowsIntegration $integration */
+		$integration = $this->getMockBuilder( VipWorkflowsIntegration::class )
+			->setConstructorArgs( [ $this->slug ] )
+			->onlyMethods( [ 'is_loaded', 'get_versions' ] )
+			->getMock();
+
+		$integration->activate();
+		$integration->method( 'is_loaded' )->willReturn( false );
+		$integration->method( 'get_versions' )->willReturn( [] );
+
+		$integration->load();
+		do_action( 'plugins_loaded' );
+
+		$this->assertFalse( $integration->is_active() );
+	}
+
+	public function test_get_selected_version_folder_returns_latest_version(): void {
+		$integration = new VipWorkflowsIntegration( $this->slug );
+		$versions    = [
+			'vip-workflows-0.1' => '0.1',
+			'vip-workflows-0.0' => '0.0',
+		];
+
+		$this->assertSame( 'vip-workflows-0.1', $integration->get_selected_version_folder( $versions ) );
+	}
+
+	public function test_get_selected_version_folder_returns_requested_version(): void {
+		$integration          = new VipWorkflowsIntegration( $this->slug );
+		$integration->version = '0.0';
+		$versions             = [
+			'vip-workflows-0.1' => '0.1',
+			'vip-workflows-0.0' => '0.0',
+		];
+
+		$this->assertSame( 'vip-workflows-0.0', $integration->get_selected_version_folder( $versions ) );
+	}
+
+	public function test_pendo_tracking_is_enabled(): void {
+		$integration = new VipWorkflowsIntegration( $this->slug );
+
+		$this->assertTrue( $integration->should_track_in_pendo() );
+	}
+}

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -50,6 +50,10 @@ if ( file_exists( __DIR__ . '/integrations/safe-publish.php' ) ) {
 	require_once __DIR__ . '/integrations/safe-publish.php';
 }
 
+if ( file_exists( __DIR__ . '/integrations/vip-workflows.php' ) ) {
+	require_once __DIR__ . '/integrations/vip-workflows.php';
+}
+
 // Register VIP integrations here.
 IntegrationsSingleton::instance()->register( new BlockDataApiIntegration( 'block-data-api' ) );
 IntegrationsSingleton::instance()->register( new ParselyIntegration( 'parsely' ) );
@@ -79,6 +83,10 @@ if ( class_exists( __NAMESPACE__ . '\\RealTimeCollaborationIntegration' ) ) {
 
 if ( class_exists( __NAMESPACE__ . '\\SafePublishIntegration' ) ) {
 	IntegrationsSingleton::instance()->register( new SafePublishIntegration( 'safe-publish' ) );
+}
+
+if ( class_exists( __NAMESPACE__ . '\\VipWorkflowsIntegration' ) ) {
+	IntegrationsSingleton::instance()->register( new VipWorkflowsIntegration( 'vip-workflows' ) );
 }
 
 // @codeCoverageIgnoreEnd

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -50,8 +50,9 @@ if ( file_exists( __DIR__ . '/integrations/safe-publish.php' ) ) {
 	require_once __DIR__ . '/integrations/safe-publish.php';
 }
 
-if ( file_exists( __DIR__ . '/integrations/vip-workflows.php' ) ) {
-	require_once __DIR__ . '/integrations/vip-workflows.php';
+$vip_workflows_wrapper = __DIR__ . '/integrations/vip-workflows.php';
+if ( file_exists( $vip_workflows_wrapper ) ) {
+	require_once $vip_workflows_wrapper;
 }
 
 // Register VIP integrations here.
@@ -86,7 +87,8 @@ if ( class_exists( __NAMESPACE__ . '\\SafePublishIntegration' ) ) {
 }
 
 if ( class_exists( __NAMESPACE__ . '\\VipWorkflowsIntegration' ) ) {
-	IntegrationsSingleton::instance()->register( new VipWorkflowsIntegration( 'vip-workflows' ) );
+	$vip_workflows_integration = new VipWorkflowsIntegration( 'vip-workflows' );
+	IntegrationsSingleton::instance()->register( $vip_workflows_integration );
 }
 
 // @codeCoverageIgnoreEnd

--- a/vip-integrations.php
+++ b/vip-integrations.php
@@ -50,9 +50,8 @@ if ( file_exists( __DIR__ . '/integrations/safe-publish.php' ) ) {
 	require_once __DIR__ . '/integrations/safe-publish.php';
 }
 
-$vip_workflows_wrapper = __DIR__ . '/integrations/vip-workflows.php';
-if ( file_exists( $vip_workflows_wrapper ) ) {
-	require_once $vip_workflows_wrapper;
+if ( file_exists( __DIR__ . '/integrations/vip-workflows.php' ) ) {
+	require_once __DIR__ . '/integrations/vip-workflows.php';
 }
 
 // Register VIP integrations here.
@@ -87,8 +86,7 @@ if ( class_exists( __NAMESPACE__ . '\\SafePublishIntegration' ) ) {
 }
 
 if ( class_exists( __NAMESPACE__ . '\\VipWorkflowsIntegration' ) ) {
-	$vip_workflows_integration = new VipWorkflowsIntegration( 'vip-workflows' );
-	IntegrationsSingleton::instance()->register( $vip_workflows_integration );
+	IntegrationsSingleton::instance()->register( new VipWorkflowsIntegration( 'vip-workflows' ) );
 }
 
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
## Summary

- register a `vip-workflows` MU integration wrapper
- load the latest versioned bundle on `plugins_loaded` with site-copy guards
- use the plural v0.0.2 constants and `vip-workflows.php` entry file
- add focused loader, version-selection, sentinel, and tracking tests

## Validation

- PHP syntax checks for all changed PHP files
- targeted PHPCS
- `git diff --check`
- PHPUnit was not available locally because OrbStack/Docker was stopped and the host WordPress test library was not installed; GitHub CI will run the suite

Linear: https://linear.app/a8c/issue/VIPPROD-610/c3-surface-3-vip-go-mu-plugins-wrapper-safe-publish-loader-model